### PR TITLE
added a query tool to look for payload that has a particualr fix base…

### DIFF
--- a/tools/find_image.rb
+++ b/tools/find_image.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+
+require 'commander'
+require 'open-uri'
+require 'nokogiri'
+require 'thread'
+
+"""
+Utility to query release page for matching payload containing a fix/PR matching a description provider by the user
+"""
+
+class QueryPayload
+  include Commander::Methods
+  # include whatever modules you need
+
+  def run
+    program :name, 'query_images'
+    program :version, '0.0.1'
+    program :description, 'Query the release page to find a matching image based on user defined query parameter'
+
+    default_command :query
+
+    command :query do |c|
+      c.syntax = 'query_images pattern, [options]'
+      c.description = ''
+      c.example 'description', 'command example'
+      c.option('-q', "--query QUERY_STRING", "search string")
+      c.option('-b', "--build_type BUILD_TYPE", "build type to filter out (ci-|nightly-)")
+      c.option('-u', "--url RELEASE_PAGE_URL", "URL of the release page")
+      c.action do |args, options|
+        options.default \
+          :build_type => "nightly-",
+          :url => "https://openshift-release.svc.ci.openshift.org/"
+        raise "missing query string" if options.query.nil?
+        doc = Nokogiri::HTML(open(options.url).read)
+        links = doc.xpath("//a[contains(text(), '#{options.build_type}')]")
+
+        target_links = links.map { |l|  options.url + l.attributes['href'].value }
+        threads = []
+        target_links.each do |link|
+          threads << Thread.new(link) do |i|
+            doc = Nokogiri::HTML(open(link).read)
+              if doc.to_s.include? options.query
+                puts "Pattern '#{options.query}' found in payload: #{link}"
+              end
+          end
+        end
+        threads.each { |thr| thr.join }
+      end
+    end
+
+    run!
+  end
+end
+
+if $0 == __FILE__
+  QueryPayload.new.run
+end


### PR DESCRIPTION
…d on message of the PR.  Example usage:

```
time ./find_image.rb --query "Position app launcher right like other masthead dropdowns"  
Pattern 'Position app launcher right like other masthead dropdowns' found in payload: https://openshift-release.svc.ci.openshift.org//releasestream/4.1.0-0.nightly/release/4.1.0-0.nightly-2019-05-06-073916
./find_image.rb --query   0.70s user 0.22s system 33% cpu 2.748 total

```