### PR TITLE
fix the name of node service for 4.x

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -84,7 +84,7 @@ Feature: SDN related networking scenarios
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run commands on the host:
-      | journalctl -l -u atomic-openshift-node --since "30s ago" \| grep SDN |
+      | journalctl -l -u kubelet --since "30s ago" \| grep SDN |
     Then the step should succeed
     And the output should contain:
       | SDN healthcheck detected unhealthy OVS server |
@@ -104,7 +104,7 @@ Feature: SDN related networking scenarios
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run commands on the host:
-      | journalctl -l -u atomic-openshift-node --since "30s ago" \| grep SDN |
+      | journalctl -l -u kubelet --since "30s ago" \| grep SDN |
     Then the step should succeed
     And the output should contain:
       | SDN healthcheck detected unhealthy OVS server |

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -564,7 +564,7 @@ Given /^I get the networking components logs of the node since "(.+)" ago$/ do |
     }.first
     @result = admin.cli_exec(:logs, resource_name: sdn_pod.name, n: "openshift-sdn", since: duration)
   else
-    @result = node.host.exec_admin("journalctl -l -u atomic-openshift-node --since \"#{duration} ago\" \| grep -E 'controller.go\|network.go'")
+    @result = node.host.exec_admin("journalctl -l -u kubelet --since \"#{duration} ago\" \| grep -E 'controller.go\|network.go'")
   end
 end
 

--- a/features/step_definitions/node.rb
+++ b/features/step_definitions/node.rb
@@ -283,9 +283,9 @@ Given /^the#{OPT_QUOTED} node service is verified$/ do |node_name|
 
   svc_verify = proc {
     # node service running
-    @result = _host.exec_admin('systemctl status atomic-openshift-node')
+    @result = _host.exec_admin('systemctl status kubelet')
     unless @result[:success] || @result[:response].include?("active (running)")
-      raise "node service not running, see log"
+      raise "kubelet service not running, see log"
     end
     # pod can be scheduled on node
     #step 'I have a project'

--- a/lib/platform/node_service.rb
+++ b/lib/platform/node_service.rb
@@ -8,7 +8,7 @@ module BushSlicer
 
       def initialize(host, env)
         super
-        @service = SystemdService.new("atomic-openshift-node.service", host)
+        @service = SystemdService.new("kubelet.service", host)
       end
 
       def config


### PR DESCRIPTION
The node service in 4.0 and 4.1 cluster is kubelet.service, which was atomic-openshift-node.service in 3.x.

Fix the node service name to make some of the node verification steps work

[root@ip-10-0-130-247 ~]# systemctl status kubelet
● kubelet.service - Kubernetes Kubelet
   Loaded: loaded (/etc/systemd/system/kubelet.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2019-03-26 06:18:41 UTC; 1h 58min ago
  Process: 934 ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state (code=exited, status=0/SUCCESS)
  Process: 932 ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests (code=exited, status=0/SUCCESS)
 Main PID: 941 (hyperkube)
    Tasks: 24 (limit: 26213)
   Memory: 220.1M
   CGroup: /system.slice/kubelet.service
           └─941 /usr/bin/hyperkube kubelet --config=/etc/kubernetes/kubelet.conf --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig --rotate-certificates --kubeconfig=/var/lib/kubelet/kubec>

Mar 26 07:33:41 ip-10-0-130-247 hyperkube[941]: E0326 07:33:41.551348     941 container_manager_linux.go:475] failed to find cgroups of kubelet - cpu and memory cgroup hierarchy not unified>
Mar 26 07:38:41 ip-10-0-130-247 hyperkube[941]: E0326 07:38:41.551729     941 container_manager_linux.go:475] failed to find cgroups of kubelet - cpu and memory cgroup hierarchy not unified>
Mar 26 07:43:41 ip-10-0-130-247 hyperkube[941]: E0326 07:43:41.552116     941 container_manager_linux.go:475] failed to find cgroups of kubelet - cpu and memory cgroup hierarchy not unified>
Mar 26 07:44:23 ip-10-0-130-247 hyperkube[941]: W0326 07:44:23.252812     941 reflector.go:256] k8s.io/kubernetes/pkg/kubelet/config/apiserver.go:47: watch of *v1.Pod ended with: too old re>
Mar 26 07:48:41 ip-10-0-130-247 hyperkube[941]: E0326 07:48:41.552456     941 container_manager_linux.go:475] failed to find cgroups of kubelet - cpu and memory cgroup hierarchy not unified>
Mar 26 07:53:41 ip-10-0-130-247 hyperkube[941]: E0326 07:53:41.552815     941 container_manager_linux.go:475] failed to find cgroups of kubelet - cpu and memory cgroup hierarchy not unified>
Mar 26 07:58:41 ip-10-0-130-247 hyperkube[941]: E0326 07:58:41.553283     941 container_manager_linux.go:475] failed to find cgroups of kubelet - cpu and memory cgroup hierarchy not unified>
Mar 26 08:03:41 ip-10-0-130-247 hyperkube[941]: E0326 08:03:41.553764     941 container_manager_linux.go:475] failed to find cgroups of kubelet - cpu and memory cgroup hierarchy not unified>
Mar 26 08:08:41 ip-10-0-130-247 hyperkube[941]: E0326 08:08:41.554738     941 container_manager_linux.go:475] failed to find cgroups of kubelet - cpu and memory cgroup hierarchy not unified>
Mar 26 08:13:41 ip-10-0-130-247 hyperkube[941]: E0326 08:13:41.555156     941 container_manager_linux.go:475] failed to find cgroups of kubelet - cpu and memory cgroup hierarchy not unified>