### PR TITLE
fix issue when YAML uses anchoring

### DIFF
--- a/lib/collections.rb
+++ b/lib/collections.rb
@@ -117,7 +117,9 @@ module BushSlicer
     # @param tgt_hash [Hash] target hash that we will be **altering**
     # @param src_hash [Hash] read from this source hash
     # @return the modified target hash
-    # @note this one does not merge Arrays
+    # @note this one does not merge Arrays; additionally when you have same
+    #   Hash object in multiple parts of the tree, when merging on one part of
+    #   the tree it will end up having same modification on the others
     def deep_merge!(tgt_hash, src_hash)
       tgt_hash.merge!(src_hash) { |key, oldval, newval|
         if oldval.kind_of?(Hash) && newval.kind_of?(Hash)

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -34,14 +34,17 @@ module BushSlicer
       raw_configs = []
       @opts[:files].each { |f| raw_configs << load_file(f) }
 
-      # merge any config files
-      @raw_config = raw_configs.shift
-      raw_configs.each { |c| Collections.deep_merge!(@raw_config, c) }
-
       # merge config from environment if present
       if ENV["BUSHSLICER_CONFIG"] && !ENV["BUSHSLICER_CONFIG"].empty?
-        Collections.deep_merge!(@raw_config, YAML.load(ENV["BUSHSLICER_CONFIG"]))
+        raw_configs << YAML.load(ENV["BUSHSLICER_CONFIG"])
       end
+
+      # merge all config files
+      # note: `deep_merge!` not appropriate because of YAML anchoring producing
+      #   same Hash objects in different parts of the tree
+      @raw_config = raw_configs.reduce { |res, c|
+        Collections.deep_merge(res, c)
+      }
 
       Collections.deep_map_hash!(@raw_config) { |k, v| [k.to_sym, v] }
 


### PR DESCRIPTION
@gpei FYI

Issue was when we use ancoring in YAML and then merge them. When anchoring is
uses, the same Hash object can be present in multiple places within the
parsed Hash object. Then merging the Hashes in place results in changing
Hash in all places while only in one part of the tree it needs to be merged.

Now we always non-destructive merge hashes to avoid this situation.