### PR TITLE
4.0 oc rules in new file

### DIFF
--- a/lib/rules/cli/4.0.yaml
+++ b/lib/rules/cli/4.0.yaml
@@ -1,1 +1,1338 @@
-3.3.yaml
+---
+:global_options:
+  # these are options as seen by `oc options`
+  :api_version: --api-version=<value>
+  :ca: --certificate-authority=<value>
+  :cluster: --cluster=<value>
+  :config: --config=<value>
+  :context: --context=<value>
+  :h: -h
+  :help: --help
+  :user: --user=<value>
+  :skip_tls_verify: --insecure-skip-tls-verify=<value>
+  :match-server-version: --match-server-version=<value>
+  :namespace: --namespace=<value>
+  :n: -n <value>
+  :loglevel: --loglevel=<value>
+  :log_dir: --log_dir=<value>
+  :log_flush_frequency: --log_flush_frequency=<value>
+  :logtostderr: --logtostderr=<value>
+  :request-timeout: --request-timeout=<value>
+  :server: --server=<value>
+  :stderrthreshold: --stderrthreshold=<value>
+  :token: --token=<value>
+  :as: --as=<value>
+  :as_group: --as-group=<value>
+:annotate:
+  :cmd: oc annotate
+  :options:
+    :resource: <value>
+    :resourcename: <value>
+    :keyval: <value>
+    :all: --all=<value>
+    :noheadersfalse: --no-headers=<value>
+    :o: -o <value>
+    :output: --output=<value>
+    :outputversion: --output-version=<value>
+    :overwrite: --overwrite=<value>
+    :resourceversion: --resource-version=<value>
+    :t: -t <value>
+    :template: --template=<value>
+:apply:
+  :cmd: oc apply
+  :options:
+    :f: -f <value>
+    :force: --force=<value>
+    :grace-period: --grace-period=<value>
+    :overwrite: --overwrite=<value>
+:apply_set_last_applied:
+  :cmd: oc apply set-last-applied
+  :options:
+    :f: -f <value>
+:apply_view_last_applied:
+  :cmd: oc apply view-last-applied
+  :options:
+    :resource: <value>
+    :resource_name: <value>
+:attach:
+  :cmd: oc attach
+  :options:
+    :cmd_name: <value>
+    :pod: <value>
+    :c: -c <value>
+    :i: -i
+    :t: -t
+    :container: --container=<value>
+    :stdin: --stdin=<value>
+    :tty: --tty=<value>
+:autoscale:
+  :cmd: oc autoscale <name>
+  :options:
+    :cpu-percent: --cpu-percent=<value>
+    :min: --min=<value>
+    :max: --max=<value>
+:build_logs:
+  :cmd: oc build-logs <build_name>
+  :options:
+    :follow: --follow=<value>
+    :nowait: --nowait=<value>
+:cancel_build:
+  :cmd: oc cancel-build
+  :options:
+    :build_name: <value>
+    :bc_name: <value>
+    :dump_logs: --dump-logs=<value>
+    :restart: --restart=<value>
+    :state: --state=<value>
+:config:
+  :cmd: oc config
+  :options:
+    :subcommand: <value>
+:config_set:
+  :cmd: oc config set <prop_name> <prop_value>
+:config_set_cluster:
+  :cmd: oc config set-cluster <name>
+  :options:
+    :cert: --certificate-authority=<value>
+    :embed: --embed-certs=<value>
+    :server: --server=<value>
+:config_set_context:
+  :cmd: oc config set-context <name>
+  :options:
+    :cluster: --cluster=<value>
+    :namespace: --namespace=<value>
+    :user: --user=<value>
+:config_set_creds:
+  :cmd: oc config set-credentials <name>
+  :options:
+    :cert:  --client-certificate=<value>
+    :key:  --client-key=<value>
+    :embed:  --embed-certs=<value>
+    :password:  --password=<value>
+    :token: --token=<value>
+    :user:  --username=<value>
+:config_use_context:
+  :cmd: oc config use-context <name>
+:config_unset:
+  :cmd: oc config unset <prop_name>
+:config_view:
+  :cmd: oc config view
+  :options:
+    :output: --output=<value>
+    :flatten: --flatten
+    :minify: --minify
+    :raw: --raw
+  :expected:
+    - "apiVersion: v"
+    - "kind: Config"
+  :optional_properties:
+    :current_context: !ruby/regexp '/^current-context: (.+)/'
+:convert:
+  :cmd: oc convert
+  :options:
+    :file: -f <value>
+    :local: --local=<value>
+    :o: -o <value>
+    :output_version: --output-version=<value>
+    :recursive: --recursive=<value>
+:cp:
+  :cmd: oc cp
+  :options:
+    :c: -c=<value>
+    :source: <value>
+    :dest: <value>
+:create:
+  :cmd: oc create
+  :options:
+    :f: -f <value>
+    :filename: --filename=<value>
+    :record: --record=<value>
+:create_clusterresourcequota:
+  :cmd: oc create clusterresourcequota <name>
+  :options:
+    :hard: --hard=<value>
+    :annotation-selector: --project-annotation-selector=<value>
+    :label-selector: --project-label-selector=<value>
+:create_configmap:
+  :cmd: oc create configmap
+  :options:
+    :name: <value>
+    :from_file: --from-file=<value>
+    :from_literal: --from-literal=<value>
+:create_namespace:
+  :cmd: oc create namespace <name>
+:create_quota:
+  :cmd: oc create quota <name>
+  :options:
+    :dry-run: --dry-run=<value>
+    :hard: --hard=<value>
+    :scopes: --scopes=<value>
+    :output: --output=<value>
+:create_route_edge:
+  :cmd: oc create route edge <name>
+  :options:
+    :hostname: --hostname=<value>
+    :service: --service=<value>
+    :cert: --cert=<value>
+    :key: --key=<value>
+    :cacert: --ca-cert=<value>
+    :path: --path=<value>
+    :insecure_policy: --insecure-policy=<value>
+    :wildcardpolicy: --wildcard-policy=<value>
+    :help: --help
+:create_route_passthrough:
+  :cmd: oc create route passthrough <name>
+  :options:
+    :hostname: --hostname=<value>
+    :service: --service=<value>
+    :wildcardpolicy: --wildcard-policy=<value>
+    :help: --help
+:create_route_reencrypt:
+  :cmd: oc create route reencrypt <name>
+  :options:
+    :hostname: --hostname=<value>
+    :service: --service=<value>
+    :cert: --cert=<value>
+    :key: --key=<value>
+    :cacert: --ca-cert=<value>
+    :destcacert: --dest-ca-cert=<value>
+    :path: --path=<value>
+    :insecure_policy: --insecure-policy=<value>
+    :wildcardpolicy: --wildcard-policy=<value>
+    :help: --help
+:create_secret:
+  :cmd: oc create secret <secret_type>
+  :options:
+    :name: <value>
+    :docker_email: --docker-email=<value>
+    :docker_password: --docker-password=<value>
+    :docker_server: --docker-server=<value>
+    :docker_username: --docker-username=<value>
+    :dry_run: --dry-run=<value>
+    :from_literal: --from-literal=<value>
+    :from_file: --from-file=<value>
+    :generator: --generator=<value>
+    :output: --output=<value>
+    :save_config: --save-config=<value>
+    :type: --type=<value>
+    :cert: --cert=<value>
+    :key: --key=<value>
+:create_service:
+  :cmd: oc create service <createservice_type>
+  :options:
+      :clusterip: --clusterip=<value>
+      :name: <value>
+      :nodeport: --node-port=<value>
+      :tcp: --tcp=<value>
+      :dry_run: --dry-run=<value>
+:create_service_loadbalancer:
+  :cmd: oc create service loadbalancer <name>
+  :options:
+    :tcp: --tcp=<value>
+:create_serviceaccount:
+  :cmd: oc create serviceaccount <serviceaccount_name>
+:test_do_not_use:
+  :cmd: <command>
+  :options:
+    :opt: <value>
+:debug:
+  :cmd: oc debug <global_options>
+  :options:
+     :resource: <value>
+     :keep_annotations: --keep-annotations
+     :keep_init_containers: --keep-init-containers=<value>
+     :keep_liveness: --keep-liveness
+     :keep_readiness: --keep-readiness
+     :one_container: --one-container=<value>
+     :node_name: --node-name=<value>
+     :c: -c <value>
+     :t: -t
+     :o: -o <value>
+     :f: -f <value>
+     :oc_opts_end: --
+     :exec_command: <value>
+     :exec_command_arg: <value>
+:delete:
+  :cmd: oc delete
+  :options:
+    :all: --all
+    #The following 'all' can be used with selectors, like the -l flag.
+    :all_no_dash: all
+    :cascade: --cascade=<value>
+    :f: -f <value>
+    :force: --force=<value>
+    :grace_period: --grace-period=<value>
+    :l: -l <value>
+    :object_name_or_id: <value>
+    :object_type: <value>
+:deploy:
+  :cmd: oc deploy <deployment_config>
+  :options:
+    :cancel: --cancel
+    :enable_triggers: --enable-triggers
+    :latest: --latest
+    :retry: --retry
+:describe:
+  :cmd: oc describe <resource>
+  :options:
+    :name: <value>
+    :l: -l <value>
+    :f: -f <value>
+    :selector: --selector=<value>
+:edit:
+  :cmd: oc edit
+  :options:
+    :filename: --filename=<value>
+    :output: --output=<value>
+# The cmd :env can be removed after 3.1 EOL (nov 2018).
+# We have both :env and :set_env since 3.2.
+# Removed :env in 3.11.
+:env:
+  :cmd: oc set env
+  :options:
+    :all: --all=<value>
+    :e: -e <value>
+    :env_name: <value>
+    :keyval: <value>
+    :list: --list=<value>
+    :o: -o <value>
+    :resource: <value>
+:exec:
+  # reorder global_options and options to allow specifying exec command
+  :cmd: oc exec <pod> <global_options> <options>
+  :options:
+    :c: -c <value>
+    :container: --container=<value>
+    :stdin: --stdin=<value>
+    :tty: --tty=<value>
+    :t: -t
+    :i: -i
+    :oc_opts_end: --
+    :exec_command: <value>
+    :exec_command_arg: <value>
+:exec_raw_oc_cmd_for_neg_tests:   # used for negative testing in which we want to deviate from yaml
+  :cmd: oc
+  :options:
+    :arg: <value>
+    :test_do_not_use: <value>
+:explain:
+  :cmd: oc explain
+  :options:
+    :resource: <value>
+:export:
+  :cmd: oc export
+  :options:
+    :resource: <value>
+    :name: <value>
+    :filename: --filename=<value>
+    :output_format: --output=<value>
+    :all: --all=<value>
+    :f: -f <value>
+    :o: -o <value>
+    :l: -l <value>
+    :t: -t <value>
+    :as_template: --as-template=<value>
+    :exact: --exact=<value>
+    :output_version: --output-version=<value>
+:expose:
+  :cmd: oc expose <resource> <resource_name>
+  :options:
+    :generator: --generator=<value>
+    :external_ip: --external-ip=<value>
+    :path: --path=<value>
+    :port: --port=<value>
+    :protocol: --protocol=<value>
+    :template: --template=<value>
+    :target_port: --target-port=<value>
+    :type: --type=<value>
+    :name: --name=<value>
+    :selector: --selector=<value>
+    :output: --output=<value>
+    :o: -o <value>
+    :path: --path=<value>
+    :hostname: --hostname=<value>
+    :wildcardpolicy: --wildcard-policy=<value>
+    :help: --help
+:extract:
+  :cmd: oc extract
+  :options:
+    :confirm: --confirm=<value>
+    :f: -f <value>
+    :filename: --filename=<value>
+    :keys: --keys=<value>
+    :resource: <value>
+    :to: --to=<value>
+:get:
+  :cmd: oc get <resource>
+  :options:
+    :a: --show-all=<value>
+    :all_namespaces: --all-namespaces=<value>
+    :export: --export=<value>
+    :fieldSelector: --field-selector=<value>
+    :L: -L <value>
+    :l: -l <value>
+    :no_headers: --no-headers=<value>
+    :o: -o <value>
+    :output: --output=<value>
+    :raw: --raw=<value>
+    :resource_name: <value>
+    :show_label: --show-labels=<value>
+    :sort_by: --sort-by=<value>
+    :template: --template=<value>
+    :w: --watch=<value>
+:help:
+  :cmd: oc help
+  :options:
+    :command_name: <value>
+    # use global `h` and `help` options if needed
+:idle:
+  :cmd: oc idle
+  :options:
+    :all: --all=<value>
+    :dry-run: --dry-run=<value>
+    :l: -l <value>
+    :resource-names-file: --resource-names-file=<value>
+    :svc_name: <value>
+:import:
+  :cmd: oc import <command>
+  :options:
+    :as_template: --as-template=<value>
+    :dry_run: --dry-run=<value>
+    :f: -f <value>
+    :o: -o <value>
+:import_image:
+  :cmd: oc import-image
+  :options:
+    :all: --all=<value>
+    :confirm: --confirm=<value>
+    :from: --from=<value>
+    :image_name: <value>
+    :insecure: --insecure=<value>
+    :reference-policy: --reference-policy=<value>
+:label:
+  :cmd: oc label <resource>
+  :options:
+    :all: --all=<value>
+    :key_val: <value>
+    :name: <value>
+    :o: -o <value>
+    :overwrite: --overwrite=<value>
+    :l: -l <value>
+:login:
+  :cmd: oc login
+  :options:
+    :u: -u <value>
+    :p: -p <value>
+    :username: --username=<value>
+    :password: --password=<value>
+    :token: --token=<value>
+  :optional_properties:
+    :username: !ruby/regexp '/ogged into ".+?" as "(.+?)"/'
+  :expected:
+    # strange, sometimes "Already logged into..." is printed to console, and
+    #   sometimes when run multiple times - not (oc v3.0.0.0)
+    #   e.g. run multiple times `oc login --username=joe`
+    - !ruby/regexp '/Login successful.|ogged into|sing project|new project/'
+:logout:
+  :cmd: oc logout
+  :expected:
+    - !ruby/regexp '/Logged ".+" out on/'
+:logs:
+  :cmd: oc logs <resource_name>
+  :options:
+    :c: -c <value>
+    :f: -f
+    :limit-bytes: --limit-bytes <value>
+    :p: -p
+    :since: --since <value>
+    :since-time: --since-time <value>
+    :tail: --tail <value>
+    :timestamps: --timestamps
+    :version: --version <value>
+:new_app:
+  :cmd: oc new-app
+  :options:
+    :allow_missing_images: --allow-missing-images=<value>
+    :allow_missing_imagestream_tags: --allow-missing-imagestream-tags=<value>
+    :app_repo: <value>
+    :as_test: --as-test=<value>
+    :build_env: --build-env=<value>
+    :build_env_file: --build-env-file=<value>
+    :code: --code=<value>
+    :context_dir: --context-dir=<value>
+    :docker_image: --docker-image=<value>
+    :dry_run: --dry-run=<value>
+    :env: --env=<value>
+    :env_file: --env-file=<value>
+    :file: --file=<value>
+    :group: --group=<value>
+    :image: --image=<value>
+    :image_stream: --image-stream=<value>
+    :insecure_registry: --insecure-registry=<value>
+    :l: -l <value>
+    :labels: --labels=<value>
+    :name: --name=<value>
+    :output: --output=<value>
+    :p: -p <value>
+    :e: -e <value>
+    :param: --param=<value>
+    :search: --search=<value>
+    :search_raw: --search <value>
+    :strategy: --strategy=<value>
+    :template: --template=<value>
+    :param_file: --param-file=<value>
+    :env_file: --env-file <value>
+    :source_secret: --source-secret=<value>
+:new_build:
+  :cmd: oc new-build
+  :options:
+    :allow_missing_imagestream_tags: --allow-missing-imagestream-tags=<value>
+    :app_repo: <value>
+    :binary: --binary <value>
+    :build_arg: --build-arg=<value>
+    :build_secret: --build-secret=<value>
+    :build_env: --build-env=<value>
+    :build_env_file: --build-env-file=<value>
+    :context_dir: --context-dir=<value>
+    :code: --code=<value>
+    :docker_image: --docker-image=<value>
+    :D : -D <value>
+    :e: -e <value>
+    :image: --image=<value>
+    :image_stream: --image-stream=<value>
+    :l: -l <value>
+    :name: --name=<value>
+    :output: --output=<value>
+    :source_image: --source-image=<value>
+    :source_image_path: --source-image-path=<value>
+    :strategy: --strategy=<value>
+    :template: --template=<value>
+    :to_docker: --to-docker=<value>
+    :to : --to=<value>
+    :no-output: --no-output=<value>
+    :env_file: --env-file=<value>
+    :source_secret: --source-secret=<value>
+    :build_config_map: --build-config-map=<value>
+:new_project:
+  :cmd: oc new-project <project_name>
+  #:expected:
+  #  - Created project <project_name>
+  :options:
+    :display_name: --display-name=<value>
+    :description: --description=<value>
+    :admin: --admin=<value>
+:new_secret:
+  :cmd: oc secrets new <secret_name> <credential_file>
+  :options:
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>  # One of: json|yaml|template|templatefile|wide
+    :output_version: --output-version=<value>
+    :template: --template=<value>
+    :type: --type=<value>
+    :quiet: --quiet=<value>
+:observe:
+  :cmd: oc observe <resource> <global_options> <options>
+  :options:
+    :a: -a=<value>
+    :command: <value>
+    :delete: --delete=<value>
+    :maximum_errors: --maximum-errors=<value>
+    :names: --names=<value>
+    :no_headers: --no-headers=<value>
+    :oc_opts_end: --
+    :once: --once=<value>
+    :resync_period: --resync-period=<value>
+:oc_secrets_new_basicauth:
+  :cmd: oc secrets new-basicauth <secret_name>
+  :options:
+    :username: --username=<value>
+    :password: --password=<value>
+    :cafile: --ca-cert=<value>
+    :gitconfig: --gitconfig=<value>
+    :prompt: --prompt=<value>
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>
+    :output_version: --output-version=<value>
+    :template: --template=<value>
+:oc_secrets_new_dockercfg:
+  :cmd: oc secrets new-dockercfg <secret_name>
+  :options:
+    :docker_email: --docker-email=<value>
+    :docker_password: --docker-password=<value>
+    :docker_server: --docker-server=<value>
+    :docker_username: --docker-username=<value>
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>  # One of: json|yaml|template|templatefile|wide
+    :output_version: --output-version=<value>
+    :template: --template=<value>
+:oc_secrets_new_sshauth:
+  :cmd: oc secrets new-sshauth <secret_name>
+  :options:
+    :ssh_privatekey: --ssh-privatekey=<value>
+    :cafile: --ca-cert=<value>
+    :gitconfig: --gitconfig=<value>
+    :prompt: --prompt=<value>
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>
+    :template: --template=<value>
+:options:
+  :cmd: oc options
+:patch:
+  :cmd: oc patch <resource>
+  :options:
+    :resource_name: <value>
+    :p: -p <value>
+    :type: --type=<value>
+:plugin:
+  :cmd: oc plugin
+  :options:
+    :cmd_name: <value>
+    :cmd_flag: <value>
+    :cmd_flag_val: <value>
+:policy_add_role_to_group:
+  :cmd: oc policy add-role-to-group <role> <group_name>
+  :options:
+    :role_namespace: --role-namespace=<value>
+:policy_add_role_to_user:
+  :cmd: oc policy add-role-to-user <role>
+  :options:
+    :role_namespace: --role-namespace=<value>
+    :serviceaccount: -z=<value>
+    :serviceaccountraw: <value>
+    :user_name: <value>
+    :rolebinding_name: --rolebinding-name=<value>
+:policy_remove_group:
+  :cmd: oc policy remove-group <group_name>
+:policy_remove_role_from_group:
+  :cmd: oc policy remove-role-from-group <role> <group_name>
+  :options:
+    :role_namespace: --role-namespace=<value>
+:policy_remove_role_from_user:
+  :cmd: oc policy remove-role-from-user <role>
+  :options:
+    :role_namespace: --role-namespace=<value>
+    :serviceaccount: -z <value>
+    :user_name: <value>
+:policy_can_i:
+  :cmd: oc policy can-i <verb> <resource>
+  :options:
+    :q: -q
+:policy_who_can:
+  :cmd: oc policy who-can <verb> <resource>
+:policy_scc_review:
+  :cmd: oc policy scc-review
+  :options:
+    :f: -f <value>
+    :serviceaccount: -z <value>
+:policy_scc_subject_review:
+  :cmd: oc policy scc-subject-review
+  :options:
+    :f: -f <value>
+    :group: -g <value>
+    :serviceaccount: -z <value>
+    :user: -u <value>
+:port_forward:
+  :cmd: oc port-forward
+  :options:
+    :pod: <value>
+    :port_spec: <value>
+:process:
+  :cmd: oc process
+  :options:
+    :f: -f <value>
+    :template: <value>
+    :v: --value=<value>
+    :l: -l <value>
+    :parameters: --parameters=<value>
+    :param_file: --param-file=<value>
+    :p: -p <value>
+:project:
+  :cmd: oc project
+  :options:
+    :project_name: <value>
+    :short:  --short=<value>
+:projects:
+  :cmd: oc projects
+  :options:
+    :short:  --short=<value>
+:proxy:
+  :cmd: oc proxy
+  :options:
+    :accept_hosts: --accept-hosts=<value>
+    :accept_paths: --accept-paths=<value>
+    :address: --address=<value>
+    :api_prefix: --api-prefix=<value>
+    :disable_filter: --disable-filter=<value>
+    :port: --port=<value>
+    :reject_methods: --reject-methods=<value>
+    :reject_paths: --reject-paths=<value>
+    :unix_socket: --unix-socket=<value>
+    :www: --www=<value>
+    :www_prefix: --www-prefix=<value>
+:replace:
+  :cmd: oc replace
+  :options:
+    :f: -f <value>
+    :force: --force
+    :output: --output=<value>
+    :cascade: --cascade
+    :grace_period: --grace-period=<value>
+:rollback:
+  :cmd: oc rollback <deployment_name>
+  :options:
+    :change_scaling_settings: --change-scaling-settings
+    :change_strategy: --change-strategy
+    :change_triggers: --change-triggers
+    :dry_run: --dry-run
+    :output: --output=<value>
+    :template: --template=<value>
+    :to_version: --to-version=<value>
+:rollout_cancel:
+  :cmd: oc rollout cancel <resource> <name>
+  :options:
+    :f: -f <value>
+    :output: --output=<value>
+:rollout_history:
+  :cmd: oc rollout history <resource>
+  :options:
+    :resource_name: <value>
+    :revision: --revision=<value>
+:rollout_latest:
+  :cmd: oc rollout latest <resource>
+  :options:
+      :f: -f <value>
+:rollout_pause:
+  :cmd: oc rollout pause <resource> <name>
+  :options:
+    :f: -f <value>
+:rollout_resume:
+  :cmd: oc rollout resume <resource> <name>
+  :options:
+    :f: -f <value>
+:rollout_retry:
+  :cmd: oc rollout retry <resource> <name>
+  :options:
+    :f: -f <value>
+    :output: --output=<value>
+:rollout_status:
+  :cmd: oc rollout status <resource> <name>
+  :options:
+    :f: -f <value>
+    :w: --watch=<value>
+:rollout_undo:
+  :cmd: oc rollout undo <resource>
+  :options:
+    :resource_name: <value>
+    :to_revision: --to-revision=<value>
+:rsh:
+  :cmd: oc rsh <global_options> <options>
+  :options:
+    :app_name: <value>
+    :no_tty: --no-tty=<value>
+    :c: --container=<value>
+    :command: <value>
+    :command_arg: <value>
+    :pod: <value>
+    :shell: --shell=<value>
+:rsync:
+  #either source or destination must be in to format POD:/remote/dir/, i.e.
+  #oc rsync ./local/dir/ POD:/remote/dir
+  #oc rsync POD:/remote/dir/ ./local/dir
+  #Please reference TC 510666 in features/cli/oc_rsync.feature for an example.
+  :cmd: oc rsync <source> <destination>
+  :options:
+    :c: --container=<value>
+    :delete: --delete=<value>
+    :strategy: --strategy=<value>
+    :w: --watch=<value>
+    :delete: --delete=<value>
+:run:
+  :cmd: oc run <name> <global_options> <options>
+  :options:
+    :attach: --attach=<value>
+    :command: --command=<value>
+    :cmd: <value>
+    :image: --image=<value>
+    :port: --port <value>
+    :replicas: --replicas <value>
+    :generator: --generator=<value>
+    :limits: --limits=<value>
+    :requests: --requests=<value>
+    :schedule: --schedule=<value>
+    :serviceaccount: --serviceaccount=<value>
+    :sleep:  -- sleep <value>
+    :oc_opt_end: --
+    :dry_run: --dry-run
+    :-i: --stdin=<value>
+    :-l: --labels=<value>
+    :-t: --template=<value>
+    :-o: --output=<value>
+    :overrides: --overrides=<value>
+    :restart: --restart=<value>
+    :tty: --tty=<value>
+    :env: --env=<value>
+:scale:
+  :cmd: oc scale <resource> <name>
+  :options:
+    :current_replicas: --current-replicas=<value>
+    :replicas:  --replicas=<value>
+    :resource_ver: --resource-version=<value>
+    :timeout: --timeout=<value>
+:secrets:
+  :cmd: oc secrets <action>
+  :options:
+    :name: <value>
+    :source: <value>
+    :serviceaccount: <value>
+    :secrets_name: <value>
+    :for: --for=<value>
+    :username: --username=<value>
+    :password: --password=<value>
+:secret_add:
+  :cmd: oc secrets add serviceaccount/<sa_name> secrets/<secret_name>
+  :options:
+    :for: --for=<value>
+:secret_link:
+  :cmd: oc secrets link serviceaccount/<sa_name> secrets/<secret_name>
+  :options:
+    :for: --for=<value>
+:secret_new:
+  :cmd: oc secrets new <secret_name>
+  :options:
+    :source: <value>
+:secret_unlink:
+  :cmd: oc secrets unlink serviceaccount/<sa_name> secrets/<secret_name>
+:serviceaccounts_get_token:
+  :cmd: oc serviceaccounts get-token <serviceaccount_name>
+:serviceaccounts_new_token:
+  :cmd: oc serviceaccounts new-token <serviceaccount_name>
+  :options:
+    :labels: --labels=<labels>
+    :timeout: --timeout=<timeout_seconds>
+:set_backends:
+  :cmd: oc set route-backends
+  :options:
+    :routename: <value>
+    :service: <value>
+    :zero: --zero
+    :adjust: --adjust
+:set_build_hook:
+  :cmd: oc set build-hook <global_options> <options>
+  :options:
+    :args: <value>
+    :buildconfig: <value>
+    :command: --command
+    :oc_opts_end: --
+    :post_commit: --post-commit=<value>
+    :remove: --remove=<value>
+    :script: --script=<value>
+    :f: -f <value>
+    :o: -o <value>
+:set_build_secret:
+  :cmd: oc set build-secret <options> <bc_name> <secret_name>
+  :options:
+    :pull: --pull=<value>
+    :push: --push=<value>
+    :remove: --remove=<value>
+    :l: --selector=<value>
+    :source: --source=<value>
+:set_deployment_hook:
+  :cmd: oc set deployment-hook <global_options> <options>
+  :options:
+    :all: --all
+    :oc_opts_end: --
+    :args: <value>
+    :deploymentconfig: <value>
+    :failure_policy: --failure-policy=<value>
+    :mid: --mid
+    :post: --post
+    :pre: --pre
+    :remove: --remove
+    :c: -c <value>
+    :e: -e <value>
+    :f: -f <value>
+    :o: -o <value>
+    :l: -l <value>
+:set_env:
+  :cmd: oc set env
+  :options:
+    :all: --all=<value>
+    :env_name: <value>
+    :from: --from=<value>
+    :keyval: <value>
+    :list: --list=<value>
+    :prefix: --prefix=<value>
+    :resource: <value>
+    :c: -c <value>
+    :e: -e <value>
+    :o: -o <value>
+    :f: -f <value>
+    :overwrite: --overwrite=<value>
+:set_image:
+  :cmd: oc set image
+  :options:
+    :keyval: <value>
+    :l: -l <value>
+    :resource: <value>
+    :type_name: <value>
+    :container_image: <value>
+    :all: --all=<value>
+    :filename: --filename=<value>
+    :local: --local=<value>
+    :source: --source=<value>
+    :output: --output=<value>
+    :record: --record=<value>
+    :selector: --selector=<value>
+:set_image_lookup:
+  :cmd: oc set image-lookup
+  :options:
+    :image_stream: <value>
+    :deployment: <value>
+:set_probe:
+  :cmd: oc set probe <global_options> <options>
+  :options:
+    :all: --all
+    :oc_opts_end: --
+    :exec_command: <value>
+    :failure_threshold: --failure-threshold=<value>
+    :get_url: --get-url=<value>
+    :initial_delay_seconds: --initial-delay-seconds=<value>
+    :liveness: --liveness
+    :no_headers: --no-headers
+    :open_tcp: --open-tcp=<value>
+    :output_version: --output-version=<value>
+    :period_seconds: --period-seconds=<value>
+    :readiness: --readiness
+    :remove: --remove
+    :resource: <value>
+    :success_threshold: --success-threshold=<value>
+    :timeout_seconds: --timeout-seconds=<value>
+    :c: -c <value>
+    :f: -f <value>
+    :l: -l <value>
+    :o: -o <value>
+:set_resources:
+  :cmd: oc set resources
+  :options:
+    :resource: <value>
+    :resourcename: <value>
+    :limits: --limits=<value>
+    :requests: --requests=<value>
+    :local: --local
+    :dryrun: --dry-run
+    :c: -c <value>
+    :f: -f <value>
+    :o: -o <value>
+:set_triggers:
+  :cmd: oc set triggers
+  :options:
+    :all: --all=<value>
+    :auto: --auto=<value>
+    :containers: --containers=<value>
+    :from_config: --from-config=<value>
+    :from_github: --from-github=<value>
+    :from_image: --from-image=<value>
+    :from_webhook: --from-webhook=<value>
+    :manual: --manual=<value>
+    :remove: --remove=<value>
+    :remove_all: --remove-all=<value>
+    :resource: <value>
+    :f: --filename=<value>
+    :l: -l <value>
+    :o: --output=<value>
+    :t: --template=<value>
+:set_volume:
+  :cmd: oc set volume
+  :options:
+    :add: --add=<value>
+    :resource: <value>
+    :resource_name: <value>
+    :action: <value>
+    :confirm: --confirm=<value>
+    :f: --filename=<value>
+    :o: --output=<value>
+    :name: --name=<value>
+    :type: --type=<value>
+    :secret-name: --secret-name=<value>
+    :source: --source=<value>
+    :mount-path: --mount-path=<value>
+    :claim-name: --claim-name=<value>
+    :claim-mode: --claim-mode=<value>
+    :claim-size: --claim-size=<value>
+    :claim-class: --claim-class=<value>
+    :configmap-name: --configmap-name=<value>
+    :all: --all=<value>
+    :selector: --selector=<value>
+    :overwrite: --overwrite
+    :path: --path=<value>
+    :confirm: --confirm
+:start_build:
+  :cmd: oc start-build
+  :options:
+    :buildconfig: <value>
+    :build_arg: --build-arg=<value>
+    :env: --env=<value>
+    :follow: --follow=<value>
+    :from_build: --from-build=<value>
+    :from_file: --from-file=<value>
+    :from_dir: --from-dir=<value>
+    :from_webhook: --from-webhook=<value>
+    :from_repo: --from-repo=<value>
+    :from_archive: --from-archive=<value>
+    :git_post: --git-post-receive=<value>
+    :git_repository: --git-repository=<value>
+    :list_webhooks: --list-webhooks=<value>
+    :wait: --wait=<value>
+    :commit: --commit=<value>
+    :o: --output=<value>
+    :no-cache: --no-cache=<value>
+    :incremental: --incremental=<value>
+:status:
+  :cmd: oc status
+  :options:
+    :v: -v
+    :suggest: --suggest
+:stop:
+  :cmd: oc stop <resource>
+  :options:
+    :f: --filename=<value>
+    :name: <value>
+:tag:
+  :cmd: oc tag <source>
+  :options:
+    :alias: --alias=<value>
+    :d: --delete=<value>
+    :dest: <value>
+    :insecure: --insecure=<value>
+    :reference: --reference=<value>
+    :reference_policy: --reference-policy=<value>
+    :scheduled: --scheduled=<value>
+    :source_type: --source=<value>
+:types:
+  :cmd: oc types
+:version:
+  :cmd: oc version
+  :expected:
+    - Client Version
+  :properties:
+    :oc_version: !ruby/regexp '/^Client.*GitVersion:"v(.+?)"/'
+  :optional_properties:
+    :kubernetes_server_version: !ruby/regexp '/^Server.*GitVersion:"v(.+?)"/'
+# The cmd :volume can be removed after 3.1 EOL (Nov 2018).
+# We have both :volume and :set_volume since 3.2.
+# Removed :volume in 3.11.
+:volume:
+  :cmd: oc set volume
+  :options:
+    :action: <value>
+    :add: --add=<value>
+    :all: --all=<value>
+    :claim-class: --claim-class=<value>
+    :claim-mode: --claim-mode=<value>
+    :claim-name: --claim-name=<value>
+    :claim-size: --claim-size=<value>
+    :confirm: --confirm=<value>
+    :f: --filename=<value>
+    :mount-path: --mount-path=<value>
+    :name: --name=<value>
+    :overwrite: --overwrite
+    :path: --path=<value>
+    :remove: --remove=<value>
+    :resource: <value>
+    :resource_name: <value>
+    :secret-name: --secret-name=<value>
+    :selector: --selector=<value>
+    :source: --source=<value>
+    :type: --type=<value>
+:wait:
+  :cmd: oc wait
+  :options:
+    :resource: <value>
+    :resource_name: <value>
+    :for:  --for=<value>
+    :l:  -l=<value>
+    :timeout:  --timeout=<value>
+:whoami:
+  :cmd: oc whoami
+  :options:
+    :invalid_option:  -b   # for negative testing
+    :c: -c
+    :t: -t
+#################### admin commands section
+:oadm_add_cluster_role_to_user:
+  :cmd: oc adm policy add-cluster-role-to-user <role_name>
+  :options:
+    :user_name: <value>
+    :z:  -z <value>
+    :serviceaccount: --serviceaccount=<value>
+:oadm_add_cluster_role_to_group:
+  :cmd: oc adm policy add-cluster-role-to-group <role_name> <group_name>
+:oadm_add_role_to_user:
+  :cmd: oc adm policy add-role-to-user <role_name> <user_name>
+  :options:
+    :role_namespace: --role-namespace=<value>
+    :rolebinding_name: --rolebinding-name=<value>
+:oadm_add_role_to_group:
+  :cmd: oc adm policy add-role-to-group <role_name> <group_name>
+  :options:
+    :rolebinding_name: --rolebinding-name=<value>
+:oadm_build_chain:
+  :cmd: oc adm build-chain
+  :options:
+    :all: --all=<value>
+    :imagestreamtag: <value>
+    :invalid_option: <value>   # for negative testing
+    :o: -o <value>
+    :trigger_only: --trigger-only=<value>
+:oadm_ca_create_key_pair:
+  :cmd: oc adm ca create-key-pair
+  :options:
+    :overwrite: --overwrite=<value>
+    :private_key: --private-key=<value>
+    :public_key: --public-key=<value>
+:oadm_ca_create_master_cert:
+  :cmd: oc adm ca create-master-certs
+  :options:
+    :certificate-authority: --certificate-authority=<value>
+    :cert-dir: --cert-dir=<value>
+    :expire-days: --expire-days=<value>
+    :hostnames: --hostnames=<value>
+    :master: --master=<value>
+    :public-master: --public-master=<value>
+    :signer-expire-days: --signer-expire-days=<value>
+    :overwrite: --overwrite=<value>
+    :signer-name: --signer-name=<value>
+:oadm_ca_create_signer_cert:
+  :cmd: oc adm ca create-signer-cert
+  :options:
+    :cert: --cert=<value>
+    :key: --key=<value>
+    :name: --name=<value>
+    :overwrite: --overwrite=<value>
+    :serial: --serial=<value>
+:oadm_config_view:
+  :cmd: oc adm config view
+  :options:
+    :flatten: --flatten
+    :minify: --minify
+    :raw: --raw
+:oadm_diagnostics:
+  :cmd: oc adm diagnostics
+  :options:
+    :diagnostics_name: <value>
+    :cluster-context: --cluster-context=<value>
+    :config: --config=<value>
+    :context: --context=<value>
+    :diaglevel: --diaglevel=<value>
+    :host: --host=<value>
+    :images: --images=<value>
+    :latest-images: --latest-images=<value>
+    :loglevel: --loglevel=<value>
+    :master-config: --master-config=<value>
+    :node-config: --node-config=<value>
+    :prevent-modification: --prevent-modification=<value>
+:oadm_drain:
+  :cmd: oc adm drain
+  :options:
+    :node_name: <value>
+    :force: --force=<value>
+    :delete-local-data: --delete-local-data=<value>
+    :ignore-daemonsets: --ignore-daemonsets=<value>
+:oadm_groups_add_users:
+  :cmd: oc adm groups add-users
+  :options:
+    :group_name: <value>
+    :user_name:  <value>
+:oadm_groups_new:
+  :cmd: oc adm groups new
+  :options:
+    :group_name: <value>
+    :user_name: <value>
+:oadm_groups_prune:
+  :cmd: oc adm groups prune
+  :options:
+    :sync_config: --sync-config=<value>
+    :blacklist: --blacklist=<value>
+    :whitelist: --whitelist=<value>
+    :confirm: --confirm
+:oadm_groups_remove_users:
+  :cmd: oc adm groups remove-users
+  :options:
+    :group_name: <value>
+    :user_name:  <value>
+:oadm_groups_sync:
+  :cmd: oc adm groups sync
+  :options:
+    :group_names: <value>
+    :sync_config: --sync-config=<value>
+    :whitelist: --whitelist=<value>
+    :blacklist: --blacklist=<value>
+    :confirm: --confirm
+    :type: --type=<value>
+    :sort_by: --sort-by=<value>
+:oadm_manage_node:
+  :cmd: oc adm manage-node <node_name>
+  :options:
+    :schedulable: --schedulable=<value>
+:oadm_manage_node_evacuate:
+  :cmd: oc adm manage-node
+  :options:
+    :dry_run: --dry-run=<value>
+    :evacuate: --evacuate=<value>
+    :list_pods: --list-pods=<value>
+    :node_name: <value>
+    :pod_selector: --pod-selector=<value>
+    :selector: --selector=<value>
+:oadm_new_project:
+  :cmd: oc adm new-project <project_name>
+  #:expected:
+  #  - Created project <project_name>
+  :options:
+    :display_name: --display-name=<value>
+    :description: --description=<value>
+    :admin: --admin=<value>
+    :node_selector: --node-selector=<value>
+:oadm_policy_add_scc_to_user:
+  :cmd: oc adm policy add-scc-to-user <scc>
+  :options:
+    :user_name: <value>
+    :serviceaccount: --serviceaccount=<value>
+:oadm_policy_reconcile_sccs:
+  :cmd: oc adm policy reconcile-sccs
+  :options:
+    :additive_only: --additive-only=<value>
+    :confirm: --confirm
+:oadm_policy_remove_scc_from_user:
+  :cmd: oc adm policy remove-scc-from-user <scc>
+  :options:
+    :user_name: <value>
+    :serviceaccount: --serviceaccount=<value>
+:oadm_policy_add_scc_to_group:
+  :cmd: oc adm policy add-scc-to-group <scc> <group_name>
+:oadm_policy_reconcile_cluster_roles:
+  :cmd: oc adm policy reconcile-cluster-roles
+  :options:
+    :confirm: --confirm=<value>
+:oadm_policy_remove_scc_from_group:
+  :cmd: oc adm policy remove-scc-from-group <scc> <group_name>
+:oadm_policy_who_can:
+  :cmd: oc adm policy who-can <verb> <resource>
+  :options:
+    :all_namespaces: --all-namespaces=<value>
+:oadm_prune_builds:
+  :cmd: oc adm prune builds
+  :options:
+    :confirm: --confirm=<value>
+    :keep_complete: --keep-complete=<value>
+    :keep_failed: --keep-failed=<value>
+    :keep_younger_than: --keep-younger-than=<value>
+    :orphans: --orphans=<value>
+    :orphans_noopt: --orphans
+:oadm_prune_deployments:
+  :cmd: oc adm prune deployments
+  :options:
+    :confirm: --confirm=<value>
+    :keep_complete: --keep-complete=<value>
+    :keep_failed: --keep-failed=<value>
+    :keep_younger_than: --keep-younger-than=<value>
+    :orphans: --orphans=<value>
+    :orphans_noopt: --orphans
+:oadm_prune_images:
+  :cmd: oc adm prune images
+  :options:
+    :confirm: --confirm=<value>
+    :keep_tag_revisions: --keep-tag-revisions=<value>
+    :keep_younger_than: --keep-younger-than=<value>
+    :prune_over_size_limit: --prune-over-size-limit=<value>
+    :registry_url: --registry-url=<value>
+    :prune_registry: --prune-registry=<value>
+:oadm_registry:
+  :cmd: oc adm registry
+  :options:
+    :images: --images=<value>
+    :mount_host: --mount-host=<value>
+    :ports: --ports=<value>
+    :serviceaccount: --service-account=<value>
+    :daemonset: --daemonset=<value>
+:oadm_remove_cluster_role_from_user:
+  :cmd: oc adm policy remove-cluster-role-from-user <role_name>
+  :options:
+    :user_name: <value>
+    :z:  -z <value>
+    :serviceaccount: --serviceaccount=<value>
+:oadm_remove_cluster_role_from_group:
+  :cmd: oc adm policy remove-cluster-role-from-group <role_name> <group_name>
+:oadm_remove_role_from_user:
+  :cmd: oc adm policy remove-role-from-user <role_name> <user_name>
+:oadm_remove_role_from_group:
+  :cmd: oc adm policy remove-role-from-group <role_name> <group_name>
+:oadm_version:
+  :cmd: oc version
+  :expected:
+    - oc v
+    - kubernetes v
+  :properties:
+    :oadm_version: !ruby/regexp '/^oc v(.+)$/'
+    :kubernetes_version: !ruby/regexp '/kubernetes v(.+)$/'
+:oadm_pod_network_join_projects:
+  :cmd: oc adm pod-network join-projects
+  :options:
+    :project: <value>
+    :selector: --selector=<value>
+    :to: --to=<value>
+:oadm_pod_network_make_projects_global:
+  :cmd: oc adm pod-network make-projects-global
+  :options:
+    :project: <value>
+    :selector: --selector=<value>
+:oadm_pod_network_isolate_projects:
+  :cmd: oc adm pod-network isolate-projects
+  :options:
+    :project: <value>
+    :selector: --selector=<value>
+:oadm_router:
+  :cmd: oc adm router <name>
+  :options:
+    :canonical_hostname: --router-canonical-hostname=<value>
+    :default_cert: --default-cert=<value>
+    :extended_logging: --extended-logging=<value>
+    :force_subdomain: --force-subdomain=<value>
+    :host_network: --host-network=<value>
+    :host_ports: --host-ports=<value>
+    :images: --images=<value>
+    :ports: --ports=<value>
+    :replicas: --replicas=<value>
+    :selector: --selector=<value>
+    :service_account: --service-account=<value>
+    :stats_passwd: --stats-password=<value>
+    :stats_port: --stats-port=<value>
+    :stats_user: --stats-user=<value>
+    :n: -n <value>
+:oadm_taint_nodes:
+  :cmd: oc adm taint nodes
+  :options:
+    :all: --all=<value>
+    :node_name: <value>
+    :key_val: <value>
+    :output: --output <value>
+    :overwrite: --overwrite=<value>
+:oadm_top_images:
+  :cmd: oc adm top images
+:openshift_version:
+  :cmd: openshift version
+  :expected:
+    - openshift v
+    - kubernetes v
+    - etcd
+  :properties:
+    :openshift_version: !ruby/regexp '/^openshift v(.+)$/'
+    :kubernetes_version: !ruby/regexp '/kubernetes v(.+)$/'
+    :etcd_version: !ruby/regexp '/etcd (.+)$/'
+:create_rolebinding:
+  :cmd: oc create rolebinding <name>
+  :options:
+    :role: --role=<value>
+:create_clusterrolebinding:
+  :cmd: oc create clusterrolebinding <name>
+  :options:
+    :clusterrole: --clusterrole=<value>


### PR DESCRIPTION
For https://github.com/openshift/verification-tests/pull/89#issuecomment-467819874
Local test passed:
For:
```
  Scenario: Test oc version
    When I run the :version client command
    Then the step should succeed
    And evaluation of `@result[:props][:oc_version]` is stored in the :oc_version clipboard
    And evaluation of `@result[:props][:kubernetes_server_version]` is stored in the :k8s_s_version clipboard
    And I pry
```
Got:
```
    Then the step should succeed
    And evaluation of `@result[:props][:oc_version]` is stored in the :oc_version clipboard
    And evaluation of `@result[:props][:kubernetes_server_version]` is stored in the :k8s_s_version clipboard                                                  
[1] pry(#<BushSlicer::DefaultWorld>)> cb.oc_version
=> "4.0.17"
[2] pry(#<BushSlicer::DefaultWorld>)> cb.k8s_s_version
=> "1.12.4+b3e6ad4"
```
@akostadinov pls help check/merge, thanks!