### PR TITLE
fix get bearer token issue for splitted oauth server endpoint

### DIFF
--- a/lib/login.rb
+++ b/lib/login.rb
@@ -102,10 +102,22 @@ module BushSlicer
       opts = {:user=> user,
               :password=> password,
               :max_redirects=>0,
-              :url=>"#{server_url}/oauth/authorize",
               :params=> {"client_id"=>"openshift-challenging-client", "response_type"=>"token"},
               :method=>"GET"
       }
+      oauth_opts = {:url => "#{server_url}/.well-known/oauth-authorization-server",
+                    :method=> "GET"
+      }
+
+      res_oauth = Http.request(**oauth_opts)
+
+      if res_oauth[:exitstatus] == 200
+        puts JSON.parse(res_oauth[:response])
+        opts[:url] = "#{JSON.parse(res_oauth[:response])["authorization_endpoint"]}"
+      else
+        opts[:url] = "{server_url}/oauth/authorization"
+      end
+
       res = Http.request(**opts)
 
       if res[:exitstatus] == 302 && res[:headers]["location"]

--- a/lib/login.rb
+++ b/lib/login.rb
@@ -114,7 +114,7 @@ module BushSlicer
       if res_oauth[:exitstatus] == 200
         opts[:url] = "#{JSON.parse(res_oauth[:response])["authorization_endpoint"]}"
       else
-        opts[:url] = "{server_url}/oauth/authorize"
+        opts[:url] = "#{server_url}/oauth/authorize"
       end
 
       res = Http.request(**opts)

--- a/lib/login.rb
+++ b/lib/login.rb
@@ -114,7 +114,7 @@ module BushSlicer
       if res_oauth[:exitstatus] == 200
         opts[:url] = "#{JSON.parse(res_oauth[:response])["authorization_endpoint"]}"
       else
-        opts[:url] = "{server_url}/oauth/authorization"
+        opts[:url] = "{server_url}/oauth/authorize"
       end
 
       res = Http.request(**opts)

--- a/lib/login.rb
+++ b/lib/login.rb
@@ -112,7 +112,6 @@ module BushSlicer
       res_oauth = Http.request(**oauth_opts)
 
       if res_oauth[:exitstatus] == 200
-        puts JSON.parse(res_oauth[:response])
         opts[:url] = "#{JSON.parse(res_oauth[:response])["authorization_endpoint"]}"
       else
         opts[:url] = "{server_url}/oauth/authorization"


### PR DESCRIPTION
```
$ curl --http1.1 https://qe-chuan-api.qe.devcluster.openshift.com:6443/.well-known/oauth-authorization-server -k -i
HTTP/1.1 200 OK
Audit-Id: dadda4da-61a8-48c3-846d-634e1878c48f
Cache-Control: no-store
Content-Type: application/json
Date: Wed, 30 Jan 2019 10:04:47 GMT
Content-Length: 606

{
  "issuer": "https://o.apps.qe-chuan.qe.devcluster.openshift.com",
  "authorization_endpoint": "https://o.apps.qe-chuan.qe.devcluster.openshift.com/oauth/authorize",
  "token_endpoint": "https://o.apps.qe-chuan.qe.devcluster.openshift.com/oauth/token",
  "scopes_supported": [
    "user:check-access",
    "user:full",
    "user:info",
    "user:list-projects",
    "user:list-scoped-projects"
  ],
  "response_types_supported": [
    "code",
    "token"
  ],
  "grant_types_supported": [
    "authorization_code",
    "implicit"
  ],
  "code_challenge_methods_supported": [
    "plain",
    "S256"
  ]
}

$ oc login https://qe-chuan-api.qe.devcluster.openshift.com:6443 -u weinliu1 -p redhat --loglevel=8 
I0130 18:05:11.885329   13782 loader.go:359] Config loaded from file /home/nathan/.kube/config
I0130 18:05:11.895456   13782 loader.go:359] Config loaded from file /home/nathan/.kube/config
I0130 18:05:11.895843   13782 round_trippers.go:383] HEAD https://qe-chuan-api.qe.devcluster.openshift.com:6443/
I0130 18:05:11.895851   13782 round_trippers.go:390] Request Headers:
I0130 18:05:12.549753   13782 round_trippers.go:408] Response Status:  in 653 milliseconds
I0130 18:05:12.549771   13782 round_trippers.go:411] Response Headers:
I0130 18:05:12.550210   13782 round_trippers.go:383] GET https://qe-chuan-api.qe.devcluster.openshift.com:6443/.well-known/oauth-authorization-server
I0130 18:05:12.550224   13782 round_trippers.go:390] Request Headers:
I0130 18:05:12.550233   13782 round_trippers.go:393]     X-Csrf-Token: 1
I0130 18:05:15.066597   13782 round_trippers.go:408] Response Status: 200 OK in 2516 milliseconds
I0130 18:05:15.066656   13782 round_trippers.go:411] Response Headers:
I0130 18:05:15.066685   13782 round_trippers.go:414]     Cache-Control: no-store
I0130 18:05:15.066705   13782 round_trippers.go:414]     Content-Type: application/json
I0130 18:05:15.066730   13782 round_trippers.go:414]     Content-Length: 606
I0130 18:05:15.066753   13782 round_trippers.go:414]     Date: Wed, 30 Jan 2019 10:05:13 GMT
I0130 18:05:15.066775   13782 round_trippers.go:414]     Audit-Id: 59a9cd7a-a873-409a-8a45-90f28e5f6257
I0130 18:05:15.067159   13782 round_trippers.go:383] GET https://o.apps.qe-chuan.qe.devcluster.openshift.com/oauth/authorize?client_id=openshift-challenging-client&code_challenge=StmcHITYp8a3Um2VQOLNNpGPbCGWyomWkKyTGHwPi6Y&code_challenge_method=S256&redirect_uri=https%3A%2F%2Fo.apps.qe-chuan.qe.devcluster.openshift.com%2Foauth%2Ftoken%2Fimplicit&response_type=code
I0130 18:05:15.067199   13782 round_trippers.go:390] Request Headers:
I0130 18:05:15.067226   13782 round_trippers.go:393]     X-Csrf-Token: 1
I0130 18:05:16.267012   13782 round_trippers.go:408] Response Status: 401 Unauthorized in 1199 milliseconds
I0130 18:05:16.267055   13782 round_trippers.go:411] Response Headers:
I0130 18:05:16.267076   13782 round_trippers.go:414]     Www-Authenticate: Basic realm="openshift"
I0130 18:05:16.267095   13782 round_trippers.go:414]     Date: Wed, 30 Jan 2019 10:05:16 GMT
I0130 18:05:16.267116   13782 round_trippers.go:414]     Content-Length: 0
I0130 18:05:16.267131   13782 round_trippers.go:414]     Set-Cookie: 4128ef351e3868accd91b3bc506b65ad=ecc0977652779021372b07165a010a99; path=/; HttpOnly; Secure
```