### PR TITLE
nodes auto-discovery and accessing on private IPs

### DIFF
--- a/lib/ssh.rb
+++ b/lib/ssh.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 require 'net/ssh'
+require 'net/ssh/proxy/jump'
+require 'net/ssh/proxy/command'
 require 'net/scp'
 require 'fileutils'
 
@@ -224,6 +226,11 @@ module BushSlicer
 
         @user = opts[:user] # can be nil for default username
         conn_opts = {keepalive: true}
+        if opts[:jump]
+          conn_opts[:proxy] = Net::SSH::Proxy::Jump.new(opts[:jump])
+        elsif opts[:proxy]
+          conn_opts[:proxy] = Net::SSH::Proxy::Command.new(opts[:proxy])
+        end
         if opts[:private_key]
           logger.debug("SSH Authenticating with publickey method")
           private_key = expand_private_path(opts[:private_key])


### PR DESCRIPTION


first it is not necessary to specify all nodes in host spec.
nodes with missing hosts will try to use node hostname from the Node object.
By default as bastion host will be used the firsts master. But if you
set a ole to some host as bastion - it will be used instead.

So you can also have completely internal cluster if you setup a special
bastion host.

The main idea though is that you can directly feed host.spec from
flexy into jenkins and have everything working automatically.

HTH
