### PR TITLE
[Hotfix] no rules found for option: wait

### DIFF
--- a/lib/rules/cli/3.3.yaml
+++ b/lib/rules/cli/3.3.yaml
@@ -265,6 +265,7 @@
     :l: -l <value>
     :object_name_or_id: <value>
     :object_type: <value>
+    :wait: --wait=<value>
 :deploy:
   :cmd: oc deploy <deployment_config>
   :options:


### PR DESCRIPTION
@akostadinov @pruan-rht

It happens when running 3.x testing with master branch,
Jenkins log, Runner-v3/40647