### PR TITLE
update the project delete step

### DIFF
--- a/lib/openshift/project.rb
+++ b/lib/openshift/project.rb
@@ -21,7 +21,7 @@ module BushSlicer
         return true
       else
         case  result[:response]
-        when /cannot get project/, /not found/
+        when /Error from server \(Forbidden\)/
           return false
         else
           raise "error getting project '#{name}' existence: #{result[:response]}"


### PR DESCRIPTION
Update project step for 4.x
```
Given the "<%= cb.prj_name %>" project is deleted                                      # features/step_definitions/project.rb:192
      project.project.openshift.io "56m0m" deleted
      
      [07:09:11] INFO> Exit Status: 0
      error getting project '56m0m' existence: 
      STDERR:
      Error from server (Forbidden): projects.project.openshift.io "56m0m" is forbidden: User "pm1" cannot get resource "projects" in API group "project.openshift.io" in the namespace "56m0m"
       (RuntimeError)
  ../redhat/verification-tests/lib/openshift/project.rb:27:in `visible?'
```