### PR TITLE
Fix scenarios

### DIFF
--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -25,10 +25,10 @@ Feature: Operator related networking scenarios
     Given evaluation of `cluster_version('version').version` is stored in the :ocp_version clipboard
     #Making sure that operator is not Degraded before proceesing further steps
     And evaluation of `cluster_operator('network').condition(type: 'Degraded')` is stored in the :degraded_status_before_patch clipboard
-    Then the expression should be true> cb.Degraded_status_before_patch["status"]=="False"
+    Then the expression should be true> cb.degraded_status_before_patch["status"]=="False"
     #Making sure that operator is not Degraded before proceesing further steps
     And evaluation of `cluster_operator('network').condition(type: 'Degraded')` is stored in the :degraded_status_before_patch clipboard
-    Then the expression should be true> cb.Degraded_status_before_patch["status"]=="False"
+    Then the expression should be true> cb.degraded_status_before_patch["status"]=="False"
     #Editing networks.config.openshift.io cluster to reflect bad config like changing networktype from OpenShiftSDN to OpenShift
     When I run the :patch admin command with:
       | resource      | networks.config.openshift.io         |

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -81,7 +81,6 @@ Feature: SDN related networking scenarios
     And evaluation of `@result[:parsed]['items'][0]['metadata']['name']` is stored in the :sdn_pod clipboard
  
     Given the cluster network plugin type and version and stored in the clipboard 
-    
     #Changing plugin version to some arbitary value ff
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 
       | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:<%= cb.net_plugin[:type] %>.ff |
@@ -108,8 +107,7 @@ Feature: SDN related networking scenarios
 
     #Changing plugin type to some arbitary value 99
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 
-	    | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:99.<%= cb.net_plugin[:version] %> |
-
+      | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:99.<%= cb.net_plugin[:version] %> |
     Then the step should succeed
     #Expecting sdn pod to be restarted due to plugin type value change
     And I wait up to 60 seconds for the steps to pass:

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -66,7 +66,6 @@ Feature: SDN related networking scenarios
   @admin
   @destructive
   Scenario: SDN will detect the version and plugin type mismatch in openflow and restart node automatically
-    Given the master version >= "3.11"
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :node_name clipboard
 

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -99,7 +99,7 @@ Feature: SDN related networking scenarios
       | Starting openshift-sdn network plugin         |
     
     """
-    # Expecting sdn pod to come back to default version the cluser was on
+    # Expecting sdn pod to come back to default version the cluser was on initially
     Given I wait up to 60 seconds for the steps to pass:
     """
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 
@@ -124,7 +124,7 @@ Feature: SDN related networking scenarios
       | Starting openshift-sdn network plugin         |
     
     """
-    # Expecting sdn pod to come back to default type the clustr was on
+    # Expecting sdn pod to come back to default type the cluster was on initially
     Given I wait up to 60 seconds for the steps to pass:
     """
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -75,7 +75,6 @@ Feature: SDN related networking scenarios
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 
       | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:<%= cb.net_plugin[:type] %>.ff |
     Then the step should succeed
-    And evaluation of `pod` is stored in the clipboard
     #Expecting sdn pod to be restarted due to vesion value change
     And I wait up to 60 seconds for the steps to pass:
     """

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -80,23 +80,26 @@ Feature: SDN related networking scenarios
     Then the step should succeed
     And evaluation of `@result[:parsed]['items'][0]['metadata']['name']` is stored in the :sdn_pod clipboard
  
+    #Below step will save plugin type and version value in net_plugin variable
     Given the cluster network plugin type and version and stored in the clipboard 
     #Changing plugin version to some arbitary value ff
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 
       | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:<%= cb.net_plugin[:type] %>.ff |
     Then the step should succeed
     #Expecting sdn pod to be restarted due to vesion value change
-    And I wait up to 60 seconds for the steps to pass:
+    And I wait up to 30 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
-      | resource_name     | <%= cb.sdn_pod %> |
-      | namespace         | openshift-sdn     |
+      | resource_name | <%= cb.sdn_pod %> |
+      | namespace     | openshift-sdn     |
+      | since         | 30s               |
     Then the step should succeed
     And the output should contain:
-      | SDN healthcheck detected unhealthy OVS server, restarting: plugin is not setup |
+      | full SDN setup required (plugin is not setup) |
+      | Starting openshift-sdn network plugin         |
     
     """
-    # Expecting sdn pod post restart to come back to default version the cluser was on
+    # Expecting sdn pod to come back to default version the cluser was on
     Given I wait up to 60 seconds for the steps to pass:
     """
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 
@@ -104,23 +107,24 @@ Feature: SDN related networking scenarios
     Then the step should succeed
     Then the output should contain "<%= cb.net_plugin[:type] %>.<%= cb.net_plugin[:version] %>"
     """
-
     #Changing plugin type to some arbitary value 99
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 
       | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:99.<%= cb.net_plugin[:version] %> |
     Then the step should succeed
     #Expecting sdn pod to be restarted due to plugin type value change
