### PR TITLE
get rest api to work with 4.0 api structure, also took out oapi refer…

### DIFF
--- a/lib/rest.rb
+++ b/lib/rest.rb
@@ -31,8 +31,6 @@ module BushSlicer
         opts = {}
 
         opts[:options] = {}
-        opts[:options][:oapi_version] = user.rest_preferences[:oapi_version] ||
-                                          user.env.api_version
         opts[:options][:api_version] = user.rest_preferences[:api_version] ||
                                           user.env.api_version
         opts[:options][:accept] = "application/json"
@@ -94,7 +92,6 @@ module BushSlicer
       def self.delegate_rest_request(req, base_opts, req_opts)
         ## use special hash like class to track usage of supplied options
         tracked_opts = UsageTrackingHash.new(base_opts.delete(:options).merge(req_opts))
-        tracked_opts[:oapi_version] # make sure this is marked accessed
         tracked_opts[:api_version] # make sure this is marked accessed
 
         case

--- a/lib/rest_kubernetes.rb
+++ b/lib/rest_kubernetes.rb
@@ -6,7 +6,7 @@ module BushSlicer
       extend Helper
 
       def self.populate(path, base_opts, opts)
-        populate_common("/api/<api_version>", path, base_opts, opts)
+        populate_common("/apis/#{path}.k8s.io/<api_version>", path, base_opts, opts)
       end
 
       class << self

--- a/lib/rest_kubernetes.rb
+++ b/lib/rest_kubernetes.rb
@@ -5,8 +5,8 @@ module BushSlicer
     module Kubernetes
       extend Helper
 
-      def self.populate(path, base_opts, opts)
-        populate_common("/apis/#{path}.k8s.io/<api_version>", path, base_opts, opts)
+      def self.populate(path, base_opts, opts, type)
+        populate_common("/apis/#{type}.k8s.io/<api_version>", path, base_opts, opts)
       end
 
       class << self

--- a/lib/rest_openshift.rb
+++ b/lib/rest_openshift.rb
@@ -5,8 +5,8 @@ module BushSlicer
     module OpenShift
       extend Helper
 
-      def self.populate(path, base_opts, opts)
-        populate_common("/oapi/<oapi_version>", path, base_opts, opts)
+      def self.populate(path, base_opts, opts, type)
+        populate_common("/apis/#{type}.openshift.io/<api_version>", path, base_opts, opts)
       end
 
       class << self
@@ -21,7 +21,7 @@ module BushSlicer
       #   "gitVersion": "v3.3.0.27",
       #   "buildDate": "2016-08-29T14:44:33Z"
       # }
-      def self.version(base_opts, opts)
+      def self.version(base_opts, opts, type="version")
         populate_common("/version", "/openshift", base_opts, opts)
         return perform(**base_opts, method: "GET") { |res|
           res[:props][:openshift] = res[:parsed]["gitVersion"]
@@ -31,28 +31,28 @@ module BushSlicer
         }
       end
 
-      def self.delete_oauthaccesstoken(base_opts, opts)
-        populate("/oauthaccesstokens/<token_to_delete>", base_opts, opts)
+      def self.delete_oauthaccesstoken(base_opts, opts, type="oauth")
+        populate("/oauthaccesstokens/<token_to_delete>", base_opts, opts, type)
         return perform(**base_opts, method: "DELETE")
       end
 
-      def self.list_projects(base_opts, opts)
-        populate("/projects", base_opts, opts)
+      def self.list_projects(base_opts, opts, type="project")
+        populate("/projects", base_opts, opts, type)
         return perform(**base_opts, method: "GET")
       end
 
-      def self.delete_project(base_opts, opts)
-        populate("/projects/<project_name>", base_opts, opts)
+      def self.delete_project(base_opts, opts, type="project")
+        populate("/projects/<project_name>", base_opts, opts, type)
         return perform(**base_opts, method: "DELETE")
       end
 
-      def self.get_project(base_opts, opts)
-        populate("/projects/<project_name>", base_opts, opts)
+      def self.get_project(base_opts, opts, type="project")
+        populate("/projects/<project_name>", base_opts, opts, type)
         return perform(**base_opts, method: "GET")
       end
 
