### PR TITLE
Ocp 22704

### DIFF
--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -12,4 +12,4 @@ Feature: Operator related networking scenarios
     #Making sure that network operator AVAILABLE status value is True
     Then the expression should be true> cb.operator_status["status"]=="True"
     #Confirm whether network operator version matches with ocp version
-    And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)==true
+    And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -1,0 +1,27 @@
+Feature: Operator related networking scenarios
+  
+  # @auther anusaxen@redhat.com
+  # @case_id OCP-22704
+  @admin
+  Scenario: The clusteroperator should be able to reflect the network operator version corresponding to the OCP version
+    Given I use the "openshift-sdn" project
+    #Getting OCP version
+    When I run the :get admin command with:
+      | resource | clusterversion                                |
+      | output   | jsonpath='{.items[*].status.desired.version}' |
+    Then the step should succeed
+    And evaluation of `@result[:response]` is stored in the :ocp_version clipboard
+
+    #Making sure that network operator AVAILABLE value is True 
+    When I run the :get admin command with:
+      | resource | clusteroperators.config.openshift.io/network                   |
+      | output   | jsonpath='{.status.conditions[?(@.type=="Available")].status}' |
+    Then the step should succeed
+    And the output should contain "True"
+
+    #Make sure that network operator version matches with ocp version
+    When I run the :get admin command with:
+      | resource | clusteroperators.config.openshift.io/network |
+      | output   | jsonpath='{.status.versions[*].version}'     |
+    Then the step should succeed
+    And the output should equal "<%= cb.ocp_version %>"

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -14,4 +14,4 @@ Feature: Operator related networking scenarios
 
     Given evaluation of `cluster_operator('network').versions` is stored in the :operator_version clipboard
     #Confirm whether network operator version matches with ocp version`
-    Then the expression should be true> cb.operator_version="<%= cb.ocp_version%>"
+    Then the expression should be true> cb.operator_version=cb.ocp_version

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -4,7 +4,7 @@ Feature: Operator related networking scenarios
   # @case_id OCP-22704
   @admin
   Scenario: The clusteroperator should be able to reflect the network operator version corresponding to the OCP version
-    Given I use the "openshift-sdn" project
+    Given I have a project
     #Getting OCP version
     When I run the :get admin command with:
       | resource | clusterversion                                |

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -11,7 +11,5 @@ Feature: Operator related networking scenarios
     And evaluation of `cluster_operator('network').condition(type: 'Available')` is stored in the :operator_status clipboard
     #Making sure that network operator AVAILABLE status value is True
     Then the expression should be true> cb.operator_status["status"]=="True"
-
-    Given evaluation of `cluster_operator('network').versions` is stored in the :operator_version clipboard
-    #Confirm whether network operator version matches with ocp version`
-    Then the expression should be true> cb.operator_version=cb.ocp_version
+    #Confirm whether network operator version matches with ocp version
+    And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)==true

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -1,27 +1,17 @@
 Feature: Operator related networking scenarios
-  
+
   # @auther anusaxen@redhat.com
   # @case_id OCP-22704
   @admin
   Scenario: The clusteroperator should be able to reflect the network operator version corresponding to the OCP version
-    Given I have a project
+
+    Given the master version > "3.11"
     #Getting OCP version
-    When I run the :get admin command with:
-      | resource | clusterversion                                |
-      | output   | jsonpath='{.items[*].status.desired.version}' |
-    Then the step should succeed
-    And evaluation of `@result[:response]` is stored in the :ocp_version clipboard
+    Given evaluation of `cluster_version('version').version` is stored in the :ocp_version clipboard
+    And evaluation of `cluster_operator('network').condition(type: 'Available')` is stored in the :operator_status clipboard
+    #Making sure that network operator AVAILABLE status value is True
+    Then the expression should be true> cb.operator_status["status"]=="True"
 
-    #Making sure that network operator AVAILABLE value is True 
-    When I run the :get admin command with:
-      | resource | clusteroperators.config.openshift.io/network                   |
-      | output   | jsonpath='{.status.conditions[?(@.type=="Available")].status}' |
-    Then the step should succeed
-    And the output should contain "True"
-
-    #Make sure that network operator version matches with ocp version
-    When I run the :get admin command with:
-      | resource | clusteroperators.config.openshift.io/network |
-      | output   | jsonpath='{.status.versions[*].version}'     |
-    Then the step should succeed
-    And the output should equal "<%= cb.ocp_version %>"
+    Given evaluation of `cluster_operator('network').versions` is stored in the :operator_version clipboard
+    #Confirm whether network operator version matches with ocp version`
+    Then the expression should be true> cb.operator_version="<%= cb.ocp_version%>"


### PR DESCRIPTION
Gherkin Scenario for SDN test case OCP-22704. Separate operator.feature is created to accommodate future network operator related tests.
The aim of this test is to make sure that the clusteroperator should be able to reflect the network operator version corresponding to the OCP version. OCP version is checked first. Network operator version is checked when its "Available" value is "True". Both version are compared to make sure they are same.
@bmeng @zhaozhanqi @pruan-rht @akostadinov 
Passing logs: https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/289/console