### PR TITLE
Log error is enough when failed to create pv

### DIFF
--- a/features/step_definitions/pv.rb
+++ b/features/step_definitions/pv.rb
@@ -175,7 +175,7 @@ When /^admin creates a PV from "([^"]*)" where:$/ do |location, table|
     }
   else
     logger.error(@result[:response])
-    raise "failed to create PV from: #{location}"
+    #raise "failed to create PV from: #{location}"
   end
 end
 


### PR DESCRIPTION
@akostadinov @pruan-rht Trying to add some negative coverage to persistent volume. Logger is enough, raise will fail the negative scenarios.