### PR TITLE
fix for oc version

### DIFF
--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -65,7 +65,7 @@ module BushSlicer
       fake_config.unlink
 
       raise "cannot execute on host #{host.hostname} as user '#{user}'" unless res[:success]
-      return res[:response].scan(/^os?c v(.+)$/)[0][0]
+      return res[:response].scan(/^os?c v(.+)$|GitVersion:"v([^"]+)"/)[0].find{|v| v != nil}
     end
 
     # try to map ocp and origin cli version to a comparable integer value


### PR DESCRIPTION
Recent https://github.com/openshift/origin/pull/21434 is merged
This makes auto fail:
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/38503/console
```
      [02:43:06] INFO> Shell Commands: oc version --config=/tmp/kubeconfig20190226-370-182k0n1
      Client Version: version.Info{Major:"4", Minor:"0+", GitVersion:"v4.0.0-0.183.0", GitCommit:"99fca4beb8", GitTreeState:"", BuildDate:"2019-02-23T23:55:36Z", GoVersion:"", Compiler:"", Platform:""}
      
      [02:43:06] INFO> Exit Status: 0
      undefined method `[]' for nil:NilClass (NoMethodError)
      /home/jenkins/workspace/Runner-v3/lib/cli_executor.rb:68:in `get_version_for'
      /home/jenkins/workspace/Runner-v3/lib/cli_executor.rb:259:in `version'
      /home/jenkins/workspace/Runner-v3/lib/cli_executor.rb:249:in `executor'
      /home/jenkins/workspace/Runner-v3/lib/cli_executor.rb:289:in `user_opts'
      /home/jenkins/workspace/Runner-v3/lib/cli_executor.rb:299:in `exec'
      /home/jenkins/workspace/Runner-v3/lib/api_accessor.rb:71:in `cli_exec'
      /home/jenkins/workspace/Runner-v3/lib/api_accessor_owner.rb:28:in `public_send'
      /home/jenkins/workspace/Runner-v3/lib/api_accessor_owner.rb:28:in `block (2 levels) in <module:APIAccessorOwner>'
      /home/jenkins/workspace/Runner-v3/lib/openshift/cluster_resource.rb:162:in `get_matching'
      /home/jenkins/workspace/Runner-v3/lib/openshift/user.rb:143:in `projects'
      /home/jenkins/workspace/Runner-v3/lib/openshift/user.rb:113:in `block in clean_projects'
      /home/jenkins/workspace/Runner-v3/lib/base_helper.rb:153:in `wait_for'
      /home/jenkins/workspace/Runner-v3/lib/openshift/user.rb:112:in `clean_projects'
      /home/jenkins/workspace/Runner-v3/lib/openshift/user.rb:138:in `clean_up_on_load'
      /home/jenkins/workspace/Runner-v3/lib/user_manager.rb:107:in `[]'
      /home/jenkins/workspace/Runner-v3/lib/world.rb:147:in `user'
      /home/jenkins/workspace/Runner-v3/features/step_definitions/project.rb:21:in `/^I have a project$/'
      features/cli/deploy.feature:35:in `Given I have a project'
```

Local test passed when using https://github.com/xingxingxia/verification-tests/commit/fe21160
@akostadinov @pruan-rht pls check/merge, thx