### PR TITLE
Delete 'grep' in sh and update it to scan

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -165,14 +165,14 @@ Feature: Pod related networking scenarios
 
     # test the bandwidth limit with qos for egress
     When I execute on the "<%= cb.iperf_client %>" pod:
-      | sh | -c | iperf3 -c <%= cb.iperf_server %> -i 1 -t 12s \| grep "1.99 Mbits" |
+      | sh | -c | iperf3 -c <%= cb.iperf_server %> -i 1 -t 12s |
     Then the step should succeed
-    And the expression should be true> @result[:response].lines.count >= 6
+    And the expression should be true> @result[:response].scan(/[12].[0-9][0-9] Mbits/).size >= 10
     # test the bandwidth limit with qos for ingress
     When I execute on the "<%= cb.iperf_client %>" pod:
-      | sh | -c | iperf3 -c <%= cb.iperf_server %> -i 1 -t 12s -R \| grep "4.98 Mbits" |
+      | sh | -c | iperf3 -c <%= cb.iperf_server %> -i 1 -t 12s -R |
     Then the step should succeed
-    And the expression should be true> @result[:response].lines.count >= 6
+    And the expression should be true> @result[:response].scan(/[45].[0-9][0-9] Mbits/).size >= 10
 
     # remove the qos pod and check if the ovs qos configurations are removed
     When I run the :delete client command with:


### PR DESCRIPTION
I often met the following error when I execute this case:
```
      [07:29:59] INFO> Shell Commands: oc exec iperf-rc-r8zsr  --config=/home/jenkins/workspace/Runner-v3/workdir/cucushift-oc311-standard-slave-94c71-0/ose_zzhao.kubeconfig -n nx8d9  -- sh -c iperf3\ -c\ 10.130.0.128\ -i\ 1\ -t\ 12s\ \|\ grep\ \"1.99\ Mbits\"
      
      STDERR:
      command terminated with exit code 1
```
but it can work when I deleted `\ \|\ grep\ \"1.99\ Mbits\`. I did not find the reason, So I changed the current way to implement.
And also 1.99 Mbits is not stable from the logs. sometimes it's 1.xx or 2.xx. So I changed to regrex [12].[0-9][0-9]
```
 [07:13:47] INFO> Shell Commands: oc exec iperf-rc-fk9wj  --config=/home/jenkins/workspace/Runner-v3/workdir/cucushift-oc311-standard-slave-2sblr-0/ose_zzhao.kubeconfig -n 7n21w  -- sh -c iperf3\ -c\ 10.129.0.38\ -i\ 1\ -t\ 12s
      Connecting to host 10.129.0.38, port 5201
      [  4] local 10.129.0.39 port 46596 connected to 10.129.0.38 port 5201
      [ ID] Interval           Transfer     Bandwidth       Retr  Cwnd
      [  4]   0.00-1.00   sec  1.55 MBytes  13.0 Mbits/sec  213   15.0 KBytes       
      [  4]   1.00-2.00   sec   188 KBytes  1.54 Mbits/sec   37   5.46 KBytes       
      [  4]   2.00-3.00   sec   314 KBytes  2.57 Mbits/sec   43   8.19 KBytes       
      [  4]   3.00-4.00   sec   188 KBytes  1.54 Mbits/sec   33   5.46 KBytes       
      [  4]   4.00-5.00   sec   251 KBytes  2.06 Mbits/sec   36   5.46 KBytes       
      [  4]   5.00-6.00   sec   251 KBytes  2.06 Mbits/sec   37   5.46 KBytes       
      [  4]   6.00-7.00   sec   251 KBytes  2.06 Mbits/sec   38   5.46 KBytes       
      [  4]   7.00-8.00   sec   188 KBytes  1.54 Mbits/sec   29   5.46 KBytes       
      [  4]   8.00-9.00   sec   251 KBytes  2.06 Mbits/sec   40   5.46 KBytes       
      [  4]   9.00-10.00  sec   188 KBytes  1.54 Mbits/sec   39   5.46 KBytes       
      [  4]  10.00-11.00  sec   251 KBytes  2.06 Mbits/sec   40   5.46 KBytes       
      [  4]  11.00-12.00  sec   188 KBytes  1.54 Mbits/sec   32   5.46 KBytes       
      - - - - - - - - - - - - - - - - - - - - - - - - -
      [ ID] Interval           Transfer     Bandwidth       Retr
      [  4]   0.00-12.00  sec  4.01 MBytes  2.80 Mbits/sec  617             sender
      [  4]   0.00-12.00  sec  3.66 MBytes  2.56 Mbits/sec                  receiver
      
      iperf Done.
```

logs:
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/38775/console
@bmeng @lihongan 
