### PR TITLE
'Failing' type to 'Degraded' change in nw operator use cases

### DIFF
--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -17,6 +17,7 @@ Feature: Operator related networking scenarios
   # @auther anusaxen@redhat.com
   # @case_id OCP-22706
   @admin
+  @destructive
   Scenario: The clusteroperator should be able to reflect the correct version field post bad network operator config
 
     Given the master version >= "4.0"
@@ -38,8 +39,14 @@ Feature: Operator related networking scenarios
     And evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status_post_patch clipboard
     Then the expression should be true> cb.failing_status_post_patch["status"]=="True"
     And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)
-
-    #Fixing bad patch to make cluster healthy before exiting the test
+    
+    #Registering clean-up steps to move networkType back to OpenShiftSDN and to check Failing status is False before test exits
+    Given I register clean-up steps:
+    """
+    20 seconds have passed
+    evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status clipboard
+    the expression should be true> cb.failing_status["status"]=="False"
+    """
     Given I register clean-up steps:
     """
     When I run the :patch admin command with:

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -23,15 +23,12 @@ Feature: Operator related networking scenarios
     Given the master version >= "4.0"
     #Getting OCP version
     Given evaluation of `cluster_version('version').version` is stored in the :ocp_version clipboard
-<<<<<<< HEAD
     #Making sure that operator is not Degraded before proceesing further steps
     And evaluation of `cluster_operator('network').condition(type: 'Degraded')` is stored in the :Degraded_status_before_patch clipboard
     Then the expression should be true> cb.Degraded_status_before_patch["status"]=="False"
-=======
-    #Making sure that operator is not Failing before proceesing further steps
-    And evaluation of `cluster_operator('network').condition(type: 'Failing')` is stored in the :failing_status_before_patch clipboard
-    Then the expression should be true> cb.failing_status_before_patch["status"]=="False"
->>>>>>> e96c99592f57c99857183b780d5c9f6471a84fdb
+    #Making sure that operator is not Degraded before proceesing further steps
+    And evaluation of `cluster_operator('network').condition(type: 'Degraded')` is stored in the :Degraded_status_before_patch clipboard
+    Then the expression should be true> cb.Degraded_status_before_patch["status"]=="False"
     #Editing networks.config.openshift.io cluster to reflect bad config like changing networktype from OpenShiftSDN to OpenShift
     When I run the :patch admin command with:
       | resource      | networks.config.openshift.io         |
@@ -40,11 +37,7 @@ Feature: Operator related networking scenarios
       | type          | merge                                |
     Then the step should succeed
 
-<<<<<<< HEAD
     #Registering clean-up steps to move networkType back to OpenShiftSDN and to check Degraded status is False before test exits
-=======
-    #Registering clean-up steps to move networkType back to OpenShiftSDN and to check Failing status is False before test exits
->>>>>>> e96c99592f57c99857183b780d5c9f6471a84fdb
     Given I register clean-up steps:
     """
     When I run the :patch admin command with:
@@ -54,7 +47,6 @@ Feature: Operator related networking scenarios
       | type          | merge                                   |
     Then the step should succeed
     20 seconds have passed
-<<<<<<< HEAD
     evaluation of `cluster_operator('network').condition(type: 'Degraded',cached: false)` is stored in the :Degraded_status clipboard
     the expression should be true> cb.Degraded_status["status"]=="False"
     """
@@ -62,15 +54,6 @@ Feature: Operator related networking scenarios
     Given 20 seconds have passed
     And evaluation of `cluster_operator('network').condition(type: 'Degraded',cached: false)` is stored in the :Degraded_status_post_patch clipboard
     Then the expression should be true> cb.Degraded_status_post_patch["status"]=="True"
-    And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)
-=======
-    evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status clipboard
-    the expression should be true> cb.failing_status["status"]=="False"
-    """
-    #Normally it takes 5-10 seconds for network config update to reconcile across the cluster but taking 20 seconds wait to make sure that Failing status becomes True post bad patch
-    Given 20 seconds have passed
-    And evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status_post_patch clipboard
-    Then the expression should be true> cb.failing_status_post_patch["status"]=="True"
     And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)
 
   # @author bmeng@redhat.com
