### PR TITLE
update ocp-9736

### DIFF
--- a/features/routing/abrouting.feature
+++ b/features/routing/abrouting.feature
@@ -201,9 +201,8 @@ Feature: Testing abrouting
     Then the step should succeed
     #Check the default load blance policy
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
-    And a pod becomes ready with labels:
-      | deploymentconfig=router |
+    And I use the router project
+    And all default router pods become ready
     Then evaluation of `pod.name` is stored in the :router_pod clipboard
     And I wait up to 5 seconds for the steps to pass:
     """

--- a/features/routing/config-manager.feature
+++ b/features/routing/config-manager.feature
@@ -7,7 +7,7 @@ Feature: Testing HAProxy dynamic configuration manager related scenarios
   Scenario: unsecured route support haproxy dynamic changes
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     Given admin ensures new router pod becomes ready after following env added:
       | ROUTER_HAPROXY_CONFIG_MANAGER=true |
     And the last reload log of a router pod is stored in :reload_1 clipboard
@@ -40,7 +40,7 @@ Feature: Testing HAProxy dynamic configuration manager related scenarios
   Scenario: edge route support haproxy dynamic changes
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     Given admin ensures new router pod becomes ready after following env added:
       | ROUTER_HAPROXY_CONFIG_MANAGER=true |
     And the last reload log of a router pod is stored in :reload_1 clipboard
@@ -75,7 +75,7 @@ Feature: Testing HAProxy dynamic configuration manager related scenarios
   Scenario: passthrough route support haproxy dynamic changes
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     Given admin ensures new router pod becomes ready after following env added:
       | ROUTER_HAPROXY_CONFIG_MANAGER=true |
     And the last reload log of a router pod is stored in :reload_1 clipboard

--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -5,10 +5,9 @@ Feature: Testing haproxy router
   @admin
   Scenario: HTTP response header should return for default haproxy 503
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
-    And a pod becomes ready with labels:
-      | deploymentconfig=router |
-    And I execute on the pod:
+    And I use the router project
+    And all default router pods become ready
+    When I execute on the pod:
       | /usr/bin/curl | -v  | 127.0.0.1:80 |
     Then the output should contain "HTTP/1.0 503 Service Unavailable"
 
@@ -204,10 +203,9 @@ Feature: Testing haproxy router
   @destructive
   Scenario: Haproxy router health check will use 1936 port if user disable the stats port
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     And default router image is stored into the :default_router_image clipboard
-    And a pod becomes ready with labels:
-      | deploymentconfig=router |
+    And all default router pods become ready
     Given default router replica count is restored after scenario
     And admin ensures "tc-516836" dc is deleted after scenario
     And admin ensures "tc-516836" service is deleted after scenario
@@ -234,7 +232,7 @@ Feature: Testing haproxy router
   @destructive
   Scenario: The route auto generated can be accessed using the default cert
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     And default router image is stored into the :default_router_image clipboard
     Given default router replica count is restored after scenario
     And admin ensures "ocp-12651" dc is deleted after scenario
@@ -297,7 +295,7 @@ Feature: Testing haproxy router
     # prepare router
     Given default router is disabled and replaced by a duplicate
     And I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     When I run the :env admin command with:
       | resource | dc/<%= cb.new_router_dc.name %>         |
       | e        | RELOAD_INTERVAL=90s                     |
@@ -437,9 +435,8 @@ Feature: Testing haproxy router
   @admin
   Scenario: The backend health check interval of unsecure route can be set by annotation
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
-    Given a pod becomes ready with labels:
-      | deploymentconfig=router |
+    And I use the router project
+    Given all default router pods become ready
     Then evaluation of `pod.name` is stored in the :router_pod clipboard
 
     Given I switch to the first user
@@ -462,7 +459,7 @@ Feature: Testing haproxy router
     Then the step should succeed
 
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     And I wait up to 10 seconds for the steps to pass:
     """
     When I execute on the "<%=cb.router_pod %>" pod:
@@ -476,9 +473,8 @@ Feature: Testing haproxy router
   @admin
   Scenario: The backend health check interval of edge route can be set by annotation
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
-    Given a pod becomes ready with labels:
-      | deploymentconfig=router |
+    And I use the router project
+    Given all default router pods become ready
     Then evaluation of `pod.name` is stored in the :router_pod clipboard
 
     Given I switch to the first user
@@ -502,7 +498,7 @@ Feature: Testing haproxy router
     Then the step should succeed
 
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     And I wait up to 10 seconds for the steps to pass:
     """
     When I execute on the "<%=cb.router_pod %>" pod:

--- a/features/routing/http2.feature
+++ b/features/routing/http2.feature
@@ -7,7 +7,7 @@ Feature: Testing HTTP/2 related scenarios
   Scenario: edge route support http2 protocol
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     Given admin ensures new router pod becomes ready after following env added:
       | ROUTER_ENABLE_HTTP2=true |
 
@@ -48,7 +48,7 @@ Feature: Testing HTTP/2 related scenarios
   Scenario: reencrypt route support http2 protocol
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     Given admin ensures new router pod becomes ready after following env added:
       | ROUTER_ENABLE_HTTP2=true |
 

--- a/features/routing/logging.feature
+++ b/features/routing/logging.feature
@@ -7,7 +7,7 @@ Feature: Testing HAProxy router logging related scenarios
   Scenario: deploy haproxy router with an rsyslog sidecar container
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     And default router image is stored into the :default_router_image clipboard
     Given default router replica count is restored after scenario
     And admin ensures "ocp-19830" dc is deleted after scenario
@@ -54,7 +54,7 @@ Feature: Testing HAProxy router logging related scenarios
 
     # check access logs in syslog container
     Given I switch to cluster admin pseudo user
-    And I use the "default" project
+    And I use the router project
     When I run the :logs client command with:
       | resource_name | <%= cb.router_pod %> |
       | c             | syslog               |

--- a/features/step_definitions/pod.rb
+++ b/features/step_definitions/pod.rb
@@ -201,6 +201,7 @@ Given /^all existing pods are ready with labels:$/ do |table|
                                              get_opts: {l: selector_to_label_arr(*labels)})
 
   current_pods.each do |pod|
+    cache_pods(pod)
     @result = pod.wait_till_ready(user, timeout - monotonic_seconds + start_time)
     unless @result[:success]
       raise "pod #{pod.name} did not become ready within allowed time"

--- a/features/step_definitions/route.rb
+++ b/features/step_definitions/route.rb
@@ -128,6 +128,6 @@ Given /^all default router pods become ready$/ do
     label_filter = "deploymentconfig=router"
   end
     step %Q/all existing pods are ready with labels:/, table(%{
-      | <%= label_filter %> |
+      | #{label_filter} |
     })
 end


### PR DESCRIPTION
update OCP-9736 to use the new steps of 4.0 compatible.

4.0 logs: https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/37755/consoleFull

@akostadinov @pruan-rht  @bmeng @zhaozhanqi  please help review, thanks.
