### PR TITLE
modify the rules for web login

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -473,7 +473,6 @@ Given /^I have a iSCSI setup in the environment$/ do
   else
     env.node_hosts.each do |host|
       setup_commands = [
-        "echo 'InitiatorName=iqn.2016-04.test.com:test.img' > /etc/iscsi/initiatorname.iscsi",
         "sed -i '/^node.session.auth./'d  /etc/iscsi/iscsid.conf",
         "cat >> /etc/iscsi/iscsid.conf << EOF\n" +
           "node.session.auth.authmethod = CHAP\n" +

--- a/lib/rules/web/console/base/login.xyaml
+++ b/lib/rules/web/console/base/login.xyaml
@@ -11,10 +11,11 @@ login_sequence:
     ref:
     - click_pre_login_button
     - pre_login_buttons_gone
+    - login_page_loaded
     if_element:
       selector: &pre_login_buttons
         # we just choose the first button per OPENSHIFTQ-12062
-        css: ".login-redhat:last-of-type, .idp:last-of-type"
+        css: ".login-redhat:first-of-type, .idp:first-of-type"
       timeout: 1
   action:
     ref: login_console
@@ -50,28 +51,32 @@ login_rhsso:
         id: password
       op: send_keys <password>
       type: input
+  elements:
     - selector:
         id: kc-login
       type: input
       op: click
+
 login_console:
   elements:
     - selector:
-        id: username
+        id: inputUsername
       op: send_keys <username>
       type: input
     - selector:
-        id: login-show-step2
-      op: click
-      type: button
-    - selector:
-        id: password
+        id: inputPassword
       op: send_keys <password>
       type: input
+  scripts:
+  - command: return document.getElementsByName("csrf").length > 0
+    expect_result: true
+  cookies:
+  - name: csrf
+    expect_result: true
   elements:
     - selector:
-        id: kc-login
-      type: input
+        text: Log In
+      type: button
       op: click
 
 login_token:
@@ -95,7 +100,7 @@ login_token:
 login_page_loaded:
   element:
     selector:
-      css: "#password, #inputPassword, .login-redhat, .idp, .navigation-container"
+      css: "#kc-form-login, #password, #inputPassword, .login-redhat, .idp, .navigation-container"
     timeout: 30
 
 verify_logged_in:

--- a/lib/rules/web/console/base/login.xyaml
+++ b/lib/rules/web/console/base/login.xyaml
@@ -11,7 +11,6 @@ login_sequence:
     ref:
     - click_pre_login_button
     - pre_login_buttons_gone
-    - login_page_loaded
     if_element:
       selector: &pre_login_buttons
         # we just choose the first button per OPENSHIFTQ-12062
@@ -56,23 +55,21 @@ login_rhsso:
 login_console:
   elements:
     - selector:
-        id: inputUsername
+        id: username
       op: send_keys <username>
       type: input
     - selector:
-        id: inputPassword
+        id: login-show-step2
+      op: click
+      type: button
+    - selector:
+        id: password
       op: send_keys <password>
       type: input
-  scripts:
-  - command: return document.getElementsByName("csrf").length > 0
-    expect_result: true
-  cookies:
-  - name: csrf
-    expect_result: true
   elements:
     - selector:
-        text: Log In
-      type: button
+        id: kc-login
+      type: input
       op: click
 
 login_token:

--- a/lib/rules/web/console/base/login.xyaml
+++ b/lib/rules/web/console/base/login.xyaml
@@ -29,7 +29,7 @@ login_sequence:
     ref: login_rhsso
     if_element:
       selector:
-        visible_text: !ruby/regexp '/Red Hat account to log in/'
+        visible_text: !ruby/regexp '/Log in to your Red Hat account/'
       timeout: 1
 oauth_proxy_login_with_openshift:
   action: click_openshift_login
@@ -43,22 +43,6 @@ login_rhsso:
       op: send_keys <username>
       type: input
     - selector:
-        id: password
-      op: send_keys <password>
-      type: input
-  elements:
-    - selector:
-        value: Log in
-      op: click
-      type: input
-
-login_console:
-  elements:
-    - selector:
-        id: username
-      op: send_keys <username>
-      type: input
-    - selector:
         id: login-show-step2
       op: click
       type: button
@@ -66,10 +50,30 @@ login_console:
         id: password
       op: send_keys <password>
       type: input
-  elements:
     - selector:
         id: kc-login
       type: input
+      op: click
+login_console:
+  elements:
+    - selector:
+        id: inputUsername
+      op: send_keys <username>
+      type: input
+    - selector:
+        id: inputPassword
+      op: send_keys <password>
+      type: input
+  scripts:
+  - command: return document.getElementsByName("csrf").length > 0
+    expect_result: true
+  cookies:
+  - name: csrf
+    expect_result: true
+  elements:
+    - selector:
+        text: Log In
+      type: button
       op: click
 
 login_token:


### PR DESCRIPTION
This PR is trying to fix the problem of the web console logging. The web console logging will fail as some logging workflow change. You can find the failed log as bellow(log1).
The log for this PR is as bellow, log2.
log1:https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/39419/console
log2:https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/39414/console
@yasun1 could you help review this PR? Thanks