@@ -80,9 +63,9 @@ Feature: Operator related networking scenarios
     Given the master version >= "4.0"
     # Check the operator object has version
     Given the expression should be true> cluster_operator('network').versions.length > 0
-    # Check the operator object has status for Failing|Progressing|Available
+    # Check the operator object has status for Degraded|Progressing|Available
     And the expression should be true> cluster_operator('network').condition(type: 'Available')['status'] == "True"
-    And the expression should be true> cluster_operator('network').condition(type: 'Failing')['status'] == "False"
+    And the expression should be true> cluster_operator('network').condition(type: 'Degraded')['status'] == "False"
     And the expression should be true> cluster_operator('network').condition(type: 'Progressing')['status'] == "False"
 
 
@@ -92,8 +75,8 @@ Feature: Operator related networking scenarios
   @destructive
   Scenario: The clusteroperator should be able to reflect the realtime status of the network when the config has problem
     Given the master version >= "4.0"
-    # Check that the operator is not failing
-    Given the expression should be true> cluster_operator('network').condition(type: 'Failing')['status'] == "False"
+    # Check that the operator is not Degraded
+    Given the expression should be true> cluster_operator('network').condition(type: 'Degraded')['status'] == "False"
     # Copy the value of the networktype for backup
     When I run the :get admin command with:
       | resource      | network.config.openshift.io |
@@ -120,7 +103,7 @@ Feature: Operator related networking scenarios
     # Check that the operator status reflect the problem
     Given I wait up to 10 seconds for the steps to pass:
     """
-    Given the status of condition "Failing" for network operator is :True
+    Given the status of condition "Degraded" for network operator is :True
     And the status of condition "Available" for network operator is :True
     """
     # Change the network.config.openshift.io back
@@ -133,7 +116,7 @@ Feature: Operator related networking scenarios
     # Check that the operator status
     Given I wait up to 20 seconds for the steps to pass:
     """
-    Given the status of condition "Failing" for network operator is :False
+    Given the status of condition "Degraded" for network operator is :False
     And the status of condition "Available" for network operator is :True
     """
 
@@ -203,4 +186,3 @@ Feature: Operator related networking scenarios
     And the output should not contain "NotReady"
     Given the status of condition "Progressing" for network operator is :False
     """
->>>>>>> e96c99592f57c99857183b780d5c9f6471a84fdb

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -13,3 +13,39 @@ Feature: Operator related networking scenarios
     Then the expression should be true> cb.operator_status["status"]=="True"
     #Confirm whether network operator version matches with ocp version
     And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)
+
+  # @auther anusaxen@redhat.com
+  # @case_id OCP-22706
+  @admin
+  Scenario: The clusteroperator should be able to reflect the correct version field post bad network operator config
+
+    Given the master version >= "4.0"
+    #Getting OCP version
+    Given evaluation of `cluster_version('version').version` is stored in the :ocp_version clipboard
+    #Making sure that operator is not Failing before proceesing further steps
+    And evaluation of `cluster_operator('network').condition(type: 'Failing')` is stored in the :failing_status_before_patch clipboard
+    Then the expression should be true> cb.failing_status_before_patch["status"]=="False"
+    #Editing networks.config.openshift.io cluster to reflect bad config like changing networktype from OpenShiftSDN to OpenShift
+    When I run the :patch admin command with:
+      | resource      | networks.config.openshift.io         |
+      | resource_name | cluster                              |
+      | p             | {"spec":{"networkType":"OpenShift"}} |
+      | type          | merge                                |
+    Then the step should succeed
+
+    #Normally it takes 5-10 seconds for network config update to reconcile across the cluster but taking 20 seconds wait to make sure that Failing status becomes True post bad patch
+    Given 20 seconds have passed
+    And evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status_post_patch clipboard
+    Then the expression should be true> cb.failing_status_post_patch["status"]=="True"
+    And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)
+
+    #Fixing bad patch to make cluster healthy before exiting the test
+    Given I register clean-up steps:
+    """
+    When I run the :patch admin command with:
+      | resource      | networks.config.openshift.io            |
+      | resource_name | cluster                                 |
+      | p             | {"spec":{"networkType":"OpenShiftSDN"}} |
+      | type          | merge                                   |
+    Then the step should succeed
+    """

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -23,9 +23,9 @@ Feature: Operator related networking scenarios
     Given the master version >= "4.0"
     #Getting OCP version
     Given evaluation of `cluster_version('version').version` is stored in the :ocp_version clipboard
-    #Making sure that operator is not Failing before proceesing further steps
-    And evaluation of `cluster_operator('network').condition(type: 'Failing')` is stored in the :failing_status_before_patch clipboard
-    Then the expression should be true> cb.failing_status_before_patch["status"]=="False"
+    #Making sure that operator is not Degraded before proceesing further steps
+    And evaluation of `cluster_operator('network').condition(type: 'Degraded')` is stored in the :Degraded_status_before_patch clipboard
+    Then the expression should be true> cb.Degraded_status_before_patch["status"]=="False"
     #Editing networks.config.openshift.io cluster to reflect bad config like changing networktype from OpenShiftSDN to OpenShift
     When I run the :patch admin command with:
       | resource      | networks.config.openshift.io         |
@@ -34,7 +34,7 @@ Feature: Operator related networking scenarios
       | type          | merge                                |
     Then the step should succeed
 
-    #Registering clean-up steps to move networkType back to OpenShiftSDN and to check Failing status is False before test exits
+    #Registering clean-up steps to move networkType back to OpenShiftSDN and to check Degraded status is False before test exits
     Given I register clean-up steps:
     """
     When I run the :patch admin command with:
