### PR TITLE
Ocp 19810

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -203,13 +203,12 @@ Feature: Pod related networking scenarios
    Then the step should succeed
    Given a pod becomes ready with labels:
      | name=udp-pods |
-   And evaluation of `pod.name` is stored in the :host_pod1_name clipboard
-   And evaluation of `pod.ip` is stored in the :host_pod1_ip clipboard
+   And evaluation of `pod` is stored in the :host_pod1 clipboard
    And evaluation of `host_subnet(cb.nodes[0].name).ip` is stored in the :node_ip clipboard
    
    When I run the :expose client command with:
      | resource      | pod                      |
-     | resource_name | <%= cb.host_pod1_name %> |
+     | resource_name | <%= cb.host_pod1.name %> |
      | type          | NodePort                 |
      | port          | 8080                     |
      | protocol      | UDP                      |
@@ -226,13 +225,12 @@ Feature: Pod related networking scenarios
    Then the step should succeed
    Given a pod becomes ready with labels:
      | name=hello-pod |
-   And evaluation of `pod.name` is stored in the :client_pod clipboard
-   And evaluation of `host_subnet(cb.nodes[1].name).ip` is stored in the :client_ip clipboard
+   And evaluation of `pod` is stored in the :client_pod clipboard
    
    # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
    #  entry which will give us enough time to validate upcoming steps 
    When I run the :exec background client command with:
-     | pod              | <%= cb.client_pod %>                                  |
+     | pod              | <%= cb.client_pod.name %>                             |
      | oc_opts_end      |                                                       | 
      | exec_command     | bash                                                  |
      | exec_command_arg | -c                                                    |
@@ -244,19 +242,19 @@ Feature: Pod related networking scenarios
      | conntrack -L \| grep <%= cb.nodeport %> | 
    Then the step should succeed 
    And the output should contain: 
-     |<%= cb.host_pod1_ip %>|
+     |<%= cb.host_pod1.ip %>|
    
    When I run the :delete client command with:
      | object_type       | pod                      |
-     | object_name_or_id | <%= cb.host_pod1_name %> | 
+     | object_name_or_id | <%= cb.host_pod1.name %> | 
    Given a pod becomes ready with labels:
      | name=udp-pods |
-   And evaluation of `pod.ip` is stored in the :host_pod2_ip clipboard
+   And evaluation of `pod` is stored in the :host_pod2 clipboard
    
    # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
    #  entry which will give us enough time to validate upcoming steps 
    When I run the :exec background client command with:
-     | pod              | <%= cb.client_pod %>                                  |
+     | pod              | <%= cb.client_pod.name %>                             |
      | oc_opts_end      |                                                       |
      | exec_command     | bash                                                  |
      | exec_command_arg | -c                                                    |
@@ -266,6 +264,6 @@ Feature: Pod related networking scenarios
    
    When I run commands on the host:
      | conntrack -L \| grep <%= cb.nodeport %> |
-   Then the output should contain "<%= cb.host_pod2_ip %>"
-   And the output should not contain "<%= cb.host_pod1_ip %>"    
+   Then the output should contain "<%= cb.host_pod2.ip %>"
+   And the output should not contain "<%= cb.host_pod1.ip %>"    
 

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -194,6 +194,7 @@ Feature: Pod related networking scenarios
   # @case_id OCP-19810
   @admin
   Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted
+   Given the master version <= "3.11"		
    Given I store the schedulable nodes in the :nodes clipboard
    Given I use the "<%= cb.nodes[0].name %>" node
    And I have a project

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -230,7 +230,7 @@ Feature: Pod related networking scenarios
    And evaluation of `host_subnet(cb.nodes[1].name).ip` is stored in the :client_ip clipboard
    
    # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
-   #  entry whuch will give us enough time to validate upcoming steps 
+   #  entry which will give us enough time to validate upcoming steps 
    When I run the :exec background client command with:
      | pod              | <%= cb.client_pod %> |
      | oc_opts_end      |    |
