### PR TITLE
Rename to consistent with repo name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,8 +7,8 @@ More info you can find in link:doc/overview.adoc[Overview document].
 === Create local dev environment
 
 . Install git if not installed already, install ruby 2.4+ if not installed
-. git clone git@github.com:openshift/bushslicer.git
-. cd bushslicer
+. git clone git@github.com:openshift/verification-tests.git
+. cd verification-tests
 . tools/install_os_deps.sh # need sudo; you may need to login again to terminal if ruby was installed via rvm during this phase
 . tools/hack_bundle.rb # normal user
 . install OKD or OpenShift Container Platform client tools
@@ -21,12 +21,12 @@ bundle update
 
 === Test scenario execution
 
-Check link:doc/configuration.adoc[Configuring a BushSlicer v3 run]
+Check link:doc/configuration.adoc[Configuring a verification-tests v3 run]
 
 This is an example:
 
 ----
-export BUSHSLICER_DEFAULT_ENVIRONMENT=ose
+export VERIFICATION_TESTS_DEFAULT_ENVIRONMENT=ose
 export OPENSHIFT_ENV_OSE_HOSTS=<host1>:etcd:master:node,<host2>:node,...
 export OPENSHIFT_ENV_OSE_USER_MANAGER_USERS=user1:redhat,user2:redhat
 # execute a whole feature file
@@ -40,14 +40,14 @@ bundle exec cucumber --tags @smoke
 For Origin environment, add the following environment variables:
 
 ----
-export BUSHSLICER_DEFAULT_ENVIRONMENT=origin
+export VERIFICATION_TESTS_DEFAULT_ENVIRONMENT=origin
 export OPENSHIFT_ENV_ORIGIN_HOSTS=<host1>:etcd:master:node,<host2>:node,...
 export OPENSHIFT_ENV_ORIGIN_USER_MANAGER_USERS=user1:redhat,user2:redhat
 ----
 
 You can check which environments are defined in link:config/config.yaml[config/config.yaml].
 
-You could also use the BUSHSLICER_CONFIG variable to override other
+You could also use the VERIFICATION_TESTS_CONFIG variable to override other
 configuration options. Add YAML/JSON into it and it will be merged with
 configuration file.
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
---- # BushSlicer framework configuration options
+--- # verification-tests framework configuration options
 global:
-  git_repo_url: https://github.com/openshift/BushSlicer
+  git_repo_url: https://github.com/openshift/verification-tests
   git_repo_default_branch: master
 
   debug_in_after_hook: false
@@ -35,10 +35,10 @@ global:
   project_docker_repo: ""
   # product_docker_repo: registry.access.redhat.com/
 
-  # use BUSHSLICER_DEFAULT_ENVIRONMENT instead of setting here
+  # use VERIFICATION_TESTS_DEFAULT_ENVIRONMENT instead of setting here
   # default_environment: ose
 
-  # use BUSHSLICER_TEST_CASE_MANAGER instead of setting here
+  # use VERIFICATION_TESTS_TEST_CASE_MANAGER instead of setting here
   # test_case_manager: tcms
 
   # select browser different from default (firefox)
@@ -88,13 +88,13 @@ environments:
 optional_classes:
   tcms_tc_manager:
     include_path: tcms/tcms_manager
-    class: BushSlicer::TCMSManager
+    class: VerificationTests::TCMSManager
     opts: {}
   polarshift_tc_manager:
     include_path: test_case_manager
-    class: BushSlicer::TestCaseManager
+    class: VerificationTests::TestCaseManager
     opts:
-      test_suite_class: BushSlicer::PolarShift::TestSuite
+      test_suite_class: VerificationTests::PolarShift::TestSuite
       test_suite_opts: {}
 services:
   AWS: &AWSBase

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -3,7 +3,7 @@
 ---
 <% now = Time.now.to_i %>
 <% default_args = " --color -r features -f pretty --expand --strict" %>
-<% tcms_args = " --color -r features -f pretty -f BushSlicer::CucuFormatter -o :auto --expand --strict --order random" %>
+<% tcms_args = " --color -r features -f pretty -f VerificationTests::CucuFormatter -o :auto --expand --strict --order random" %>
 <% branch = `git branch | grep "*"  | sed "s/* //"`.strip %>
 <% common_libs = " -r features/step_definitions/ -r features/support/ "%>
 
@@ -13,12 +13,12 @@
 default: --profile devel
 debug: --profile _debug --profile devel
 devel: --profile _devel <%= default_args %>
-tcms: BUSHSLICER_TEST_CASE_MANAGER=tcms <%= tcms_args %>
-polarshift: BUSHSLICER_TEST_CASE_MANAGER=polarshift <%= tcms_args %>
+tcms: VERIFICATION_TESTS_TEST_CASE_MANAGER=tcms <%= tcms_args %>
+polarshift: VERIFICATION_TESTS_TEST_CASE_MANAGER=polarshift <%= tcms_args %>
 junit: <%= default_args %> -f junit -o "<%= junit_dir %>" --profile dir_embedder
-dir_embedder: -f BushSlicer::SaveToDirEmbeddingFormatter -o "embedded_files"
+dir_embedder: -f VerificationTests::SaveToDirEmbeddingFormatter -o "embedded_files"
 
-_debug: BUSHSLICER_LOG_LEVEL=debug
-_devel: BUSHSLICER_DEBUG_AFTER_FAIL=true BUSHSLICER_DEBUG_ATTACHER_TIMEOUT=true
+_debug: VERIFICATION_TESTS_LOG_LEVEL=debug
+_devel: VERIFICATION_TESTS_DEBUG_AFTER_FAIL=true VERIFICATION_TESTS_DEBUG_ATTACHER_TIMEOUT=true
 #
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/doc/coding_guide.adoc
+++ b/doc/coding_guide.adoc
@@ -8,7 +8,7 @@ https://github.com/bbatsov/ruby-style-guide
 Try to make sure, when you look at your code, it looks descent. See link:vim.adoc[vim.adoc] for some tips.
 
 == Tool to help indentation
-BushSlicer uses http://editorconfig.org/[EditorConfig] to have a universal
+verification-tests uses http://editorconfig.org/[EditorConfig] to have a universal
 indentation styles.  It supports various IDEs.  You can download a plugin and
 install it into your IDE from http://editorconfig.org/#download
 

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -4,7 +4,7 @@
 
 Main configuration is inside `config/config.yaml`. Content of that file is also merged with `PRIVATE/config.yaml` and `PRIVATE/config/config.yaml` if such files exist.
 You shouldn't submit private configuraion and/or credential files to public Git repos thus `PRIVATE` is a good place to put them in.
-It defaults to `bushslicer_dir/private` dir and is listed in `.gitignore` not to be submitted to the BushSlicer repo.
+It defaults to `verification-tests_dir/private` dir and is listed in `.gitignore` not to be submitted to the verification-tests repo.
 
 We have also some configuration in `config/cucumber.yml`. There are some profiles defined for easily calling with proper options.
 
@@ -20,9 +20,9 @@ Some of these options can be overwritten by environment variables, see `#env_ove
 
 Under `environments` there are default options for different environment types. The name of environment does not matter, you can rename environment but if you use same options, the end result should be the same. Names are to just make it easy to start with some reasonable defaults.
 
-The default environment is determined by the `default_environment` global option. It's usually set by the BUSHSLICER_DEFAULT_ENVIRONMENT env variable.
+The default environment is determined by the `default_environment` global option. It's usually set by the VERIFICATION_TESTS_DEFAULT_ENVIRONMENT env variable.
 
-Let's take one example - OSE environment. It has as a default `hosts_type: SSHAccessibleHost`. If we want to override it, we can specify env variable OPENSHIFT_ENV_OSE_HOSTS_TYPE. Its the same with any other option. All variables that start with `OPENSHIFT_ENV_<env name>_SOMETHING` get an option for the named environment set. The first part `OPENSHIFT_ENV_<env name>_` is removed, then the other part `SOMETHING` is downcased and converted to a Symbol to become a key in the configuration Hash that is passed to the environment class constructor. That is taken care of in the `#load_env` private method of `BushSlicer::EnvironmentManager` class.
+Let's take one example - OSE environment. It has as a default `hosts_type: SSHAccessibleHost`. If we want to override it, we can specify env variable OPENSHIFT_ENV_OSE_HOSTS_TYPE. Its the same with any other option. All variables that start with `OPENSHIFT_ENV_<env name>_SOMETHING` get an option for the named environment set. The first part `OPENSHIFT_ENV_<env name>_` is removed, then the other part `SOMETHING` is downcased and converted to a Symbol to become a key in the configuration Hash that is passed to the environment class constructor. That is taken care of in the `#load_env` private method of `VerificationTests::EnvironmentManager` class.
 
 == user configuration
 
@@ -33,7 +33,7 @@ So far we only have `StaticUserManager` so users are defined with the `OPENSHIFT
 * by user/password
 * by token
 
-User/password pairs are easier unless you run in environment where you can't login with a password, e.g. google auth, kerberos auth, etc. You have to generate a token via browser and then supply it to BushSlicer.
+User/password pairs are easier unless you run in environment where you can't login with a password, e.g. google auth, kerberos auth, etc. You have to generate a token via browser and then supply it to verification-tests.
 
 Username should be written in full. e.g. with kerberos auth the client tool can take a short username like `asd`. But you need to use the full username like `asd@EXAMPLE.COM`.
 

--- a/doc/overview.adoc
+++ b/doc/overview.adoc
@@ -1,4 +1,4 @@
-= High Level BushSlicer v3 Overview
+= High Level verification-tests v3 Overview
 
 == Knowledge needed to understand this doc
 
@@ -46,7 +46,7 @@ see link:test_case_management.adoc[Test case management].
 
 === Public/Private
 
-In the BushSlicer::PRIVATE dir (see `lib/cucumber.rb`) we can have other classes and configuration that expose internal information or is security sensitive (keys for test services, etc.). We intend to have most of the code open sourced so we keep anything forbidden to public in the PRIVATE dir. It is a separate git internal repo.
+In the VerificationTests::PRIVATE dir (see `lib/cucumber.rb`) we can have other classes and configuration that expose internal information or is security sensitive (keys for test services, etc.). We intend to have most of the code open sourced so we keep anything forbidden to public in the PRIVATE dir. It is a separate git internal repo.
 
 In the beginning of our `env.rb` we have a call to `PRIVATE/env.rb` if it exists. So any private code can be injected in this way, including to substitute DefaultWorld and DefaultManager.
 

--- a/doc/test_case_management.adoc
+++ b/doc/test_case_management.adoc
@@ -4,7 +4,7 @@
 
 == Overview
 
-BushSlicer has a feature to use an external test case manager for cases to be run and reporting of status and test artifacts. This is achieved by the collaboration of the following classes:
+verification-tests has a feature to use an external test case manager for cases to be run and reporting of status and test artifacts. This is achieved by the collaboration of the following classes:
 
 * TestCaseManagerFilter - this is a http://www.rubydoc.info/github/cucumber/cucumber-ruby-core/Cucumber/Core/Filter[cucumber filter] that would ask actual test case manager if a test case is to be run and inform test case manager for events like begin/end execution of scenario. It needs to be the last Cucumber filter, otherwise operation of the whole system will be compromised.
 * CucuFormatter - custom cucumber formatter that creates HTML log files and accumulates test artifacts (TBD); also accepts requests to produce scenario result html file for attaching to test case by the test case manager
@@ -20,7 +20,7 @@ Selection of test case manager is done by inserting a filter in the Cucumber fil
 
 Filter is usually inserted in Cucumber `AfterConfiguration`. We do it with `features/support/env.rb`. But in fact `env.rb` is delegating this to `Manager#init_test_case_manager` method inside `lib/manager.rb`.
 
-Selection of manager is based on `BUSHSLICER_TEST_CASE_MANAGER` env variable or the `test_case_manager` global configuration option. If we have `BUSHSLICER_TEST_CASE_MANAGER=foo`, then optional class `foo_tc_manager` is loaded and used as the manager (see `Configuration#get_optional_class_instance`).
+Selection of manager is based on `VERIFICATION_TESTS_TEST_CASE_MANAGER` env variable or the `test_case_manager` global configuration option. If we have `VERIFICATION_TESTS_TEST_CASE_MANAGER=foo`, then optional class `foo_tc_manager` is loaded and used as the manager (see `Configuration#get_optional_class_instance`).
 
 Look at the following section for how exactly we setup optional classes for TCMS and Polarion. Basically inlcude path, class name and options are provided in the configuration file. Then a profile in `config/cucumber.yml` is created for easier invoking the desired manager.
 
@@ -52,17 +52,17 @@ Manager setup for Polarshift can be seen in config/config.yaml
 optional_classes:
   polarshift_tc_manager:
     include_path: test_case_manager
-    class: BushSlicer::TestCaseManager
+    class: VerificationTests::TestCaseManager
     opts:
-      test_suite_class: BushSlicer::PolarShift::TestSuite
+      test_suite_class: VerificationTests::PolarShift::TestSuite
       test_suite_opts: {}
 ----
 
-You can see how we select the generic `TestCaseManager` class and initialize it with options to create an instance of `BushSlicer::PolarShift::TestSuite` class for handling PolarShift specific interactions.
+You can see how we select the generic `TestCaseManager` class and initialize it with options to create an instance of `VerificationTests::PolarShift::TestSuite` class for handling PolarShift specific interactions.
 
 === PolarShift loading and configuration
 
-`PolarShift` module and classes are setup for autoloading by `autoload :PolarShift, "polarshift/autoload"` line in `lib/bushslicer.rb`.
+`PolarShift` module and classes are setup for autoloading by `autoload :PolarShift, "polarshift/autoload"` line in `lib/verification-tests.rb`.
 You can then see how autoloading of the rest of the PolarShift classes is setup in `lib/polarshift/autoload.rb`. Some of them use regular `require` though.
 
 PolarShift logic is split into two parts - low-level requests and test management object model.
@@ -124,7 +124,7 @@ services:
     ca_path: config/ca # you can use ca_file: as well or none for insecure
 ----
 
-`ca_path` is in the format of openssl ca_path directory. The path or file specified can be absolute or relative. When relative, it is searched for in the `PRIVATE` dir, user home dir or BushSlicer::HOME dir.
+`ca_path` is in the format of openssl ca_path directory. The path or file specified can be absolute or relative. When relative, it is searched for in the `PRIVATE` dir, user home dir or VerificationTests::HOME dir.
 
 Only HTTP basic auth is supported by xmlrpc client. User/password pair can be supplied wither through `user` adn `password` configuration options, or using environment variables `TCMS_USER`, `TCMS_PASSWORD`. In absence of the above, user is asked for them on the console prompt. The latter method is most secure but not possible with jenkins and cron test runs.
 

--- a/doc/user_pools.adoc
+++ b/doc/user_pools.adoc
@@ -2,7 +2,7 @@
 
 == Overview
 
-To allow easier sharing of environment users, BushSlicer supports putting
+To allow easier sharing of environment users, verification-tests supports putting
 users into a user pool using a generic locker/allocator web app and then
 reserving and releasing locks over the users as there is a demand for it.
 
@@ -40,7 +40,7 @@ Because the OwnThat app is generic purpose, the convention is to put into
 
 Only active entries will be used for creating actual locks later. You can
 use the note field to clarify origin of the user or reason why it is not
-active. In any case the `note` field is irrelevant for BushSlicer and is only
+active. In any case the `note` field is irrelevant for verification-tests and is only
 meant to serve human users that manage the pools.
 
 === launching Cucumber
@@ -52,7 +52,7 @@ or set to `auto`. The other thing is to have users set to `pool:<pool name>`.
 [source,bash]
 ----
 ...
-export BUSHSLICER_DEFAULT_ENVIRONMENT=ocp
+export VERIFICATION_TESTS_DEFAULT_ENVIRONMENT=ocp
 export OPENSHIFT_ENV_OCP_USER_MANAGER=auto # this might be default already
 export OPENSHIFT_ENV_OCP_USER_MANAGER_USERS=pool:mypool
 cucumber <opts>

--- a/doc/webauto.adoc
+++ b/doc/webauto.adoc
@@ -9,7 +9,7 @@
 The "web rules" represent whole structure we are using for web automation.
 The web rules were implemented for several reasons:
 
-* separate web automation from the BushSlicer core.
+* separate web automation from the verification-tests core.
 * allow cross-browser && cross-version testing with one feature file.
 * make Scenarios maintenance easier when new releases coming.
 * provide neat way of communication with browser.
@@ -240,7 +240,7 @@ rule:
 
 ==== `type:`
 Subtype of the element could be specified. Currently supported types are listed
-in the https://github.com/openshift/BushSlicer/blob/master/lib/webauto/web4cucumber.rb#L13-L28[FUNMAP] constant.
+in the https://github.com/openshift/verification-tests/blob/master/lib/webauto/web4cucumber.rb#L13-L28[FUNMAP] constant.
 
 ==== `op:`
 After the element was successfully found `click`,`hover`,`clear`,`set`,
@@ -258,7 +258,7 @@ rule:
 
 the `op` which could be performed on the element depends on the element type.
 Full picture of `element_type` - `op` сorrespondence can be found in the
-https://github.com/openshift/BushSlicer/blob/master/lib/webauto/web4cucumber.rb#L391-L429[source].
+https://github.com/openshift/verification-tests/blob/master/lib/webauto/web4cucumber.rb#L391-L429[source].
 
 ==== `missing:`
 **default:false**
@@ -508,7 +508,7 @@ check whether the changed `*.xyaml` file has valid format.
 ** A: When we are trying to check if element is missing on the page we need to wait for default timeout before the rule will fail. This was one of the reason to include `missing:` option.
 
 * Q: Why do we need to create an empty actions in web auto?
-** A: Our Scenarios in *.feature files are permanent for all version, but our web rules separated by version folder. Intention was to put all possible checks and operations which could change with upcoming releases to the web rules. So when we have new release we could just change web rules in appropriate folder and left Scenario untouched(so it works for previous version fine without any additional changes). Sometimes it happens that in new release we don't need action which was performed for previous releases, in this case we could left this action empty(If we'll simply delete this action, then Scenario will fail cause it couldn't find this action). For example look https://github.com/openshift/BushSlicer/search?utf8=%E2%9C%93&q=save_updated_env_value&type=[here]. We had separated "save button" for each env value in the second version, but when the editor was changed and this action is useless, so we just replaced the action content with {}.
+** A: Our Scenarios in *.feature files are permanent for all version, but our web rules separated by version folder. Intention was to put all possible checks and operations which could change with upcoming releases to the web rules. So when we have new release we could just change web rules in appropriate folder and left Scenario untouched(so it works for previous version fine without any additional changes). Sometimes it happens that in new release we don't need action which was performed for previous releases, in this case we could left this action empty(If we'll simply delete this action, then Scenario will fail cause it couldn't find this action). For example look https://github.com/openshift/verification-tests/search?utf8=%E2%9C%93&q=save_updated_env_value&type=[here]. We had separated "save button" for each env value in the second version, but when the editor was changed and this action is useless, so we just replaced the action content with {}.
 
 == Debugging Javascript in Firefox/Chrome
 
