### PR TITLE
update webauto libs and remove ureliable ff legacy support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,9 @@ gem 'azure_mgmt_network', '~>0.17.0'
 ## Logging
 gem 'term-ansicolor'
 ## Webauto
-gem 'watir', '~> 6.10.3' # undefined methodnew' for nil:NilClass in #6276
+gem 'watir'
 gem 'headless'
-gem 'selenium-webdriver', "~>3.11.0" # limit webdriver to support legacy ff
+gem 'selenium-webdriver'
 ## Docs
 # beware https://github.com/pry/pry/issues/1465
 #        https://bugzilla.redhat.com/show_bug.cgi?id=1257578

--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -104,19 +104,6 @@ require "base64"
         if @size
           browser.window.resize_to(*@size)
         end
-      elsif @browser_type == :firefox_legacy
-        # legacy driver usage https://github.com/watir/watir/issues/634
-        # we should switch to marionette once FF ESR becomes version  54+
-        logger.info "Launching Firefox Legacy"
-        caps = Selenium::WebDriver::Remote::Capabilities.firefox marionette: false, profile: firefox_profile #, firefox_binary: "/home/user/local/firefox-52-esr/firefox"
-        if Integer === @scroll_strategy
-          caps[:element_scroll_behavior] = @scroll_strategy
-        end
-        driver = Selenium::WebDriver.for :firefox, desired_capabilities: caps, http_client: client
-        @browser = Watir::Browser.new driver
-        if @size
-          browser.window.resize_to(*@size)
-        end
       elsif @browser_type == :chrome
         logger.info "Launching Chrome"
         if Integer === @scroll_strategy

--- a/tools/jenkins/slaves/Dockerfile
+++ b/tools/jenkins/slaves/Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile.rhel7


### PR DESCRIPTION
Seeingsome failures in smoke runs related to webdriver-browser communication. I think updating web gems can help this. Also ff legacy is unreliable and we don't use it anymore. It doesn't work with the new gems.