### PR TITLE
fix OCP-19577 check project page

### DIFF
--- a/lib/rules/web/admin_console/3.11/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/3.11/common_ui_elements.xyaml
@@ -9,11 +9,6 @@ click_create_button:
   - selector:
       xpath: //button[contains(text(),'Create')]
     op: click
-click_delete_button:
-  elements:
-  - selector:
-      xpath: //button[contains(text(),'Delete')]
-    op: click
 click_resource_action_icon:
   elements:
   - selector:
@@ -63,6 +58,9 @@ check_resource_details:
     if_param: name
     ref: check_resource_name
   action:
+    if_param: display_name
+    ref: check_resource_display_name
+  action:
     if_param: labels
     ref: check_resource_labels
   action:
@@ -85,6 +83,11 @@ check_resource_name:
   params:
     key: Name
     value: <name>
+  action: check_resource_details_key_and_value
+check_resource_display_name:
+  params:
+    key: Display Name
+    value: <display_name>
   action: check_resource_details_key_and_value
 check_resource_labels:
   params:

--- a/lib/rules/web/admin_console/3.11/projects.xyaml
+++ b/lib/rules/web/admin_console/3.11/projects.xyaml
@@ -27,29 +27,10 @@ set_project_description:
       xpath: //textarea[contains(@id,'input-description')]
     op: set <description>
     type: textarea
-delete_project_on_list_page:
-  action: click_resource_action_icon
-  action: click_delete_project_icon
-  action: send_delete_string
-  action: click_delete_button
-click_delete_project_icon:
-  action: operate_action_from_dropdown
 send_delete_string:
   elements:
   - selector:
       xpath: //input[@class='form-control']
     type: input
     op: send_keys <resource_name>
-check_project_on_overview_page:
-  elements:
-  - selector:
-      xpath: //dt[text()="Name"]/following-sibling::dd[1][text()="<project_name>"]
-  - selector:
-      xpath: //dt[text()="Display Name"]/following-sibling::dd[1][text()="<display_name>"]
-check_project_list:
-  action: goto_projects_page
-  elements:
-  - selector:
-      xpath: //a[contains(@href,'project/')]
-    type: a
 

--- a/lib/rules/web/admin_console/4.0/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.0/common_ui_elements.xyaml
@@ -9,11 +9,6 @@ click_create_button:
   - selector:
       xpath: //button[contains(text(),'Create')]
     op: click
-click_delete_button:
-  elements:
-  - selector:
-      xpath: //button[contains(text(),'Delete')]
-    op: click
 click_resource_action_icon:
   elements:
   - selector:
@@ -63,6 +58,9 @@ check_resource_details:
     if_param: name
     ref: check_resource_name
   action:
+    if_param: display_name
+    ref: check_resource_display_name
+  action:
     if_param: labels
     ref: check_resource_labels
   action:
@@ -85,6 +83,11 @@ check_resource_name:
   params:
     key: Name
     value: <name>
+  action: check_resource_details_key_and_value
+check_resource_display_name:
+  params:
+    key: Display Name
+    value: <display_name>
   action: check_resource_details_key_and_value
 check_resource_labels:
   params:

--- a/lib/rules/web/admin_console/4.0/projects.xyaml
+++ b/lib/rules/web/admin_console/4.0/projects.xyaml
@@ -27,29 +27,10 @@ set_project_description:
       xpath: //textarea[contains(@id,'input-description')]
     op: set <description>
     type: textarea
-delete_project_on_list_page:
-  action: click_resource_action_icon
-  action: click_delete_project_icon
-  action: send_delete_string
-  action: click_delete_button
-click_delete_project_icon:
-  action: operate_action_from_dropdown
 send_delete_string:
   elements:
   - selector:
       xpath: //input[@class='form-control']
     type: input
     op: send_keys <resource_name>
-check_project_on_overview_page:
-  elements:
-  - selector:
-      xpath: //dt[text()="Name"]/following-sibling::dd[1][text()="<project_name>"]
-  - selector:
-      xpath: //dt[text()="Display Name"]/following-sibling::dd[1][text()="<display_name>"]
-check_project_list:
-  action: goto_projects_page
-  elements:
-  - selector:
-      xpath: //a[contains(@href,'project/')]
-    type: a
 


### PR DESCRIPTION
Since 4.0, icon operation nearby resource name in list page has been removed.  http://pastebin.test.redhat.com/669046 As the implementation of `click_one_dropdown_action` written in #3, will give pass log after that pr merge.
@yapei  help to review, thanks


 