### PR TITLE
[networking] automated multus cases for multiple cni plugins

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -666,7 +666,7 @@ end
 Given /^I run command on the#{OPT_QUOTED} node's sdn pod:$/ do |node_name, table|
   ensure_admin_tagged
   network_cmd = table.raw
-  node_name = node.name
+  node_name ||= node.name
 
   sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
     pod.node_name == node_name

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -661,3 +661,16 @@ Given /^the status of condition#{OPT_QUOTED} for network operator is :(.+)$/ do 
 
   raise "The status of condition #{type} is incorrect." unless expected_status == real_status
 end
+
+
+Given /^I run network command on the#{OPT_QUOTED} node's sdn pod:$/ do |node_name, table|
+  ensure_admin_tagged
+  network_cmd = table.raw
+  node_name = node_name
+
+  sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    pod.node_name == node_name
+  }.first
+  @result = sdn_pod.exec(network_cmd, as: admin)
+  raise "Failed to execute network command!" unless @result[:success]
+end

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -663,10 +663,10 @@ Given /^the status of condition#{OPT_QUOTED} for network operator is :(.+)$/ do 
 end
 
 
-Given /^I run network command on the#{OPT_QUOTED} node's sdn pod:$/ do |node_name, table|
+Given /^I run command on the#{OPT_QUOTED} node's sdn pod:$/ do |node_name, table|
   ensure_admin_tagged
   network_cmd = table.raw
-  node_name = node_name
+  node_name = node.name
 
   sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
     pod.node_name == node_name


### PR DESCRIPTION
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/39878/console

Add a new step to run network related command on the sdn pod (since the sdn pod is running as hostnetwork).

Automated some more multus test cases.

@zhaozhanqi @anuragthehatter PTAL