### PR TITLE
added support when user specify a local kubeconfig location

### DIFF
--- a/lib/admin_credentials.rb
+++ b/lib/admin_credentials.rb
@@ -77,6 +77,14 @@ module BushSlicer
     end
   end
 
+  class LocalKubeconfigCredentials < AdminCredentials
+    def get
+      raise "kubeconfig does not exists" unless File.exists? opts[:spec]
+      config = File.open(opts[:spec]).read
+      return accessor_from_kubeconfig(config)
+    end
+  end
+
   class AutoKubeconfigCredentials < AdminCredentials
     def get
       case opts[:spec]
@@ -84,6 +92,8 @@ module BushSlicer
         MasterOsAdminCredentials.new(env, **opts).get
       when %r{://}
         URLKubeconfigCredentials.new(env, **opts).get
+      when opts[:spec]
+        LocalKubeconfigCredentials.new(env, **opts).get
       else
         raise "unknown credentials specification: #{opts[:spec]}"
       end


### PR DESCRIPTION
similiar to #83, but accept kubeconfig that's stored locally.  This will be helpful in case the URL is not accesible.  You can set environment variable like so
`export OPENSHIFT_ENV_OCP4_ADMIN_CREDS_SPEC=~/.kube/config`