### PR TITLE
OCP_16217 fixes to be merged in v3 branch

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -70,27 +70,18 @@ Feature: SDN related networking scenarios
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :node_name clipboard
 
-    #Capturing the node's corresponding sdn pod to execute ovs commands on it
-    When I run the :get admin command with:
-       | resource      | pods                              |
-       | fieldSelector | spec.nodeName=<%= cb.node_name %> |
-       | namespace     | openshift-sdn                     |
-       | l             | app=sdn                           |
-       | output        | json                              |
-    Then the step should succeed
-    And evaluation of `@result[:parsed]['items'][0]['metadata']['name']` is stored in the :sdn_pod clipboard
- 
     #Below step will save plugin type and version value in net_plugin variable
     Given the cluster network plugin type and version and stored in the clipboard 
     #Changing plugin version to some arbitary value ff
     When I run command on the "<%= cb.node_name %>" node's sdn pod: 
       | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:<%= cb.net_plugin[:type] %>.ff |
     Then the step should succeed
+    And evaluation of `pod` is stored in the clipboard
     #Expecting sdn pod to be restarted due to vesion value change
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
-      | resource_name | <%= cb.sdn_pod %> |
+      | resource_name | pod.name |
       | namespace     | openshift-sdn     |
       | since         | 30s               |
     Then the step should succeed
@@ -115,7 +106,7 @@ Feature: SDN related networking scenarios
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
-      | resource_name | <%= cb.sdn_pod %> |
+      | resource_name | pod.name |
       | namespace     | openshift-sdn     |
       | since         | 30s               |
     Then the step should succeed

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -81,7 +81,7 @@ Feature: SDN related networking scenarios
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
-      | resource_name | pod.name |
+      | resource_name | <%= pod.name %> |
       | namespace     | openshift-sdn     |
       | since         | 30s               |
     Then the step should succeed
@@ -106,7 +106,7 @@ Feature: SDN related networking scenarios
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
-      | resource_name | pod.name |
+      | resource_name | <%= pod.name %> |
       | namespace     | openshift-sdn     |
       | since         | 30s               |
     Then the step should succeed

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -66,53 +66,69 @@ Feature: SDN related networking scenarios
   @admin
   @destructive
   Scenario: SDN will detect the version and plugin type mismatch in openflow and restart node automatically
-    Given the master version >= "3.7"
-    And I select a random node's host
-    Given the cluster network plugin type and version and stored in the clipboard
-    And system verification steps are used:
+    Given the master version >= "3.10"
+    Given I select a random node's host
+    And evaluation of `node.name` is stored in the :node_name clipboard
+
+    #Capturing the node's corresponding sdn pod to execute ovs commands on it
+    When I run the :get admin command with:
+       | resource      | pods                              |
+       | fieldSelector | spec.nodeName=<%= cb.node_name %> |
+       | namespace     | openshift-sdn                     |
+       | l             | app=sdn                           |
+       | output        | json                              |
+    Then the step should succeed
+    And evaluation of `@result[:parsed]['items'][0]['metadata']['name']` is stored in the :sdn_pod clipboard
+ 
+    #Below step will save plugin type and version value in net_plugin variable
+    Given the cluster network plugin type and version and stored in the clipboard 
+    #Changing plugin version to some arbitary value ff
+    When I run command on the "<%= cb.node_name %>" node's sdn pod: 
+      | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:<%= cb.net_plugin[:type] %>.ff |
+    Then the step should succeed
+    #Expecting sdn pod to be restarted due to vesion value change
+    And I wait up to 60 seconds for the steps to pass:
     """
-    When I run ovs dump flows commands on the host
+    When I run the :logs admin command with:
+      | resource_name | <%= cb.sdn_pod %> |
+      | namespace     | openshift-sdn     |
+      | since         | 30s               |
+    Then the step should succeed
+    And the output should contain:
+      | full SDN setup required (plugin is not setup) |
+      | Starting openshift-sdn network plugin         |
+    
+    """
+    # Expecting sdn pod to come back to default version the cluser was on initially
+    Given I wait up to 60 seconds for the steps to pass:
+    """
+    When I run command on the "<%= cb.node_name %>" node's sdn pod: 
+      | ovs-ofctl| -O | openflow13 | dump-flows | br0 |
     Then the step should succeed
     Then the output should contain "<%= cb.net_plugin[:type] %>.<%= cb.net_plugin[:version] %>"
     """
-    And the node service is verified
-    And the node network is verified
-
-    When I run the ovs commands on the host:
-      | ovs-ofctl -O openflow13 mod-flows br0 "table=253, actions=note:<%= cb.net_plugin[:type] %>.ff" |
+    #Changing plugin type to some arbitary value 99
+    When I run command on the "<%= cb.node_name %>" node's sdn pod: 
+      | ovs-ofctl| -O | openflow13 | mod-flows | br0 | table=253, actions=note:99.<%= cb.net_plugin[:version] %> |
     Then the step should succeed