-    And I wait up to 60 seconds for the steps to pass:
+    And I wait up to 30 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
-      | resource_name     | <%= cb.sdn_pod %> |
-      | namespace         | openshift-sdn     |
+      | resource_name | <%= cb.sdn_pod %> |
+      | namespace     | openshift-sdn     |
+      | since         | 30s               |
     Then the step should succeed
     And the output should contain:
-      | SDN healthcheck detected unhealthy OVS server, restarting: plugin is not setup |
- 
+      | full SDN setup required (plugin is not setup) |
+      | Starting openshift-sdn network plugin         |
+    
     """
-    # Expecting sdn pod post restart to come back to default type the clustr was on
+    # Expecting sdn pod to come back to default type the clustr was on
     Given I wait up to 60 seconds for the steps to pass:
     """
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -87,7 +87,7 @@ Feature: SDN related networking scenarios
       | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:<%= cb.net_plugin[:type] %>.ff |
     Then the step should succeed
     #Expecting sdn pod to be restarted due to vesion value change
-    And I wait up to 30 seconds for the steps to pass:
+    And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
       | resource_name | <%= cb.sdn_pod %> |
@@ -112,7 +112,7 @@ Feature: SDN related networking scenarios
       | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:99.<%= cb.net_plugin[:version] %> |
     Then the step should succeed
     #Expecting sdn pod to be restarted due to plugin type value change
-    And I wait up to 30 seconds for the steps to pass:
+    And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
       | resource_name | <%= cb.sdn_pod %> |

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -69,27 +69,18 @@ Feature: SDN related networking scenarios
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :node_name clipboard
 
-    #Capturing the node's corresponding sdn pod to execute ovs commands on it
-    When I run the :get admin command with:
-       | resource      | pods                              |
-       | fieldSelector | spec.nodeName=<%= cb.node_name %> |
-       | namespace     | openshift-sdn                     |
-       | l             | app=sdn                           |
-       | output        | json                              |
-    Then the step should succeed
-    And evaluation of `@result[:parsed]['items'][0]['metadata']['name']` is stored in the :sdn_pod clipboard
- 
     #Below step will save plugin type and version value in net_plugin variable
     Given the cluster network plugin type and version and stored in the clipboard 
     #Changing plugin version to some arbitary value ff
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 
       | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:<%= cb.net_plugin[:type] %>.ff |
     Then the step should succeed
+    And evaluation of `pod` is stored in the clipboard
     #Expecting sdn pod to be restarted due to vesion value change
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
-      | resource_name | <%= cb.sdn_pod %> |
+      | resource_name | <%= pod.name %> |
       | namespace     | openshift-sdn     |
       | since         | 30s               |
     Then the step should succeed
@@ -114,7 +105,7 @@ Feature: SDN related networking scenarios
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
-      | resource_name | <%= cb.sdn_pod %> |
+      | resource_name | <%= pod.name %> |
       | namespace     | openshift-sdn     |
       | since         | 30s               |
     Then the step should succeed

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -66,53 +66,67 @@ Feature: SDN related networking scenarios
   @admin
   @destructive
   Scenario: SDN will detect the version and plugin type mismatch in openflow and restart node automatically
-    Given the master version >= "3.7"
-    And I select a random node's host
-    Given the cluster network plugin type and version and stored in the clipboard
-    And system verification steps are used:
+    Given the master version >= "3.11"
+    Given I select a random node's host
+    And evaluation of `node.name` is stored in the :node_name clipboard
+
+    #Capturing the node's corresponding sdn pod to execute ovs commands on it
+    When I run the :get admin command with:
+       | resource      | pods                              |
+       | fieldSelector | spec.nodeName=<%= cb.node_name %> |
+       | namespace     | openshift-sdn                     |
+       | l             | app=sdn                           |
+       | output        | json                              |
+    Then the step should succeed
+    And evaluation of `@result[:parsed]['items'][0]['metadata']['name']` is stored in the :sdn_pod clipboard
+ 
+    Given the cluster network plugin type and version and stored in the clipboard 
+    
+    #Changing plugin version to some arbitary value ff
+    When I run command on the "<%= cb.node_name %>" node's sdn pod: 
+      | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:<%= cb.net_plugin[:type] %>.ff |
+    Then the step should succeed
+    #Expecting sdn pod to be restarted due to vesion value change
+    And I wait up to 60 seconds for the steps to pass:
     """
-    When I run ovs dump flows commands on the host
+    When I run the :logs admin command with:
+      | resource_name     | <%= cb.sdn_pod %> |
+      | namespace         | openshift-sdn     |
+    Then the step should succeed
+    And the output should contain:
+      | SDN healthcheck detected unhealthy OVS server, restarting: plugin is not setup |
+    
+    """
+    # Expecting sdn pod post restart to come back to default version the cluser was on
+    Given I wait up to 60 seconds for the steps to pass:
+    """
+    When I run command on the "<%= cb.node_name %>" node's sdn pod: 
+      | ovs-ofctl| -O | openflow13 | dump-flows | br0 |
     Then the step should succeed
     Then the output should contain "<%= cb.net_plugin[:type] %>.<%= cb.net_plugin[:version] %>"
     """