@@ -44,11 +44,11 @@ Feature: Operator related networking scenarios
       | type          | merge                                   |
     Then the step should succeed
     20 seconds have passed
-    evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status clipboard
-    the expression should be true> cb.failing_status["status"]=="False"
+    evaluation of `cluster_operator('network').condition(type: 'Degraded',cached: false)` is stored in the :Degraded_status clipboard
+    the expression should be true> cb.Degraded_status["status"]=="False"
     """
-    #Normally it takes 5-10 seconds for network config update to reconcile across the cluster but taking 20 seconds wait to make sure that Failing status becomes True post bad patch
+    #Normally it takes 5-10 seconds for network config update to reconcile across the cluster but taking 20 seconds wait to make sure that Degraded status becomes True post bad patch
     Given 20 seconds have passed
-    And evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status_post_patch clipboard
-    Then the expression should be true> cb.failing_status_post_patch["status"]=="True"
+    And evaluation of `cluster_operator('network').condition(type: 'Degraded',cached: false)` is stored in the :Degraded_status_post_patch clipboard
+    Then the expression should be true> cb.Degraded_status_post_patch["status"]=="True"
     And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -34,12 +34,6 @@ Feature: Operator related networking scenarios
       | type          | merge                                |
     Then the step should succeed
 
-    #Normally it takes 5-10 seconds for network config update to reconcile across the cluster but taking 20 seconds wait to make sure that Failing status becomes True post bad patch
-    Given 20 seconds have passed
-    And evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status_post_patch clipboard
-    Then the expression should be true> cb.failing_status_post_patch["status"]=="True"
-    And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)
-    
     #Registering clean-up steps to move networkType back to OpenShiftSDN and to check Failing status is False before test exits
     Given I register clean-up steps:
     """
@@ -53,3 +47,8 @@ Feature: Operator related networking scenarios
     evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status clipboard
     the expression should be true> cb.failing_status["status"]=="False"
     """
+    #Normally it takes 5-10 seconds for network config update to reconcile across the cluster but taking 20 seconds wait to make sure that Failing status becomes True post bad patch
+    Given 20 seconds have passed
+    And evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status_post_patch clipboard
+    Then the expression should be true> cb.failing_status_post_patch["status"]=="True"
+    And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -43,16 +43,13 @@ Feature: Operator related networking scenarios
     #Registering clean-up steps to move networkType back to OpenShiftSDN and to check Failing status is False before test exits
     Given I register clean-up steps:
     """