+    #Expecting sdn pod to be restarted due to plugin type value change
     And I wait up to 60 seconds for the steps to pass:
     """
-    When I run commands on the host:
-      | journalctl -l -u atomic-openshift-node --since "30s ago" \| grep SDN |
+    When I run the :logs admin command with:
+      | resource_name | <%= cb.sdn_pod %> |
+      | namespace     | openshift-sdn     |
+      | since         | 30s               |
     Then the step should succeed
     And the output should contain:
-      | SDN healthcheck detected unhealthy OVS server |
-      | full SDN setup required |
+      | full SDN setup required (plugin is not setup) |
+      | Starting openshift-sdn network plugin         |
+    
     """
-    # wait 120s for the node restarting and ovs rule come back
-    Given I wait up to 120 seconds for the steps to pass:
+    # Expecting sdn pod to come back to default type the cluster was on initially
+    Given I wait up to 60 seconds for the steps to pass:
     """
-    When I run ovs dump flows commands on the host
-    Then the step should succeed
-    Then the output should contain "<%= cb.net_plugin[:type] %>.<%= cb.net_plugin[:version] %>"
-    """
-
-    When I run the ovs commands on the host:
-      | ovs-ofctl -O openflow13 mod-flows br0 "table=253, actions=note:99.<%= cb.net_plugin[:version] %>" |
-    Then the step should succeed
-    And I wait up to 60 seconds for the steps to pass:
-    """
-    When I run commands on the host:
-      | journalctl -l -u atomic-openshift-node --since "30s ago" \| grep SDN |
-    Then the step should succeed
-    And the output should contain:
-      | SDN healthcheck detected unhealthy OVS server |
-      | full SDN setup required |
-    """
-    Given I wait up to 120 seconds for the steps to pass:
-    """
-    When I run ovs dump flows commands on the host
+    When I run command on the "<%= cb.node_name %>" node's sdn pod: 
+      | ovs-ofctl| -O | openflow13 | dump-flows | br0 |
     Then the step should succeed
     Then the output should contain "<%= cb.net_plugin[:type] %>.<%= cb.net_plugin[:version] %>"
     """

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -437,19 +437,19 @@ end
 Given /^the cluster network plugin type and version and stored in the clipboard$/ do
   ensure_admin_tagged
   _host = node.host
-
-  step %Q/I run the ovs commands on the host:/, table([[
-    "ovs-ofctl dump-flows br0 -O openflow13 | grep table=253 | sed -n -e 's/^.*note://p'"
-  ]])
-  if @result[:success]
-    of_note = @result[:response].chomp
+  
+  if env.version_lt("3.10", user: user)
+    step %Q/I run the ovs commands on the host:/, table([["ovs-ofctl dump-flows br0 -O openflow13"]])
+    unless @result[:success]
+      raise "Unable to execute ovs command successfully. Check your command."
+    end
+  else
+    step %Q/I run command on the node's sdn pod:/, table([["ovs-ofctl"],["dump-flows"],["br0"],["-O"],["openflow13"]])
+    unless @result[:success]
+      raise "Unable to execute ovs command successfully. Check your command."
+    end
+    of_note = @result[:response].partition('note:').last.chomp
   end
-
-  cb.net_plugin = {
-    type: of_note[0,2],
-    version: of_note[3,2]
-  }
-end
 
 Given /^I wait for the networking components of the node to be terminated$/ do
   ensure_admin_tagged

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -637,3 +637,16 @@ Given /^an IP echo service is setup on the master node and the ip is stored in t
     raise "Failed to delete the docker container." unless @result[:success]
   }
 end
+
+Given /^I run command on the#{OPT_QUOTED} node's sdn pod:$/ do |node_name, table|
+  ensure_admin_tagged
+  network_cmd = table.raw
+  node_name ||= node.name
+
+  sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    pod.node_name == node_name
+  }.first
+  cache_resources sdn_pod
+  @result = sdn_pod.exec(network_cmd, as: admin)
+  raise "Failed to execute network command!" unless @result[:success]
+end

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -451,6 +451,12 @@ Given /^the cluster network plugin type and version and stored in the clipboard$
     of_note = @result[:response].partition('note:').last.chomp
   end
 
+  cb.net_plugin = {
+    type: of_note[0,2],
+    version: of_note[3,2]
+  }
+end
+
 Given /^I wait for the networking components of the node to be terminated$/ do
   ensure_admin_tagged
 


### PR DESCRIPTION
This is similar to #194  but relevant to v3 branch. As @akostadinov suggested to keep changes separate for separate branches. networking.rb is fixed accordingly and gating criteria in scenario is clear now. Please help merging it. As per recent testing, there is lot of work to be involved to make this work on >=3.7 and <3.10 which comparatively get less testing request as compare to 3.10,3.11 and 4.x branch. So i suggest we merge it to avoid manual investigation in demanding branches during regression and needless to say, we can always keep working on it to support max branches in future
@bmeng @zhaozhanqi