@@ -529,6 +529,6 @@ Once the inspector appears, you can look at several things, including a console,
 
 For chrome, the same instructions can be located here: [Chrome DevTools  |  Tools for Web Developers  |  Google Developers](https://developers.google.com/web/tools/chrome-devtools/)
 
-BushSlicer specific concerns:
+verification-tests specific concerns:
 
 At times, it is difficult to diagnose an automated run. To debug Javascript or HTML issues, it is preferred to diagnose a testcase locally. If this is not possible, insert `console.log()` print lines in the Javascript of the test case, to print out values that would otherwise be hidden. Liberal use of `pry` commands to freeze on a particular step aid in the debugging process as well.

--- a/features/metrics/install_uninstall.feature
+++ b/features/metrics/install_uninstall.feature
@@ -55,7 +55,7 @@ Feature: metrics logging and uninstall tests
     # 1. pvc working
     Then the expression should be true> pvc('metrics-cassandra-1').ready?[:success]
     # 2. check pod volume name matches 'metrics-cassandra-1'
-    Then the expression should be true> pod.volumes.find { |v| v.name == 'cassandra-data' && v.kind_of?(BushSlicer::PVCPodVolumeSpec) && v.claim.name == 'metrics-cassandra-1' }
+    Then the expression should be true> pod.volumes.find { |v| v.name == 'cassandra-data' && v.kind_of?(VerificationTests::PVCPodVolumeSpec) && v.claim.name == 'metrics-cassandra-1' }
     # 3. check volume cassandra-data was mounted to /cassandra_data" in pod spec
     Then the expression should be true> pod.container(name: 'hawkular-cassandra-1').spec.volume_mounts.select { |v| v['mountPath'] == "/cassandra_data" }.count > 0
 

--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -47,7 +47,7 @@ Feature: Egress-ingress related networking scenarios
     And evaluation of `project.name` is stored in the :proj1 clipboard
   
     # Create egress policy in project-1
-    And evaluation of `BushSlicer::Common::Net.dns_lookup("yahoo.com")` is stored in the :yahoo_ip clipboard
+    And evaluation of `VerificationTests::Common::Net.dns_lookup("yahoo.com")` is stored in the :yahoo_ip clipboard
     When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/egress-ingress/dns-egresspolicy1.json"
     And I replace lines in "dns-egresspolicy1.json":
       | 98.138.0.0/16 | <%= cb.yahoo_ip %>/32 |
@@ -109,7 +109,7 @@ Feature: Egress-ingress related networking scenarios
     And evaluation of `project.name` is stored in the :proj1 clipboard
  
     # Create egress policy in project-1
-    And evaluation of `BushSlicer::Common::Net.dns_lookup("yahoo.com")` is stored in the :yahoo_ip clipboard
+    And evaluation of `VerificationTests::Common::Net.dns_lookup("yahoo.com")` is stored in the :yahoo_ip clipboard
     When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/egress-ingress/dns-egresspolicy1.json"
     And I replace lines in "dns-egresspolicy1.json":
       | 98.138.0.0/16 | <%= cb.yahoo_ip %>/32 |
@@ -147,7 +147,7 @@ Feature: Egress-ingress related networking scenarios
     Given I have a project  
     Given I have a pod-for-ping in the project
     And evaluation of `project.name` is stored in the :proj1 clipboard
-    And evaluation of `BushSlicer::Common::Net.dns_lookup("www.yahoo.com", multi: true)` is stored in the :yahoo clipboard
+    And evaluation of `VerificationTests::Common::Net.dns_lookup("www.yahoo.com", multi: true)` is stored in the :yahoo clipboard
     Then the expression should be true> cb.yahoo.size >= 3
 
     # Create egress policy 

--- a/features/online/quota.feature
+++ b/features/online/quota.feature
@@ -74,7 +74,7 @@ Feature: ONLY ONLINE Quota related scripts in this file
   # @case_id OCP-10291
   Scenario: Can not create resource exceed the hard quota in appliedclusterresourcequota  
     Given I have a project  
-    And evaluation of `BushSlicer::AppliedClusterResourceQuota.list(user: user, project: project)` is stored in the :acrq clipboard
+    And evaluation of `VerificationTests::AppliedClusterResourceQuota.list(user: user, project: project)` is stored in the :acrq clipboard
     And evaluation of `cb.acrq.find{|o|o.name.end_with?("-compute")}` is stored in the :memory_crq clipboard
     And evaluation of `cb.acrq.find{|o|o.name.end_with?('-timebound')}` is stored in the :memory_terminate_crq clipboard
     And evaluation of `cb.acrq.find{|o|o.name.end_with?('-noncompute')}` is stored in the :storage_crq clipboard

--- a/features/step_definitions/admin_console.rb
+++ b/features/step_definitions/admin_console.rb
@@ -4,8 +4,8 @@
 # end
 
 Given /^I open admin console in a browser$/ do
-  base_rules = BushSlicer::WebConsoleExecutor::RULES_DIR + "/base/"
-  snippets_dir = BushSlicer::WebConsoleExecutor::SNIPPETS_DIR
+  base_rules = VerificationTests::WebConsoleExecutor::RULES_DIR + "/base/"
+  snippets_dir = VerificationTests::WebConsoleExecutor::SNIPPETS_DIR
 
   version = env.webconsole_executor.get_master_version(user, via_rest: true)
 

--- a/features/step_definitions/build.rb
+++ b/features/step_definitions/build.rb
@@ -79,7 +79,7 @@ Then(/^I save pruned builds in the #{QUOTED} project into the #{SYM} clipboard$/
   # lookbehind does not support quantifiers and jruby no support of \K
   build_names = @result[:response].scan(%r%(?<=^#{Regexp.escape(project.name)})\s+[^\s]*$%)
   builds = build_names.map { |bn|
-    BushSlicer::Build.new(name: bn.strip, project: project)
+    VerificationTests::Build.new(name: bn.strip, project: project)
   }
   cb[cb_name] = builds
 end

--- a/features/step_definitions/clouds/gce.rb
+++ b/features/step_definitions/clouds/gce.rb
@@ -2,7 +2,7 @@
 #   but not the same zone as master
 Given /^a GCE zone without any cluster masters is stored in the#{OPT_SYM} clipboard$/ do |clipboard|
   clipboard ||= "zone"
-  regions = BushSlicer::GCE.regions
+  regions = VerificationTests::GCE.regions
   getzonecmd = "curl -sS -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/zone | sed -re 's#.*/(.+)$#\\1#'"
   current_zones = env.master_hosts.map{|h| h.exec_checked(getzonecmd)[:response]}.uniq
   allowed_zones = regions.reject {|r,z| (z&current_zones).empty?}.map(&:last).reduce([], &:+)

--- a/features/step_definitions/cluster_configuration/localstorage.rb
+++ b/features/step_definitions/cluster_configuration/localstorage.rb
@@ -29,7 +29,7 @@ Given /^I deploy local storage provisioner(?: with "([^ ]+?)" version)?$/ do |im
     project.delete(by: admin)
     project.wait_to_disappear(admin)
 
-    BushSlicer::PersistentVolume.list(user: admin).each { |pv|
+    VerificationTests::PersistentVolume.list(user: admin).each { |pv|
       pv.delete(by: admin) if pv.name.start_with?("local-pv-") && (pv.local_path&.start_with?("#{path}/fast") || pv.local_path&.start_with?("#{path}/slow"))
     }
   end
@@ -101,7 +101,7 @@ Given /^I deploy local storage provisioner(?: with "([^ ]+?)" version)?$/ do |im
   })
 
   pv_count = 0
-  BushSlicer::PersistentVolume.list(user: admin).each { |pv|
+  VerificationTests::PersistentVolume.list(user: admin).each { |pv|
     if pv.name.start_with?("local-pv-") && (pv.local_path&.start_with?("#{path}/fast") || pv.local_path&.start_with?("#{path}/slow"))
       pv_count += 1
     end
@@ -153,7 +153,7 @@ Given /^I deploy local raw block devices provisioner(?: with "([^ ]+?)" version)
   if project.exists?(user: admin)
     project.delete(by: admin)
 
-    BushSlicer::PersistentVolume.list(user: admin).each { |pv|
+    VerificationTests::PersistentVolume.list(user: admin).each { |pv|
       pv.delete(by: admin) if pv.name.start_with?("local-pv-") && pv.local_path&.start_with?("#{path}/block-devices")
     }
   end
@@ -224,7 +224,7 @@ Given /^I deploy local raw block devices provisioner(?: with "([^ ]+?)" version)
   })
 
   pv_count = 0
-  BushSlicer::PersistentVolume.list(user: admin).each { |pv|
+  VerificationTests::PersistentVolume.list(user: admin).each { |pv|
     pv_count += 1 if pv.name.start_with?("local-pv-") && (pv.local_path&.start_with?("#{path}/block-devices"))
   }
 

--- a/features/step_definitions/cluster_resource_quota.rb
+++ b/features/step_definitions/cluster_resource_quota.rb
@@ -1,6 +1,6 @@
 Given /the #{QUOTED} applied_cluster_resource_quota is stored in the#{OPT_QUOTED} clipboard/ do |type, cb_name|
   cb_name ||= "acrq"
-  list = BushSlicer::AppliedClusterResourceQuota.list(user: user, project: project)
+  list = VerificationTests::AppliedClusterResourceQuota.list(user: user, project: project)
   cb["#{cb_name}-list"] = list
   cb[cb_name] = list.find { |o| o.name.end_with?("-#{type}") }
 end

--- a/features/step_definitions/csc.rb
+++ b/features/step_definitions/csc.rb
@@ -5,7 +5,7 @@
 # indexed listing
 Given /^cluster service classes are indexed by external name in the#{OPT_SYM} clipboard$/ do | cb_name |
   cb_name ||= :csc_list
-  cb[cb_name] = BushSlicer::ClusterServiceClass.list(user: admin).map { |csc|
+  cb[cb_name] = VerificationTests::ClusterServiceClass.list(user: admin).map { |csc|
     [csc.external_name, csc]
   }.to_h
   cache_resources *cb[cb_name].values

--- a/features/step_definitions/dc.rb
+++ b/features/step_definitions/dc.rb
@@ -39,7 +39,7 @@ Given /^default (router|docker-registry) deployment config is restored after sce
   # first we need to save the current version
 
   # TODO: maybe we just use dc status => latestVersion ?
-  _rc = BushSlicer::ReplicationController.get_labeled(
+  _rc = VerificationTests::ReplicationController.get_labeled(
     resource,
     user: _admin,
     project: _project
@@ -99,7 +99,7 @@ end
 Given /^number of replicas of#{OPT_QUOTED} deployment config becomes:$/ do |name, table|
   options = hash_symkeys(table.rows_hash)
 
-  int_keys = %i[seconds] + BushSlicer::DeploymentConfig::REPLICA_COUNTERS.keys
+  int_keys = %i[seconds] + VerificationTests::DeploymentConfig::REPLICA_COUNTERS.keys
   int_options = options.slice(*int_keys)
   int_options.transform_values!(&:to_i)
   int_options[:seconds] ||= 5 * 60
@@ -204,7 +204,7 @@ Given /^a deploymentConfig becomes ready with labels:$/ do |table|
   dc_timeout = 10 * 60
   ready_timeout = 15 * 60
 
-  @result = BushSlicer::DeploymentConfig.wait_for_labeled(*labels, user: user, project: project, seconds: dc_timeout)
+  @result = VerificationTests::DeploymentConfig.wait_for_labeled(*labels, user: user, project: project, seconds: dc_timeout)
 
   if @result[:matching].empty?
     raise "See log, waiting for labeled dcs futile: #{labels.join(',')}"

--- a/features/step_definitions/deployment.rb
+++ b/features/step_definitions/deployment.rb
@@ -20,7 +20,7 @@ end
 Given /^number of replicas of#{OPT_QUOTED} deployment becomes:$/ do |name, table|
   options = hash_symkeys(table.rows_hash)
 
-  int_keys = %i[seconds] + BushSlicer::Deployment::REPLICA_COUNTERS.keys
+  int_keys = %i[seconds] + VerificationTests::Deployment::REPLICA_COUNTERS.keys
   int_options = options.slice(*int_keys)
   int_options.transform_values!(&:to_i)
   int_options[:seconds] ||= 5 * 60
@@ -37,7 +37,7 @@ end
 Given /^number of replicas of the current replica set for the#{OPT_QUOTED} deployment becomes:$/ do |name, table|
   options = hash_symkeys(table.rows_hash)
 
-  int_keys = %i[seconds] + BushSlicer::ReplicaSet::REPLICA_COUNTERS.keys
+  int_keys = %i[seconds] + VerificationTests::ReplicaSet::REPLICA_COUNTERS.keys
   int_options = options.slice(*int_keys)
   int_options.transform_values!(&:to_i)
   int_options[:seconds] ||= 5 * 60

--- a/features/step_definitions/ds.rb
+++ b/features/step_definitions/ds.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/hash/transform_values.rb'
 Given /^number of replicas of#{OPT_QUOTED} daemon set becomes:$/ do |name, table|
   options = hash_symkeys(table.rows_hash)
 
-  int_keys = %i[seconds] + BushSlicer::DaemonSet::REPLICA_COUNTERS.keys
+  int_keys = %i[seconds] + VerificationTests::DaemonSet::REPLICA_COUNTERS.keys
   int_options = options.slice(*int_keys)
   int_options.transform_values!(&:to_i)
   int_options[:seconds] ||= 5 * 60

--- a/features/step_definitions/git.rb
+++ b/features/step_definitions/git.rb
@@ -6,7 +6,7 @@ require 'uri'
 # @param [String] dir_path Directory path
 # @note Clones the remote repository
 When /^I git clone the repo #{QUOTED}(?: to #{QUOTED})?$/ do |repo_url, dir_path|
-  git = BushSlicer::Git.new(uri: repo_url, dir: dir_path)
+  git = VerificationTests::Git.new(uri: repo_url, dir: dir_path)
   git.clone
 end
 
@@ -28,7 +28,7 @@ And /^I get the latest git commit id from repo "([^"]+)"$/ do | spec |
     uri = nil
     dir = spec
   end
-  git = BushSlicer::Git.new(uri: uri, dir: dir)
+  git = VerificationTests::Git.new(uri: uri, dir: dir)
   cb[:git_commit_id] = git.get_latest_commit_id
 end
 # @param [String] repo_url git repo that we want to commit
@@ -41,7 +41,7 @@ When /^I commit all changes in repo "([^"]*)" with message "([^"]+)"$/ do | spec
     uri = nil
     dir = spec
   end
-  git = BushSlicer::Git.new(uri: uri, dir: dir)
+  git = VerificationTests::Git.new(uri: uri, dir: dir)
   git.add(files:nil, :all => true)
   git.commit(:msg => message)
 end
@@ -53,7 +53,7 @@ Given /^I remove the remote repository "([^"]*)" from the "([^"]+)" repo$/ do |r
     uri = nil
     dir = spec
   end
-  git = BushSlicer::Git.new(uri: uri, dir: dir)
+  git = VerificationTests::Git.new(uri: uri, dir: dir)
   git.remove_remote(remote)
 end
 
@@ -71,6 +71,6 @@ Given /^I set local git global config with:$/ do |table|
     teardown_annotate_last annotation
   end
 
-  git = BushSlicer::Git.new(dir: localhost.workdir)
+  git = VerificationTests::Git.new(dir: localhost.workdir)
   git.set_global_config(opts_array_to_hash(table.raw, sym_mode: false))
 end

--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -154,7 +154,7 @@ Given /^I have LDAP service in my project$/ do
     step %Q/the step should succeed/
     step %Q/I wait until replicationController "ldapserver-1" is ready/
 
-    cb.ldap_pod = BushSlicer::Pod.get_labeled(["run", "ldapserver"], user: user, project: project).first
+    cb.ldap_pod = VerificationTests::Pod.get_labeled(["run", "ldapserver"], user: user, project: project).first
     cb.ldap_pod_name = cb.ldap_pod.name
     cache_pods cb.ldap_pod
 
@@ -187,7 +187,7 @@ Given /^I have an ssh-git service in the(?: "([^ ]+?)")? project$/ do |project_n
   raise "cannot create git-server service" unless @result[:success]
 
   # wait to become available
-  @result = BushSlicer::Pod.wait_for_labeled("deployment-config=git-server",
+  @result = VerificationTests::Pod.wait_for_labeled("deployment-config=git-server",
                                             "run=git-server",
                                             count: 1,
                                             user: user,
@@ -200,7 +200,7 @@ Given /^I have an ssh-git service in the(?: "([^ ]+?)")? project$/ do |project_n
 
   # Setup SSH key
   cache_pods *@result[:matching]
-  ssh_key = BushSlicer::SSH::Helper.gen_rsa_key
+  ssh_key = VerificationTests::SSH::Helper.gen_rsa_key
   @result = pod.exec(
     "bash", "-c",
     "echo '#{ssh_key.to_pub_key_string}' >> /home/git/.ssh/authorized_keys",
@@ -255,7 +255,7 @@ Given /^I have an http-git service in the(?: "([^ ]+?)")? project$/ do |project_
   cache_pods *@result[:matching]
   unless pod.name.start_with? "git-"
     raise("looks like underlying implementation changed and service ready" +
-      "status does not return matching pods anymore; report BushSlicer bug")
+      "status does not return matching pods anymore; report VerificationTests bug")
   end
 
   # set some clipboards
@@ -276,7 +276,7 @@ Given /^I have a git client pod in the#{OPT_QUOTED} project$/ do |project_name|
   @result = user.cli_exec(:run, name: "git-client", image: "openshift/origin-gitserver", env: 'GIT_HOME=/var/lib/git')
   raise "could not create the git client pod" unless @result[:success]
 
-  @result = BushSlicer::Pod.wait_for_labeled("run=git-client", count: 1,
+  @result = VerificationTests::Pod.wait_for_labeled("run=git-client", count: 1,
                                             user: user, project: project, seconds: 300)
   raise "#{pod.name} pod did not become ready" unless @result[:success]
 
@@ -354,7 +354,7 @@ Given /^I have a header test service in the#{OPT_QUOTED} project$/ do |project_n
   cb.header_test_route = route("header-test-insecure",
                                service("header-test-insecure"))
 
-  @result = BushSlicer::Pod.wait_for_labeled(
+  @result = VerificationTests::Pod.wait_for_labeled(
     "deploymentconfig=header-test",
     count: 1, user: user, project: project, seconds: 300)
   raise "timeout waiting for header test pod to start" unless @result[:success]
@@ -583,7 +583,7 @@ end
 
 Given /^I have a registry in my project$/ do
   ensure_admin_tagged
-  if BushSlicer::Project::SYSTEM_PROJECTS.include?(project(generate: false).name)
+  if VerificationTests::Project::SYSTEM_PROJECTS.include?(project(generate: false).name)
     raise "I refuse create registry in a system project: #{project.name}"
   end
   @result = admin.cli_exec(:new_app, docker_image: "registry:2.5.1", namespace: project.name)
@@ -601,7 +601,7 @@ end
 
 Given /^I have a registry with htpasswd authentication enabled in my project$/ do
   ensure_admin_tagged
-  if BushSlicer::Project::SYSTEM_PROJECTS.include?(project(generate: false).name)
+  if VerificationTests::Project::SYSTEM_PROJECTS.include?(project(generate: false).name)
     raise "I refuse create registry in a system project: #{project.name}"
   end
   @result = admin.cli_exec(:new_app, docker_image: "registry:2", namespace: project.name)

--- a/features/step_definitions/host_subnet.rb
+++ b/features/step_definitions/host_subnet.rb
@@ -1,7 +1,7 @@
 Given /^host subnets are stored in the#{OPT_SYM} clipboard$/ do |clipboard|
   clipboard ||= "host_subnets"
 
-  cb[clipboard] = BushSlicer::HostSubnet.list(user: admin)
+  cb[clipboard] = VerificationTests::HostSubnet.list(user: admin)
   cache_resources *cb[clipboard]
 end
 

--- a/features/step_definitions/images/jenkins.rb
+++ b/features/step_definitions/images/jenkins.rb
@@ -15,7 +15,7 @@ Given /^I have an?( ephemeral| persistent)? jenkins v#{NUMBER} application(?: fr
     source = "| file | #{cust_templ} |"
   else
     unless type
-      scs = BushSlicer::StorageClass.get_matching(user: user) { |sc, sc_hash|
+      scs = VerificationTests::StorageClass.get_matching(user: user) { |sc, sc_hash|
         sc.default?
       }
       if scs.size != 1

--- a/features/step_definitions/is.rb
+++ b/features/step_definitions/is.rb
@@ -31,7 +31,7 @@ Given /^I store the image stream tag of the#{OPT_QUOTED} image stream latest tag
 
   cb[cb_name] = image_stream.latest_tag_status.tag.from
 
-  unless BushSlicer::ImageStreamTag === cb[cb_name]
+  unless VerificationTests::ImageStreamTag === cb[cb_name]
     raise "step expected to see ImageStreamTag as latest tag in the " \
       "#{image_stream.name} image stream but it was #{cb[cb_name].inspect}"
   end

--- a/features/step_definitions/local_storage.rb
+++ b/features/step_definitions/local_storage.rb
@@ -1,7 +1,7 @@
 Given /^There are no PVs with local path #{QUOTED}$/ do | local_path |
   ensure_admin_tagged
 
-  pvs = BushSlicer::PersistentVolume.list(user: admin)
+  pvs = VerificationTests::PersistentVolume.list(user: admin)
   pvs.each { |pv|
     if pv.local_path == local_path
        raise "There is a persistentvolume for local path:#{local_path}"

--- a/features/step_definitions/logging_metrics.rb
+++ b/features/step_definitions/logging_metrics.rb
@@ -19,7 +19,7 @@ And /^I save the (logging|metrics) project name to the#{OPT_SYM} clipboard$/ do 
   else
     expected_rc_name = "hawkular-metrics"
   end
-  found_proj = BushSlicer::Project.get_matching(user: admin) { |project, project_hash|
+  found_proj = VerificationTests::Project.get_matching(user: admin) { |project, project_hash|
     rc(expected_rc_name, project).exists?(user: admin, quiet: true)
   }
   if found_proj.count != 1
@@ -38,7 +38,7 @@ Given /^there should be (\d+) (logging|metrics) services? installed/ do |count, 
     expected_rc_name = "hawkular-metrics"
   end
 
-  found_proj = BushSlicer::Project.get_matching(user: admin) { |project, project_hash|
+  found_proj = VerificationTests::Project.get_matching(user: admin) { |project, project_hash|
     rc(expected_rc_name, project).exists?(user: admin, quiet: true)
   }
   if found_proj.count != Integer(count)
@@ -128,7 +128,7 @@ When /^I perform the (GET|POST) metrics rest request with:$/ do | op_type, table
   end
   cb.metrics_data = []
 
-  @result = BushSlicer::Http.request(url: url, **https_opts, method: op_type)
+  @result = VerificationTests::Http.request(url: url, **https_opts, method: op_type)
 
   @result[:parsed] = YAML.load(@result[:response]) if @result[:success]
   if (@result[:parsed].is_a? Array) and (op_type == 'GET') and opts[:metrics_id].nil?
@@ -136,7 +136,7 @@ When /^I perform the (GET|POST) metrics rest request with:$/ do | op_type, table
       logger.info("Getting data from metrics id #{res['id']}...")
       query_url = url + "/" + res['id']
       # get the id to construct the metric_url to do the QUERY operation
-      result = BushSlicer::Http.request(url: query_url, **https_opts, method: op_type)
+      result = VerificationTests::Http.request(url: query_url, **https_opts, method: op_type)
       result[:parsed] = YAML.load(result[:response])
       cb.metrics_data << result
     end
@@ -751,7 +751,7 @@ Given /^logging service is installed in the#{OPT_QUOTED} project using deployer:
   step %Q|I run oc create over ERB URL: https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/logging_metrics/logging_deployer_configmap.yaml |
   step %Q/the step should succeed/
   # must create a label or else installation will fail
-  registry_nodes = BushSlicer::Node.get_labeled(["registry"], user: user)
+  registry_nodes = VerificationTests::Node.get_labeled(["registry"], user: user)
   registry_nodes.each do |node|
     step %Q/label "logging-infra-fluentd=true" is added to the "#{node.name}" node/
     step %Q/the step should succeed/
@@ -942,7 +942,7 @@ end
 
 # wrapper step to spin up a ansible-pod based on ose/ansible docker image
 # To override the image tag from the puddle, we need to do something like
-# export BUSHSLICER_CONFIG='{"global":
+# export VERIFICATION_TESTS_CONFIG='{"global":
 #                             {"base_ansible_image_tag": "latest",
 #                             {"ansible_image_src: "openshift3/ose-ansible"}}'
 # possible 'image_src' values are openshift/origin-ansible (master) or
@@ -1308,5 +1308,5 @@ Given /^I get the #{QUOTED} node's prometheus metrics$/ do |node_name|
   # get kubelet metrics and write to a file
   @result = pod.exec("/prom2json", "-cert=/cert/master.kubelet-client.crt", "-key=/key/master.kubelet-client.key", "-accept-invalid-cert=true", "https://#{node_name}:10250/metrics", as: user)
   raise "Failed when getting kubelet metrics" unless @result[:success]
-  cb.node_metrics = BushSlicer::PrometheusMetricsData.new(@result[:stdout])
+  cb.node_metrics = VerificationTests::PrometheusMetricsData.new(@result[:stdout])
 end

--- a/features/step_definitions/master.rb
+++ b/features/step_definitions/master.rb
@@ -14,13 +14,13 @@ Given /^master config is merged with the following hash:$/ do |yaml_string|
 end
 
 Given /^master config is restored from backup$/ do
-  @result = BushSlicer::ResultHash.aggregate_results(
+  @result = VerificationTests::ResultHash.aggregate_results(
     *env.master_services.map { |s| s.config.restore() }
   )
 end
 
 #Given(/^admin will download the master config to "(.+?)" file$/) do |file|
-#  @result = BushSlicer::MasterConfig.raw(env)
+#  @result = VerificationTests::MasterConfig.raw(env)
 #  if @result[:success]
 #    file = File.join(localhost.workdir, file)
 #    File.write(file, @result[:response])
@@ -28,12 +28,12 @@ end
 #end
 
 #Given(/^admin will update master config from "(.+?)" file$/) do |file|
-#  BushSlicer::MasterConfig.backup(env)
+#  VerificationTests::MasterConfig.backup(env)
 #  content = File.read(File.expand_path(file))
-#  @result = BushSlicer::MasterConfig.update(env, content)
+#  @result = VerificationTests::MasterConfig.update(env, content)
 
 #  teardown_add {
-#    BushSlicer::MasterConfig.restore(env)
+#    VerificationTests::MasterConfig.restore(env)
 #  }
 #end
 
@@ -68,7 +68,7 @@ Given /^I try to restart the master service on all master nodes$/ do
   env.master_services.each { |service|
     results.push(service.restart)
   }
-  @result = BushSlicer::ResultHash.aggregate_results(results)
+  @result = VerificationTests::ResultHash.aggregate_results(results)
 end
 
 Given /^I use the first master host$/ do
@@ -78,7 +78,7 @@ end
 
 Given /^I run commands on all masters:$/ do |table|
   ensure_admin_tagged
-  @result = BushSlicer::ResultHash.aggregate_results env.master_hosts.map { |host|
+  @result = VerificationTests::ResultHash.aggregate_results env.master_hosts.map { |host|
     host.exec_admin(table.raw.flatten)
   }
 end

--- a/features/step_definitions/metering.rb
+++ b/features/step_definitions/metering.rb
@@ -63,7 +63,7 @@ Given /^I get the #{QUOTED} report and store it in the#{OPT_SYM} clipboard using
   run_now = opts[:run_now].nil? ? 'true' : opts[:run_now]
   report_format = opts[:format].nil? ? default_format : opts[:format]
   # create the report resource
-  opts[:report_yaml] = BushSlicer::Report.generate_yaml(
+  opts[:report_yaml] = VerificationTests::Report.generate_yaml(
     query_type: query_type, start_time: start_time, end_time: end_time,
     run_now: run_now) unless opts[:report_yaml]
   logger.info("#### gernated report using the following yaml:\n #{opts[:report_yaml]}")
@@ -128,7 +128,7 @@ end
 
 Given /^I enable route for#{OPT_QUOTED} metering service$/ do | metering_name |
   metering_name ||= "openshift-metering"
-  htpasswd = BushSlicer::SSL.sha1_htpasswd(username: user.name, password: user.password)
+  htpasswd = VerificationTests::SSL.sha1_htpasswd(username: user.name, password: user.password)
   cookie_seed = rand_str(32, :hex)
   route_yaml = <<BASE_TEMPLATE
     apiVersion: metering.openshift.io/v1alpha1

--- a/features/step_definitions/net.rb
+++ b/features/step_definitions/net.rb
@@ -56,12 +56,12 @@ When /^I open( secure)? web server via the(?: "(.+?)")? route$/ do |secure, rout
 end
 
 When /^I open web server via the(?: "(.+?)")? url$/ do |url|
-  @result = BushSlicer::Http.get(url: url, cookies: cb.http_cookies)
+  @result = VerificationTests::Http.get(url: url, cookies: cb.http_cookies)
 end
 
 Given /^I download a file from "(.+?)"(?: into the "(.+?)" dir)?$/ do |url, dl_path|
   retries = 3
-  @result = BushSlicer::Http.get(url: url, cookies: cb.http_cookies)
+  @result = VerificationTests::Http.get(url: url, cookies: cb.http_cookies)
   # force failure
   while true
     if @result[:success]
@@ -77,7 +77,7 @@ Given /^I download a file from "(.+?)"(?: into the "(.+?)" dir)?$/ do |url, dl_p
       @result[:abs_path] = File.absolute_path(file_name)
       break
     elsif @result[:exitstatus] >= 500 && retries > 0
-      @result = BushSlicer::Http.get(url: url, cookies: cb.http_cookies)
+      @result = VerificationTests::Http.get(url: url, cookies: cb.http_cookies)
     else
       raise "Failed to download file from #{url} with HTTP status #{@result[:exitstatus]}"
     end
@@ -93,7 +93,7 @@ end
 When /^I download a big file from "(.+?)"$/ do |url|
   file_name = File.basename(URI.parse(url).path)
   File.open(file_name, 'wb') do |file|
-    @result = BushSlicer::Http.get(url: url) do |chunk|
+    @result = VerificationTests::Http.get(url: url) do |chunk|
       file.write chunk
     end
   end
@@ -123,7 +123,7 @@ When /^I perform the HTTP request:$/ do |yaml_request|
   if Symbol == opts[:cookies]
     opts[:cookies] = cb[opts[:cookies]]
   end
-  @result = BushSlicer::Http.request(opts)
+  @result = VerificationTests::Http.request(opts)
   begin
     # only parse it if we are dealing with JSON/YAML return type
     if (['json', 'yaml'].any? { |word| @result[:headers]['content-type'][0].include?(word) })
@@ -140,7 +140,7 @@ When /^I perform (\d+) HTTP requests with concurrency (\d+):$/ do |num, concurre
   opts = YAML.load yaml_request
   opts[:count] = num.to_i
   opts[:concurrency] = concurrency.to_i
-  @result = BushSlicer::Http.flood_count(**opts)
+  @result = VerificationTests::Http.flood_count(**opts)
 end
 
 When /^I perform (\d+) HTTP GET requests with concurrency (\d+) to: (.+)$/ do |num, concurrency, url|
@@ -159,7 +159,7 @@ When /^I wait for the #{QUOTED} TCP server to start accepting connections$/ do |
   host, garbage, port = hostport.rpartition(":")
   port = Integer(port)
 
-  @result = BushSlicer::Common::Net.wait_for_tcp(host: host,
+  @result = VerificationTests::Common::Net.wait_for_tcp(host: host,
                                                 port: port,
                                                 timeout: seconds)
 

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -15,7 +15,7 @@ Given /^I run the ovs commands on the host:$/ do | table |
   # For 3.10 and runc env, should get containerID from the pod which landed on the node
   elsif env.version_ge("3.10", user: user)
     logger.info("OCP version >= 3.10 and environment may using runc to launch openvswith")
-    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    ovs_pod = VerificationTests::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
       pod.node_name == node.name
     }.first
     container_id = ovs_pod.containers.first.id
@@ -111,7 +111,7 @@ Given /^the#{OPT_QUOTED} node network is verified$/ do |node_name|
 
   net_verify = proc {
     # to simplify the process, ping all node's tun0 IP including the node itself, even test env has only one node
-    hostsubnet = BushSlicer::HostSubnet.list(user: admin)
+    hostsubnet = VerificationTests::HostSubnet.list(user: admin)
     hostsubnet.each do | hostsubnet |
       dest_ip = IPAddr.new(hostsubnet.subnet).succ
       @result = _host.exec("ping -c 2 -W 2 #{dest_ip}")
@@ -455,11 +455,11 @@ Given /^I wait for the networking components of the node to be terminated$/ do
   ensure_admin_tagged
 
   if env.version_ge("3.10", user: user)
-    sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    sdn_pod = VerificationTests::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
       pod.node_name == node.name
     }.first
 
-    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    ovs_pod = VerificationTests::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
       pod.node_name == node.name
     }.first
 
@@ -485,11 +485,11 @@ Given /^I wait for the networking components of the node to become ready$/ do
   ensure_admin_tagged
 
   if env.version_ge("3.10", user: user)
-    sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    sdn_pod = VerificationTests::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
       pod.node_name == node.name
     }.first
 
-    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    ovs_pod = VerificationTests::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
       pod.node_name == node.name
     }.first
 
@@ -516,7 +516,7 @@ Given /^I restart the openvswitch service on the node$/ do
   # For 3.10 version, should delete the ovs container to restart service 
   if env.version_ge("3.10", user: user)
     logger.info("OCP version >= 3.10")
-    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    ovs_pod = VerificationTests::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
       pod.node_name == node.name
     }.first
     @result = ovs_pod.ensure_deleted(user: _admin)
@@ -538,7 +538,7 @@ Given /^I restart the network components on the node( after scenario)?$/ do |aft
     # For 3.10 version, should delete the sdn pod to restart network components
     if env.version_ge("3.10", user: user)
       logger.info("OCP version >= 3.10")
-      sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: _admin) { |pod, hash|
+      sdn_pod = VerificationTests::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: _admin) { |pod, hash|
         pod.node_name == _node.name
       }.first
       @result = sdn_pod.ensure_deleted(user: _admin)
@@ -559,7 +559,7 @@ Given /^I get the networking components logs of the node since "(.+)" ago$/ do |
   ensure_admin_tagged
 
   if env.version_ge("3.10", user: user)
-    sdn_pod = cb.sdn_pod || BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    sdn_pod = cb.sdn_pod || VerificationTests::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
       pod.node_name == node.name
     }.first
     @result = admin.cli_exec(:logs, resource_name: sdn_pod.name, n: "openshift-sdn", since: duration)

--- a/features/step_definitions/node.rb
+++ b/features/step_definitions/node.rb
@@ -36,7 +36,7 @@ Given /^(I|admin) stores? in the#{OPT_SYM} clipboard the nodes backing pods(?: i
     _user = user
   end
 
-  pods = BushSlicer::Pod.get_labeled(*labels.raw.flatten,
+  pods = VerificationTests::Pod.get_labeled(*labels.raw.flatten,
                                        project: project(project),
                                        user: _user)
 
@@ -86,7 +86,7 @@ Given /^I run( background)? commands on the hosts in the#{OPT_SYM} clipboard:$/ 
   cbname ||= "hosts"
 
   unless Array === cb[cbname] && cb[cbname].size > 0 &&
-      cb[cbname].all? {|e| BushSlicer::Host === e}
+      cb[cbname].all? {|e| VerificationTests::Host === e}
     raise "You must set a clipboard prior to running this step"
   end
 
@@ -164,7 +164,7 @@ Given /^the #{QUOTED} file is restored on all hosts in the#{OPT_QUOTED} clipboar
 
   orig_host = @host
   cb[cb_name].each { |h|
-    @host = BushSlicer::Host === h ? h : h.host
+    @host = VerificationTests::Host === h ? h : h.host
     step %{the "#{path}" file is restored on host after scenario}
   }
   @host = orig_host
@@ -358,7 +358,7 @@ end
 
 Given /^all nodes config is restored$/ do
   ensure_destructive_tagged
-  BushSlicer::ResultHash.aggregate_results(
+  VerificationTests::ResultHash.aggregate_results(
     *env.nodes.map(&:service).each { |s| s.config.restore() }
   )
 end
@@ -401,7 +401,7 @@ Given /^I try to restart the node service on all( schedulable)? nodes$/ do |sche
     results.push(@result = service.restart)
   }
 
-  @result = BushSlicer::ResultHash.aggregate_results(results)
+  @result = VerificationTests::ResultHash.aggregate_results(results)
 end
 
 Given /^I try to restart the node service on node#{OPT_QUOTED}$/ do |node_name|
@@ -442,7 +442,7 @@ Given /^the taints of the nodes in the#{OPT_SYM} clipboard are restored after sc
   _original_taints = _nodes.map { |n| [n,n.taints] }.to_h
 
   teardown_add {
-    BushSlicer::Resource.bulk_update(user: admin, resources: _nodes)
+    VerificationTests::Resource.bulk_update(user: admin, resources: _nodes)
     _current_taints = _nodes.map { |n| [n,n.taints] }.to_h
     _diff_taints = _nodes.map do |node|
       [node, _current_taints[node] - _original_taints[node]]
@@ -473,7 +473,7 @@ Given /^the taints of the nodes in the#{OPT_SYM} clipboard are restored after sc
     end
 
     # verify if the restoration process was succesfull
-    BushSlicer::Resource.bulk_update(user: admin, resources: _nodes)
+    VerificationTests::Resource.bulk_update(user: admin, resources: _nodes)
     _current_taints = _nodes.map { |n| [n,n.taints] }.to_h
     _diff_taints = _nodes.map do |node|
       [node, _current_taints[node] - _original_taints[node]]
@@ -487,7 +487,7 @@ end
 
 Given /^I run commands on all nodes:$/ do |table|
   ensure_admin_tagged
-  @result = BushSlicer::ResultHash.aggregate_results env.node_hosts.map { |host|
+  @result = VerificationTests::ResultHash.aggregate_results env.node_hosts.map { |host|
     host.exec_admin(table.raw.flatten)
   }
 end

--- a/features/step_definitions/online.rb
+++ b/features/step_definitions/online.rb
@@ -1,6 +1,6 @@
 Given /^I open accountant console in a browser$/ do
-  base_rules = BushSlicer::WebConsoleExecutor::RULES_DIR + "/base/"
-  snippets_dir = BushSlicer::WebConsoleExecutor::SNIPPETS_DIR
+  base_rules = VerificationTests::WebConsoleExecutor::RULES_DIR + "/base/"
+  snippets_dir = VerificationTests::WebConsoleExecutor::SNIPPETS_DIR
 
   step "evaluation of `env.web_console_url[/(?<=\\.).*(?=\.openshift)/]` is stored in the :acc_console_url clipboard"
   step "I have a browser with:", table(%{

--- a/features/step_definitions/pod.rb
+++ b/features/step_definitions/pod.rb
@@ -2,7 +2,7 @@ Given /^a pod becomes ready with labels:$/ do |table|
   labels = table.raw.flatten # dimentions irrelevant
   pod_timeout = 15 * 60
 
-  @result = BushSlicer::Pod.wait_for_labeled(*labels, user: user, project: project, seconds: pod_timeout) { |p,h| p.ready?(cached: true)[:success] }
+  @result = VerificationTests::Pod.wait_for_labeled(*labels, user: user, project: project, seconds: pod_timeout) { |p,h| p.ready?(cached: true)[:success] }
 
   if @result[:matching].empty?
     # logger.info("Pod list:\n#{@result[:response]}")
@@ -58,7 +58,7 @@ Given /^a pod is present with labels:$/ do |table|
 
   pods = project.pods(by:user)
 
-  @result = BushSlicer::Pod.wait_for_labeled(*labels, user: user, project: project, seconds: pod_timeout)
+  @result = VerificationTests::Pod.wait_for_labeled(*labels, user: user, project: project, seconds: pod_timeout)
   if @result[:matching].empty?
     raise "See log, waiting for labeled pods futile: #{labels.join(',')}"
   end
@@ -68,7 +68,7 @@ end
 
 Given /^I store in the#{OPT_SYM} clipboard the pods labeled:$/ do |cbn, labels|
   cbn ||= :pods
-  cb[cbn] = BushSlicer::Pod.get_labeled(*labels.raw.flatten,
+  cb[cbn] = VerificationTests::Pod.get_labeled(*labels.raw.flatten,
                                        project: project,
                                        user: user)
 end
@@ -87,7 +87,7 @@ Given /^status becomes :([^\s]*?) of( exactly)? ([0-9]+) pods? labeled:$/ do |st
   timeout = 15 * 60
   labels = labels.raw.flatten
 
-  @result = BushSlicer::Pod.wait_for_labeled(*labels, count: count.to_i,
+  @result = VerificationTests::Pod.wait_for_labeled(*labels, count: count.to_i,
               user: user, project: project, seconds: timeout) { |p, p_hash|
     p.status?(status: status.to_sym, user: user, cached: true, quiet: true)
   }
@@ -107,7 +107,7 @@ Given /^all the pods in the project reach a successful state$/ do
   logger.info("Number of pods: #{pods.count}")
   pods.each do | pod |
     cache_pods(pod)
-    res = pod.wait_till_status(BushSlicer::Pod::SUCCESS_STATUSES, user, 15*60)
+    res = pod.wait_till_status(VerificationTests::Pod::SUCCESS_STATUSES, user, 15*60)
 
     unless res[:success]
       raise "pod #{self.pod.name} did not reach expected status"
@@ -138,7 +138,7 @@ Given /^#{NUMBER} pods become ready with labels:$/ do |count, table|
   num = Integer(count)
 
   # TODO: make waiting a single step like for PVs and PVCs
-  @result = BushSlicer::Pod.wait_for_labeled(*labels, count: num,
+  @result = VerificationTests::Pod.wait_for_labeled(*labels, count: num,
                        user: user, project: project, seconds: pod_timeout)
 
   if !@result[:success] || @result[:matching].size < num
@@ -150,7 +150,7 @@ Given /^#{NUMBER} pods become ready with labels:$/ do |count, table|
 
   # keep last waiting @result as the @result for knowing how pod failed
   @result[:matching].each do |pod|
-    @result = pod.wait_till_status(BushSlicer::Pod::SUCCESS_STATUSES, user, ready_timeout)
+    @result = pod.wait_till_status(VerificationTests::Pod::SUCCESS_STATUSES, user, ready_timeout)
 
     unless @result[:success]
       raise "pod #{pod.name} did not reach expected status"
@@ -179,12 +179,12 @@ Given /^all existing pods die with labels:$/ do |table|
   timeout = 10 * 60
   start_time = monotonic_seconds
 
-  current_pods = BushSlicer::Pod.get_matching(user: user, project: project,
+  current_pods = VerificationTests::Pod.get_matching(user: user, project: project,
                                              get_opts: {l: selector_to_label_arr(*labels)})
 
   current_pods.each do |pod|
     @result =
-        pod.wait_till_status(BushSlicer::Pod::TERMINAL_STATUSES, user,
+        pod.wait_till_status(VerificationTests::Pod::TERMINAL_STATUSES, user,
                              timeout - monotonic_seconds + start_time)
     unless @result[:success]
       raise "pod #{pod.name} did not die within allowed time"
@@ -197,7 +197,7 @@ Given /^all existing pods are ready with labels:$/ do |table|
   timeout = 15 * 60
   start_time = monotonic_seconds
 
-  current_pods = BushSlicer::Pod.get_matching(user: user, project: project,
+  current_pods = VerificationTests::Pod.get_matching(user: user, project: project,
                                              get_opts: {l: selector_to_label_arr(*labels)})
 
   current_pods.each do |pod|

--- a/features/step_definitions/policy.rb
+++ b/features/step_definitions/policy.rb
@@ -50,7 +50,7 @@ Given /^cluster role #{QUOTED} is (added to|removed from) the #{QUOTED} (user|gr
     _add_command = :oadm_add_cluster_role_to_group
     _remove_command = :oadm_remove_cluster_role_from_group
     if which.start_with? "system:"
-      _subject = ::BushSlicer::SystemGroup.new(name: which, env: env)
+      _subject = ::VerificationTests::SystemGroup.new(name: which, env: env)
     else
       _subject = group(which)
     end
@@ -59,7 +59,7 @@ Given /^cluster role #{QUOTED} is (added to|removed from) the #{QUOTED} (user|gr
   when "user", "service account"
     if type == "user"
       if which.start_with? "system:"
-        _subject = ::BushSlicer::SystemUser.new(name: which, env: env)
+        _subject = ::VerificationTests::SystemUser.new(name: which, env: env)
       else
         _subject = user(word_to_num(which), switch: false)
       end
@@ -78,14 +78,14 @@ Given /^cluster role #{QUOTED} is (added to|removed from) the #{QUOTED} (user|gr
 
   case op
   when "added to"
-    if BushSlicer::ClusterRoleBinding.list(user: _admin).any? { |crb| crb.role.name == role && crb.subjects.include?(_subject) }
+    if VerificationTests::ClusterRoleBinding.list(user: _admin).any? { |crb| crb.role.name == role && crb.subjects.include?(_subject) }
       logger.info "#{_subject_name} already has role #{role}"
       next
     end
     _command = _add_command
     _teardown_command = _remove_command
   when "removed from"
-    if BushSlicer::ClusterRoleBinding.list(user: _admin).none? { |crb| crb.role.name == role && crb.subjects.include?(_subject) }
+    if VerificationTests::ClusterRoleBinding.list(user: _admin).none? { |crb| crb.role.name == role && crb.subjects.include?(_subject) }
       logger.info "#{_subject_name} does not have role #{role}"
       next
     end

--- a/features/step_definitions/project.rb
+++ b/features/step_definitions/project.rb
@@ -6,7 +6,7 @@ end
 
 Given /^I have a project$/ do
   # system projects should not be selected by default
-  sys_projects = BushSlicer::Project::SYSTEM_PROJECTS
+  sys_projects = VerificationTests::Project::SYSTEM_PROJECTS
 
   project = @projects.reverse.find {|p|
     !sys_projects.include?(p.name) &&
@@ -36,7 +36,7 @@ end
 
 # try to create a new project with current user
 When /^I create a new project(?: via (.*?))?$/ do |via|
-  @result = BushSlicer::Project.create(by: user, name: rand_str(5, :dns), _via: (via.to_sym if via))
+  @result = VerificationTests::Project.create(by: user, name: rand_str(5, :dns), _via: (via.to_sym if via))
   if @result[:success]
     @projects << @result[:project]
     @result = @result[:project].wait_to_be_created(user)
@@ -56,7 +56,7 @@ end
 # https://stackoverflow.com/questions/33827789/self-signed-certificate-dnsname-components-must-begin-with-a-letter
 # https://bugs.openjdk.java.net/browse/JDK-8054380
 Given /^I create a project with non-leading digit name$/ do
-  @result = BushSlicer::Project.create(by: user, name: rand_str(5, :dns952))
+  @result = VerificationTests::Project.create(by: user, name: rand_str(5, :dns952))
   if @result[:success]
     @projects << @result[:project]
     @result = @result[:project].wait_to_be_created(user)
@@ -80,7 +80,7 @@ end
 # create a new project with user options,either via web or cli
 When /^I create a project via (.+?) with:$/ do |via, table|
   opts = opts_array_to_hash(table.raw)
-  @result = BushSlicer::Project.create(by: user, name: rand_str(5, :dns), _via: (via.to_sym if via), **opts)
+  @result = VerificationTests::Project.create(by: user, name: rand_str(5, :dns), _via: (via.to_sym if via), **opts)
   if @result[:success]
     @projects << @result[:project]
     @result = @result[:project].wait_to_be_created(user)
@@ -96,7 +96,7 @@ end
 
 Given /^I use the "(.+?)" project$/ do |project_name|
   # this would find project in cache and move it up the stack
-  # or create a new BushSlicer::Project object and put it on top of stack
+  # or create a new VerificationTests::Project object and put it on top of stack
   project(project_name)
 
   # setup cli to have it as default project
@@ -246,7 +246,7 @@ When /^I get project ([-a-zA-Z_]+) named #{QUOTED}(?: as (YAML|JSON))?$/ do |res
     # this is a hack but it is needed for backward compatibility and it is
     # too ugly to allow #get accept format as a parameter
     @result[:response] = JSON.pretty_generate(
-      BushSlicer::Resource.struct_iso8601_time(@result[:parsed])
+      VerificationTests::Resource.struct_iso8601_time(@result[:parsed])
     )
   end
 end
@@ -266,7 +266,7 @@ When /^I get project ([-a-zA-Z_]+) as (YAML|JSON)$/ do |type, format|
   @result = {}
   clazz = resource_class(type)
 
-  unless BushSlicer::ProjectResource > clazz
+  unless VerificationTests::ProjectResource > clazz
     raise "#{clazz} is not a project resource"
   end
 

--- a/features/step_definitions/pv.rb
+++ b/features/step_definitions/pv.rb
@@ -101,7 +101,7 @@ Given /^([0-9]+) PVs become #{SYM}(?: within (\d+) seconds)? with labels:$/ do |
   status = status.to_sym
   num = Integer(count)
 
-  @result = BushSlicer::PersistentVolume.wait_for_labeled(*labels, count: num,
+  @result = VerificationTests::PersistentVolume.wait_for_labeled(*labels, count: num,
                        user: admin, seconds: timeout) do |pv, pv_hash|
     pv.status?(user: admin, status: status, cached: true)[:success]
   end
@@ -158,7 +158,7 @@ When /^admin creates a PV from "([^"]*)" where:$/ do |location, table|
   end
 
   logger.info("Creating PV:\n#{pv_hash.to_yaml}")
-  @result = BushSlicer::PersistentVolume.create(by: admin, spec: pv_hash)
+  @result = VerificationTests::PersistentVolume.create(by: admin, spec: pv_hash)
 
   if @result[:success]
     cache_resources *@result[:resource]

--- a/features/step_definitions/pvc.rb
+++ b/features/step_definitions/pvc.rb
@@ -37,7 +37,7 @@ Given /^([0-9]+) PVCs become #{SYM}(?: within (\d+) seconds)? with labels:$/ do 
   status = status.to_sym
   num = Integer(count)
 
-  @result = BushSlicer::PersistentVolumeClaim.wait_for_labeled(*labels,
+  @result = VerificationTests::PersistentVolumeClaim.wait_for_labeled(*labels,
               project: project, count: num, user: user, seconds: timeout) do |pvc, pvc_hash|
     pvc.status?(user: user, status: status, cached: true)[:success]
   end

--- a/features/step_definitions/rc.rb
+++ b/features/step_definitions/rc.rb
@@ -34,7 +34,7 @@ Given /^a replicationController becomes ready with labels:$/ do |table|
   rc_timeout = 10 * 60
   ready_timeout = 15 * 60
 
-  @result = BushSlicer::ReplicationController.wait_for_labeled(*labels, user: user, project: project, seconds: rc_timeout)
+  @result = VerificationTests::ReplicationController.wait_for_labeled(*labels, user: user, project: project, seconds: rc_timeout)
 
   if @result[:matching].empty?
     raise "See log, waiting for labeled rcs futile: #{labels.join(',')}"

--- a/features/step_definitions/registry.rb
+++ b/features/step_definitions/registry.rb
@@ -45,7 +45,7 @@ end
 
 Given /^I wait until the latest rc of internal registry is ready$/ do
   ensure_admin_tagged
-  _rc = BushSlicer::ReplicationController.get_labeled(
+  _rc = VerificationTests::ReplicationController.get_labeled(
     "docker-registry",
     user: admin,
     project: project("default", switch: false)

--- a/features/step_definitions/resources.rb
+++ b/features/step_definitions/resources.rb
@@ -44,7 +44,7 @@ Given /^the #{QUOTED} (\w+) is recreated( by admin)? in the#{OPT_QUOTED} project
     _user = user
   end
   _resource = resource(resource_name, resource_type, project_name: project_name)
-  unless BushSlicer::ProjectResource > _resource.class
+  unless VerificationTests::ProjectResource > _resource.class
     raise "step only supports project resources, but #{_resource.class} is not"
   end
 
@@ -75,7 +75,7 @@ Given /^(I|admin) checks? that there are no (\w+)(?: in the#{OPT_QUOTED} project
   _user = who == "admin" ? admin : user
 
   clazz = resource_class(resource_type)
-  if BushSlicer::ProjectResource > clazz
+  if VerificationTests::ProjectResource > clazz
     list = clazz.list(user: _user, project: project(namespace))
   else
     list = clazz.list(user: _user)
@@ -91,7 +91,7 @@ Given /^(I|admin) waits? for all (\w+) in the#{OPT_QUOTED} project to become rea
   _user = by == "admin" ? admin : user
   clazz = resource_class(type)
 
-  unless BushSlicer::ProjectResource > clazz
+  unless VerificationTests::ProjectResource > clazz
     raise "#{clazz} is not a ProjectResource"
   end
 
@@ -108,7 +108,7 @@ Given /^(I|admin) waits? for all (\w+) in the#{OPT_QUOTED} project to become rea
     end
     @result
   end
-  @result = BushSlicer::ResultHash.aggregate_results(results)
+  @result = VerificationTests::ResultHash.aggregate_results(results)
 end
 
 Given /^(I|admin) waits? for the#{OPT_QUOTED} (\w+) to become ready(?: in the#{OPT_QUOTED} project)?(?: up to (\d+) seconds)?$/ do |by, name, type, project_name, timeout|
@@ -192,9 +192,9 @@ Given /^#{WORD}( in the#{OPT_QUOTED} project)? with name matching #{RE} are stor
   clazz = resource_class(type)
   list_opts = {user: user}
 
-  if in_project && !(BushSlicer::ProjectResource > clazz)
+  if in_project && !(VerificationTests::ProjectResource > clazz)
     raise "#{clazz} is not a ProjectResource"
-  elsif BushSlicer::ProjectResource > clazz
+  elsif VerificationTests::ProjectResource > clazz
     list_opts[:project] = project(pr_name, generate: false)
   end
 

--- a/features/step_definitions/rs.rb
+++ b/features/step_definitions/rs.rb
@@ -20,7 +20,7 @@ end
 Given /^number of replicas of#{OPT_QUOTED} replica set becomes:$/ do |name, table|
   options = hash_symkeys(table.rows_hash)
 
-  int_keys = %i[seconds] + BushSlicer::ReplicaSet::REPLICA_COUNTERS.keys
+  int_keys = %i[seconds] + VerificationTests::ReplicaSet::REPLICA_COUNTERS.keys
   int_options = options.slice(*int_keys)
   int_options.transform_values!(&:to_i)
   int_options[:seconds] ||= 5 * 60

--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -40,7 +40,7 @@ When /^admin creates a StorageClass( in the node's zone)? from #{QUOTED} where:$
   end
 
   logger.info("Creating StorageClass:\n#{sc_hash.to_yaml}")
-  @result = BushSlicer::StorageClass.create(by: admin, spec: sc_hash)
+  @result = VerificationTests::StorageClass.create(by: admin, spec: sc_hash)
 
   if @result[:success]
     cache_resources *@result[:resource]
@@ -72,7 +72,7 @@ Given(/^I run commands on the StorageClass "([^"]*)" backing host:$/) do | stora
 
   opts = conf[:services, :storage_class_host]
 
-  host = BushSlicer::SSHAccessibleHost.new(hostname, opts)
+  host = VerificationTests::SSHAccessibleHost.new(hostname, opts)
 
   @result = host.exec_admin(*table.raw.flatten)
 end
@@ -80,7 +80,7 @@ end
 Given(/^default storage class is deleted$/) do
   ensure_destructive_tagged
   if env.version_ge("3.3", user: user)
-    _sc = BushSlicer::StorageClass.get_matching(user: user) { |sc, sc_hash|
+    _sc = VerificationTests::StorageClass.get_matching(user: user) { |sc, sc_hash|
       sc.default?
     }.first
     if _sc
@@ -91,11 +91,11 @@ Given(/^default storage class is deleted$/) do
       # Restore storeclass after scenario
       _admin = admin
       teardown_add {
-        raw = BushSlicer::Collections.deep_merge(
+        raw = VerificationTests::Collections.deep_merge(
           _sc.raw_resource,
           { "metadata" => { "creationTimestamp" => nil } }
         )
-        @result = BushSlicer::StorageClass.create(by: _admin, spec: raw)
+        @result = VerificationTests::StorageClass.create(by: _admin, spec: raw)
         unless @result[:success]
           raise "Warning unable to restore default storage class #{_sc.name}!"
         end
@@ -136,7 +136,7 @@ Given(/^admin recreate storage class #{QUOTED} with:$/) do |sc_name, table|
   src_sc.ensure_deleted(user: admin)
 
   logger.info("Creating StorageClass:\n#{sc_hash.to_yaml}")
-  @result = BushSlicer::StorageClass.create(by: admin, spec: sc_hash)
+  @result = VerificationTests::StorageClass.create(by: admin, spec: sc_hash)
 
   if @result[:success]
     cache_resources *@result[:resource]
@@ -146,7 +146,7 @@ Given(/^admin recreate storage class #{QUOTED} with:$/) do |sc_name, table|
     _admin = admin
     teardown_add {
       _sc.ensure_deleted(user: _admin)
-      BushSlicer::StorageClass.create(by: admin, spec: sc_org)
+      VerificationTests::StorageClass.create(by: admin, spec: sc_org)
     }
   else
     logger.error(@result[:response])
@@ -159,7 +159,7 @@ Given(/^admin clones storage class #{QUOTED} from #{QUOTED} with:$/) do |target_
 
   # Use :default to comment out the different storage class names on AWS/GCE/OpenStack
   if "#{src_sc}" == ":default"
-    _sc = BushSlicer::StorageClass.get_matching(user: user) { |sc, sc_hash| sc.default? }.first
+    _sc = VerificationTests::StorageClass.get_matching(user: user) { |sc, sc_hash| sc.default? }.first
     src_sc = _sc.raw_resource.dig("metadata", "name")
   end
   step %Q/I run the :get admin command with:/, table(%{
@@ -191,7 +191,7 @@ Given(/^admin clones storage class #{QUOTED} from #{QUOTED} with:$/) do |target_
   end
 
   logger.info("Creating StorageClass:\n#{sc_hash.to_yaml}")
-  @result = BushSlicer::StorageClass.create(by: admin, spec: sc_hash)
+  @result = VerificationTests::StorageClass.create(by: admin, spec: sc_hash)
 
   if @result[:success]
     cache_resources *@result[:resource]

--- a/features/step_definitions/web.rb
+++ b/features/step_definitions/web.rb
@@ -84,8 +84,8 @@ Given /^I have a browser with:$/ do |table|
 end
 
 Given /^I open registry console in a browser$/ do
-  base_rules = BushSlicer::WebConsoleExecutor::RULES_DIR + "/base/"
-  snippets_dir = BushSlicer::WebConsoleExecutor::SNIPPETS_DIR
+  base_rules = VerificationTests::WebConsoleExecutor::RULES_DIR + "/base/"
+  snippets_dir = VerificationTests::WebConsoleExecutor::SNIPPETS_DIR
   step "default registry-console route is stored in the :reg_console_url clipboard"
   step "I have a browser with:", table(%{
     | rules        | #{base_rules}                     |

--- a/features/support/cucu_formatter.rb
+++ b/features/support/cucu_formatter.rb
@@ -15,7 +15,7 @@ require 'zlib'
 
 require 'common' # mainly localhost is used
 
-module BushSlicer
+module VerificationTests
   # custom Cucumber HTML formatter that also cooperates with test case manager
   # TODO: new API https://github.com/cucumber/cucumber-ruby/pull/851/files/
 class CucuFormatter

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,26 +8,26 @@ if Cucumber::VERSION.split('.')[0].to_i < 2
   raise "Cucumber version < 2 not supported"
 end
 
-SkipBushSlicerManagerDefault = true # should manager.rb skip setting Manager
+SkipVerificationTestsManagerDefault = true # should manager.rb skip setting Manager
 
 require 'common' # common code
-require 'world' # our custom bushslicer world
-require 'log' # BushSlicer::Logger
+require 'world' # our custom verification-tests world
+require 'log' # VerificationTests::Logger
 require 'manager' # our shared global state
 require 'environment' # environment types classes
 require 'debug'
 
-## default course of action would be to update BushSlicer files when
+## default course of action would be to update VerificationTests files when
 #  changes are needed but some features are specific to team and test
 #  environment; lets allow customizing base classes by loading a separate
 #  project tree
-private_env_rb = File.expand_path(BushSlicer::PRIVATE_DIR + "/env.rb")
+private_env_rb = File.expand_path(VerificationTests::PRIVATE_DIR + "/env.rb")
 require private_env_rb if File.exist? private_env_rb
 
 World do
   # the new object created here would be the context Before and After hooks
   # execute in. So extend that class with methods you want to call.
-  BushSlicer::World.new
+  VerificationTests::World.new
 end
 
 ## while we can move everything inside World, lets try to outline here the
@@ -72,7 +72,7 @@ After do |_scenario|
   manager.test_case_manager.signal(:finish_after_hook, scenario, err)
   hook_error!(err)
   logger.info("=== End After Scenario: #{_scenario.name} ===")
-  BushSlicer::Logger.reset_runtime # otherwise we lose output from test case mgmt
+  VerificationTests::Logger.reset_runtime # otherwise we lose output from test case mgmt
 end
 
 AfterStep do |scenario|
@@ -81,25 +81,25 @@ AfterStep do |scenario|
 end
 
 AfterConfiguration do |config|
-  BushSlicer::Common::Setup.handle_signals
-  BushSlicer::Common::Setup.set_bushslicer_home
+  VerificationTests::Common::Setup.handle_signals
+  VerificationTests::Common::Setup.set_verification_tests_home
 
   ## use default classes if these were not overriden by private ones
-  BushSlicer::Manager ||= BushSlicer::DefaultManager
-  BushSlicer::World   ||= BushSlicer::DefaultWorld
+  VerificationTests::Manager ||= VerificationTests::DefaultManager
+  VerificationTests::World   ||= VerificationTests::DefaultWorld
 
   ## install step failure debugging code
-  if BushSlicer::Manager.conf[:debug_failed_steps]
-    BushSlicer::Debug.step_fail_cucumber2
+  if VerificationTests::Manager.conf[:debug_failed_steps]
+    VerificationTests::Debug.step_fail_cucumber2
   end
 
   ## set test case manager if requested (adds a scenario filter as well)
-  BushSlicer::Manager.instance.init_test_case_manager(config)
+  VerificationTests::Manager.instance.init_test_case_manager(config)
 end
 
 at_exit do
-  BushSlicer::Logger.reset_runtime # otherwise we lose output
-  BushSlicer::Manager.instance.logger.info("=== At Exit ===")
-  BushSlicer::Manager.instance.test_case_manager.signal(:at_exit)
-  BushSlicer::Manager.instance.at_exit
+  VerificationTests::Logger.reset_runtime # otherwise we lose output
+  VerificationTests::Manager.instance.logger.info("=== At Exit ===")
+  VerificationTests::Manager.instance.test_case_manager.signal(:at_exit)
+  VerificationTests::Manager.instance.at_exit
 end

--- a/features/support/formatter_template.html
+++ b/features/support/formatter_template.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="UTF-8" />
-<title>BushSlicer Report</title>
+<title>verification-tests Report</title>
 <style type="text/css">
 /* Background color for the whole web page */
 body {

--- a/features/support/save_to_dir_embedding_formatter.rb
+++ b/features/support/save_to_dir_embedding_formatter.rb
@@ -2,7 +2,7 @@ require 'base64'
 require 'fileutils'
 require 'tmpdir' # Dir.tmpdir
 
-module BushSlicer
+module VerificationTests
   class SaveToDirEmbeddingFormatter
     attr_reader :target_dir, :log
     private :target_dir, :log

--- a/lib/admin_credentials.rb
+++ b/lib/admin_credentials.rb
@@ -2,7 +2,7 @@ require 'base64'
 require 'openssl'
 require 'yaml'
 
-module BushSlicer
+module VerificationTests
   class MasterOsAdminCredentials
     include Common::Helper
 

--- a/lib/api_accessor.rb
+++ b/lib/api_accessor.rb
@@ -1,11 +1,11 @@
-module BushSlicer
+module VerificationTests
   # common methods for all classes that have api access
   class APIAccessor
     attr_reader :env, :rest_preferences, :token, :expires, :client_cert,
       :client_key
     attr_writer :id
 
-    # @param env [BushSlicer::Environment] the test environment of accessor
+    # @param env [VerificationTests::Environment] the test environment of accessor
     # @param expires [Time, false] the time our auth is valid until, false
     #   if never expired
     # @param id [String] symbolic string to identify this API accessor, usually
@@ -15,7 +15,7 @@ module BushSlicer
     # @param token_protected [Boolean] are allowed to invalidate token
     # @param client_cert [Array] see [CliExecutor::client_cert_from_cli], if
     #   cert auth is to be used
-    # @param env [BushSlicer::Environment] the test environment of accessor
+    # @param env [VerificationTests::Environment] the test environment of accessor
     # @return [User]
     def initialize(id: nil, token: nil, token_protected: true,
                    expires: false, client_cert: nil, client_key: nil, env:)

--- a/lib/api_accessor_owner.rb
+++ b/lib/api_accessor_owner.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module APIAccessorOwner
     # add a token in plain string format to cached tokens
     # @param token [String] the bearer token

--- a/lib/base_helper.rb
+++ b/lib/base_helper.rb
@@ -1,10 +1,10 @@
 # should not require 'common'
-# should only include helpers that do NOT load any other BushSlicer classes
+# should only include helpers that do NOT load any other VerificationTests classes
 require 'securerandom'
 require 'find'
 require 'pathname'
 
-module BushSlicer
+module VerificationTests
   module Common
     module BaseHelper
       def to_bool(param)

--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -4,7 +4,7 @@ require 'yaml'
 
 require 'rules_command_executor'
 
-module BushSlicer
+module VerificationTests
   class CliExecutor
     include Common::Helper
 
@@ -17,11 +17,11 @@ module BushSlicer
       @opts = opts
     end
 
-    # @param [BushSlicer::User, BushSlicer::APIAccessor] user user to execute
+    # @param [VerificationTests::User, VerificationTests::APIAccessor] user user to execute
     #   command with
     # @param [Symbol] key command key
     # @param [Hash] opts command options
-    # @return [BushSlicer::ResultHash]
+    # @return [VerificationTests::ResultHash]
     def exec(user, key, opts={})
       raise
     end
@@ -54,7 +54,7 @@ module BushSlicer
 
     # get `oc` version on some host running as some username
     # @param user [String] string username
-    # @param host [BushSlicer::Host] the host to execute command on
+    # @param host [VerificationTests::Host] the host to execute command on
     # @return [String] version string
     def self.get_version_for(user, host)
       fake_config = Tempfile.new("kubeconfig")
@@ -184,7 +184,7 @@ module BushSlicer
       @executors = {}
     end
 
-    # @param [BushSlicer::APIAccessor] api accessor to execute command with
+    # @param [VerificationTests::APIAccessor] api accessor to execute command with
     # @return rules executor, separate one per user
     private def executor(user, cli_tool: nil)
       executor_id = "#{cli_tool}:#{user}"
@@ -209,7 +209,7 @@ module BushSlicer
     end
 
     # @param user [String] the user we want to get version for
-    # @param host [BushSlicer::Host] the host we'll be running commands on
+    # @param host [VerificationTests::Host] the host we'll be running commands on
     private def version_for_user(user, host)
       # we assume all users will use same oc version;
       #   we may revisit later if needed

--- a/lib/collections.rb
+++ b/lib/collections.rb
@@ -2,7 +2,7 @@ require 'set'
 
 # should not require 'common'
 
-module BushSlicer
+module VerificationTests
   # a collections module that can be included
   module CollectionsIncl
     # @param struc [Object] array, hash or object to be deeply freezed

--- a/lib/common.rb
+++ b/lib/common.rb
@@ -1,16 +1,16 @@
 require 'open3'
 
-require 'bushslicer'
+require 'verification-tests'
 require 'manager'
 require 'base_helper'
 
-module BushSlicer
+module VerificationTests
   module Common
     module Helper
       include BaseHelper
 
       def manager
-        BushSlicer::Manager.instance
+        VerificationTests::Manager.instance
       end
 
       def conf
@@ -33,8 +33,8 @@ module BushSlicer
           return Host.localhost.absolute_path(path)
         elsif File.exist?(PRIVATE_DIR + "/" + path)
           return PRIVATE_DIR + "/" + path
-        elsif public_safe && File.exist?(BushSlicer::HOME + "/" + path)
-          return BushSlicer::HOME + "/" + path
+        elsif public_safe && File.exist?(VerificationTests::HOME + "/" + path)
+          return VerificationTests::HOME + "/" + path
         elsif File.exist?(File.expand_path("~/#{path}"))
           return File.expand_path("~/#{path}")
         else
@@ -104,7 +104,7 @@ module BushSlicer
         return result
       end
 
-      ## @param res [BushSlicer::ResultHash] the result to verify
+      ## @param res [VerificationTests::ResultHash] the result to verify
       ## @note will log and raise error unless result is successful
       #def result_should_be_success(res)
       #  unless res[:success]
@@ -113,7 +113,7 @@ module BushSlicer
       #  end
       #end
       #
-      ## @param res [BushSlicer::ResultHash] the result to examine
+      ## @param res [VerificationTests::ResultHash] the result to examine
       ## @note will log and raise error unless result is failure
       #def result_should_be_failure(res)
       #  if res[:success]
@@ -125,7 +125,7 @@ module BushSlicer
       # hack to have host.rb autoloaded when it is used through Helper outside
       # Cucumber (at the same time avoiding circular dependencies). That avoids
       # need for the external script to know that host.rb is required.
-      BushSlicer.autoload :Host, "host"
+      VerificationTests.autoload :Host, "host"
     end # module Helper
 
     # some ugly hack that we need to be more reliable
@@ -166,10 +166,10 @@ module BushSlicer
         #Signal.trap('SIGTERM') { exit(false) } # it works like that already
       end
 
-      def self.set_bushslicer_home
-        # BushSlicer.const_set(:HOME, File.expand_path(__FILE__ + "../../.."))
-        BushSlicer::HOME.freeze
-        ENV["BUSHSLICER_HOME"] = BushSlicer::HOME
+      def self.set_verification_tests_home
+        # VerificationTests.const_set(:HOME, File.expand_path(__FILE__ + "../../.."))
+        VerificationTests::HOME.freeze
+        ENV["VERIFICATION_TESTS_HOME"] = VerificationTests::HOME
       end
     end
   end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,11 +1,11 @@
 require 'yaml'
 
-require 'bushslicer'
+require 'verification-tests'
 require 'collections'
 # should not require 'common'
 
-module BushSlicer
-  # @note bushslicer configuration logic
+module VerificationTests
+  # @note verification-tests configuration logic
   class Configuration
 
     def initialize(opts = {})
@@ -17,7 +17,7 @@ module BushSlicer
           "/config/config.yaml",
           "/config.yaml"
         ].each { |priv_config|
-          file = File.expand_path(BushSlicer::PRIVATE_DIR + priv_config)
+          file = File.expand_path(VerificationTests::PRIVATE_DIR + priv_config)
           opts[:files] << file if File.exist?(file)
         }
       end
@@ -39,8 +39,8 @@ module BushSlicer
       raw_configs.each { |c| Collections.deep_merge!(@raw_config, c) }
 
       # merge config from environment if present
-      if ENV["BUSHSLICER_CONFIG"] && !ENV["BUSHSLICER_CONFIG"].empty?
-        Collections.deep_merge!(@raw_config, YAML.load(ENV["BUSHSLICER_CONFIG"]))
+      if ENV["VERIFICATION_TESTS_CONFIG"] && !ENV["VERIFICATION_TESTS_CONFIG"].empty?
+        Collections.deep_merge!(@raw_config, YAML.load(ENV["VERIFICATION_TESTS_CONFIG"]))
       end
 
       Collections.deep_map_hash!(@raw_config) { |k, v| [k.to_sym, v] }
@@ -56,11 +56,11 @@ module BushSlicer
     # logic to overrige configuration from environment variables
     def env_overrides(conf)
       global_overrides = {
-        debug_in_after_hook: "BUSHSLICER_DEBUG_AFTER_FAIL",
-        debug_in_after_hook_always: "BUSHSLICER_DEBUG_AFTER_HOOK",
-        debug_attacher_timeout: "BUSHSLICER_DEBUG_ATTACHER_TIMEOUT",
-        debug_failed_steps: "BUSHSLICER_DEBUG_FAILSTEP",
-        default_environment: "BUSHSLICER_DEFAULT_ENVIRONMENT"
+        debug_in_after_hook: "VERIFICATION_TESTS_DEBUG_AFTER_FAIL",
+        debug_in_after_hook_always: "VERIFICATION_TESTS_DEBUG_AFTER_HOOK",
+        debug_attacher_timeout: "VERIFICATION_TESTS_DEBUG_ATTACHER_TIMEOUT",
+        debug_failed_steps: "VERIFICATION_TESTS_DEBUG_FAILSTEP",
+        default_environment: "VERIFICATION_TESTS_DEFAULT_ENVIRONMENT"
       }
 
       # if envvariable is set, then override the value where "false" is false

--- a/lib/debug.rb
+++ b/lib/debug.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
 
   # @note contain some debugging related code
   module Debug

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -10,7 +10,7 @@ require 'rest'
 require 'openshift/node'
 require 'webauto/webconsole_executor'
 
-module BushSlicer
+module VerificationTests
   # @note this class represents an OpenShift test environment and allows setting it up and in some cases creating and destroying it
   class Environment
     include Common::Helper
@@ -76,13 +76,13 @@ module BushSlicer
           StaticUserManager.new(self, **opts)
         end
       else
-        BushSlicer.const_get(opts[:user_manager]).new(self, **opts)
+        VerificationTests.const_get(opts[:user_manager]).new(self, **opts)
       end
     end
     alias users user_manager
 
     def cli_executor
-      @cli_executor ||= BushSlicer.const_get(opts[:cli]).new(self, **opts)
+      @cli_executor ||= VerificationTests.const_get(opts[:cli]).new(self, **opts)
     end
 
     def admin
@@ -101,7 +101,7 @@ module BushSlicer
 
     private def admin_creds
       if admin?
-        BushSlicer.const_get(opts[:admin_creds]).new(self, **opts)
+        VerificationTests.const_get(opts[:admin_creds]).new(self, **opts)
       else
         raise UnsupportedOperationError,
           "we cannot run as admins in this environment"
@@ -271,8 +271,8 @@ module BushSlicer
     end
 
     # obtain router detals like default router subdomain and router IPs
-    # @param user [BushSlicer::User]
-    # @param project [BushSlicer::project]
+    # @param user [VerificationTests::User]
+    # @param project [VerificationTests::project]
     def get_routing_details(user:, project:)
       clean_project = false
 
@@ -346,7 +346,7 @@ module BushSlicer
     end
 
     def master_services
-      @master_services_type ||= BushSlicer::Platform::MasterService.type(self.master_hosts.first)
+      @master_services_type ||= VerificationTests::Platform::MasterService.type(self.master_hosts.first)
       @master_services ||= self.master_hosts.map { |host|
         @master_services_type&.new(host, self)
       }
@@ -412,7 +412,7 @@ module BushSlicer
           host_type = opts[:hosts_type]
           hostname, garbage, roles = host.partition(":")
           roles = roles.split(":").map(&:to_sym)
-          hlist << BushSlicer.const_get(host_type).new(hostname, **opts, roles: roles)
+          hlist << VerificationTests.const_get(host_type).new(hostname, **opts, roles: roles)
         end
 
         missing_roles = MANDATORY_OPENSHIFT_ROLES.reject{|r| hlist.find {|h| h.has_role?(r)}}

--- a/lib/environment_manager.rb
+++ b/lib/environment_manager.rb
@@ -1,6 +1,6 @@
 # should not require 'common' and 'manager'
 
-module BushSlicer
+module VerificationTests
   # this will manage available environments during a test run
   class EnvironmentManager
     # def self.get
@@ -37,7 +37,7 @@ module BushSlicer
       raise "no '#{key}' environment configuration found" if ! env_class || env_class.empty?
 
       env_opts[:key] = key # lets have it for a reference
-      return BushSlicer.const_get(env_class).new(env_opts)
+      return VerificationTests.const_get(env_class).new(env_opts)
     end
 
     def clean_up

--- a/lib/error.rb
+++ b/lib/error.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class TimeoutError < RuntimeError
   end
   class UnsupportedOperationError < RuntimeError

--- a/lib/gherkin_parse.rb
+++ b/lib/gherkin_parse.rb
@@ -5,9 +5,9 @@ require 'gherkin/parser'
 require 'gherkin/pickles/compiler'
 require 'pathname'
 
-require 'bushslicer'
+require 'verification-tests'
 
-module BushSlicer
+module VerificationTests
   # @note Used to help parse out feature files using Gherkin 3
   class GherkinParse
     include Common::BaseHelper

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # let you operate a git repo
   class Git
     include Common::Helper
@@ -7,7 +7,7 @@ module BushSlicer
     # @param [String] uri remote git uri; when nil, checking the `origin` remote
     # @param [String] dir base directory of git repo;
     #   might be a relative to workdir or absolute path on host
-    # @param [BushSlicer::Host] host the host repo is to be located
+    # @param [VerificationTests::Host] host the host repo is to be located
     # @param [String] user the host os user to run git as; usage is discouraged
     def initialize(uri: nil, dir: nil, host: nil, user: nil)
       @uri = uri
@@ -75,7 +75,7 @@ module BushSlicer
     def set_git_config
       res = host.exec_as(user, "git -C #{dir} config user.name")
       unless res[:success]
-        res = host.exec_as(user, "git -C #{dir} config user.name #{host.shell_escape 'BushSlicer User'}")
+        res = host.exec_as(user, "git -C #{dir} config user.name #{host.shell_escape 'VerificationTests User'}")
         unless res[:success]
           raise "git config user.name failed"
         end

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -2,7 +2,7 @@ require 'rest-client'
 require 'http-cookie'
 require 'thread'
 
-module BushSlicer
+module VerificationTests
   module Http
     extend Common::Helper # include methods statically
 
@@ -26,7 +26,7 @@ module BushSlicer
     #   with chunks of body content as read by the remote server; note that
     #   HTTP status redirections, cookies, headers, etc. are all lost from
     #   response when a block is passed
-    # @return [BushSlicer::ResultHash] standard bushslicer result hash;
+    # @return [VerificationTests::ResultHash] standard verification-tests result hash;
     #   there is :headers populated as a [Hash] where headers are lower-cased
     def self.http_request(url:,
                           method:,

--- a/lib/iaas/iaas.rb
+++ b/lib/iaas/iaas.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-module BushSlicer
+module VerificationTests
   module IAAS
     # will select the configured iaas provider and create the required iaas object to query the API
     def self.select_provider(env)
@@ -19,7 +19,7 @@ module BushSlicer
         when "gce"
           return {:type => "gce", :provider => self.init_gce(env)}
         else
-          raise "The IAAS provider #{iaas_provider_name} does not exist or is currently not supported by BushSlicer!"
+          raise "The IAAS provider #{iaas_provider_name} does not exist or is currently not supported by VerificationTests!"
         end
       end
       raise "There is no IAAS provider configured for this instance of Openshift!"
@@ -37,7 +37,7 @@ module BushSlicer
         iaas_conf_params[params[0].strip] = params[1].strip
       end
 
-      return BushSlicer::OpenStack.instance(
+      return VerificationTests::OpenStack.instance(
         :url => iaas_conf_params['auth-url'] + "tokens",
         :user => iaas_conf_params["username"],
         :password => iaas_conf_params["password"],

--- a/lib/jira_rht.rb
+++ b/lib/jira_rht.rb
@@ -6,13 +6,13 @@ end
 require 'jira-ruby'
 require 'common'
 
-module BushSlicer
+module VerificationTests
   class Jira
     include Common::Helper
 
     def initialize(options={})
       raise "No default options detected, please makse sure the PRIVATE_REPO \
-      is cloned into your repo or ENV BUSHSLICER_PRIVATE_DIR is defined" if default_opts.nil?
+      is cloned into your repo or ENV VERIFICATION_TESTS_PRIVATE_DIR is defined" if default_opts.nil?
       @options = default_opts.merge options
       ## try to obtain user/password in all possible ways
       @options[:username] = ENV['JIRA_USER'] if ENV['JIRA_USER']

--- a/lib/launchers/alicloud.rb
+++ b/lib/launchers/alicloud.rb
@@ -14,7 +14,7 @@ require 'collections'
 require 'common'
 require 'http'
 
-module BushSlicer
+module VerificationTests
   class Alicloud
     include Common::Helper
     include CollectionsIncl
@@ -130,8 +130,8 @@ module BushSlicer
 
     # @param create_opts [Hash] VM launch options according to Alibaba docs
     # @param host_opts [Hash] additional machine access options, should be
-    #   options valid for use in [BushSlicer::Host] constructor
-    # @return [Array] of [Alicloud::Instance, BushSlicer::Host] pairs
+    #   options valid for use in [VerificationTests::Host] constructor
+    # @return [Array] of [Alicloud::Instance, VerificationTests::Host] pairs
     # @see https://www.alibabacloud.com/help/doc-detail/63440.htm
     def create_instance(create_opts: {}, host_opts: {}, generate_host: true)
 
@@ -180,7 +180,7 @@ module BushSlicer
     end
 
     # @param vm [Alicloud::Instance]
-    # @return [BushSlicer::Host]
+    # @return [VerificationTests::Host]
     def get_vm_host(vm, host_opts = {})
       host_opts = (config[:host_opts] || {}).merge host_opts
       host_opts[:cloud_instance] = vm
@@ -358,7 +358,7 @@ module BushSlicer
       }
 
       unless success
-        raise BushSlicer::TimeoutError, "Timeout waiting for tasks: #{ids}"
+        raise VerificationTests::TimeoutError, "Timeout waiting for tasks: #{ids}"
       end
     end
 
@@ -508,7 +508,7 @@ module BushSlicer
             status(cached: false) == "Stopped"
           }
           unless success
-            raise BushSlicer::TimeoutError,
+            raise VerificationTests::TimeoutError,
               "Timeout waiting for instance #{id} to stop. Status: #{status}"
           end
           return nil
@@ -545,7 +545,7 @@ module BushSlicer
             status(cached: false) == "Deleted"
           }
           unless success
-            raise BushSlicer::TimeoutError,
+            raise VerificationTests::TimeoutError,
               "Timeout waiting to delete instance #{id}. Status: #{status}"
           end
           return nil
@@ -559,8 +559,8 @@ end
 
 ## Standalone test
 if __FILE__ == $0
-  extend BushSlicer::Common::Helper
-  ali = BushSlicer::Alicloud.new(service_name: "alicloud")
+  extend VerificationTests::Common::Helper
+  ali = VerificationTests::Alicloud.new(service_name: "alicloud")
 
   # params = {
   #   "RegionId" => "cn-zhangjiakou",
@@ -575,7 +575,7 @@ if __FILE__ == $0
   test_res = {}
   conf[:services].each do |name, service|
     if service[:cloud_type] == 'alibaba'
-      ali = BushSlicer::Alicloud.new(service_name: name)
+      ali = VerificationTests::Alicloud.new(service_name: name)
       res = true
       test_res[name] = res
       begin

--- a/lib/launchers/amz.rb
+++ b/lib/launchers/amz.rb
@@ -5,7 +5,7 @@ require 'common'
 require 'host'
 require 'launchers/cloud_helper'
 
-module BushSlicer
+module VerificationTests
 
   class Amz_EC2
     include Common::Helper
@@ -352,7 +352,7 @@ module BushSlicer
       end
 
       hostname = instance.public_dns_name
-      host = BushSlicer.const_get(config[:hosts_type]).new(hostname, host_opts)
+      host = VerificationTests.const_get(config[:hosts_type]).new(hostname, host_opts)
       if wait
         logger.info("Waiting for #{hostname} to become accessible..")
         begin
@@ -442,7 +442,7 @@ module BushSlicer
     #   http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Resource.html#create_instances-instance_method
     # @param [Integer] max_retries max retries to try (TODO)
     #
-    # @return [Array] of [amz_instance, BushSlicer::Host] pairs
+    # @return [Array] of [amz_instance, VerificationTests::Host] pairs
     #
     def launch_instances(image: nil,
                          tag_name: nil,

--- a/lib/launchers/azure.rb
+++ b/lib/launchers/azure.rb
@@ -11,7 +11,7 @@ require 'azure_mgmt_network'
 require 'collections'
 require 'common'
 
-module BushSlicer
+module VerificationTests
   class Azure
     include Common::Helper
     include CollectionsIncl
@@ -152,14 +152,14 @@ module BushSlicer
     # @param user_data [String] convenience to add metadata `startup-script` key
     # @param instance_opts [Hash] additional machines launch options
     # @param host_opts [Hash] additional machine access options, should be
-    #   options valid for use in [BushSlicer::Host] constructor
+    #   options valid for use in [VerificationTests::Host] constructor
     # @param boot_disk_opts [Hash] convenience way to merge some options for
     #   the boot disk without need to replace the whole disks configuration;
     #   disks from global config will be searched for the boot option and that
     #   disk entry will be intelligently merged
     # @param availability_set [String] name of availability set for VM, if value
     #   is :auto, a new one is created based on VM name without trailing numbers
-    # @return [Array] of [Instance, BushSlicer::Host] pairs
+    # @return [Array] of [Instance, VerificationTests::Host] pairs
     def create_instance( names,
                          fqdn_names: azure_config[:fqdn_names],
                          user_data: azure_config[:user_data],
@@ -339,12 +339,12 @@ module BushSlicer
     end
 
     def is_blob_uri?(str)
-      BushSlicer::Azure.is_blob_uri? str
+      VerificationTests::Azure.is_blob_uri? str
     end
 
     # @return [String, nil] when the string is not a blob URI
     def storage_account_from_blob_uri(str)
-      BushSlicer::Azure.send :storage_account_from_blob_uri, str
+      VerificationTests::Azure.send :storage_account_from_blob_uri, str
     end
 
     # creates or finds an availability set for a given future VM
@@ -454,7 +454,7 @@ module BushSlicer
             ref.version = opts[:os_disk][:params][:version]
           end
         end
-        type = BushSlicer::Azure.const_get opts[:os_disk][:type]
+        type = VerificationTests::Azure.const_get opts[:os_disk][:type]
         unless type = ComputeModels::DiskCreateOptionTypes::FromImage
           raise "only fromImage is presently supported"
         end
@@ -483,7 +483,7 @@ module BushSlicer
               vhd.uri = opts[:os_disk][:params][:image]
             end
             # e.g. Azure::ARM::Compute::Models::OperatingSystemTypes::Linux
-            os_disk.os_type = BushSlicer::Azure.const_get opts[:os_disk][:params][:os_type]
+            os_disk.os_type = VerificationTests::Azure.const_get opts[:os_disk][:params][:os_type]
           end
           os_disk.name = "#{vmname}"
           if opts.dig(:os_disk, :disk_size_gb)
@@ -696,17 +696,17 @@ end
 
 ## Standalone test
 if __FILE__ == $0
-  extend BushSlicer::Common::Helper
-  azure = BushSlicer::Azure.new
+  extend VerificationTests::Common::Helper
+  azure = VerificationTests::Azure.new
   vms = azure.create_instances(["test-terminate"], fqdn_names: true)
 
-  storage_account = BushSlicer::Azure.instance_storage_account vms[0][0]
+  storage_account = VerificationTests::Azure.instance_storage_account vms[0][0]
 
   require 'pry'; binding.pry
 
   # https://github.com/Azure/azure-sdk-for-ruby/issues/1615
   # resource_group = vms[0][0].resource_group
-  resource_group = BushSlicer::Azure.resource_group_from_id(vms[0][0].id)
+  resource_group = VerificationTests::Azure.resource_group_from_id(vms[0][0].id)
   azure.delete_instance vms[0][0].name
 
   if storage_account

--- a/lib/launchers/cloud_helper.rb
+++ b/lib/launchers/cloud_helper.rb
@@ -1,7 +1,7 @@
 # should not require 'common'
-# should only include helpers that do NOT load any other BushSlicer classes
+# should only include helpers that do NOT load any other VerificationTests classes
 
-module BushSlicer
+module VerificationTests
   module Common
     module CloudHelper
       # based on information in https://github.com/openshift/vagrant-openshift/blob/master/lib/vagrant-openshift/templates/command/init-openshift/box_info.yaml
@@ -28,15 +28,15 @@ module BushSlicer
         when "aws"
           Amz_EC2.new(service_name: service_name)
         when "azure"
-          BushSlicer::Azure.new(service_name: service_name)
+          VerificationTests::Azure.new(service_name: service_name)
         when "openstack"
-          BushSlicer::OpenStack.instance(service_name: service_name)
+          VerificationTests::OpenStack.instance(service_name: service_name)
         when "gce"
-          BushSlicer::GCE.new(service_name: service_name)
+          VerificationTests::GCE.new(service_name: service_name)
         when "vsphere"
-          BushSlicer::VSphere.new(service_name: service_name)
+          VerificationTests::VSphere.new(service_name: service_name)
         when "alibaba"
-          BushSlicer::Alicloud.new(service_name: service_name)
+          VerificationTests::Alicloud.new(service_name: service_name)
         else
           raise "unknown service type " \
             "#{conf[:services, service_name, :cloud_type]} for cloud " \

--- a/lib/launchers/dyn/dynect.rb
+++ b/lib/launchers/dyn/dynect.rb
@@ -1,7 +1,7 @@
 require_relative 'oo_exception'
 require_relative 'dynect_plugin'
 
-module BushSlicer
+module VerificationTests
   # we reuse DynectPlugin and add our convenience methods
   class Dynect < ::OpenShift::DynectPlugin
     # FYI logger method is overridden by Helper so we should be good to go

--- a/lib/launchers/gce.rb
+++ b/lib/launchers/gce.rb
@@ -10,7 +10,7 @@ end
 require 'collections'
 require 'common'
 
-module BushSlicer
+module VerificationTests
   class GCE
     include Common::Helper
     include CollectionsIncl
@@ -46,7 +46,7 @@ module BushSlicer
       return @compute if @compute
 
       @compute = Compute::ComputeService.new
-      @compute.client_options.application_name = "BushSlicer"
+      @compute.client_options.application_name = "VerificationTests"
       @compute.client_options.application_version = GIT_HASH
       # @compute.client_options.proxy_url = ENV['http_proxy'] if ENV['http_proxy']
 
@@ -138,12 +138,12 @@ module BushSlicer
     # @param user_data [String] convenience to add metadata `startup-script` key
     # @param instance_opts [Hash] additional machines launch options
     # @param host_opts [Hash] additional machine access options, should be
-    #   options valid for use in [BushSlicer::Host] constructor
+    #   options valid for use in [VerificationTests::Host] constructor
     # @param boot_disk_opts [Hash] convenience way to merge some options for
     #   the boot disk without need to replace the whole disks configuration;
     #   disks from global config will be searched for the boot option and that
     #   disk entry will be intelligently merged
-    # @return [Array] of [Instance, BushSlicer::Host] pairs
+    # @return [Array] of [Instance, VerificationTests::Host] pairs
     def create_instance( names,
                          project: config[:project],
                          zone: config[:zone],
@@ -421,7 +421,7 @@ module BushSlicer
 
     # @param instance_spec [Instance, Hash] instance object or hash
     #   representation
-    # @return [Array] with two elements - Instance and BushSlicer::Host
+    # @return [Array] with two elements - Instance and VerificationTests::Host
     def get_instance_host(instance_spec, host_opts = {})
       host_opts = config[:host_opts].merge host_opts
       instance = instance_spec.kind_of?(Hash) ?

--- a/lib/launchers/openstack.rb
+++ b/lib/launchers/openstack.rb
@@ -8,7 +8,7 @@ end
 require_relative 'openstack4'
 require_relative 'openstack10'
 
-module BushSlicer
+module VerificationTests
   class OpenStack
     extend Common::Helper
 
@@ -51,11 +51,11 @@ end
 
 ## Standalone test
 if __FILE__ == $0
-  extend BushSlicer::Common::Helper
+  extend VerificationTests::Common::Helper
   test_res = {}
   conf[:services].each do |name, service|
     if service[:cloud_type] == 'openstack' && service[:password]
-      os = BushSlicer::OpenStack.instance(service_name: name)
+      os = VerificationTests::OpenStack.instance(service_name: name)
       res = true
       test_res[name] = res
       begin

--- a/lib/launchers/openstack10.rb
+++ b/lib/launchers/openstack10.rb
@@ -15,7 +15,7 @@ require 'host'
 require 'http'
 require 'net'
 
-module BushSlicer
+module VerificationTests
   # works with OSP10 and OSP7
   class OpenStack10
     include Common::Helper
@@ -436,7 +436,7 @@ module BushSlicer
           "volume": {
             "availability_zone": null,
             "source_volid": "#{id}",
-            "description": "BushSlicer created volume",
+            "description": "VerificationTests created volume",
             "multiattach ": false,
             "snapshot_id": null,
             "name": "#{name}"
@@ -461,7 +461,7 @@ module BushSlicer
             "size": #{size},
             "availability_zone": null,
             "source_volid": null,
-            "description": "BushSlicer created volume",
+            "description": "VerificationTests created volume",
             "multiattach ": false,
             "snapshot_id": null,
             "name": "#{name}",
@@ -668,7 +668,7 @@ module BushSlicer
         params[:floatingip].merge!({
           project_id: self.os_tenant_id,
           floating_network_id: floating_ip_networks[0]["id"],
-          description: "IP allocated automatically by BushSlicer"
+          description: "IP allocated automatically by VerificationTests"
         })
       end
 
@@ -706,7 +706,7 @@ module BushSlicer
     # @param host_opts [Hash<Symbol, Object>] options for connecting the host
     # @param names [Array<String>] array of names to give to new machines
     # @return [Hash] a hash of name => hostname pairs
-    # TODO: make this return a [Hash] of name => BushSlicer::Host pairs
+    # TODO: make this return a [Hash] of name => VerificationTests::Host pairs
     def launch_instances(names:, **create_opts)
       res = {}
       host_opts = create_opts.delete(:host_opts) || {}
@@ -725,7 +725,7 @@ module BushSlicer
     class Instance
       attr_reader :client
 
-      # @param client [BushSlicer::OpenStack] the client to use for operations
+      # @param client [VerificationTests::OpenStack] the client to use for operations
       # @param name [String] instance name as shown in console; required unless
       #   `spec` is provided
       # @param spec [Hash] the hash describing instance as returned by API
@@ -853,7 +853,7 @@ end
 
 ## Standalone test
 if __FILE__ == $0
-  extend BushSlicer::Common::Helper
+  extend VerificationTests::Common::Helper
   require 'pry'
   test_res = {}
   service_matcher = ARGV.first || ""
@@ -861,7 +861,7 @@ if __FILE__ == $0
     if service[:cloud_type] == 'openstack' &&
         name.to_s.include?(service_matcher) &&
         service[:password]
-      os = BushSlicer::OpenStack10.new(service_name: name)
+      os = VerificationTests::OpenStack10.new(service_name: name)
       res = true
       test_res[name] = res
       begin

--- a/lib/launchers/openstack4.rb
+++ b/lib/launchers/openstack4.rb
@@ -16,7 +16,7 @@ require 'http'
 require 'net'
 
 # Will be deleted, obsolete code
-module BushSlicer
+module VerificationTests
   # works with OSP4 and OSP7
   # @deprecated Please do not use
   class OpenStack4
@@ -359,7 +359,7 @@ module BushSlicer
           "volume": {
             "availability_zone": null,
             "source_volid": "#{id}",
-            "description": "BushSlicer created volume",
+            "description": "VerificationTests created volume",
             "multiattach ": false,
             "snapshot_id": null,
             "name": "#{name}"
@@ -384,7 +384,7 @@ module BushSlicer
             "size": #{size},
             "availability_zone": null,
             "source_volid": null,
-            "description": "BushSlicer created volume",
+            "description": "VerificationTests created volume",
             "multiattach ": false,
             "snapshot_id": null,
             "name": "#{name}",
@@ -548,7 +548,7 @@ module BushSlicer
     # @param os_opts [Hash] options to pass to [OpenStack::new]
     # @param names [Array<String>] array of names to give to new machines
     # @return [Hash] a hash of name => hostname pairs
-    # TODO: make this return a [Hash] of name => BushSlicer::Host pairs
+    # TODO: make this return a [Hash] of name => VerificationTests::Host pairs
     def launch_instances(names:, **create_opts)
       res = {}
       host_opts = create_opts[:host_opts] || {}
@@ -566,7 +566,7 @@ module BushSlicer
     class Instance
       attr_reader :client
 
-      # @param client [BushSlicer::OpenStack] the client to use for operations
+      # @param client [VerificationTests::OpenStack] the client to use for operations
       # @param name [String] instance name as shown in console; required unless
       #   `spec` is provided
       # @param spec [Hash] the hash describing instance as returned by API
@@ -673,11 +673,11 @@ end
 
 ## Standalone test
 if __FILE__ == $0
-  extend BushSlicer::Common::Helper
+  extend VerificationTests::Common::Helper
   test_res = {}
   conf[:services].each do |name, service|
     if service[:cloud_type] == 'openstack' && service[:ver] == 7 && service[:password]
-      os = BushSlicer::OpenStack4.new(service_name: name)
+      os = VerificationTests::OpenStack4.new(service_name: name)
       res = true
       test_res[name] = res
       begin

--- a/lib/launchers/v_sphere.rb
+++ b/lib/launchers/v_sphere.rb
@@ -8,7 +8,7 @@ end
 require 'collections'
 require 'common'
 
-module BushSlicer
+module VerificationTests
   class VSphere
     include Common::Helper
     include CollectionsIncl
@@ -32,8 +32,8 @@ module BushSlicer
     # @param user_data [String] not implemented yet
     # @param instance_opts [Hash] additional machines launch options
     # @param host_opts [Hash] additional machine access options, should be
-    #   options valid for use in [BushSlicer::Host] constructor
-    # @return [Array] of [RbVmomi::VIM::VirtualMachine, BushSlicer::Host] pairs
+    #   options valid for use in [VerificationTests::Host] constructor
+    # @return [Array] of [RbVmomi::VIM::VirtualMachine, VerificationTests::Host] pairs
     def create_instance( names,
                          user_data: nil,
                          create_opts: {},
@@ -204,7 +204,7 @@ module BushSlicer
         return ip if ip
       }
 
-      raise BushSlicer::TimeoutError, "VM #{vmname} did not get an IP within " \
+      raise VerificationTests::TimeoutError, "VM #{vmname} did not get an IP within " \
         "#{timeout} seconds"
     rescue RbVmomi::Fault => e
       if e.message.start_with? "NotAuthenticated:"
@@ -216,7 +216,7 @@ module BushSlicer
     end
 
     # @param vm [RbVmomi::VIM::VirtualMachine] vm object
-    # @return [BushSlicer::Host]
+    # @return [VerificationTests::Host]
     def get_vm_host(vm, host_opts = {})
       host_opts = (config[:host_connect_opts] || {}).merge host_opts
       host_opts[:cloud_instance] = vm
@@ -401,11 +401,11 @@ end
 
 ## Standalone test
 if __FILE__ == $0
-  extend BushSlicer::Common::Helper
+  extend VerificationTests::Common::Helper
   test_res = {}
   conf[:services].each do |name, service|
     if service[:cloud_type] == 'vsphere' && service.dig(:connect, :password)
-      vim = BushSlicer::VSphere.new(service_name: name)
+      vim = VerificationTests::VSphere.new(service_name: name)
       res = true
       test_res[name] = res
       begin

--- a/lib/local_process.rb
+++ b/lib/local_process.rb
@@ -1,6 +1,6 @@
 require 'common'
 
-module BushSlicer
+module VerificationTests
   # handle lifecycle of local spawned process and it's IO
   # IO is handled in the most simple way - using a separate thread for each
   #   stream. That can be improved in the future using select over all processes

--- a/lib/log.rb
+++ b/lib/log.rb
@@ -11,7 +11,7 @@ require 'base_helper'
 # filename is log.rb to avoid interference with logger ruby feature
 require 'base_helper'
 
-module BushSlicer
+module VerificationTests
   class Logger
     include Common::BaseHelper
 
@@ -67,8 +67,8 @@ module BushSlicer
     def initialize(level=nil)
       if level
         @level = level
-      elsif ENV['BUSHSLICER_LOG_LEVEL']
-        @level = Logger.const_get(ENV['BUSHSLICER_LOG_LEVEL'].upcase)
+      elsif ENV['VERIFICATION_TESTS_LOG_LEVEL']
+        @level = Logger.const_get(ENV['VERIFICATION_TESTS_LOG_LEVEL'].upcase)
       else
         @level = INFO
       end
@@ -364,7 +364,7 @@ if __FILE__ == $0
     "message3"
   ]
 
-  logger = BushSlicer::Logger.new
+  logger = VerificationTests::Logger.new
 
   logger.dedup_start
   messages.each { |m| logger.info m }

--- a/lib/login.rb
+++ b/lib/login.rb
@@ -4,7 +4,7 @@ require 'uri'
 
 require 'http'
 
-module BushSlicer
+module VerificationTests
   # this file hosts necessary logic to login into OpenShift via username and
   # password
   module LoginIncl
@@ -44,11 +44,11 @@ module BushSlicer
     #   password
     # @param [String] login_url the address where we are directed to log in
     # @param [String] user the user to get a token for
-    # @return [BushSlicer::ResultHash] (:token key should be set on success)
+    # @return [VerificationTests::ResultHash] (:token key should be set on success)
     def web_bearer_token_obtain(user:, password:, login_url:)
       obtain_time = Time.now
 
-      res = BushSlicer::Http.http_request(method: :get, url: login_url)
+      res = VerificationTests::Http.http_request(method: :get, url: login_url)
       return res unless res[:success]
 
       cookies = res[:cookies]
@@ -61,7 +61,7 @@ module BushSlicer
         return res
       end
 
-      res = BushSlicer::Http.http_request(method: :post, url: login_action, cookies: cookies, payload: {username: user, password: password})
+      res = VerificationTests::Http.http_request(method: :post, url: login_action, cookies: cookies, payload: {username: user, password: password})
 
       if res[:exitstatus] == 302
         redir302 = res[:headers]["location"].first
@@ -75,7 +75,7 @@ module BushSlicer
           # referer: login_action
         }
 
-        res = BushSlicer::Http.http_request(method: :get, url: redir302, cookies: cookies, headers: headers)
+        res = VerificationTests::Http.http_request(method: :get, url: redir302, cookies: cookies, headers: headers)
       end
 
       return res unless res[:success]
@@ -95,7 +95,7 @@ module BushSlicer
     # @param [String] server_url e.g. "https://master.cluster.local:8443"
     # @param [String] user the username to get a token for
     # @param [String] password
-    # @return [BushSlicer::ResultHash]
+    # @return [VerificationTests::ResultHash]
     # @note curl -u joe -kv -H "X-CSRF-Token: xxx" 'https://master.cluster.local:8443/oauth/authorize?client_id=openshift-challenging-client&response_type=token'
     def oauth_bearer_token_challenge(server_url:, user:, password:)
       # :headers => {'X-CSRF-Token' => 'xx'} seems not needed

--- a/lib/manager.rb
+++ b/lib/manager.rb
@@ -5,7 +5,7 @@ require 'configuration'
 require 'environment_manager'
 # should not require 'common'
 
-module BushSlicer
+module VerificationTests
   # @note this class allows accessing global test execution state.
   #       Get the singleton object by calling Manager.instance.
   #       Manager should point always at the correct manager implementation.
@@ -20,7 +20,7 @@ module BushSlicer
 
       # # @browsers = ...
 
-      # keep reference to BushSlicer custom formatters so we can interact;
+      # keep reference to VerificationTests custom formatters so we can interact;
       #   at the moment we use to call #process_scenario_log from the test case
       #   manager to get hold on scenario log and artifacts at convenient time
       @custom_formatters = []
@@ -70,7 +70,7 @@ module BushSlicer
     end
 
     def init_test_case_manager(cucumbler_config)
-      tc_mngr = ENV['BUSHSLICER_TEST_CASE_MANAGER'] || conf[:test_case_manager]
+      tc_mngr = ENV['VERIFICATION_TESTS_TEST_CASE_MANAGER'] || conf[:test_case_manager]
       tc_mngr = tc_mngr ? tc_mngr + '_tc_manager' : false
       if tc_mngr
         logger.info("Using #{tc_mngr} test case manager")
@@ -92,7 +92,7 @@ module BushSlicer
   end
 
   # allow seamless use of manager outside Cucumber
-  unless defined?(SkipBushSlicerManagerDefault) && SkipBushSlicerManagerDefault
+  unless defined?(SkipVerificationTestsManagerDefault) && SkipVerificationTestsManagerDefault
     Manager ||= DefaultManager
   end
 end

--- a/lib/net.rb
+++ b/lib/net.rb
@@ -2,7 +2,7 @@ require 'socket'
 
 require 'base_helper'
 
-module BushSlicer
+module VerificationTests
   module Common
     module Net
       extend BaseHelper

--- a/lib/openshift/applied_cluster_resource_quota.rb
+++ b/lib/openshift/applied_cluster_resource_quota.rb
@@ -1,7 +1,7 @@
 require 'openshift/project_resource'
 require 'openshift/quota_limits'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift applied cluster resource quota
   class AppliedClusterResourceQuota < ProjectResource
     RESOURCE = 'appliedclusterresourcequotas'

--- a/lib/openshift/build.rb
+++ b/lib/openshift/build.rb
@@ -1,6 +1,6 @@
 require 'openshift/project_resource'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift build
   class Build < ProjectResource
     RESOURCE = "builds"
@@ -9,28 +9,28 @@ module BushSlicer
     STATUSES = [:complete, :running, :pending, :new, :failed, :error, :cancelled]
     TERMINAL_STATUSES = [:complete, :failed, :cancelled, :error]
 
-    # @return [BushSlicer::ResultHash] :success if build completes regardless of
+    # @return [VerificationTests::ResultHash] :success if build completes regardless of
     #   completion status
     def finished?(user:, quiet: false)
       status?(user: user, status: TERMINAL_STATUSES, quiet: quiet)
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending on status
+    # @return [VerificationTests::ResultHash] with :success depending on status
     def completed?(user:)
       status?(user: user, status: :complete)
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending on status
+    # @return [VerificationTests::ResultHash] with :success depending on status
     def failed?(user:)
       status?(user: user, status: :failed)
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending on status
+    # @return [VerificationTests::ResultHash] with :success depending on status
     def running?(user:)
       status?(user: user, status: :running)
     end
 
-    # @return [BushSlicer::ResultHash] with :success true if we've eventually got
+    # @return [VerificationTests::ResultHash] with :success true if we've eventually got
     #   the build finished regardless of status, false if build never started or
     #   still running; the result hash is from last executed get call
     def wait_till_finished(user, seconds)
@@ -54,13 +54,13 @@ module BushSlicer
       return res
     end
 
-    # @return [BushSlicer::ResultHash] with :success true if we've eventually got
+    # @return [VerificationTests::ResultHash] with :success true if we've eventually got
     #   the build completed; the result hash is from last executed get call
     def wait_till_completed(user, seconds)
       wait_till_status(:complete, user, seconds)
     end
 
-    # @return [BushSlicer::ResultHash] with :success true if we've eventually got
+    # @return [VerificationTests::ResultHash] with :success true if we've eventually got
     #   the build failed; the result hash is from last executed get call
     def wait_till_failed(user, seconds)
       wait_till_status(:failed, user, seconds)

--- a/lib/openshift/build_config.rb
+++ b/lib/openshift/build_config.rb
@@ -3,7 +3,7 @@ require 'openshift/project_resource'
 require 'openshift/flakes/build_config_trigger'
 require 'openshift/flakes/build_strategy'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift build
   class BuildConfig < ProjectResource
     RESOURCE = "buildconfigs"

--- a/lib/openshift/bundle.rb
+++ b/lib/openshift/bundle.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # represents an OpenShift ConfigMap
   class Bundle < ProjectResource
     RESOURCE = "bundles"

--- a/lib/openshift/bundle_binding.rb
+++ b/lib/openshift/bundle_binding.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
 
   class BundleBinding < ProjectResource
     RESOURCE = "bundlebindings"

--- a/lib/openshift/bundle_instance.rb
+++ b/lib/openshift/bundle_instance.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
 
   class BundleInstance < ProjectResource
     RESOURCE = "bundleinstances"

--- a/lib/openshift/cluster_resource.rb
+++ b/lib/openshift/cluster_resource.rb
@@ -2,7 +2,7 @@ require 'yaml'
 
 require_relative 'resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents a Resource / OpenShift API Object
   class ClusterResource < Resource
 
@@ -24,11 +24,11 @@ module BushSlicer
     end
 
     # creates a new OpenShift Cluster Resource from spec
-    # @param by [BushSlicer::APIAccessorOwner, BushSlicer::APIAccessor] the user to create
+    # @param by [VerificationTests::APIAccessorOwner, VerificationTests::APIAccessor] the user to create
     #   Resource as
     # @param spec [String, Hash] the Hash representaion of the API object to
     #   be created or a String path of a JSON/YAML file
-    # @return [BushSlicer::ResultHash]
+    # @return [VerificationTests::ResultHash]
     # @note unify with ProjectResource and remove opts parameter
     def self.create(by:, spec:, **opts)
       if spec.kind_of? String
@@ -84,7 +84,7 @@ module BushSlicer
     end
 
     # @param labels [String, Array<String,String>] labels to filter on, read
-    #   [BushSlicer::Common::BaseHelper#selector_to_label_arr] carefully
+    #   [VerificationTests::Common::BaseHelper#selector_to_label_arr] carefully
     # @param count [Integer] minimum number of resources to wait for
     def self.wait_for_labeled(*labels, count: 1, user:, seconds:)
       wait_for_matching(user: user, seconds: seconds,
@@ -96,7 +96,7 @@ module BushSlicer
 
     # @param count [Integer] minimum number of items to wait for
     # @yield block that selects items by returning true; see [#get_matching]
-    # @return [BushSlicer::ResultHash] with :matching key being array of matched
+    # @return [VerificationTests::ResultHash] with :matching key being array of matched
     #   resource items;
     def self.wait_for_matching(count: 1, user:, seconds:, get_opts: [])
       res = {}
@@ -127,7 +127,7 @@ module BushSlicer
       return res
     end
     # @param labels [String, Array<String,String>] labels to filter on, read
-    #   [BushSlicer::Common::BaseHelper#selector_to_label_arr] carefully
+    #   [VerificationTests::Common::BaseHelper#selector_to_label_arr] carefully
     # @return [Array<ProjectResource>] with :matching key being array of matched
     #   resources
     def self.get_labeled(*labels, user:, result: {}, quiet: false)
@@ -139,7 +139,7 @@ module BushSlicer
       end
     end
     # list resources by a user
-    # @param user [BushSlicer::User] the user we list resources as
+    # @param user [VerificationTests::User] the user we list resources as
     # @param result [ResultHash] can be used to get full result hash from op
     # @param get_opts [Hash, Array] other options to pass down to oc get
     # @return [Array<ClusterResource>]

--- a/lib/openshift/cluster_resource_quota.rb
+++ b/lib/openshift/cluster_resource_quota.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift cluster resource quota
   class ClusterResourceQuota < ClusterResource
     RESOURCE = 'clusterresourcequotas'

--- a/lib/openshift/cluster_role.rb
+++ b/lib/openshift/cluster_role.rb
@@ -2,7 +2,7 @@ require 'openshift/cluster_resource'
 
 require_relative 'flakes/policy_rule'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Persistent Volume
   class ClusterRole < ClusterResource
     RESOURCE = 'clusterroles'

--- a/lib/openshift/cluster_role_binding.rb
+++ b/lib/openshift/cluster_role_binding.rb
@@ -1,7 +1,7 @@
 require 'openshift/cluster_resource'
 require 'openshift/flakes/unknown_role_binding_subject'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Persistent Volume
   class ClusterRoleBinding < ClusterResource
     RESOURCE = 'clusterrolebindings'
@@ -27,7 +27,7 @@ module BushSlicer
         props[:subjects] = rbs.map { |rb|
           case rb["kind"]
           when "SystemUser", "SystemGroup", "User", "Group"
-            Object.const_get("::BushSlicer::#{rb['kind']}")
+            Object.const_get("::VerificationTests::#{rb['kind']}")
               .new(name: rb["name"], env: env)
           when "ServiceAccount"
             ServiceAccount.new(

--- a/lib/openshift/cluster_service_broker.rb
+++ b/lib/openshift/cluster_service_broker.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Cluster Service Broker
   class ClusterServiceBroker < ClusterResource
     RESOURCE = "clusterservicebrokers"
@@ -34,7 +34,7 @@ module BushSlicer
       return rr.dig("spec", "url")
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending on
+    # @return [VerificationTests::ResultHash] with :success depending on
     #   condition type=Ready and status=True
     def ready?(user:, quiet: false, cached: false)
       if cached && props[:raw]

--- a/lib/openshift/cluster_service_class.rb
+++ b/lib/openshift/cluster_service_class.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Cluster Service Class
   class ClusterServiceClass < ClusterResource
     RESOURCE = "clusterserviceclasses"
@@ -40,7 +40,7 @@ module BushSlicer
       return props[:plans]
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending on
+    # @return [VerificationTests::ResultHash] with :success depending on
     #   condition type=Ready and status=True
     def ready?(user:, quiet: false, cached: false)
       if cached && props[:raw]

--- a/lib/openshift/cluster_service_plan.rb
+++ b/lib/openshift/cluster_service_plan.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Cluster Service Plan
   class ClusterServicePlan < ClusterResource
     RESOURCE = "clusterserviceplans"

--- a/lib/openshift/config_map.rb
+++ b/lib/openshift/config_map.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # represents an OpenShift ConfigMap
   class ConfigMap < ProjectResource
     RESOURCE = 'configmaps'

--- a/lib/openshift/cron_job.rb
+++ b/lib/openshift/cron_job.rb
@@ -1,6 +1,6 @@
 require 'openshift/project_resource'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift CronJob https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
   class CronJob < ProjectResource
     RESOURCE = "cronjobs"

--- a/lib/openshift/daemon_set.rb
+++ b/lib/openshift/daemon_set.rb
@@ -1,6 +1,6 @@
 require 'openshift/pod_replicator'
 
-module BushSlicer
+module VerificationTests
   # represnets an Openshift StatefulSets
   class DaemonSet < PodReplicator
     RESOURCE = "daemonsets"

--- a/lib/openshift/deployment.rb
+++ b/lib/openshift/deployment.rb
@@ -4,7 +4,7 @@ require 'openshift/pod_replicator'
 
 # TODO: DRY together with replica_set.rb
 
-module BushSlicer
+module VerificationTests
 
   # represents an Openshift Deployment
   class Deployment < PodReplicator
@@ -35,7 +35,7 @@ module BushSlicer
       labels = match_labels(**shared_options, cached: cached)
       revision = self.revision(**shared_options)
 
-      BushSlicer::ReplicaSet.get_labeled(*labels, user: user, project: project)
+      VerificationTests::ReplicaSet.get_labeled(*labels, user: user, project: project)
         .select { |item| item.revision(**shared_options) == revision }
         .max_by { |item| item.created_at(**shared_options) }
     end

--- a/lib/openshift/deployment_config.rb
+++ b/lib/openshift/deployment_config.rb
@@ -6,7 +6,7 @@ require 'openshift/replication_controller'
 require 'openshift/flakes/container_spec'
 require 'openshift/flakes/deployment_config_trigger'
 
-module BushSlicer
+module VerificationTests
 
   # represents an OpenShift DeploymentConfig (dc for short) used for scaling pods
   class DeploymentConfig < PodReplicator
@@ -53,7 +53,7 @@ module BushSlicer
       return res
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending the rc readiness for the dc that it belongs to
+    # @return [VerificationTests::ResultHash] with :success depending the rc readiness for the dc that it belongs to
     def ready?(user: nil, cached: false, quiet: false)
       rc(user: user, cached: cached, quiet: quiet).ready?(user: user, cached: cached, quiet: quiet)
     end
@@ -79,7 +79,7 @@ module BushSlicer
         dig("status", "latestVersion")
     end
 
-    # @return [BushSlicer::ReplicationController]
+    # @return [VerificationTests::ReplicationController]
     def replication_controller(user: nil, cached: true, quiet: true)
       version = latest_version(user: user, cached: cached, quiet: quiet)
 

--- a/lib/openshift/endpoint_address.rb
+++ b/lib/openshift/endpoint_address.rb
@@ -1,8 +1,8 @@
 require 'base_helper'
-module BushSlicer
+module VerificationTests
 
   # this class should help with parsing endpoint address element
-  #   [3] pry(#<BushSlicer::Endpoints>)> addrs[0]
+  #   [3] pry(#<VerificationTests::Endpoints>)> addrs[0]
   # => {
   #          "ip" => "10.10.10.101",
   #    "nodeName" => "myhost.example.com",

--- a/lib/openshift/endpoint_port.rb
+++ b/lib/openshift/endpoint_port.rb
@@ -1,6 +1,6 @@
 require 'base_helper'
 
-module BushSlicer
+module VerificationTests
 
   # this class should help with parsing endpoint port element
   class EndpointPort

--- a/lib/openshift/endpoint_subset.rb
+++ b/lib/openshift/endpoint_subset.rb
@@ -1,6 +1,6 @@
 require 'base_helper'
 
-module BushSlicer
+module VerificationTests
   # pls reference to kubernetes doc for more details
   # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#endpointsubset-v1-core
   class EndpointSubset

--- a/lib/openshift/endpoints.rb
+++ b/lib/openshift/endpoints.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#endpoints-v1-core
   class Endpoints < ProjectResource
     RESOURCE = "endpoints"

--- a/lib/openshift/flakes/build_config_trigger.rb
+++ b/lib/openshift/flakes/build_config_trigger.rb
@@ -1,7 +1,7 @@
 require_relative 'image_ref'
 require 'openshift/object_reference'
 
-module BushSlicer
+module VerificationTests
   # represents a trigger structure inside a build config
   class BuildConfigTrigger
     attr_reader :params, :spec, :bc

--- a/lib/openshift/flakes/build_strategy.rb
+++ b/lib/openshift/flakes/build_strategy.rb
@@ -1,6 +1,6 @@
 require 'openshift/object_reference'
 
-module BushSlicer
+module VerificationTests
   class BuildStrategy
     SUBCLASSES = []
 

--- a/lib/openshift/flakes/container.rb
+++ b/lib/openshift/flakes/container.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class Container
     include Common::Helper
 

--- a/lib/openshift/flakes/container_spec.rb
+++ b/lib/openshift/flakes/container_spec.rb
@@ -1,6 +1,6 @@
 require 'base_helper'
 
-module BushSlicer
+module VerificationTests
 
   # this class should help with parsing container specifications
   class ContainerSpec

--- a/lib/openshift/flakes/deployment_config_trigger.rb
+++ b/lib/openshift/flakes/deployment_config_trigger.rb
@@ -1,7 +1,7 @@
 require 'openshift/object_reference'
 require_relative 'image_ref'
 
-module BushSlicer
+module VerificationTests
   # represents a trigger structure inside a deployment config
   class DeploymentConfigTrigger
     attr_reader :params, :spec, :from

--- a/lib/openshift/flakes/docker_image.rb
+++ b/lib/openshift/flakes/docker_image.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class DockerImage
     attr_reader :raw, :owner, :name
     private :raw, :owner

--- a/lib/openshift/flakes/image_ref.rb
+++ b/lib/openshift/flakes/image_ref.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # represents a trigger structure inside a deployment/build config
   class ImageRef
     attr_reader :uri, :hash_type, :hash_value, :name

--- a/lib/openshift/flakes/image_stream_tag_event.rb
+++ b/lib/openshift/flakes/image_stream_tag_event.rb
@@ -1,6 +1,6 @@
 require_relative 'image_ref'
 
-module BushSlicer
+module VerificationTests
   class ImageStreamTagEvent
     attr_reader :raw, :generation, :imageref, :created, :owner, :status
     private :raw, :owner

--- a/lib/openshift/flakes/image_stream_tag_spec.rb
+++ b/lib/openshift/flakes/image_stream_tag_spec.rb
@@ -1,6 +1,6 @@
 require 'openshift/object_reference'
 
-module BushSlicer
+module VerificationTests
   # this is the spec->tags section inside ImageStream and is very different
   #   from the ImageStreamTag resource
   class ImageStreamTagSpec

--- a/lib/openshift/flakes/image_stream_tag_status.rb
+++ b/lib/openshift/flakes/image_stream_tag_status.rb
@@ -1,6 +1,6 @@
 require_relative 'image_stream_tag_event'
 
-module BushSlicer
+module VerificationTests
   # represents a tag status within an ImageStream, nothing to do with the
   #   ImageStreamTag resource
   class ImageStreamTagStatus

--- a/lib/openshift/flakes/limit_range_constraint.rb
+++ b/lib/openshift/flakes/limit_range_constraint.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # https://docs.openshift.com/online/rest_api/api/v1.LimitRange.html
   class LimitRangeConstraint
     include Common::BaseHelper

--- a/lib/openshift/flakes/limit_range_item.rb
+++ b/lib/openshift/flakes/limit_range_item.rb
@@ -1,6 +1,6 @@
 require_relative 'limit_range_constraint'
 
-module BushSlicer
+module VerificationTests
   # https://docs.openshift.com/online/rest_api/api/v1.LimitRange.html
   class LimitRangeItem
     include Common::BaseHelper

--- a/lib/openshift/flakes/pod_volume_spec.rb
+++ b/lib/openshift/flakes/pod_volume_spec.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class PodVolumeSpec
     attr_reader :raw, :name, :owner
     private :raw, :owner

--- a/lib/openshift/flakes/pod_volume_spec/pvc_pod_volume_spec.rb
+++ b/lib/openshift/flakes/pod_volume_spec/pvc_pod_volume_spec.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class PVCPodVolumeSpec < PodVolumeSpec
     TYPE = "persistentVolumeClaim"
 

--- a/lib/openshift/flakes/pod_volume_spec/unknown_pod_volume_spec.rb
+++ b/lib/openshift/flakes/pod_volume_spec/unknown_pod_volume_spec.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class UnknownPodVolumeSpec < PodVolumeSpec
     TYPE = nil
   end

--- a/lib/openshift/flakes/policy_rule.rb
+++ b/lib/openshift/flakes/policy_rule.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # represents a rule inside a cluster role
   class PolicyRule
     attr_reader :non_resource_urls, :resource_names, :verbs

--- a/lib/openshift/flakes/unknown_role_binding_subject.rb
+++ b/lib/openshift/flakes/unknown_role_binding_subject.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class UnknownRoleBindingSubject
   end
 end

--- a/lib/openshift/group.rb
+++ b/lib/openshift/group.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Group
   class Group < ClusterResource
     RESOURCE = 'groups'

--- a/lib/openshift/horizontal_pod_autoscaler.rb
+++ b/lib/openshift/horizontal_pod_autoscaler.rb
@@ -1,6 +1,6 @@
 require 'openshift/pod_replicator'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift Image Stream
   class HorizontalPodAutoscaler < PodReplicator
     RESOURCE = "horizontalpodautoscalers"

--- a/lib/openshift/host_subnet.rb
+++ b/lib/openshift/host_subnet.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Host Subnet
   class HostSubnet < ClusterResource
     RESOURCE = 'hostsubnets'

--- a/lib/openshift/identity.rb
+++ b/lib/openshift/identity.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift Identity
   class Identity < ClusterResource
     RESOURCE = 'identities'

--- a/lib/openshift/image.rb
+++ b/lib/openshift/image.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class Image < ClusterResource
     RESOURCE = "images"
   end

--- a/lib/openshift/image_stream.rb
+++ b/lib/openshift/image_stream.rb
@@ -1,7 +1,7 @@
 require 'openshift/flakes/image_stream_tag_spec'
 require 'openshift/flakes/image_stream_tag_status'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift Image Stream
   class ImageStream < ProjectResource
     RESOURCE = "imagestreams"

--- a/lib/openshift/image_stream_tag.rb
+++ b/lib/openshift/image_stream_tag.rb
@@ -1,6 +1,6 @@
 require 'openshift/project_resource'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift Image Stream Tag
   class ImageStreamTag < ProjectResource
     RESOURCE = "imagestreamtags"

--- a/lib/openshift/ingress.rb
+++ b/lib/openshift/ingress.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class Ingress < ProjectResource
     RESOURCE = "ingresses"
   end

--- a/lib/openshift/job.rb
+++ b/lib/openshift/job.rb
@@ -1,6 +1,6 @@
 require 'openshift/project_resource'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift ReplicationController (rc for short) used for scaling pods
   class Job < ProjectResource
     RESOURCE = "jobs"
@@ -18,7 +18,7 @@ module BushSlicer
       return self # mainly to help ::from_api_object
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending on
+    # @return [VerificationTests::ResultHash] with :success depending on
     #   status['replicas'] == spec['replicas']
     # @note we also need to check that the spec.replicas is > 0
     def ready?(user:, quiet: false, cached: false)

--- a/lib/openshift/limit_range.rb
+++ b/lib/openshift/limit_range.rb
@@ -1,6 +1,6 @@
 require 'openshift/flakes/limit_range_item'
 
-module BushSlicer
+module VerificationTests
   # https://docs.openshift.com/online/rest_api/api/v1.LimitRange.html
   class LimitRange < ProjectResource
     RESOURCE = 'limitranges'

--- a/lib/openshift/metering.rb
+++ b/lib/openshift/metering.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # represents Metering CRD
   class Metering < ProjectResource
     RESOURCE = 'metering'

--- a/lib/openshift/net_namespace.rb
+++ b/lib/openshift/net_namespace.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # represnets an Openshift NetNamespace
   class NetNamespace < ClusterResource
     RESOURCE = 'netnamespaces'

--- a/lib/openshift/network_policy.rb
+++ b/lib/openshift/network_policy.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Network Policy
   class NetworkPolicy < ClusterResource
     RESOURCE = 'networkpolicies'

--- a/lib/openshift/node.rb
+++ b/lib/openshift/node.rb
@@ -1,9 +1,9 @@
 require 'openshift/cluster_resource'
 require 'openshift/node_taint'
 
-module BushSlicer
+module VerificationTests
   # @note this class represents OpenShift environment Node API pbject and this
-  #   is different from a BushSlicer::Host. Underlying a Node, there always is a
+  #   is different from a VerificationTests::Host. Underlying a Node, there always is a
   #   Host but not all Hosts are Nodes. Not sure if we can always have a
   #   mapping between Nodes and Hosts. Depends on access we have to the env
   #   under testing and proper configuration.
@@ -21,7 +21,7 @@ module BushSlicer
       return self
     end
 
-    # @return [BushSlicer:Host] underlying this node
+    # @return [VerificationTests:Host] underlying this node
     # @note may raise depending on proper OPENSHIFT_ENV_<NAME>_HOSTS
     # @note will return acorrding to:
     # 1. if the node name matches hosts, then use host
@@ -51,7 +51,7 @@ module BushSlicer
     end
 
     def service
-      @service ||= BushSlicer::Platform::NodeService.discover(host, env)
+      @service ||= VerificationTests::Platform::NodeService.discover(host, env)
     end
 
     def schedulable?(user: nil, cached: true, quiet: false)

--- a/lib/openshift/node_taint.rb
+++ b/lib/openshift/node_taint.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class NodeTaint
     attr_reader :node, :effect, :key, :time_added, :value
 

--- a/lib/openshift/o_auth_access_token.rb
+++ b/lib/openshift/o_auth_access_token.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class OAuthAccessToken < ClusterResource
     RESOURCE = "oauthaccesstokens"
 

--- a/lib/openshift/o_auth_client.rb
+++ b/lib/openshift/o_auth_client.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class OAuthClient < ClusterResource
     RESOURCE = "oauthclients"
     # pls refer https://github.com/openshift-qe/output_refrences/tree/master/oauthclient for output example

--- a/lib/openshift/object_reference.rb
+++ b/lib/openshift/object_reference.rb
@@ -1,6 +1,6 @@
 require 'base_helper'
 
-module BushSlicer
+module VerificationTests
   # pls reference to kubernetes doc for more details
   # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#objectreference-v1-core
   # targetRef is a sub-component of a endpoint address
@@ -58,7 +58,7 @@ module BushSlicer
       def resource(referer)
         return @resource if @resource
 
-        clazz = Object.const_get("::BushSlicer::#{kind}")
+        clazz = Object.const_get("::VerificationTests::#{kind}")
         @resource = clazz.from_reference(self, referer)
         return @resource
       end

--- a/lib/openshift/persistent_volume.rb
+++ b/lib/openshift/persistent_volume.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Persistent Volume
   class PersistentVolume < ClusterResource
     STATUSES = [:available, :bound, :pending, :released, :failed]

--- a/lib/openshift/persistent_volume_claim.rb
+++ b/lib/openshift/persistent_volume_claim.rb
@@ -1,6 +1,6 @@
 require 'openshift/project_resource'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift PersistentVolumeClaim (pvc for short)
   class PersistentVolumeClaim < ProjectResource
     STATUSES = [:bound, :failed, :pending, :lost, :terminating]
@@ -21,7 +21,7 @@ module BushSlicer
       return self # mainly to help ::from_api_object
     end
 
-    # @return [BushSlicer::ResultHash] with :success if status is Bound
+    # @return [VerificationTests::ResultHash] with :success if status is Bound
     def ready?(user: nil, quiet: false, cached: false)
       status?(user: user, status: :bound, quiet: quiet, cached: cached)
     end

--- a/lib/openshift/pod.rb
+++ b/lib/openshift/pod.rb
@@ -4,7 +4,7 @@ require 'openshift/flakes/container'
 require 'openshift/flakes/container_spec'
 require 'openshift/flakes/pod_volume_spec'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift pod
   class Pod < ProjectResource
     RESOURCE = "pods"
@@ -55,7 +55,7 @@ module BushSlicer
       return self # mainly to help ::from_api_object
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending on pod
+    # @return [VerificationTests::ResultHash] with :success depending on pod
     #   condition type=Ready and status=True; only `Running` pods with all
     #   containers probes succeeding appear to have this
     def ready?(user: nil, quiet: false, cached: false)
@@ -155,7 +155,7 @@ module BushSlicer
         props[:containers] = container_specs(user: user,
                                              cached: cached,
                                              quiet: quiet).map { |spec|
-          BushSlicer::Container.new(name: spec.name, pod: self)
+          VerificationTests::Container.new(name: spec.name, pod: self)
         }
       end
       return props[:containers]

--- a/lib/openshift/pod_replicator.rb
+++ b/lib/openshift/pod_replicator.rb
@@ -4,7 +4,7 @@ require 'openshift/project_resource'
 require 'active_support/core_ext/hash/slice'
 require 'base_helper'
 
-module BushSlicer
+module VerificationTests
   class PodReplicator < ProjectResource
 
     ## must be defined in subclasses

--- a/lib/openshift/pod_security_policy.rb
+++ b/lib/openshift/pod_security_policy.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   class PodSecurityPolicy < ClusterResource
     RESOURCE = 'podsecuritypolicies'
 

--- a/lib/openshift/project.rb
+++ b/lib/openshift/project.rb
@@ -5,7 +5,7 @@ require_relative 'cluster_resource'
 require_relative 'pod'
 require_relative 'role_binding'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment project
   class Project < ClusterResource
     RESOURCE = "projects".freeze
@@ -72,9 +72,9 @@ module BushSlicer
     end
 
     # creates a new project
-    # @param by [BushSlicer::APIAccessorOwner, BushSlicer::APIAccessor] the user to create project as
+    # @param by [VerificationTests::APIAccessorOwner, VerificationTests::APIAccessor] the user to create project as
     # @param name [String] the name of the project
-    # @return [BushSlicer::ResultHash]
+    # @return [VerificationTests::ResultHash]
     def self.create(by:, name: nil, **opts)
       if name
         res = self.new(name: name, env: by.env).create(by: by, **opts)
@@ -165,7 +165,7 @@ module BushSlicer
     #services/mysql-55-centos7
     #services/ruby-hello-world
     # @param labels [String, Array<String,String>, read carefully description of
-    #   [BushSlicer::Common::BaseHelper#selector_to_label_arr]
+    #   [VerificationTests::Common::BaseHelper#selector_to_label_arr]
     # @param by [User] the user to execute operation with
     # @param cmd_opts [**Hash] command line options overrides
     def delete_all_labeled(*labels, by:, **cmd_opts)

--- a/lib/openshift/project_resource.rb
+++ b/lib/openshift/project_resource.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 require 'openshift/resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift namespaced Resource (part of a Project)
   class ProjectResource < Resource
     attr_reader :project
@@ -11,7 +11,7 @@ module BushSlicer
     # RESOURCE = "define me"
 
     # @param name [String] name of the resource
-    # @param project [BushSlicer::Project] the project we belong to
+    # @param project [VerificationTests::Project] the project we belong to
     # @param props [Hash] additional properties of the resource
     def initialize(name:, project:)
       unless String === name
@@ -30,12 +30,12 @@ module BushSlicer
     end
 
     # creates a new OpenShift Project Resource via API
-    # @param by [BushSlicer::APIAccessorOwner, BushSlicer::APIAccessor] the user to create
+    # @param by [VerificationTests::APIAccessorOwner, VerificationTests::APIAccessor] the user to create
     #   ProjectResource as
-    # @param project [BushSlicer::Project] the namespace for the new resource
+    # @param project [VerificationTests::Project] the namespace for the new resource
     # @param spec [String, Hash] the Hash object to create project resource or
     #   a String path of a JSON/YAML file
-    # @return [BushSlicer::ResultHash]
+    # @return [VerificationTests::ResultHash]
     def self.create(by:, project:, spec:, **opts)
       if spec.kind_of? String
         # assume a file path (TODO: be more intelligent)
@@ -122,7 +122,7 @@ module BushSlicer
     end
 
     # @param labels [String, Array<String,String>] labels to filter on, read
-    #   [BushSlicer::Common::BaseHelper#selector_to_label_arr] carefully
+    #   [VerificationTests::Common::BaseHelper#selector_to_label_arr] carefully
     # @param count [Integer] minimum number of resources to wait for
     def self.wait_for_labeled(*labels, count: 1, user:, project:, seconds:)
       wait_for_matching(user: user, project: project, seconds: seconds,
@@ -134,7 +134,7 @@ module BushSlicer
 
     # @param count [Integer] minimum number of items to wait for
     # @yield block that selects items by returning true; see [#get_matching]
-    # @return [BushSlicer::ResultHash] with :matching key being array of matched
+    # @return [VerificationTests::ResultHash] with :matching key being array of matched
     #   resource items;
     def self.wait_for_matching(count: 1, user:, project:, seconds:,
                                                                   get_opts: [])
@@ -167,7 +167,7 @@ module BushSlicer
     end
 
     # @param labels [String, Array<String,String>] labels to filter on, read
-    #   [BushSlicer::Common::BaseHelper#selector_to_label_arr] carefully
+    #   [VerificationTests::Common::BaseHelper#selector_to_label_arr] carefully
     # @return [Array<ProjectResource>] with :matching key being array of matched
     #   resources
     def self.get_labeled(*labels, user:, project:, result: {}, quiet: false)

--- a/lib/openshift/quota_limits.rb
+++ b/lib/openshift/quota_limits.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # helper to access qoota limit values for classes like
   #   AppliedClusterResourceQuota
   class QuotaLimits

--- a/lib/openshift/replica_set.rb
+++ b/lib/openshift/replica_set.rb
@@ -4,7 +4,7 @@ require 'openshift/pod_replicator'
 
 # TODO: DRY together with deployment.rb
 
-module BushSlicer
+module VerificationTests
 
   # represents an Openshift ReplicaSets (rs for short)
   class ReplicaSet < PodReplicator

--- a/lib/openshift/replication_controller.rb
+++ b/lib/openshift/replication_controller.rb
@@ -3,7 +3,7 @@ require 'openshift/pod_replicator'
 
 require 'openshift/flakes/container_spec'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift ReplicationController (rc for short) used for scaling pods
   class ReplicationController < PodReplicator
     RESOURCE = "replicationcontrollers"
@@ -102,7 +102,7 @@ module BushSlicer
                 quiet: quiet)
     end
 
-    # @return [BushSlicer::ResultHash] with :success when ready and desired
+    # @return [VerificationTests::ResultHash] with :success when ready and desired
     #   replicas match and are more than zero
     # @note the complicated logic t oconstruct a result hash is to keep
     #   backward compatibility
@@ -128,7 +128,7 @@ module BushSlicer
       return res
     end
 
-    # @return [BushSlicer::ResultHash]
+    # @return [VerificationTests::ResultHash]
     def replica_count_match?(user:, state:, replica_count:, quiet: false)
       res = describe(user, quiet: quiet)
       if res[:success]

--- a/lib/openshift/report.rb
+++ b/lib/openshift/report.rb
@@ -1,6 +1,6 @@
 # for reference on how to use Metering please consult the following link
 # https://github.com/operator-framework/operator-metering/blob/master/Documentation/using-metering.md
-module BushSlicer
+module VerificationTests
   class Report < ProjectResource
     RESOURCE = "reports"
 

--- a/lib/openshift/resource.rb
+++ b/lib/openshift/resource.rb
@@ -4,7 +4,7 @@ require 'yaml'
 require 'common'
 require 'openshift/resource_not_found_error'
 
-module BushSlicer
+module VerificationTests
   # @note represents a Resource / OpenShift API Object
   class Resource
     include Common::Helper
@@ -56,7 +56,7 @@ module BushSlicer
       if exists?(user: user, quiet: quiet, result: res)
         return res
       else
-        raise BushSlicer::ResourceNotFoundError,
+        raise VerificationTests::ResourceNotFoundError,
           "#{self.class::RESOURCE} '#{name}' not found"
       end
     end
@@ -185,7 +185,7 @@ module BushSlicer
       return res
     end
 
-    # @return [BushSlicer::ResultHash]
+    # @return [VerificationTests::ResultHash]
     def wait_to_appear(user, seconds = 30)
       res = {}
       iterations = 0
@@ -306,7 +306,7 @@ module BushSlicer
       return res
     end
 
-    # @return [BushSlicer::ResultHash] with :success true if we've eventually got
+    # @return [VerificationTests::ResultHash] with :success true if we've eventually got
     #   the resource in ready status; the result hash is from last executed
     #   get call
     # @note sub-class needs to implement the `#ready?` method

--- a/lib/openshift/resource_not_found_error.rb
+++ b/lib/openshift/resource_not_found_error.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class ResourceNotFoundError < RuntimeError
   end
 end

--- a/lib/openshift/resource_quota.rb
+++ b/lib/openshift/resource_quota.rb
@@ -1,7 +1,7 @@
 require 'openshift/project_resource'
 require 'openshift/quota_limits'
 
-module BushSlicer
+module VerificationTests
   class ResourceQuota < ProjectResource
     RESOURCE = 'resourcequotas'
 

--- a/lib/openshift/role_binding.rb
+++ b/lib/openshift/role_binding.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class RoleBinding < ProjectResource
     RESOURCE = 'rolebindings'
 

--- a/lib/openshift/role_binding_restriction.rb
+++ b/lib/openshift/role_binding_restriction.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class RoleBindingRestriction < ProjectResource
     RESOURCE = 'rolebindingrestrictions'
   end

--- a/lib/openshift/route.rb
+++ b/lib/openshift/route.rb
@@ -1,7 +1,7 @@
 require 'common'
 require 'openshift/project_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift route to a service
   #   https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
   class Route < ProjectResource
@@ -11,7 +11,7 @@ module BushSlicer
     attr_writer :service
 
     # @param name [String] name of route
-    # @param service [BushSlicer::Service] the service exposed via this route
+    # @param service [VerificationTests::Service] the service exposed via this route
     # @param props [Hash] additional properties of the route
     # @note custom constructor for historical reasons but should be compatible
     #   with ProjectResource@initialize
@@ -29,7 +29,7 @@ module BushSlicer
 
     def http_get(by:, proto: "http", port: nil, **http_opts)
       portstr = port ? ":#{port}" : ""
-      BushSlicer::Http.get(url: proto + "://" + dns(by: by) + portstr,
+      VerificationTests::Http.get(url: proto + "://" + dns(by: by) + portstr,
                           **http_opts)
     end
 

--- a/lib/openshift/secret.rb
+++ b/lib/openshift/secret.rb
@@ -2,7 +2,7 @@ require "base64"
 
 require 'common'
 
-module BushSlicer
+module VerificationTests
   # represents an OpenShift Secret
   class Secret < ProjectResource
     RESOURCE = "secrets"
@@ -13,12 +13,12 @@ module BushSlicer
       return obj['type']
     end
 
-    # @param user [BushSlicer::User] the user to run cli commands with if needed
+    # @param user [VerificationTests::User] the user to run cli commands with if needed
     def bearer_token?(user: nil, cached: true, quiet: false)
       type(user: user, cached: cached, quiet: quiet).include?('service-account-token') && raw_resource.dig('data', 'token')
     end
 
-    # @param user [BushSlicer::User] the user to run cli commands with if needed
+    # @param user [VerificationTests::User] the user to run cli commands with if needed
     # @return [String] bearer token
     def token(user: nil, cached: true, quiet: false)
       if bearer_token?(user: user, cached: cached, quiet: quiet)

--- a/lib/openshift/security_context_constraints.rb
+++ b/lib/openshift/security_context_constraints.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Persistent Volume
   class SecurityContextConstraints < ClusterResource
     RESOURCE = 'securitycontextconstraints'

--- a/lib/openshift/service.rb
+++ b/lib/openshift/service.rb
@@ -5,12 +5,12 @@ require 'openshift/project_resource'
 require 'openshift/pod'
 require 'openshift/route'
 
-module BushSlicer
+module VerificationTests
   # represents OpenShift v3 Service concept
   class Service < ProjectResource
     RESOURCE = "services"
 
-    # @return [BushSlicer::ResultHash] with :success if at least one pod by
+    # @return [VerificationTests::ResultHash] with :success if at least one pod by
     #   selector is ready
     def ready?(user: nil, quiet: false, cached: false)
       res = {}
@@ -36,7 +36,7 @@ module BushSlicer
       return props[:pods]
     end
 
-    # @param by [BushSlicer::User] the user to create route with
+    # @param by [VerificationTests::User] the user to create route with
     def expose(user: nil, port: nil)
       opts = {
         output: :yaml,

--- a/lib/openshift/service_account.rb
+++ b/lib/openshift/service_account.rb
@@ -3,10 +3,10 @@ require 'json'
 require 'api_accessor_owner'
 require 'openshift/secret'
 
-module BushSlicer
+module VerificationTests
   # represents OpenShift v3 Service account
   class ServiceAccount < ProjectResource
-    include BushSlicer::APIAccessorOwner
+    include VerificationTests::APIAccessorOwner
 
     RESOURCE = "serviceaccounts"
 

--- a/lib/openshift/service_binding.rb
+++ b/lib/openshift/service_binding.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class ServiceBinding < ProjectResource
     RESOURCE = "servicebindings"
     
@@ -7,7 +7,7 @@ module BushSlicer
       rr.dig('spec', 'externalID')
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending on
+    # @return [VerificationTests::ResultHash] with :success depending on
     #   condition type=Ready and status=True
     def ready?(user:, quiet: false, cached: false)
       if cached && props[:raw]

--- a/lib/openshift/service_instance.rb
+++ b/lib/openshift/service_instance.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # represents an OpenShift ConfigMap
   class ServiceInstance < ProjectResource
     RESOURCE = "serviceinstances"
@@ -23,7 +23,7 @@ module BushSlicer
       rr.dig('spec', 'clusterServiceClassRef')
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending on
+    # @return [VerificationTests::ResultHash] with :success depending on
     #   condition type=Ready and status=True
     def ready?(user:, quiet: false, cached: false)
       if cached && props[:raw]

--- a/lib/openshift/stateful_set.rb
+++ b/lib/openshift/stateful_set.rb
@@ -1,6 +1,6 @@
 require 'openshift/project_resource'
 
-module BushSlicer
+module VerificationTests
   # represnets an Openshift StatefulSets
   class StatefulSet < PodReplicator
     RESOURCE = "statefulsets"

--- a/lib/openshift/storage_class.rb
+++ b/lib/openshift/storage_class.rb
@@ -1,6 +1,6 @@
 require 'openshift/cluster_resource'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment Storage Class
   class StorageClass < ClusterResource
     RESOURCE = "storageclasses"

--- a/lib/openshift/system_group.rb
+++ b/lib/openshift/system_group.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment SystemGroup (undocumented seems)
   class SystemGroup
     attr_reader :name, :env

--- a/lib/openshift/system_user.rb
+++ b/lib/openshift/system_user.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment SystemUser (undocumented it seems)
   class SystemUser
     attr_reader :name, :env

--- a/lib/openshift/template.rb
+++ b/lib/openshift/template.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class Template < ProjectResource
     RESOURCE = "templates"
   end

--- a/lib/openshift/user.rb
+++ b/lib/openshift/user.rb
@@ -4,17 +4,17 @@ require 'login'
 require 'subscription_plan'
 require_relative 'project'
 
-module BushSlicer
+module VerificationTests
   # @note represents an OpenShift environment user account
   class User < ClusterResource
-    include BushSlicer::APIAccessorOwner
+    include VerificationTests::APIAccessorOwner
 
     attr_accessor :auth_name, :password
 
     RESOURCE = "users"
 
     # @param token [String] auth bearer token in plain string format
-    # @param env [BushSlicer::Environment] the test environment user belongs to
+    # @param env [VerificationTests::Environment] the test environment user belongs to
     # @return [User]
     def self.from_token(token, env:)
       api_accessor = APIAccessor.new(
@@ -29,7 +29,7 @@ module BushSlicer
       return user
     end
 
-    # @param env [BushSlicer::Environment] the test environment user belongs to
+    # @param env [VerificationTests::Environment] the test environment user belongs to
     # @param name [String] optional username as returned by `get user '~'
     # @param auth_name [String] the name used to auth to OpenShift
     # @param password [String] password

--- a/lib/openshift/volume_snapshot.rb
+++ b/lib/openshift/volume_snapshot.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class VolumeSnapshot < ProjectResource
     RESOURCE = "volumesnapshots"
 
@@ -7,7 +7,7 @@ module BushSlicer
       rr.dig('spec', 'snapshotDataName')
     end
 
-    # @return [BushSlicer::ResultHash] with :success depending on
+    # @return [VerificationTests::ResultHash] with :success depending on
     #   condition type=Ready and status=True
     def ready?(user:, quiet: false, cached: false)
       if cached && props[:raw]

--- a/lib/openshift/volume_snapshot_data.rb
+++ b/lib/openshift/volume_snapshot_data.rb
@@ -1,8 +1,8 @@
-module BushSlicer
+module VerificationTests
   class VolumeSnapshotData < ClusterResource
     RESOURCE = "volumesnapshotdata"
 
-    # @return [BushSlicer::ResultHash] with :success depending on
+    # @return [VerificationTests::ResultHash] with :success depending on
     #   condition type=Ready and status=True
     def ready?(user:, quiet: false, cached: false)
       if cached && props[:raw]

--- a/lib/ownthat.rb
+++ b/lib/ownthat.rb
@@ -4,7 +4,7 @@ require 'common'
 require 'collections'
 require 'http'
 
-module BushSlicer
+module VerificationTests
   # let you operate a git repo
   class OwnThat
     include Common::Helper

--- a/lib/platform/aggregation_service.rb
+++ b/lib/platform/aggregation_service.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     class AggregationService
       attr_reader :services
@@ -10,19 +10,19 @@ module BushSlicer
       end
 
       def start(**opts)
-        BushSlicer::ResultHash.aggregate_results(services.map(&:start))
+        VerificationTests::ResultHash.aggregate_results(services.map(&:start))
       end
 
       def stop(**opts)
-        BushSlicer::ResultHash.aggregate_results(services.reverse_each.map(&:stop))
+        VerificationTests::ResultHash.aggregate_results(services.reverse_each.map(&:stop))
       end
 
       def restart(**opts)
-        BushSlicer::ResultHash.aggregate_results services.map { |s|
+        VerificationTests::ResultHash.aggregate_results services.map { |s|
           if s.respond_to? :restart
             s.restart
           else
-            BushSlicer::ResultHash.aggregate_results([s.stop, s.start])
+            VerificationTests::ResultHash.aggregate_results([s.stop, s.start])
           end
         }
       end

--- a/lib/platform/autoload.rb
+++ b/lib/platform/autoload.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     autoload :OpenShiftService, "platform/openshift_service"
     autoload :MasterService, "platform/master_service"

--- a/lib/platform/master_config.rb
+++ b/lib/platform/master_config.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     class MasterConfig
       def self.for(service)

--- a/lib/platform/master_scripted_static_pod_service.rb
+++ b/lib/platform/master_scripted_static_pod_service.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     class MasterScriptedStaticPodService < MasterService
       attr_reader :env

--- a/lib/platform/master_service.rb
+++ b/lib/platform/master_service.rb
@@ -1,6 +1,6 @@
 require 'http'
 
-module BushSlicer
+module VerificationTests
   module Platform
     # @note this class represents an OpenShift master server that is running
     #   Kubernetes Services like API and Controller
@@ -14,7 +14,7 @@ module BushSlicer
       end
 
       def config
-        @config ||= BushSlicer::Platform::MasterConfig.for(self)
+        @config ||= VerificationTests::Platform::MasterConfig.for(self)
       end
 
       private def expected_load_time
@@ -45,14 +45,14 @@ module BushSlicer
       end
 
       def start(**opts)
-        BushSlicer::ResultHash.aggregate_results([super, wait_start(**opts)])
+        VerificationTests::ResultHash.aggregate_results([super, wait_start(**opts)])
       end
 
       def restart(**opts)
         res = super
         # no better idea than hardcoding time needed for node to react on master restart command
         sleep 10
-        BushSlicer::ResultHash.aggregate_results([res, wait_start(**opts)])
+        VerificationTests::ResultHash.aggregate_results([res, wait_start(**opts)])
       end
     end
   end

--- a/lib/platform/master_systemd_service.rb
+++ b/lib/platform/master_systemd_service.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     class MasterSystemdService < MasterService
       attr_reader :env

--- a/lib/platform/node_config.rb
+++ b/lib/platform/node_config.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-module BushSlicer
+module VerificationTests
   module Platform
     # class to help operation over node-config.yaml file on the OpenShift nodes
     class NodeConfig

--- a/lib/platform/node_config_map_sync_config.rb
+++ b/lib/platform/node_config_map_sync_config.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     # handles the fact node config is synced with a config map in 3.10
     class NodeConfigMapSyncConfig

--- a/lib/platform/node_service.rb
+++ b/lib/platform/node_service.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     class NodeService < OpenShiftService
 
@@ -12,7 +12,7 @@ module BushSlicer
       end
 
       def config
-        @config ||= BushSlicer::Platform::NodeConfig.for(self)
+        @config ||= VerificationTests::Platform::NodeConfig.for(self)
       end
     end
   end

--- a/lib/platform/openshift_service.rb
+++ b/lib/platform/openshift_service.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     class OpenShiftService
       attr_reader :service, :host, :env

--- a/lib/platform/restorable_file.rb
+++ b/lib/platform/restorable_file.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     # a file with backup on modification so it can be restored later
     class RestorableFile

--- a/lib/platform/script_service.rb
+++ b/lib/platform/script_service.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     # service controlled by custom scripting
     class ScriptService
@@ -54,7 +54,7 @@ module BushSlicer
         if restart_script
           exec_script(:restart, restart_script, **opts)
         else
-          BushSlicer::ResultHash.aggregate_results [
+          VerificationTests::ResultHash.aggregate_results [
             stop(**opts),
             start(**opts)
           ]

--- a/lib/platform/simple_service_yaml_config.rb
+++ b/lib/platform/simple_service_yaml_config.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-module BushSlicer
+module VerificationTests
   module Platform
     # class to help operations over master-config.yaml file on the masters
     class SimpleServiceYAMLConfig

--- a/lib/platform/systemd_service.rb
+++ b/lib/platform/systemd_service.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module Platform
     # Class which represents a generic openshift service running on a host
     class SystemdService
@@ -76,7 +76,7 @@ module BushSlicer
           if opts[:raise]
             raise "could not stop service #{name} on #{host.hostname}"
           end
-          return BushSlicer::ResultHash.aggregate_results(results)
+          return VerificationTests::ResultHash.aggregate_results(results)
         end
 
         sleep 5 # lets guess some hardcoded sleep after stop for the time being
@@ -97,7 +97,7 @@ module BushSlicer
           end
         end
 
-        return BushSlicer::ResultHash.aggregate_results(results)
+        return VerificationTests::ResultHash.aggregate_results(results)
       end
 
       # Will restart the service.
@@ -114,7 +114,7 @@ module BushSlicer
           if opts[:raise]
             raise "could not restart service #{name} on #{host.hostname}"
           end
-          return BushSlicer::ResultHash.aggregate_results(results)
+          return VerificationTests::ResultHash.aggregate_results(results)
         end
 
         ## this below seems to not make much sense
@@ -129,7 +129,7 @@ module BushSlicer
         #  # the `:raise` option is not respected here because unless service
         #  #   reach some stable status, we can't say for sure whether
         #  #   restart failed or not (it could be just too slow)
-        #  raise BushSlicer::TimeoutError,
+        #  raise VerificationTests::TimeoutError,
         #    "service #{service} on #{host.hostname} never reached " \
         #    "a stable status:\n#{result[:response]}"
         #end
@@ -153,13 +153,13 @@ module BushSlicer
         #  err_msg = "service #{service} on #{host.hostname} could not be" \
         #    "activated:\n#{result[:response]}"
         #  if opts[:raise]
-        #    raise BushSlicer::TimeoutError, err_msg
+        #    raise VerificationTests::TimeoutError, err_msg
         #  else
         #    logger.warn err_msg
         #  end
         #end
 
-        return BushSlicer::ResultHash.aggregate_results(results)
+        return VerificationTests::ResultHash.aggregate_results(results)
       end
 
       # Will restart the service.
@@ -186,7 +186,7 @@ module BushSlicer
           if opts[:raise]
             raise "could not start service #{name} on #{host.hostname}"
           end
-          return BushSlicer::ResultHash.aggregate_results(results)
+          return VerificationTests::ResultHash.aggregate_results(results)
         end
 
         sleep expected_load_time
@@ -203,7 +203,7 @@ module BushSlicer
           end
         end
 
-        return BushSlicer::ResultHash.aggregate_results(results)
+        return VerificationTests::ResultHash.aggregate_results(results)
       end
     end
   end

--- a/lib/platform/yaml_restorable_file.rb
+++ b/lib/platform/yaml_restorable_file.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-module BushSlicer
+module VerificationTests
   module Platform
     class YAMLRestorableFile < RestorableFile
       def as_hash
@@ -16,7 +16,7 @@ module BushSlicer
         else
           raise ArgumentError, "unknown merge yaml merge data #{yaml.inspect}"
         end
-        update(BushSlicer::Collections.deep_merge(as_hash, yaml).to_yaml)
+        update(VerificationTests::Collections.deep_merge(as_hash, yaml).to_yaml)
       end
     end
   end

--- a/lib/polarshift/autoload.rb
+++ b/lib/polarshift/autoload.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   module PolarShift
     autoload :Request, "polarshift/request"
     autoload :TestSuite, "polarshift/test_suite"

--- a/lib/polarshift/request.rb
+++ b/lib/polarshift/request.rb
@@ -2,7 +2,7 @@
 
 require 'http'
 
-module BushSlicer
+module VerificationTests
   module PolarShift
     class Request
       include Common::Helper

--- a/lib/polarshift/scenario_wrapper.rb
+++ b/lib/polarshift/scenario_wrapper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module BushSlicer
+module VerificationTests
   module PolarShift
     # wrapper for Cucumber scenarios
     class ScenarioWrapper

--- a/lib/polarshift/test_case.rb
+++ b/lib/polarshift/test_case.rb
@@ -2,7 +2,7 @@
 
 require_relative 'scenario_wrapper'
 
-module BushSlicer
+module VerificationTests
   module PolarShift
     class TestCase
       attr_reader :request, :scenarios, :struct

--- a/lib/polarshift/test_record.rb
+++ b/lib/polarshift/test_record.rb
@@ -3,7 +3,7 @@
 require 'time'
 require_relative 'test_case'
 
-module BushSlicer
+module VerificationTests
   module PolarShift
     class TestRecord
       attr_reader :test_run, :struct

--- a/lib/polarshift/test_run.rb
+++ b/lib/polarshift/test_run.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module BushSlicer
+module VerificationTests
   module PolarShift
     class TestRun
       attr_reader :request, :struct

--- a/lib/polarshift/test_suite.rb
+++ b/lib/polarshift/test_suite.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module BushSlicer
+module VerificationTests
   module PolarShift
     class TestSuite
       attr_reader :opts, :request, :test_run

--- a/lib/promethues_metrics_data.rb
+++ b/lib/promethues_metrics_data.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class PrometheusMetricsData
 
     def initialize(metrics)

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -3,14 +3,14 @@ require "openshift/cluster_resource"
 require "openshift/project_resource"
 require "openshift/pod_replicator"
 
-module BushSlicer
+module VerificationTests
   RESOURCES = {}
 
   Dir["#{File.dirname(__FILE__)}/openshift/*.rb"].each_entry do |file|
     snake_case_class = File.basename(file, ".rb").freeze
     require "openshift/#{snake_case_class}"
     camel_case_class = Common::BaseHelperStatic.snake_to_camel_case(snake_case_class).freeze
-    clazz = Object.const_get("::BushSlicer::#{camel_case_class}")
+    clazz = Object.const_get("::VerificationTests::#{camel_case_class}")
     if defined? clazz::RESOURCE
       RESOURCES[clazz] = snake_case_class.to_sym
     end

--- a/lib/rest.rb
+++ b/lib/rest.rb
@@ -2,7 +2,7 @@ require 'common'
 require 'rest_openshift'
 require 'rest_kubernetes'
 
-module BushSlicer
+module VerificationTests
   module Rest
     class RequestExecutor
       extend Common::Helper
@@ -86,7 +86,7 @@ module BushSlicer
       # @param [Hash] base_opts the base HTTP options relevant to server,
       #   authentication, and other things common between requests; these opts
       #   represent options in the format accepted but the
-      #   [BushSlicer::Http#http_request] method; but should not contain :params
+      #   [VerificationTests::Http#http_request] method; but should not contain :params
       #   and :payload
       # @param [Hash] req_opts the request options as understood by the
       #   specific `req` method to enrich base_opts for the actual API call

--- a/lib/rest_helper.rb
+++ b/lib/rest_helper.rb
@@ -2,7 +2,7 @@ require 'http'
 require 'json'
 require 'yaml'
 
-module BushSlicer
+module VerificationTests
   module Rest
     module Helper
       include Common::Helper

--- a/lib/rest_kubernetes.rb
+++ b/lib/rest_kubernetes.rb
@@ -1,6 +1,6 @@
 require 'rest_helper'
 
-module BushSlicer
+module VerificationTests
   module Rest
     module Kubernetes
       extend Helper

--- a/lib/rest_openshift.rb
+++ b/lib/rest_openshift.rb
@@ -1,6 +1,6 @@
 require 'rest_helper'
 
-module BushSlicer
+module VerificationTests
   module Rest
     module OpenShift
       extend Helper

--- a/lib/result_hash.rb
+++ b/lib/result_hash.rb
@@ -1,5 +1,5 @@
 
-module BushSlicer
+module VerificationTests
   # just a placeholder to define what a result hash means
   #   A ResultHash should contain at least the following keys:
   #   * :success       # true/false value showing if operation succeeded

--- a/lib/rules_command_executor.rb
+++ b/lib/rules_command_executor.rb
@@ -4,14 +4,14 @@ require 'find'
 require 'collections'
 require 'rules_common.rb'
 
-module BushSlicer
+module VerificationTests
   class RulesCommandExecutor
-    # include BushSlicer::Common::Helper
+    # include VerificationTests::Common::Helper
 
     attr_reader :host
 
     # @param [Object] rules might be parsed rules, file, directory or array of any of these. All rules are merged and error is raised on duplicate rules. If directory string ends with slash `/` character, then it is loaded recursively.
-    # @param [BushSlicer::Host] host host to execute the commands on
+    # @param [VerificationTests::Host] host host to execute the commands on
     # @param [String] user host os user to execute command as (e.g. sudo)
     def initialize(host:, user: nil, rules:)
       @host = host
@@ -44,7 +44,7 @@ module BushSlicer
     #   `:unexpected` is strings in the output showing command failure
     #   `:properties` are parsed proparties from the command output returned
     #   `:optional_properties` same as above but will not cause fail if missing
-    # @return [BushSlicer::ResultHash] result hash
+    # @return [VerificationTests::ResultHash] result hash
     # @see #build_command_line
     # @see #build_expectations
     # @see #process_result

--- a/lib/rules_common.rb
+++ b/lib/rules_common.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-module BushSlicer
+module VerificationTests
   module Common
     module Rules
       def self.load(*sources)

--- a/lib/ssh.rb
+++ b/lib/ssh.rb
@@ -3,7 +3,7 @@ require 'net/ssh'
 require 'net/scp'
 require 'fileutils'
 
-module BushSlicer
+module VerificationTests
   module SSH
     module Helper
       # generate a key pair mainly useful for SSH but can be generic
@@ -12,7 +12,7 @@ module BushSlicer
         key = OpenSSL::PKey::RSA.generate(len)
         key.singleton_class.class_eval do
           def to_pub_key_string
-            ::BushSlicer::SSH::Helper.to_pub_key_string(self)
+            ::VerificationTests::SSH::Helper.to_pub_key_string(self)
           end
         end
 
@@ -114,7 +114,7 @@ module BushSlicer
           result { |r| r.has_key? :success }
         }
         unless result.has_key? :success
-          raise BushSlicer::TimeoutError, "timeout waiting for command to start exution"
+          raise VerificationTests::TimeoutError, "timeout waiting for command to start exution"
         end
       end
 
@@ -167,7 +167,7 @@ module BushSlicer
             else
               logger.error("ssh channel timeout @#{host}: #{command}")
             end
-            result[:error] = BushSlicer::TimeoutError.new("ssh channel timeout @#{host}: #{command}")
+            result[:error] = VerificationTests::TimeoutError.new("ssh channel timeout @#{host}: #{command}")
           end
         end
         unless opts[:quiet]
@@ -190,7 +190,7 @@ module BushSlicer
       def inspect
         cmd = result[:command]
         cmd = "#{cmd[0..25]}.." if cmd.size > 25
-        "#<BushSlicer::SSH::Command #{user}@#{host} #{cmd.inspect}>"
+        "#<VerificationTests::SSH::Command #{user}@#{host} #{cmd.inspect}>"
       end
     end
 

--- a/lib/ssl.rb
+++ b/lib/ssl.rb
@@ -2,7 +2,7 @@ require 'socket'
 require 'openssl'
 require 'base64'
 
-module BushSlicer
+module VerificationTests
   module SSL
     # @param dst [String] the hostname or IP of SSL server
     # @param port [String, Integer] the port number to connect

--- a/lib/subscription_plan.rb
+++ b/lib/subscription_plan.rb
@@ -1,4 +1,4 @@
-module BushSlicer
+module VerificationTests
   class SubscriptionPlan
     attr_reader :id
 

--- a/lib/tcms/tcms.rb
+++ b/lib/tcms/tcms.rb
@@ -15,7 +15,7 @@ require 'timeout' # to avoid freezes waiting for user input
 
 require 'common'
 
-module BushSlicer
+module VerificationTests
   class TCMS
     include Common::Helper
 
@@ -42,7 +42,7 @@ module BushSlicer
     #mapping tags=>Integer
     @@tags = {}
     def initialize(options={})
-      raise "No default options detected, please makse sure the PRIVATE_REPO is cloned into your repo or ENV BUSHSLICER_PRIVATE_DIR is defined" if default_opts.nil?
+      raise "No default options detected, please makse sure the PRIVATE_REPO is cloned into your repo or ENV VERIFICATION_TESTS_PRIVATE_DIR is defined" if default_opts.nil?
       @options = default_opts.merge options
 
       ## try to obtain user/password in all possible ways

--- a/lib/tcms/tcms_case_set.rb
+++ b/lib/tcms/tcms_case_set.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-module BushSlicer
+module VerificationTests
   class TCMSCaseSet
     @cases = []
 

--- a/lib/tcms/tcms_manager.rb
+++ b/lib/tcms/tcms_manager.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'common'
 require_relative 'tcms'
 
-module BushSlicer
+module VerificationTests
   # this is our TCMS test case manager
   # tried to make it quick and dirty but it became only dirty
   class TCMSManager
@@ -33,7 +33,7 @@ module BushSlicer
 
     ############ test case manager interface methods ############
 
-    # act according to signal from BushSlicer
+    # act according to signal from VerificationTests
     #   job == TCMS test case == some set of Cucumber scenarios/test cases
     #   test case == Cucumber scenario
     # @note see [TCMSTestCaseRun#overall_status=] for how status works
@@ -225,7 +225,7 @@ module BushSlicer
         ## move artifacts to a separate dir
         dir = formatter.process_scenario_log(after_failed: after_failed?,
                                              before_failed: before_failed?)
-        #target_dir = Dir.mktmpdir("bushslicer_artifacts_")
+        #target_dir = Dir.mktmpdir("verification-tests_artifacts_")
         #FileUtils.mv dir, target_dir
 
         ## add attach_queue workitem
@@ -235,11 +235,11 @@ module BushSlicer
       end
     end
 
-    # @return [BushSlicer::Host] of the server storing logs and artifacts
+    # @return [VerificationTests::Host] of the server storing logs and artifacts
     def artifacts_filer
       @artifacts_filer if @artifacts_filer
 
-      @artifacts_filer = BushSlicer.
+      @artifacts_filer = VerificationTests.
         const_get(conf[:services, :artifacts_file_server, :host_type]).
         new(
           conf[:services, :artifacts_file_server, :hostname],

--- a/lib/test_case_manager.rb
+++ b/lib/test_case_manager.rb
@@ -5,7 +5,7 @@ require 'find'
 
 require 'common'
 
-module BushSlicer
+module VerificationTests
   # generic test case manager that delegates to specific test case management
   #   system test suite class
   class TestCaseManager
@@ -18,7 +18,7 @@ module BushSlicer
     def initialize(**opts)
       @opts = opts
 
-      @test_suite = BushSlicer.const_get(opts[:test_suite_class]).
+      @test_suite = VerificationTests.const_get(opts[:test_suite_class]).
                                             new(opts[:test_suite_opts])
 
       @attach_queue = Queue.new
@@ -31,7 +31,7 @@ module BushSlicer
 
     ############ test case manager interface methods ############
 
-    # act according to signal from BushSlicer
+    # act according to signal from VerificationTests
     #   job == TCMS test case == some set of Cucumber scenarios/test cases
     #   test case == Cucumber scenario
     # @note see [TCMSTestCaseRun#overall_status=] for how status works
@@ -207,11 +207,11 @@ module BushSlicer
       return urls
     end
 
-    # @return [BushSlicer::Host] of the server storing logs and artifacts
+    # @return [VerificationTests::Host] of the server storing logs and artifacts
     def artifacts_filer
       @artifacts_filer if @artifacts_filer
 
-      @artifacts_filer = BushSlicer.
+      @artifacts_filer = VerificationTests.
         const_get(conf[:services, :artifacts_file_server, :host_type]).
         new(
           conf[:services, :artifacts_file_server, :hostname],

--- a/lib/test_case_manager_filter.rb
+++ b/lib/test_case_manager_filter.rb
@@ -1,6 +1,6 @@
 require 'cucumber/core/filter'
 
-module BushSlicer
+module VerificationTests
   # this class lives throughout the whole test execution
   #  it passes filter events to the Test Case Manager
   #  IMPORTANT: needs to run as last filter in the chain because test case

--- a/lib/user_manager.rb
+++ b/lib/user_manager.rb
@@ -4,7 +4,7 @@ require 'api_accessor'
 require 'common'
 require 'openshift/user'
 
-module BushSlicer
+module VerificationTests
   class UserManager
     include Common::Helper
     attr_reader :env, :opts

--- a/lib/verification-tests.rb
+++ b/lib/verification-tests.rb
@@ -6,7 +6,7 @@ require 'socket'
 require_relative 'error'
 
 # @note put only very base things here, do not use for configuration settings
-module BushSlicer
+module VerificationTests
   # autoload to avoid too much require statements and speed-up load times
   autoload :Dynect, 'launchers/dyn/dynect'
   autoload :Alicloud, 'launchers/alicloud'
@@ -29,7 +29,7 @@ module BushSlicer
   autoload :DockerImage, "openshift/flakes/docker_image"
 
   HOME = File.expand_path(__FILE__ + "/../..")
-  PRIVATE_DIR = ENV['BUSHSLICER_PRIVATE_DIR'] || File.expand_path(HOME + "/private")
+  PRIVATE_DIR = ENV['VERIFICATION_TESTS_PRIVATE_DIR'] || File.expand_path(HOME + "/private")
   HOSTNAME = Socket.gethostname.freeze
   LOCAL_USER = Etc.getlogin.freeze
 

--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -783,7 +783,7 @@ require "base64"
       end
     end
 
-    # parse BushSlicer webauto single rules file; that is a YAML file with the
+    # parse VerificationTests webauto single rules file; that is a YAML file with the
     #   only difference that duplicate keys on the second level are allowed;
     #   i.e. we can specify multiple `url`, `elements`, `action`, etc. child
     #   elements inside action rules

--- a/lib/webauto/webconsole_executor.rb
+++ b/lib/webauto/webconsole_executor.rb
@@ -6,7 +6,7 @@ require 'common'
 require 'rules_common'
 require_relative 'web4cucumber'
 
-module BushSlicer
+module VerificationTests
   class WebConsoleExecutor
     include Common::Helper
 

--- a/lib/world.rb
+++ b/lib/world.rb
@@ -2,7 +2,7 @@ require 'ostruct'
 require 'common'
 require 'collections'
 
-module BushSlicer
+module VerificationTests
   # @note this is our default cucumber World extension implementation
   class DefaultWorld
     include CollectionsIncl
@@ -35,7 +35,7 @@ module BushSlicer
     end
 
     def setup_logger
-      BushSlicer::Logger.runtime = @__cucumber_runtime
+      VerificationTests::Logger.runtime = @__cucumber_runtime
     end
 
     def debug_in_after_hook?
@@ -92,7 +92,7 @@ module BushSlicer
     def env(key=nil)
       return @env if key.nil? && @env
       key ||= conf[:default_environment]
-      raise "please specify default environment key in config or BUSHSLICER_DEFAULT_ENVIRONMENT env variable" unless key
+      raise "please specify default environment key in config or VERIFICATION_TESTS_DEFAULT_ENVIRONMENT env variable" unless key
       return @env = manager.environments[key]
     end
 
@@ -151,7 +151,7 @@ module BushSlicer
     # @return project from cached projects for this scenario
     #   note that you need to have default `#env` set already;
     #   if no name is spefified, returns the last requested project;
-    #   otherwise a BushSlicer::Project object is created (but not created in
+    #   otherwise a VerificationTests::Project object is created (but not created in
     #   the actual OpenShift environment)
     # @note we use a custom getter instead of auto-generated resource getters
     #   to allow generating project names; maybe that can be refactored some day
@@ -275,7 +275,7 @@ module BushSlicer
           cache << cache.delete(r)
           return r
         else
-          # create new BushSlicer::ProjectResource object with specified name
+          # create new VerificationTests::ProjectResource object with specified name
           cache << clazz.new(name: name, project: project)
           cache.last.default_user = user
           return cache.last
@@ -312,7 +312,7 @@ module BushSlicer
           var << var.delete(r) if switch
           return r
         else
-          # create new BushSlicer::ClusterResource object with specified name
+          # create new VerificationTests::ClusterResource object with specified name
           var << clazz.new(name: name, env: env)
           return var.last
         end
@@ -350,7 +350,7 @@ module BushSlicer
       end
     end
 
-    # convert from resource cli string to BushSlicer class
+    # convert from resource cli string to VerificationTests class
     def resource_class(cli_string)
       unless @shorthands
         @shorthands = {
@@ -374,7 +374,7 @@ module BushSlicer
 
       type = @shorthands[cli_string.to_sym] || cli_string
 
-      # classes = ObjectSpace.each_object(BushSlicer::Resource.singleton_class)
+      # classes = ObjectSpace.each_object(VerificationTests::Resource.singleton_class)
       # clazz = classes.find do |c|
       clazz = RESOURCES.keys.find do |c|
         defined?(c::RESOURCE) && [type, type + "s", type+"es"].include?(c::RESOURCE)

--- a/tools/case_id_splitter.rb
+++ b/tools/case_id_splitter.rb
@@ -13,7 +13,7 @@ require_relative 'common/load_path'
 require 'common'
 require "gherkin_parse"
 
-module BushSlicer
+module VerificationTests
   class CaseIDSplitter
     include Commander::Methods
     include Common::Helper
@@ -144,5 +144,5 @@ module BushSlicer
 end
 
 if __FILE__ == $0
-  BushSlicer::CaseIDSplitter.new.run
+  VerificationTests::CaseIDSplitter.new.run
 end

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -76,9 +76,9 @@ function need_sudo()
 # Setup sudo configuration
 function setup_sudo()
 {
-    $(need_sudo) grep BUSHSLICER_SETUP /etc/sudoers && return
+    $(need_sudo) grep VERIFICATION_TESTS_SETUP /etc/sudoers && return
     $(need_sudo) cat > /etc/sudoers <<END
-# BUSHSLICER_SETUP #
+# VERIFICATION_TESTS_SETUP #
 Defaults    env_reset
 Defaults    env_keep =  "COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR LS_COLORS"
 Defaults    env_keep += "MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE"
@@ -90,7 +90,7 @@ Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/u
 
 root    ALL=(ALL)       ALL
 %wheel  ALL=NOPASSWD: ALL
-# BUSHSLICER_SETUP #
+# VERIFICATION_TESTS_SETUP #
 END
 }
 

--- a/tools/dyn.rb
+++ b/tools/dyn.rb
@@ -10,7 +10,7 @@ require 'commander'
 require 'common'
 require 'launchers/dyn/dynect'
 
-module BushSlicer
+module VerificationTests
   class DynManager
     include Commander::Methods
     include Common::Helper
@@ -95,5 +95,5 @@ module BushSlicer
 end
 
 if __FILE__ == $0
-  BushSlicer::DynManager.new.run
+  VerificationTests::DynManager.new.run
 end

--- a/tools/jenkins/slaves/Dockerfile.centos
+++ b/tools/jenkins/slaves/Dockerfile.centos
@@ -1,13 +1,13 @@
-# The standard name for this image is aosqe/bushslicer-base
+# The standard name for this image is aosqe/verification-tests-base
 
 FROM openshift/jenkins-slave-base-centos7
 
 LABEL vendor="Red Hat inc."
 LABEL maintainer="AOS QE Team"
 
-ADD . $HOME/bushslicer
-RUN [ -d $HOME/bushslicer/private/config/ca ] && \
-    ( cd $HOME/bushslicer/private/config/ca && \
+ADD . $HOME/verification-tests
+RUN [ -d $HOME/verification-tests/private/config/ca ] && \
+    ( cd $HOME/verification-tests/private/config/ca && \
     cp -v *.pem /etc/pki/ca-trust/source/anchors/ && \
     update-ca-trust extract || \
     exit 1 ) || :
@@ -30,8 +30,8 @@ RUN set -x && \
     yum install -y /tmp/epel-release-latest-7.noarch.rpm && \
     mkdir -p $HOME/bin
 
-RUN scl enable rh-ror50 "$HOME/bushslicer/tools/install_os_deps.sh"
-RUN scl enable rh-ror50 $HOME/bushslicer/tools/hack_bundle.rb
+RUN scl enable rh-ror50 "$HOME/verification-tests/tools/install_os_deps.sh"
+RUN scl enable rh-ror50 $HOME/verification-tests/tools/hack_bundle.rb
 
 # -k is a bad option, put certificated under private/config/ca instead
 # be mindful image will be visible if image is made public which is a mild
@@ -40,7 +40,7 @@ RUN scl enable rh-ror50 $HOME/bushslicer/tools/hack_bundle.rb
 
 RUN rpm -qa && \
     yum clean all -y && \
-    rm -rf /var/cache/yum /tmp/* "$HOME"/bushslicer/private* "$HOME"/bushslicer/tierN
+    rm -rf /var/cache/yum /tmp/* "$HOME"/verification-tests/private* "$HOME"/verification-tests/tierN
 
 RUN dbus-uuidgen > /etc/machine-id # e.g. needed for firefox
 RUN chown -R 1001:0 $HOME && chmod -R g+rw $HOME /etc/machine-id
@@ -54,8 +54,8 @@ RUN echo -e '#!/bin/bash\nexec "$@"' > /usr/local/bin/sudo && chmod 755 /usr/loc
 
 USER 1001
 
-# Start in the bushslicer top level directory to run containerized bushslicer tests
-WORKDIR $HOME/bushslicer
+# Start in the verification-tests top level directory to run containerized verification-tests tests
+WORKDIR $HOME/verification-tests
 
 # we need ruby and some gems from ror
 ENTRYPOINT ["/usr/bin/scl", "enable", "rh-git29", "rh-ror50", "--", "/usr/local/bin/run-jnlp-client"]

--- a/tools/jenkins/slaves/Dockerfile.rhel7
+++ b/tools/jenkins/slaves/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-# The standard name for this image is aosqe/bushslicer-base
+# The standard name for this image is aosqe/verification-tests-base
 
 FROM openshift3/jenkins-slave-base-rhel7
 
@@ -30,10 +30,10 @@ RUN set -x && \
     mkdir -p $HOME/bin
 
 # make sure context dir is at the repo root
-ADD . $HOME/bushslicer
-# RUN scl enable rh-git29 "git clone --depth 1 --single-branch 'https://github.com/openshift/verification-tests.git' '$HOME/bushslicer'"
-RUN scl enable rh-ror50 "$HOME/bushslicer/tools/install_os_deps.sh"
-RUN scl enable rh-ror50 "$HOME/bushslicer/tools/hack_bundle.rb"
+ADD . $HOME/verification-tests
+# RUN scl enable rh-git29 "git clone --depth 1 --single-branch 'https://github.com/openshift/verification-tests.git' '$HOME/verification-tests'"
+RUN scl enable rh-ror50 "$HOME/verification-tests/tools/install_os_deps.sh"
+RUN scl enable rh-ror50 "$HOME/verification-tests/tools/hack_bundle.rb"
 
 # -k is a bad option, put certificated under private/config/ca instead
 # be mindful image will be visible if image is made public which is a mild
@@ -42,7 +42,7 @@ RUN scl enable rh-ror50 "$HOME/bushslicer/tools/hack_bundle.rb"
 
 RUN rpm -qa && \
     yum clean all -y && \
-    rm -rf $HOME/bushslicer /var/cache/yum /tmp/*
+    rm -rf $HOME/verification-tests /var/cache/yum /tmp/*
 
 RUN dbus-uuidgen > /etc/machine-id # e.g. needed for firefox
 RUN chown -R 1001:0 $HOME && chmod -R g+rw $HOME /etc/machine-id

--- a/tools/jenkins/slaves/README.adoc
+++ b/tools/jenkins/slaves/README.adoc
@@ -12,7 +12,7 @@
 # $HOME/go/bin/imagebuilder .
 # where the '.' folder contains a Dockerfile.
 #
-# To use this particular Dockerfile, copy this to the top-level bushslicer dir,
+# To use this particular Dockerfile, copy this to the top-level verification-tests dir,
 # change the name to remove the .centos/.rhel7 extension, and run imagebuilder.
 #
 # At this point, the image can be tagged and pushed to an internal repository

--- a/tools/openshift-ci/Dockerfile.centos
+++ b/tools/openshift-ci/Dockerfile.centos
@@ -1,4 +1,4 @@
-# The standard name for this image is aosqe/bushslicer-base
+# The standard name for this image is aosqe/verification-tests-base
 
 FROM centos
 
@@ -7,7 +7,7 @@ LABEL maintainer="AOS QE Team"
 
 USER root
 
-ADD . /bushslicer/
+ADD . /verification-tests/
 
 RUN set -x && \
     SCL_BASE_PKGS="centos-release-scl scl-utils-build" && \
@@ -22,10 +22,10 @@ RUN set -x && \
     curl -sSL https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -o /tmp/epel-release-latest-7.noarch.rpm && \
     yum install -y /tmp/epel-release-latest-7.noarch.rpm
 
-RUN scl enable rh-ror50 /bushslicer/tools/install_os_deps.sh
-RUN scl enable rh-ror50 /bushslicer/tools/hack_bundle.rb
+RUN scl enable rh-ror50 /verification-tests/tools/install_os_deps.sh
+RUN scl enable rh-ror50 /verification-tests/tools/hack_bundle.rb
 
 RUN yum install -y http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/origin-clients-3.10.0-1.el7.git.0.0c4577e.x86_64.rpm
 
 RUN yum clean all -y && \
-    rm -rf /bushslicer /var/cache/yum /tmp/*
+    rm -rf /verification-tests /var/cache/yum /tmp/*

--- a/tools/polarshift.rb
+++ b/tools/polarshift.rb
@@ -15,7 +15,7 @@ require "gherkin_parse"
 
 require_relative "stompbus/stompbus"
 
-module BushSlicer
+module VerificationTests
   class PolarShiftCli
     include Commander::Methods
     include Common::Helper
@@ -215,7 +215,7 @@ module BushSlicer
 
     def print_fileno(locations)
       puts "To execute listed test cases on command line, use this filter:"
-      home = Pathname.new(::BushSlicer::HOME)
+      home = Pathname.new(::VerificationTests::HOME)
       puts HighLine.color(
         locations.
           map(&:last).
@@ -329,5 +329,5 @@ module BushSlicer
 end
 
 if __FILE__ == $0
-  BushSlicer::PolarShiftCli.new.run
+  VerificationTests::PolarShiftCli.new.run
 end

--- a/tools/stompbus/stompbus.rb
+++ b/tools/stompbus/stompbus.rb
@@ -10,7 +10,7 @@ require_relative "../common/load_path"
 require 'common'
 
 class STOMPBus
-  include BushSlicer::Common::Helper
+  include VerificationTests::Common::Helper
 
   LOGIN_OPTS = [[:login, :passcode], [:cert_file, :key_file]].freeze
   REQUIRED_HOST_OPTS = [:host, :port].freeze

--- a/tools/stompbus/stompbuscli.rb
+++ b/tools/stompbus/stompbuscli.rb
@@ -12,7 +12,7 @@ require_relative "stompbus"
 # require 'common'
 
 
-module BushSlicer
+module VerificationTests
   class STOMPBusCli
     include Commander::Methods
     # include Common::Helper
@@ -144,5 +144,5 @@ module BushSlicer
 end
 
 if __FILE__ == $0
-  BushSlicer::STOMPBusCli.new.run
+  VerificationTests::STOMPBusCli.new.run
 end

--- a/tools/tcms_backup_plans.rb
+++ b/tools/tcms_backup_plans.rb
@@ -11,7 +11,7 @@ require 'zlib'
 require 'asciidoctor' # to generate html
 require 'term/ansicolor' #colorized terminal output
 
-module BushSlicer
+module VerificationTests
   class TcmsBackup
     include Commander::Methods
 
@@ -27,7 +27,7 @@ module BushSlicer
 
     def tcms
       return @tcms if @tcms
-      @tcms = BushSlicer::TCMS.new
+      @tcms = VerificationTests::TCMS.new
     end
 
     def run
@@ -608,7 +608,7 @@ module BushSlicer
             end
             begin
               #Use the Gherkin parser to collect all feature scenarios
-              gparser = BushSlicer::GherkinParse.new
+              gparser = VerificationTests::GherkinParse.new
               file_contents = gparser.parse_feature(File.join("#{HOME}/features", feature_file))
             rescue => e
               general_errors[case_id].push "Error in case #: #{case_id}, #{e.message}"
@@ -701,5 +701,5 @@ module BushSlicer
 end
 
 if __FILE__ == $0
-  BushSlicer::TcmsBackup.new.run
+  VerificationTests::TcmsBackup.new.run
 end

--- a/tools/tcms_query.rb
+++ b/tools/tcms_query.rb
@@ -191,7 +191,7 @@ def report_query_result(options)
 
   query_file = options.query
   params = YAML.load_file(query_file)
-  params_hash = BushSlicer::Collections.hash_symkeys(params['filters'])
+  params_hash = VerificationTests::Collections.hash_symkeys(params['filters'])
 
   # translate tag names into ids
   if params_hash[:tag__in]
@@ -242,8 +242,8 @@ def update_notes(options)
   tcms.update_testcases(cases, {"notes" => notes})
 end
 
-def get_bushslicer_home
-  ENV['BUSHSLICER_HOME'] || File.dirname(File.dirname(__FILE__))
+def get_verification_tests_home
+  ENV['VERIFICATION_TESTS_HOME'] || File.dirname(File.dirname(__FILE__))
 end
 
 def sync_tags(tcms)
@@ -300,8 +300,8 @@ def update_script(options)
   polarion_arg_field = nil
   tags = []
 
-  gparser = BushSlicer::GherkinParse.new
-  file_contents = gparser.parse_feature(File.join(get_bushslicer_home, path))
+  gparser = VerificationTests::GherkinParse.new
+  file_contents = gparser.parse_feature(File.join(get_verification_tests_home, path))
   #Iterate over each scenario in a file
   # XXX for gherkin 4.0  or greater, the hash structures have changed and not
   # backward compatible
@@ -604,10 +604,10 @@ if __FILE__ == $0
       options.create_run=true
     end
   end.parse!
-  tcms = BushSlicer::TCMS.new(options.to_h)
+  tcms = VerificationTests::TCMS.new(options.to_h)
   options.tcms = tcms
   if options.create_jira
-    jira = BushSlicer::Jira.new(options.to_h)
+    jira = VerificationTests::Jira.new(options.to_h)
     options.jira = jira
   end
   cases = []


### PR DESCRIPTION
I hope we will not do repo rename any more.

@akostadinov @pruan-rht @openshift/team-qe  

I'm trying to test the changes, but it requires runner-v3 parameters changes at the same time. So I skip the test/change. Maybe do that after a basic review is done here ?


How these changes are made.
```bash
# find all ruby files and replace BushSlicer to VerificationTests
Files=`find . -name "*.rb" -exec grep -l -- 'BushSlicer' {} \;`
sed -i 's/BushSlicer/VerificationTests/g' $Files
git diff
git add .

# all BushSlicer:: replace with VerificationTests::
Files=`grep -lr -- 'BushSlicer::' *`
sed -i 's/BushSlicer::/VerificationTests::/g' $Files
git diff
git add .

# all BUSHSLICER replaced with VERIFICATION_TESTS
Files=`grep -lr BUSHSLICER *`
sed -i 's/BUSHSLICER/VERIFICATION_TESTS/g' $Files
git diff
git add .

# remaining BushSlicer to verification-tests
Files=`grep -lr -- 'BushSlicer' *`
sed -i 's/BushSlicer/verification-tests/g' $Files
git diff
git add .

# remaining bushslicer...
vim `grep -rli BushSlicer * `
git diff
git add .
```