@@ -254,7 +254,7 @@ Feature: Pod related networking scenarios
    And evaluation of `pod.ip` is stored in the :host_pod2_ip clipboard
    
    # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
-   #  entry whuch will give us enough time to validate upcoming steps 
+   #  entry which will give us enough time to validate upcoming steps 
    When I run the :exec background client command with:
      | pod              | <%= cb.client_pod %> |
      | oc_opts_end      |    |

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -208,16 +208,16 @@ Feature: Pod related networking scenarios
    And evaluation of `host_subnet(cb.nodes[0].name).ip` is stored in the :node_ip clipboard
    
    When I run the :expose client command with:
-     | resource          | pod |
-     | resource_name     | <%= cb.host_pod1_name %> |
-     | type              | NodePort |
-     | port              | 8080 |
-     | protocol          | UDP |
+     | resource      | pod                      |
+     | resource_name | <%= cb.host_pod1_name %> |
+     | type          | NodePort                 |
+     | port          | 8080                     |
+     | protocol      | UDP                      |
    Then the step should succeed
    
    When I run the :get client command with:
-     | resource      | service |
-     | output        | jsonpath='{.items[*].spec.ports[*].nodePort}' | 
+     | resource | service                                       |
+     | output   | jsonpath='{.items[*].spec.ports[*].nodePort}' | 
    Then the step should succeed
    And evaluation of `@result[:response]` is stored in the :nodeport clipboard
    
@@ -232,10 +232,10 @@ Feature: Pod related networking scenarios
    # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
    #  entry which will give us enough time to validate upcoming steps 
    When I run the :exec background client command with:
-     | pod              | <%= cb.client_pod %> |
-     | oc_opts_end      |    |
-     | exec_command     | bash |
-     | exec_command_arg | -c |
+     | pod              | <%= cb.client_pod %>                                  |
+     | oc_opts_end      |                                                       | 
+     | exec_command     | bash                                                  |
+     | exec_command_arg | -c                                                    |
      | exec_command_arg | yes "h">/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
    Given 3 seconds have passed
    And I terminate last background process
@@ -247,7 +247,7 @@ Feature: Pod related networking scenarios
      |<%= cb.host_pod1_ip %>|
    
    When I run the :delete client command with:
-     | object_type       | pod     |
+     | object_type       | pod                      |
      | object_name_or_id | <%= cb.host_pod1_name %> | 
    Given a pod becomes ready with labels:
      | name=udp-pods |
@@ -256,10 +256,10 @@ Feature: Pod related networking scenarios
    # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
    #  entry which will give us enough time to validate upcoming steps 
    When I run the :exec background client command with:
-     | pod              | <%= cb.client_pod %> |
-     | oc_opts_end      |    |
-     | exec_command     | bash |
-     | exec_command_arg | -c |
+     | pod              | <%= cb.client_pod %>                                  |
+     | oc_opts_end      |                                                       |
+     | exec_command     | bash                                                  |
+     | exec_command_arg | -c                                                    |
      | exec_command_arg | yes "h">/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
    Given 3 seconds have passed
    And I terminate last background process


### PR DESCRIPTION
Gherkin Scenario for SDN test case **OCP-19810**. 
The aim of the test is to make sure conntrack rule for UDP traffic should be removed when the pod for NodePort service is deleted.

A pod on schedule able host node is created under a project (via a json template) which is listening to udp traffic. The pod will be exposed on node ip via a nodeport with protocol UDP . A client pod will send udp traffic to that node ip and exposed port to make sure that a conntrack entry is created. When the host pod gets deleted, rc will create a similar new pod with udp listener. We send udp traffic to new pod and check the conntrack entries to make sure deleted pod entry should not exist in conntrack table but the new pod one.  

Already discussed with Bo Meng offline. Made some changes as per his suggestions and hence opening PR finally.

**Passed Logs for reference**: https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/248/console