-    And the node service is verified
-    And the node network is verified
 
-    When I run the ovs commands on the host:
-      | ovs-ofctl -O openflow13 mod-flows br0 "table=253, actions=note:<%= cb.net_plugin[:type] %>.ff" |
+    #Changing plugin type to some arbitary value 99
+    When I run command on the "<%= cb.node_name %>" node's sdn pod: 
+	    | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:99.<%= cb.net_plugin[:version] %> |
+
     Then the step should succeed
+    #Expecting sdn pod to be restarted due to plugin type value change
     And I wait up to 60 seconds for the steps to pass:
     """
-    When I run commands on the host:
-      | journalctl -l -u kubelet --since "30s ago" \| grep SDN |
+    When I run the :logs admin command with:
+      | resource_name     | <%= cb.sdn_pod %> |
+      | namespace         | openshift-sdn     |
     Then the step should succeed
     And the output should contain:
-      | SDN healthcheck detected unhealthy OVS server |
-      | full SDN setup required |
+      | SDN healthcheck detected unhealthy OVS server, restarting: plugin is not setup |
+ 
     """
-    # wait 120s for the node restarting and ovs rule come back
-    Given I wait up to 120 seconds for the steps to pass:
+    # Expecting sdn pod post restart to come back to default type the clustr was on
+    Given I wait up to 60 seconds for the steps to pass:
     """
-    When I run ovs dump flows commands on the host
-    Then the step should succeed
-    Then the output should contain "<%= cb.net_plugin[:type] %>.<%= cb.net_plugin[:version] %>"
-    """
-
-    When I run the ovs commands on the host:
-      | ovs-ofctl -O openflow13 mod-flows br0 "table=253, actions=note:99.<%= cb.net_plugin[:version] %>" |
-    Then the step should succeed
-    And I wait up to 60 seconds for the steps to pass:
-    """
-    When I run commands on the host:
-      | journalctl -l -u kubelet --since "30s ago" \| grep SDN |
-    Then the step should succeed
-    And the output should contain:
-      | SDN healthcheck detected unhealthy OVS server |
-      | full SDN setup required |
-    """
-    Given I wait up to 120 seconds for the steps to pass:
-    """
-    When I run ovs dump flows commands on the host
+    When I run command on the "<%= cb.node_name %>" node's sdn pod: 
+      | ovs-ofctl| -O | openflow13 | dump-flows | br0 |
     Then the step should succeed
     Then the output should contain "<%= cb.net_plugin[:type] %>.<%= cb.net_plugin[:version] %>"
     """

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -438,19 +438,11 @@ Given /^the cluster network plugin type and version and stored in the clipboard$
   ensure_admin_tagged
   _host = node.host
   
-  if env.version_lt("3.11", user: user)
-    step %Q/I run the ovs commands on the host:/, table([["ovs-ofctl dump-flows br0 -O openflow13"]])
-    unless @result[:success]
-      raise "Unable to execute ovs command successfully. Check your command."
-    end
-  else
-    step %Q/I run command on the node's sdn pod:/, table([["ovs-ofctl"],["dump-flows"],["br0"],["-O"],["openflow13"]])
-    unless @result[:success]
-      raise "Unable to execute ovs command successfully. Check your command."
-    end
-    of_note = @result[:response].partition('note:').last.chomp
+  step %Q/I run command on the node's sdn pod:/, table([["ovs-ofctl"],["dump-flows"],["br0"],["-O"],["openflow13"]])
+  unless @result[:success]
+    raise "Unable to execute ovs command successfully. Check your command."
   end
-
+  of_note = @result[:response].partition('note:').last.chomp
   cb.net_plugin = {
     type: of_note[0,2],
     version: of_note[3,2]

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -437,12 +437,18 @@ end
 Given /^the cluster network plugin type and version and stored in the clipboard$/ do
   ensure_admin_tagged
   _host = node.host
-
-  step %Q/I run the ovs commands on the host:/, table([[
-    "ovs-ofctl dump-flows br0 -O openflow13 | grep table=253 | sed -n -e 's/^.*note://p'"
-  ]])
-  if @result[:success]
-    of_note = @result[:response].chomp
+  
+  if env.version_lt("3.11", user: user)
+    step %Q/I run the ovs commands on the host:/, table([["ovs-ofctl dump-flows br0 -O openflow13"]])
+    unless @result[:success]
+      raise "Unable to execute ovs command successfully. Check your command."
+    end
+  else
+    step %Q/I run command on the node's sdn pod:/, table([["ovs-ofctl"],["dump-flows"],["br0"],["-O"],["openflow13"]])
+    unless @result[:success]
+      raise "Unable to execute ovs command successfully. Check your command."
+    end
+    of_note = @result[:response].partition('note:').last.chomp
   end
 
   cb.net_plugin = {


### PR DESCRIPTION
Fixing OCP-16710 to support 3.11 and 4.1. Broke every time during 3.11 or 4.x regression
Pass logs on 3.11 - https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/338/console
Pass logs on 4.1 - https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/339/console
@bmeng @zhaozhanqi 