### PR TITLE
Adding scenario OCP-19810 for v3

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -194,77 +194,67 @@ Feature: Pod related networking scenarios
   # @case_id OCP-19810
   @admin
   Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted
-   Given the master version <= "3.11"		
-   Given I store the schedulable nodes in the :nodes clipboard
-   Given I use the "<%= cb.nodes[0].name %>" node
-   And I have a project
-   
-   When I run the :create client command with:
-     | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/pod_with_udp_port_listener.json |
-   Then the step should succeed
-   Given a pod becomes ready with labels:
-     | name=udp-pods |
-   And evaluation of `pod` is stored in the :host_pod1 clipboard
-   And evaluation of `host_subnet(cb.nodes[0].name).ip` is stored in the :node_ip clipboard
-   
-   When I run the :expose client command with:
-     | resource      | pod                      |
-     | resource_name | <%= cb.host_pod1.name %> |
-     | type          | NodePort                 |
-     | port          | 8080                     |
-     | protocol      | UDP                      |
-   Then the step should succeed
-   
-   When I run the :get client command with:
-     | resource | service                                       |
-     | output   | jsonpath='{.items[*].spec.ports[*].nodePort}' | 
-   Then the step should succeed
-   And evaluation of `@result[:response]` is stored in the :nodeport clipboard
-   
-   When I run the :create client command with:
-     | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/aosqe-pod-for-ping.json |
-   Then the step should succeed
-   Given a pod becomes ready with labels:
-     | name=hello-pod |
-   And evaluation of `pod` is stored in the :client_pod clipboard
-   
-   # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
-   #  entry which will give us enough time to validate upcoming steps 
-   When I run the :exec background client command with:
-     | pod              | <%= cb.client_pod.name %>                             |
-     | oc_opts_end      |                                                       | 
-     | exec_command     | bash                                                  |
-     | exec_command_arg | -c                                                    |
-     | exec_command_arg | yes "h">/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
-   Given 3 seconds have passed
-   And I terminate last background process
-   
-   When I run commands on the host:
-     | conntrack -L \| grep <%= cb.nodeport %> | 
-   Then the step should succeed 
-   And the output should contain: 
-     |<%= cb.host_pod1.ip %>|
-   
-   When I run the :delete client command with:
-     | object_type       | pod                      |
-     | object_name_or_id | <%= cb.host_pod1.name %> | 
-   Given a pod becomes ready with labels:
-     | name=udp-pods |
-   And evaluation of `pod` is stored in the :host_pod2 clipboard
-   
-   # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
-   #  entry which will give us enough time to validate upcoming steps 
-   When I run the :exec background client command with:
-     | pod              | <%= cb.client_pod.name %>                             |
-     | oc_opts_end      |                                                       |
-     | exec_command     | bash                                                  |
-     | exec_command_arg | -c                                                    |
-     | exec_command_arg | yes "h">/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
-   Given 3 seconds have passed
-   And I terminate last background process
-   
-   When I run commands on the host:
-     | conntrack -L \| grep <%= cb.nodeport %> |
-   Then the output should contain "<%= cb.host_pod2.ip %>"
-   And the output should not contain "<%= cb.host_pod1.ip %>"    
-
+    Given the master version <= "3.11"		
+    Given I store the schedulable nodes in the :nodes clipboard
+    Given I use the "<%= cb.nodes[0].name %>" node
+    And I have a project
+    When I run the :create client command with:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/pod_with_udp_port_listener.json |
+    Then the step should succeed
+    Given a pod becomes ready with labels:
+      | name=udp-pods |
+    And evaluation of `pod` is stored in the :host_pod1 clipboard
+    And evaluation of `host_subnet(cb.nodes[0].name).ip` is stored in the :node_ip clipboard
+    When I run the :expose client command with:
+      | resource      | pod                      |
+      | resource_name | <%= cb.host_pod1.name %> |
+      | type          | NodePort                 |
+      | port          | 8080                     |
+      | protocol      | UDP                      |
+    Then the step should succeed
+    When I run the :get client command with:
+      | resource | service                                       |
+      | output   | jsonpath='{.items[*].spec.ports[*].nodePort}' | 
+    Then the step should succeed
+    And evaluation of `@result[:response]` is stored in the :nodeport clipboard
+    When I run the :create client command with:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/aosqe-pod-for-ping.json |
+    Then the step should succeed
+    Given a pod becomes ready with labels:
+      | name=hello-pod |
+    And evaluation of `pod` is stored in the :client_pod clipboard
+    # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
+    #  entry which will give us enough time to validate upcoming steps 
+    When I run the :exec background client command with:
+      | pod              | <%= cb.client_pod.name %>                             |
+      | oc_opts_end      |                                                       | 
+      | exec_command     | bash                                                  |
+      | exec_command_arg | -c                                                    |
+      | exec_command_arg | yes "h">/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
+    Given 3 seconds have passed
+    And I terminate last background process
+    When I run commands on the host:
+      | conntrack -L \| grep <%= cb.nodeport %> | 
+    Then the step should succeed 
+    And the output should contain: 
+      |<%= cb.host_pod1.ip %>|
+    When I run the :delete client command with:
+      | object_type       | pod                      |
+      | object_name_or_id | <%= cb.host_pod1.name %> | 
+    Given a pod becomes ready with labels:
+      | name=udp-pods |
+    And evaluation of `pod` is stored in the :host_pod2 clipboard
+    # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
+    #  entry which will give us enough time to validate upcoming steps 
+    When I run the :exec background client command with:
+      | pod              | <%= cb.client_pod.name %>                             |
+      | oc_opts_end      |                                                       |
+      | exec_command     | bash                                                  |
+      | exec_command_arg | -c                                                    |
+      | exec_command_arg | yes "h">/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
+    Given 3 seconds have passed
+    And I terminate last background process
+    When I run commands on the host:
+      | conntrack -L \| grep <%= cb.nodeport %> |
+    Then the output should contain "<%= cb.host_pod2.ip %>"
+    And the output should not contain "<%= cb.host_pod1.ip %>"    

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -189,4 +189,82 @@ Feature: Pod related networking scenarios
       | ovs-vsctl list interface \| grep ingress |
     Then the step should succeed
     And the output should not contain "ingress_policing_rate: 1953"