-    20 seconds have passed
-    evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status clipboard
-    the expression should be true> cb.failing_status["status"]=="False"
-    """
-    Given I register clean-up steps:
-    """
     When I run the :patch admin command with:
       | resource      | networks.config.openshift.io            |
       | resource_name | cluster                                 |
       | p             | {"spec":{"networkType":"OpenShiftSDN"}} |
       | type          | merge                                   |
     Then the step should succeed
+    20 seconds have passed
+    evaluation of `cluster_operator('network').condition(type: 'Failing',cached: false)` is stored in the :failing_status clipboard
+    the expression should be true> cb.failing_status["status"]=="False"
     """

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -24,10 +24,10 @@ Feature: Operator related networking scenarios
     #Getting OCP version
     Given evaluation of `cluster_version('version').version` is stored in the :ocp_version clipboard
     #Making sure that operator is not Degraded before proceesing further steps
-    And evaluation of `cluster_operator('network').condition(type: 'Degraded')` is stored in the :Degraded_status_before_patch clipboard
+    And evaluation of `cluster_operator('network').condition(type: 'Degraded')` is stored in the :degraded_status_before_patch clipboard
     Then the expression should be true> cb.Degraded_status_before_patch["status"]=="False"
     #Making sure that operator is not Degraded before proceesing further steps
-    And evaluation of `cluster_operator('network').condition(type: 'Degraded')` is stored in the :Degraded_status_before_patch clipboard
+    And evaluation of `cluster_operator('network').condition(type: 'Degraded')` is stored in the :degraded_status_before_patch clipboard
     Then the expression should be true> cb.Degraded_status_before_patch["status"]=="False"
     #Editing networks.config.openshift.io cluster to reflect bad config like changing networktype from OpenShiftSDN to OpenShift
     When I run the :patch admin command with:
@@ -47,13 +47,13 @@ Feature: Operator related networking scenarios
       | type          | merge                                   |
     Then the step should succeed
     20 seconds have passed
-    evaluation of `cluster_operator('network').condition(type: 'Degraded',cached: false)` is stored in the :Degraded_status clipboard
-    the expression should be true> cb.Degraded_status["status"]=="False"
+    evaluation of `cluster_operator('network').condition(type: 'Degraded',cached: false)` is stored in the :degraded_status clipboard
+    the expression should be true> cb.degraded_status["status"]=="False"
     """
     #Normally it takes 5-10 seconds for network config update to reconcile across the cluster but taking 20 seconds wait to make sure that Degraded status becomes True post bad patch
     Given 20 seconds have passed
-    And evaluation of `cluster_operator('network').condition(type: 'Degraded',cached: false)` is stored in the :Degraded_status_post_patch clipboard
-    Then the expression should be true> cb.Degraded_status_post_patch["status"]=="True"
+    And evaluation of `cluster_operator('network').condition(type: 'Degraded',cached: false)` is stored in the :degraded_status_post_patch clipboard
+    Then the expression should be true> cb.degraded_status_post_patch["status"]=="True"
     And the expression should be true> cluster_operator('network').version_exists?(version: cb.ocp_version)
 
   # @author bmeng@redhat.com

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -652,8 +652,8 @@ Given /^the status of condition#{OPT_QUOTED} for network operator is :(.+)$/ do 
   elsif type == "Progressing"
     @result = admin.cli_exec(:get, resource: "clusteroperators", resource_name: "network", o: "jsonpath={.status.conditions[?(.type == \"Progressing\")].status}")
     real_status = @result[:response]
-  elsif type == "Failing"
-    @result = admin.cli_exec(:get, resource: "clusteroperators", resource_name: "network", o: "jsonpath={.status.conditions[?(.type == \"Failing\")].status}")
+  elsif type == "Degraded"
+    @result = admin.cli_exec(:get, resource: "clusteroperators", resource_name: "network", o: "jsonpath={.status.conditions[?(.type == \"Degraded\")].status}")
     real_status = @result[:response]
   else
     raise "Unknown condition type!"


### PR DESCRIPTION
Nothing big but just changed 'Failing' type to 'Degraded' in scenarios due to https://github.com/openshift/cluster-network-operator/pull/147 .Confirmed Tests works fine after this change
PTAL @bmeng @zhaozhanqi 