### PR TITLE
update asb namespace in v4.0

### DIFF
--- a/features/step_definitions/cluster_service_broker.rb
+++ b/features/step_definitions/cluster_service_broker.rb
@@ -25,7 +25,7 @@ Given /^I save the first service broker registry prefix to#{OPT_SYM} clipboard$/
   ensure_admin_tagged
   cb_name ||= :reg_prefix
   org_project = project(generate: false) rescue nil
-  project('openshift-ansible-service-broker')
+  project('ansible-service-broker')
   cb[cb_name] = YAML.load(config_map('broker-config').value_of('broker-config', user: admin))['registry'].first['name']
   project(org_project&.name)
 end

--- a/features/svc-catalog_asb/asb.feature
+++ b/features/svc-catalog_asb/asb.feature
@@ -8,7 +8,7 @@ Feature: Ansible-service-broker related scenarios
     And evaluation of `project.name` is stored in the :org_proj_name clipboard
     # Get the registry name from the configmap
     When I switch to cluster admin pseudo user
-    And I use the "openshift-ansible-service-broker" project
+    And I use the "ansible-service-broker" project
     And evaluation of `YAML.load(config_map('broker-config').value_of('broker-config'))['registry'][0]['name']` is stored in the :prefix clipboard
     # need to swtich back to normal user mode
     And I switch to the first user


### PR DESCRIPTION
In V4.0, ASB namespace changed from `openshift-ansible-service-broker` to 'ansible-service-broker`. 
Update namespace in cases.

Here's log:
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/39499/console
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/39498/console

@chengzhang1016 @pruan-rht @akostadinov  please help review and merge. Thanks.