+ 
+  # @author anusaxen@redhat.com
+  # @case_id OCP-19810
+  @admin
+  Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted
+   Given the master version <= "3.11"		
+   Given I store the schedulable nodes in the :nodes clipboard
+   Given I use the "<%= cb.nodes[0].name %>" node
+   And I have a project
+   
+   When I run the :create client command with:
+     | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/pod_with_udp_port_listener.json |
+   Then the step should succeed
+   Given a pod becomes ready with labels:
+     | name=udp-pods |
+   And evaluation of `pod` is stored in the :host_pod1 clipboard
+   And evaluation of `host_subnet(cb.nodes[0].name).ip` is stored in the :node_ip clipboard
+   
+   When I run the :expose client command with:
+     | resource      | pod                      |
+     | resource_name | <%= cb.host_pod1.name %> |
+     | type          | NodePort                 |
+     | port          | 8080                     |
+     | protocol      | UDP                      |
+   Then the step should succeed
+   
+   When I run the :get client command with:
+     | resource | service                                       |
+     | output   | jsonpath='{.items[*].spec.ports[*].nodePort}' | 
+   Then the step should succeed
+   And evaluation of `@result[:response]` is stored in the :nodeport clipboard
+   
+   When I run the :create client command with:
+     | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/aosqe-pod-for-ping.json |
+   Then the step should succeed
+   Given a pod becomes ready with labels:
+     | name=hello-pod |
+   And evaluation of `pod` is stored in the :client_pod clipboard
+   
+   # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
+   #  entry which will give us enough time to validate upcoming steps 
+   When I run the :exec background client command with:
+     | pod              | <%= cb.client_pod.name %>                             |
+     | oc_opts_end      |                                                       | 
+     | exec_command     | bash                                                  |
+     | exec_command_arg | -c                                                    |
+     | exec_command_arg | yes "h">/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
+   Given 3 seconds have passed
+   And I terminate last background process
+   
+   When I run commands on the host:
+     | conntrack -L \| grep <%= cb.nodeport %> | 
+   Then the step should succeed 
+   And the output should contain: 
+     |<%= cb.host_pod1.ip %>|
+   
+   When I run the :delete client command with:
+     | object_type       | pod                      |
+     | object_name_or_id | <%= cb.host_pod1.name %> | 
+   Given a pod becomes ready with labels:
+     | name=udp-pods |
+   And evaluation of `pod` is stored in the :host_pod2 clipboard
+   
+   # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
+   #  entry which will give us enough time to validate upcoming steps 
+   When I run the :exec background client command with:
+     | pod              | <%= cb.client_pod.name %>                             |
+     | oc_opts_end      |                                                       |
+     | exec_command     | bash                                                  |
+     | exec_command_arg | -c                                                    |
+     | exec_command_arg | yes "h">/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
+   Given 3 seconds have passed
+   And I terminate last background process
+   
+   When I run commands on the host:
+     | conntrack -L \| grep <%= cb.nodeport %> |
+   Then the output should contain "<%= cb.host_pod2.ip %>"
+   And the output should not contain "<%= cb.host_pod1.ip %>"    
 

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -194,10 +194,12 @@ Feature: Pod related networking scenarios
   # @case_id OCP-19810
   @admin
   Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted
