### PR TITLE
Add instructions for downloading and installing Web Driver

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,8 @@ More info you can find in link:doc/overview.adoc[Overview document].
 . cd verification-tests
 . tools/install_os_deps.sh # need sudo; you may need to login again to terminal if ruby was installed via rvm during this phase
 . tools/hack_bundle.rb # normal user
-. install OKD or OpenShift Container Platform client tools
+. Install OKD or OpenShift Container Platform client tools
+. Install the web driver if you desire to run tests which work with the Web UI. See link:doc/configuration.adoc[Web Driver]
 
 === Update local dev environment
 

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -49,6 +49,19 @@ So far we also have `optional_classes` root configuration option. It is used to 
 
 Also we have `services` to define some third party services options. Access to those configuration options is not wrapped in any way. Information should be accessed directly, see below.
 
+== Web Driver
+
+For tests which require a web driver please install the driver for the browser you would prefer to use.
+
+Firefox:
+ Please download the server from https://github.com/mozilla/geckodriver/releases and place it somewhere on your PATH.
+ See https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver for more information
+
+Chrome:
+ Please download the driver from http://chromedriver.storage.googleapis.com/index.html that matches the version of Chrome you are using, place it somewhere on your PATH and set the following environment variable. 
+
+* `export BUSHSLICER_CONFIG='{"global": {"browser": "chrome"}}'`
+
 == accessing configuration
 
 Whenever you are, you should usually have the convenience `#conf` method available to get current loaded configuration. Reference to configuration is kept in the Manager object `Manager#conf` but direct use from manager is discouraged.


### PR DESCRIPTION
This PR adds instructions for download and installing the web driver for both Firefox and Chrome. Several test cases require a web driver otherwise they fail and this requirement was not documented anywhere previously. Instructions should be identical for all branches.

This is identical to https://github.com/openshift/verification-tests/pull/144 but for the master branch.