### PR TITLE
support situations where floating IPs not needed

### DIFF
--- a/lib/launchers/openstack10.rb
+++ b/lib/launchers/openstack10.rb
@@ -596,7 +596,8 @@ module BushSlicer
           res = create_instance_api_call(instance_name, **create_opts)
           server = Instance.new(spec: res["server"], client: self) rescue next
           sleep 15
-        elsif server.status == "ACTIVE" && server.floating_ip
+        elsif server.status == "ACTIVE" &&
+                ( opts[:public_network] || server.floating_ip )
           return server
         elsif server.status == "ACTIVE" && !ip_assigned
           ip_assigned = assign_ip(server)[:success]
@@ -720,7 +721,11 @@ module BushSlicer
         instance = create_instance(name, **create_opts)
         host_opts[:cloud_instance_name] = instance.name
         host_opts[:cloud_instance] = instance
-        res[name] = Host.from_ip(instance.floating_ip, host_opts)
+        if opts[:public_network]
+          res[name] = Host.from_ip(instance.internal_ip, host_opts)
+        else
+          res[name] = Host.from_ip(instance.floating_ip, host_opts)
+        end
         res[name].local_ip = instance.internal_ip
       }
       return res


### PR DESCRIPTION
Still install does not work and fails with

```
fatal: [vm-10-0-76-152.example.com]: FAILED! => {"changed": false, "module_stderr": "KeyError('ansible_os_family',)\nTraceback (most recent call last):\n  File \"/tmp/ansible__mqusB/ansible_module_openshift_facts.py\", line 1300, in <module>\n    main()\n  File \"/tmp/ansible__mqusB/ansible_module_openshift_facts.py\", line 1287, in main\n    additive_facts_to_overwrite)\n  File \"/tmp/ansible__mqusB/ansible_module_openshift_facts.py\", line 1039, in __init__\n    additive_facts_to_overwrite)\n  File \"/tmp/ansible__mqusB/ansible_module_openshift_facts.py\", line 1061, in generate_facts\n    provider_facts = self.init_provider_facts()\n  File \"/tmp/ansible__mqusB/ansible_module_openshift_facts.py\", line 1194, in init_provider_facts\n    provider_info.get('metadata')\n  File \"/tmp/ansible__mqusB/ansible_module_openshift_facts.py\", line 345, in normalize_provider_facts\n    facts = normalize_openstack_facts(metadata, facts)\n  File \"/tmp/ansible__mqusB/ansible_module_openshift_facts.py\", line 310, in normalize_openstack_facts\n    if socket.gethostbyname(metadata['ec2_compat'][h_var]) == metadata['ec2_compat'][ip_var].split(',')[0]:\nAttributeError: 'list' object has no attribute 'split'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```

see flexy/build/55153

Still this is useful to create machines without floating IPs as well
hopefully openshift-ansible hopefully will start to support such setup.