-    Given the master version <= "3.11"		
+    Given the master version <= "3.11"
     Given I store the schedulable nodes in the :nodes clipboard
     Given I use the "<%= cb.nodes[0].name %>" node
     And I have a project
+
+    #Creating a pod with udp listener on a scedulable node
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/pod_with_udp_port_listener.json |
     Then the step should succeed
@@ -205,6 +207,8 @@ Feature: Pod related networking scenarios
       | name=udp-pods |
     And evaluation of `pod` is stored in the :host_pod1 clipboard
     And evaluation of `host_subnet(cb.nodes[0].name).ip` is stored in the :node_ip clipboard
+
+    #Using node port to expose the service on port 8080 on the node IP address
     When I run the :expose client command with:
       | resource      | pod                      |
       | resource_name | <%= cb.host_pod1.name %> |
@@ -212,40 +216,23 @@ Feature: Pod related networking scenarios
       | port          | 8080                     |
       | protocol      | UDP                      |
     Then the step should succeed
+    
     When I run the :get client command with:
       | resource | service                                       |
-      | output   | jsonpath='{.items[*].spec.ports[*].nodePort}' | 
+      | output   | jsonpath='{.items[*].spec.ports[*].nodePort}' |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :nodeport clipboard
+    
+    #Creating a simple client pod to generate traffic from it towards the exposed node IP address
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/aosqe-pod-for-ping.json |
     Then the step should succeed
     Given a pod becomes ready with labels:
       | name=hello-pod |
     And evaluation of `pod` is stored in the :client_pod clipboard
+    
     # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
-    #  entry which will give us enough time to validate upcoming steps 
-    When I run the :exec background client command with:
-      | pod              | <%= cb.client_pod.name %>                             |
-      | oc_opts_end      |                                                       | 
-      | exec_command     | bash                                                  |
-      | exec_command_arg | -c                                                    |
-      | exec_command_arg | yes "h">/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
-    Given 3 seconds have passed
-    And I terminate last background process
-    When I run commands on the host:
-      | conntrack -L \| grep <%= cb.nodeport %> | 
-    Then the step should succeed 
-    And the output should contain: 
-      |<%= cb.host_pod1.ip %>|
-    When I run the :delete client command with:
-      | object_type       | pod                      |
-      | object_name_or_id | <%= cb.host_pod1.name %> | 
-    Given a pod becomes ready with labels:
-      | name=udp-pods |
-    And evaluation of `pod` is stored in the :host_pod2 clipboard
-    # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
-    #  entry which will give us enough time to validate upcoming steps 
+    #  entry which will give us enough time to validate upcoming steps
     When I run the :exec background client command with:
       | pod              | <%= cb.client_pod.name %>                             |
       | oc_opts_end      |                                                       |
@@ -256,5 +243,31 @@ Feature: Pod related networking scenarios
     And I terminate last background process
     When I run commands on the host:
       | conntrack -L \| grep <%= cb.nodeport %> |
+    Then the step should succeed
+    And the output should contain:
+      |<%= cb.host_pod1.ip %>|
+
+    #Deleting the udp listener pod which will trigger a new udp listener pod with new IP
+    When I run the :delete client command with:
+      | object_type       | pod                      |
+      | object_name_or_id | <%= cb.host_pod1.name %> |
+    Given a pod becomes ready with labels:
+      | name=udp-pods |
+    And evaluation of `pod` is stored in the :host_pod2 clipboard
+
+    # 'yes' command will send a character "h" continously for 3 seconds to /dev/udp on listener where the node is listening for udp traffic on exposed nodeport. The 3 seconds mechanism will create an Assured
+    #  entry which will give us enough time to validate upcoming steps
+    When I run the :exec background client command with:
+      | pod              | <%= cb.client_pod.name %>                             |
+      | oc_opts_end      |                                                       |
+      | exec_command     | bash                                                  |
+      | exec_command_arg | -c                                                    |
+      | exec_command_arg | yes "h">/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
+    Given 3 seconds have passed
+    And I terminate last background process
+    
+    #Making sure that the conntrack table should not contain old deleted udp listener pod IP entries but new pod one's
+    When I run commands on the host:
+      | conntrack -L \| grep <%= cb.nodeport %> |
     Then the output should contain "<%= cb.host_pod2.ip %>"
-    And the output should not contain "<%= cb.host_pod1.ip %>"    
+    And the output should not contain "<%= cb.host_pod1.ip %>"


### PR DESCRIPTION
This is clone of PR 91 (https://github.com/openshift/verification-tests/pull/91) to be merged in v3 branch as the scenario is not supported right now on 4.x version and master now points to 4.x. All the reviewers comment has been taken care of except passing on 4.x version. The scenario is gated to be work on <=3.11 version. 
@bmeng @zhaozhanqi @pruan-rht @akostadinov 

Discussed with @bmeng and @pruan-rht.

Passing logs : https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/282/console