-      def self.get_user(base_opts, opts)
-        populate("/users/<username>", base_opts, opts)
+      def self.get_user(base_opts, opts, type="user")
+        populate("/users/<username>", base_opts, opts, type)
         return perform(**base_opts, method: "GET") { |res|
           res[:props][:name] = res[:parsed]["metadata"]["name"]
           res[:props][:uid] = res[:parsed]["metadata"]["uid"]
@@ -60,46 +60,44 @@ module BushSlicer
       end
 
       # this usually creates a project in fact
-      def self.create_project_request(base_opts, opts)
+      def self.create_project_request(base_opts, opts, type="project")
         base_opts[:payload] = {}
         # see https://bugzilla.redhat.com/show_bug.cgi?id=1244889 for apiVersion
-        base_opts[:payload][:apiVersion] = opts[:oapi_version]
         base_opts[:payload]["displayName"] = opts[:display_name] if opts[:display_name]
         base_opts[:payload]["description"] = opts[:description] if opts[:description]
         # base_opts[:payload][:kind] = "ProjectRequest"
         base_opts[:payload][:metadata] = {name: opts[:project_name]}
 
-        populate("/projectrequests", base_opts, opts)
+        populate("/projectrequests", base_opts, opts, type)
         return Http.request(**base_opts, method: "POST")
       end
 
-      def self.post_local_resource_access_reviews(base_opts, opts)
+      def self.post_local_resource_access_reviews(base_opts, opts, type="authorization")
         base_opts[:payload] = {}
-        base_opts[:payload][:apiVersion] = opts[:oapi_version]
         base_opts[:payload][:kind] = "LocalResourceAccessReview"
         base_opts[:payload][:verb] = opts[:verb]
         base_opts[:payload][:resource] = opts[:resource]
         project_name = opts[:project_name]
-        populate("/namespaces/<project_name>/localresourceaccessreviews", base_opts, opts)
+        populate("/namespaces/<project_name>/localresourceaccessreviews", base_opts, opts, type)
         return perform(**base_opts, method: "POST")
       end
 
       # did not find out how to use this one yet
-      def self.create_oauth_access_token(base_opts, opts)
+      def self.create_oauth_access_token(base_opts, opts, type="oauth")
         base_opts[:payload] = {}
         base_opts[:payload]["expiresIn"] = opts[:expires_in] if opts[:expires_in]
         base_opts[:payload]["userName"] = opts[:user_name] if opts[:user_name]
         base_opts[:payload][:scopes] = opts[:scopes] if opts[:scopes]
 
 
-        populate("/oauthaccesstokens", base_opts, opts)
+        populate("/oauthaccesstokens", base_opts, opts, type)
         return perform(**base_opts, method: "POST") { |res|
           # res[:props][:name] = res[:parsed]["metadata"]["name"]
           # res[:props][:uid] = res[:parsed]["metadata"]["uid"]
         }
       end
 
-      def self.rollback_deploy(base_opts, opts)
+      def self.rollback_deploy(base_opts, opts, type="apps")
         base_opts[:payload] = {}
         base_opts[:payload][:spec] = {}
         base_opts[:payload][:spec][:from] = {name: opts[:deploy_name]}
@@ -110,42 +108,26 @@ module BushSlicer
 
         project_name = opts[:project_name]
 
-        populate("/namespaces/<project_name>/deploymentconfigrollbacks", base_opts, opts)
+        populate("/namespaces/<project_name>/deploymentconfigrollbacks", base_opts, opts, type)
         return Http.request(**base_opts, method: "POST")
       end
 
-      def self.get_subresources_oapi(base_opts, opts)
-        populate("/namespaces/<project_name>/<resource_type>/<resource_name>/status", base_opts, opts)
-        return Http.request(**base_opts, method: "GET")
-      end
 
-      def self.post_role_oapi(base_opts, opts)
-        base_opts[:payload] = {}
-        base_opts[:payload]["kind"] = opts[:kind]
-        base_opts[:payload]["apiVersion"] = opts[:api_version]
-        base_opts[:payload]["verb"] = opts[:verb]
-        base_opts[:payload]["resource"] = opts[:resource]
-        base_opts[:payload]["user"] = opts[:user]
-
-        populate("/namespaces/<project_name>/<role>", base_opts, opts)
-        return Http.request(**base_opts, method: "POST")
-      end
-
-      def self.post_pod_security_policy_self_subject_reviews(base_opts, opts)
+      def self.post_pod_security_policy_self_subject_reviews(base_opts, opts,  type="security")
         base_opts[:payload] = File.read(expand_path(opts[:payload_file]))
-        populate("/namespaces/<project_name>/podsecuritypolicyselfsubjectreviews", base_opts, opts)
+        populate("/namespaces/<project_name>/podsecuritypolicyselfsubjectreviews", base_opts, opts, type)
         return perform(**base_opts, method: "POST")
       end
 
-      def self.post_pod_security_policy_subject_reviews(base_opts, opts)
+      def self.post_pod_security_policy_subject_reviews(base_opts, opts, type="security")
         base_opts[:payload] = File.read(expand_path(opts[:payload_file]))
-        populate("/namespaces/<project_name>/podsecuritypolicysubjectreviews", base_opts, opts)
+        populate("/namespaces/<project_name>/podsecuritypolicysubjectreviews", base_opts, opts, type)
         return perform(**base_opts, method: "POST")
       end
 
-      def self.post_pod_security_policy_reviews(base_opts, opts)
+      def self.post_pod_security_policy_reviews(base_opts, opts, type="security")
         base_opts[:payload] = File.read(expand_path(opts[:payload_file]))
-        populate("/namespaces/<project_name>/podsecuritypolicyreviews", base_opts, opts)
+        populate("/namespaces/<project_name>/podsecuritypolicyreviews", base_opts, opts, type)
         return perform(**base_opts, method: "POST")
       end
 

--- a/lib/rest_openshift.rb
+++ b/lib/rest_openshift.rb
@@ -22,7 +22,7 @@ module BushSlicer
       #   "buildDate": "2016-08-29T14:44:33Z"
       # }
       def self.version(base_opts, opts)
-        populate_common("/version", "/openshift", base_opts, opts, type="version")
+        populate_common("/version", "/openshift", base_opts, opts)
         return perform(**base_opts, method: "GET") { |res|
           res[:props][:openshift] = res[:parsed]["gitVersion"]
           res[:props][:major] = res[:parsed]["major"]

--- a/lib/rest_openshift.rb
+++ b/lib/rest_openshift.rb
@@ -21,8 +21,8 @@ module BushSlicer
       #   "gitVersion": "v3.3.0.27",
       #   "buildDate": "2016-08-29T14:44:33Z"
       # }
-      def self.version(base_opts, opts, type="version")
-        populate_common("/version", "/openshift", base_opts, opts)
+      def self.version(base_opts, opts)
+        populate_common("/version", "/openshift", base_opts, opts, type="version")
         return perform(**base_opts, method: "GET") { |res|
           res[:props][:openshift] = res[:parsed]["gitVersion"]
           res[:props][:major] = res[:parsed]["major"]
@@ -31,28 +31,28 @@ module BushSlicer
         }
       end
 
-      def self.delete_oauthaccesstoken(base_opts, opts, type="oauth")
-        populate("/oauthaccesstokens/<token_to_delete>", base_opts, opts, type)
+      def self.delete_oauthaccesstoken(base_opts, opts)
+        populate("/oauthaccesstokens/<token_to_delete>", base_opts, opts, type="oauth")
         return perform(**base_opts, method: "DELETE")
       end
 
-      def self.list_projects(base_opts, opts, type="project")
-        populate("/projects", base_opts, opts, type)
+      def self.list_projects(base_opts, opts)
+        populate("/projects", base_opts, opts, type="project")
         return perform(**base_opts, method: "GET")
       end
 
-      def self.delete_project(base_opts, opts, type="project")
-        populate("/projects/<project_name>", base_opts, opts, type)
+      def self.delete_project(base_opts, opts)
+        populate("/projects/<project_name>", base_opts, opts, type="project")
         return perform(**base_opts, method: "DELETE")
       end
 
-      def self.get_project(base_opts, opts, type="project")
-        populate("/projects/<project_name>", base_opts, opts, type)
+      def self.get_project(base_opts, opts)
+        populate("/projects/<project_name>", base_opts, opts, type="project")
         return perform(**base_opts, method: "GET")
       end
 
-      def self.get_user(base_opts, opts, type="user")
-        populate("/users/<username>", base_opts, opts, type)
+      def self.get_user(base_opts, opts)
+        populate("/users/<username>", base_opts, opts, type="user")
         return perform(**base_opts, method: "GET") { |res|
           res[:props][:name] = res[:parsed]["metadata"]["name"]
           res[:props][:uid] = res[:parsed]["metadata"]["uid"]
@@ -60,7 +60,7 @@ module BushSlicer
       end
 
       # this usually creates a project in fact
-      def self.create_project_request(base_opts, opts, type="project")
+      def self.create_project_request(base_opts, opts)
         base_opts[:payload] = {}
         # see https://bugzilla.redhat.com/show_bug.cgi?id=1244889 for apiVersion
         base_opts[:payload]["displayName"] = opts[:display_name] if opts[:display_name]
@@ -68,36 +68,36 @@ module BushSlicer
         # base_opts[:payload][:kind] = "ProjectRequest"
         base_opts[:payload][:metadata] = {name: opts[:project_name]}
 
-        populate("/projectrequests", base_opts, opts, type)
+        populate("/projectrequests", base_opts, opts, type="project")
         return Http.request(**base_opts, method: "POST")
       end
 
-      def self.post_local_resource_access_reviews(base_opts, opts, type="authorization")
+      def self.post_local_resource_access_reviews(base_opts, opts)
         base_opts[:payload] = {}
         base_opts[:payload][:kind] = "LocalResourceAccessReview"
         base_opts[:payload][:verb] = opts[:verb]
         base_opts[:payload][:resource] = opts[:resource]
         project_name = opts[:project_name]
-        populate("/namespaces/<project_name>/localresourceaccessreviews", base_opts, opts, type)
+        populate("/namespaces/<project_name>/localresourceaccessreviews", base_opts, opts, type="authorization")
         return perform(**base_opts, method: "POST")
       end
 
       # did not find out how to use this one yet
-      def self.create_oauth_access_token(base_opts, opts, type="oauth")
+      def self.create_oauth_access_token(base_opts, opts)
         base_opts[:payload] = {}
         base_opts[:payload]["expiresIn"] = opts[:expires_in] if opts[:expires_in]
         base_opts[:payload]["userName"] = opts[:user_name] if opts[:user_name]
         base_opts[:payload][:scopes] = opts[:scopes] if opts[:scopes]
 
 
-        populate("/oauthaccesstokens", base_opts, opts, type)
+        populate("/oauthaccesstokens", base_opts, opts, type="oauth")
         return perform(**base_opts, method: "POST") { |res|
           # res[:props][:name] = res[:parsed]["metadata"]["name"]
           # res[:props][:uid] = res[:parsed]["metadata"]["uid"]
         }
       end
 
-      def self.rollback_deploy(base_opts, opts, type="apps")
+      def self.rollback_deploy(base_opts, opts)
         base_opts[:payload] = {}
         base_opts[:payload][:spec] = {}
         base_opts[:payload][:spec][:from] = {name: opts[:deploy_name]}
@@ -108,26 +108,26 @@ module BushSlicer
 
         project_name = opts[:project_name]
 
-        populate("/namespaces/<project_name>/deploymentconfigrollbacks", base_opts, opts, type)
+        populate("/namespaces/<project_name>/deploymentconfigrollbacks", base_opts, opts, type="apps")
         return Http.request(**base_opts, method: "POST")
       end
 
 
-      def self.post_pod_security_policy_self_subject_reviews(base_opts, opts,  type="security")
+      def self.post_pod_security_policy_self_subject_reviews(base_opts, opts)
         base_opts[:payload] = File.read(expand_path(opts[:payload_file]))
-        populate("/namespaces/<project_name>/podsecuritypolicyselfsubjectreviews", base_opts, opts, type)
+        populate("/namespaces/<project_name>/podsecuritypolicyselfsubjectreviews", base_opts, opts, type="security")
         return perform(**base_opts, method: "POST")
       end
 
-      def self.post_pod_security_policy_subject_reviews(base_opts, opts, type="security")
+      def self.post_pod_security_policy_subject_reviews(base_opts, opts)
         base_opts[:payload] = File.read(expand_path(opts[:payload_file]))
-        populate("/namespaces/<project_name>/podsecuritypolicysubjectreviews", base_opts, opts, type)
+        populate("/namespaces/<project_name>/podsecuritypolicysubjectreviews", base_opts, opts, type="security")
         return perform(**base_opts, method: "POST")
       end
 
-      def self.post_pod_security_policy_reviews(base_opts, opts, type="security")
+      def self.post_pod_security_policy_reviews(base_opts, opts)
         base_opts[:payload] = File.read(expand_path(opts[:payload_file]))
-        populate("/namespaces/<project_name>/podsecuritypolicyreviews", base_opts, opts, type)
+        populate("/namespaces/<project_name>/podsecuritypolicyreviews", base_opts, opts, type="security")
         return perform(**base_opts, method: "POST")
       end
 

--- a/lib/rest_openshift.rb
+++ b/lib/rest_openshift.rb
@@ -32,27 +32,27 @@ module BushSlicer
       end
 
       def self.delete_oauthaccesstoken(base_opts, opts)
-        populate("/oauthaccesstokens/<token_to_delete>", base_opts, opts, type="oauth")
+        populate("/oauthaccesstokens/<token_to_delete>", base_opts, opts, "oauth")
         return perform(**base_opts, method: "DELETE")
       end
 
       def self.list_projects(base_opts, opts)
-        populate("/projects", base_opts, opts, type="project")
+        populate("/projects", base_opts, opts, "project")
         return perform(**base_opts, method: "GET")
       end
 
       def self.delete_project(base_opts, opts)
-        populate("/projects/<project_name>", base_opts, opts, type="project")
+        populate("/projects/<project_name>", base_opts, opts, "project")
         return perform(**base_opts, method: "DELETE")
       end
 
       def self.get_project(base_opts, opts)
-        populate("/projects/<project_name>", base_opts, opts, type="project")
+        populate("/projects/<project_name>", base_opts, opts, "project")
         return perform(**base_opts, method: "GET")
       end
 
       def self.get_user(base_opts, opts)
-        populate("/users/<username>", base_opts, opts, type="user")
+        populate("/users/<username>", base_opts, opts, "user")
         return perform(**base_opts, method: "GET") { |res|
           res[:props][:name] = res[:parsed]["metadata"]["name"]
           res[:props][:uid] = res[:parsed]["metadata"]["uid"]
@@ -68,7 +68,7 @@ module BushSlicer
         # base_opts[:payload][:kind] = "ProjectRequest"
         base_opts[:payload][:metadata] = {name: opts[:project_name]}
 
-        populate("/projectrequests", base_opts, opts, type="project")
+        populate("/projectrequests", base_opts, opts, "project")
         return Http.request(**base_opts, method: "POST")
       end
 
@@ -78,7 +78,7 @@ module BushSlicer
         base_opts[:payload][:verb] = opts[:verb]
         base_opts[:payload][:resource] = opts[:resource]
         project_name = opts[:project_name]
-        populate("/namespaces/<project_name>/localresourceaccessreviews", base_opts, opts, type="authorization")
+        populate("/namespaces/<project_name>/localresourceaccessreviews", base_opts, opts, "authorization")
         return perform(**base_opts, method: "POST")
       end
 
@@ -90,7 +90,7 @@ module BushSlicer
         base_opts[:payload][:scopes] = opts[:scopes] if opts[:scopes]
 
 
-        populate("/oauthaccesstokens", base_opts, opts, type="oauth")
+        populate("/oauthaccesstokens", base_opts, opts, "oauth")
         return perform(**base_opts, method: "POST") { |res|
           # res[:props][:name] = res[:parsed]["metadata"]["name"]
           # res[:props][:uid] = res[:parsed]["metadata"]["uid"]
@@ -108,26 +108,26 @@ module BushSlicer
 
         project_name = opts[:project_name]
 
-        populate("/namespaces/<project_name>/deploymentconfigrollbacks", base_opts, opts, type="apps")
+        populate("/namespaces/<project_name>/deploymentconfigrollbacks", base_opts, opts, "apps")
         return Http.request(**base_opts, method: "POST")
       end
 
 
       def self.post_pod_security_policy_self_subject_reviews(base_opts, opts)
         base_opts[:payload] = File.read(expand_path(opts[:payload_file]))
-        populate("/namespaces/<project_name>/podsecuritypolicyselfsubjectreviews", base_opts, opts, type="security")
+        populate("/namespaces/<project_name>/podsecuritypolicyselfsubjectreviews", base_opts, opts, "security")
         return perform(**base_opts, method: "POST")
       end
 
       def self.post_pod_security_policy_subject_reviews(base_opts, opts)
         base_opts[:payload] = File.read(expand_path(opts[:payload_file]))
-        populate("/namespaces/<project_name>/podsecuritypolicysubjectreviews", base_opts, opts, type="security")
+        populate("/namespaces/<project_name>/podsecuritypolicysubjectreviews", base_opts, opts, "security")
         return perform(**base_opts, method: "POST")
       end
 
       def self.post_pod_security_policy_reviews(base_opts, opts)
         base_opts[:payload] = File.read(expand_path(opts[:payload_file]))
-        populate("/namespaces/<project_name>/podsecuritypolicyreviews", base_opts, opts, type="security")
+        populate("/namespaces/<project_name>/podsecuritypolicyreviews", base_opts, opts, "security")
         return perform(**base_opts, method: "POST")
       end
 


### PR DESCRIPTION
…ences since it has become obsolete.   According to the [upstream documentation](https://docs.okd.io/latest/rest_api/) there are still differences between `k8s` and `openshift` in term of base URL.  Introduce `type` to use to build the url to fetch from.