### PR TITLE
deprecated the 'new-app' command for asb/tsb test scenarios

### DIFF
--- a/features/svc-catalog_asb/apb-update.feature
+++ b/features/svc-catalog_asb/apb-update.feature
@@ -6,22 +6,22 @@ Feature: Update sql apb related feature
     Given I save the first service broker registry prefix to :prefix clipboard
     #provision postgresql
     And I have a project
-    When I run the :new_app client command with:
-      | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-template.yaml |
-      | param | INSTANCE_NAME=<db_name>                                                                                      |
-      | param | CLASS_EXTERNAL_NAME=<db_name>                                                                                |
-      | param | PLAN_EXTERNAL_NAME=<db_plan_1>                                                                               |
-      | param | SECRET_NAME=<secret_name>                                                                                    |
-      | param | INSTANCE_NAMESPACE=<%= project.name %>                                                                       |
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-template.yaml |
+      | p | INSTANCE_NAME=<db_name>                                                                                      |
+      | p | CLASS_EXTERNAL_NAME=<db_name>                                                                                |
+      | p | PLAN_EXTERNAL_NAME=<db_plan_1>                                                                               |
+      | p | SECRET_NAME=<secret_name>                                                                                    |
+      | p | INSTANCE_NAMESPACE=<%= project.name %>                                                                       |
     Then the step should succeed
     And evaluation of `service_instance("<db_name>").uid` is stored in the :db_uid clipboard
-    When I run the :new_app client command with:
-      | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-parameters-template.yaml                 |
-      | param | SECRET_NAME=<secret_name>                                                                                                               |
-      | param | INSTANCE_NAME=<db_name>                                                                                                                 |
-      | param | PARAMETERS={"postgresql_database":"admin","postgresql_user":"admin","postgresql_version":"<db_version>","postgresql_password":"test"}   |
-      | param | UID=<%= cb.db_uid %>                                                                                                                    |
-      | n     | <%= project.name %>                                                                                                                     |
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-parameters-template.yaml                 |
+      | p | SECRET_NAME=<secret_name>                                                                                                               |
+      | p | INSTANCE_NAME=<db_name>                                                                                                                 |
+      | p | PARAMETERS={"postgresql_database":"admin","postgresql_user":"admin","postgresql_version":"<db_version>","postgresql_password":"test"}   |
+      | p | UID=<%= cb.db_uid %>                                                                                                                    |
+      | n | <%= project.name %>                                                                                                                     |
     Then the step should succeed
     Given I wait for the "<db_name>" service_instance to become ready up to 360 seconds
     And dc with name matching /postgresql/ are stored in the :dc_1 clipboard

--- a/features/svc-catalog_asb/asb.feature
+++ b/features/svc-catalog_asb/asb.feature
@@ -15,39 +15,39 @@ Feature: Ansible-service-broker related scenarios
     And I use the "<%= cb.org_proj_name %>" project
 
     # Provision mediawiki apb
-    When I run the :new_app client command with:
-      | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-template.yaml |
-      | param | INSTANCE_NAME=<%= cb.prefix %>-mediawiki-apb          |
-      | param | CLASS_EXTERNAL_NAME=<%= cb.prefix %>-mediawiki-apb    |
-      | param | SECRET_NAME=<%= cb.prefix %>-mediawiki-apb-parameters |
-      | param | INSTANCE_NAMESPACE=<%= project.name %>                |
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-template.yaml |
+      | p | INSTANCE_NAME=<%= cb.prefix %>-mediawiki-apb          |
+      | p | CLASS_EXTERNAL_NAME=<%= cb.prefix %>-mediawiki-apb    |
+      | p | SECRET_NAME=<%= cb.prefix %>-mediawiki-apb-parameters |
+      | p | INSTANCE_NAMESPACE=<%= project.name %>                |
     Then the step should succeed
     And evaluation of `service_instance(cb.prefix + "-mediawiki-apb").uid(user: user)` is stored in the :mediawiki_uid clipboard
-    When I run the :new_app client command with:
+    When I process and create:
       | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-parameters-template.yaml |
-      | param | SECRET_NAME=<%= cb.prefix %>-mediawiki-apb-parameters |
-      | param | INSTANCE_NAME=<%= cb.prefix %>-mediawiki-apb          |
-      | param | UID=<%= cb.mediawiki_uid %>                           |
-      | n     | <%= project.name %>                                   |
+      | p | SECRET_NAME=<%= cb.prefix %>-mediawiki-apb-parameters |
+      | p | INSTANCE_NAME=<%= cb.prefix %>-mediawiki-apb          |
+      | p | UID=<%= cb.mediawiki_uid %>                           |
+      | n | <%= project.name %>                                   |
     Then the step should succeed
 
     # Provision DB apb
-    When I run the :new_app client command with:
-      | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-template.yaml |
-      | param | INSTANCE_NAME=<db_name>                               |
-      | param | CLASS_EXTERNAL_NAME=<db_name>                         |
-      | param | PLAN_EXTERNAL_NAME=<db_plan>                          |
-      | param | SECRET_NAME=<db_secret_name>                          |
-      | param | INSTANCE_NAMESPACE=<%= project.name %>                |
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-template.yaml |
+      | p | INSTANCE_NAME=<db_name>                               |
+      | p | CLASS_EXTERNAL_NAME=<db_name>                         |
+      | p | PLAN_EXTERNAL_NAME=<db_plan>                          |
+      | p | SECRET_NAME=<db_secret_name>                          |
+      | p | INSTANCE_NAMESPACE=<%= project.name %>                |
     Then the step should succeed
     And evaluation of `service_instance("<db_name>").uid(user: user)` is stored in the :db_uid clipboard
-    When I run the :new_app client command with:
-      | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-parameters-template.yaml |
-      | param | SECRET_NAME=<db_secret_name>                                                                                            |
-      | param | INSTANCE_NAME=<db_name>                                                                                                 |
-      | param | PARAMETERS=<db_parameters>                                                                                              |
-      | param | UID=<%= cb.db_uid %>                                                                                            |
-      | n     | <%= project.name %>                                                                                                     |
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/serviceinstance-parameters-template.yaml |
+      | p | SECRET_NAME=<db_secret_name>                                                                                            |
+      | p | INSTANCE_NAME=<db_name>                                                                                                 |
+      | p | PARAMETERS=<db_parameters>                                                                                              |
+      | p | UID=<%= cb.db_uid %>                                                                                            |
+      | n | <%= project.name %>                                                                                                     |
     Then the step should succeed
     And I wait for all service_instance in the project to become ready up to 360 seconds
 
@@ -71,12 +71,12 @@ Feature: Ansible-service-broker related scenarios
     """
 
     # Create servicebinding of DB apb
-    When I run the :new_app client command with:
-      | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/servicebinding-template.yaml |
-      | param | BINDING_NAME=<db_name>                                                                                      |
-      | param | INSTANCE_NAME=<db_name>                                                                                     |
-      | param | SECRET_NAME=<db_credentials>                                                                                |
-      | n     | <%= project.name %>                                                                                         |
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/servicebinding-template.yaml |
+      | p | BINDING_NAME=<db_name>                                                                                      |
+      | p | INSTANCE_NAME=<db_name>                                                                                     |
+      | p | SECRET_NAME=<db_credentials>                                                                                |
+      | n | <%= project.name %>                                                                                         |
     And I wait up to 20 seconds for the steps to pass:
     """
     When I run the :describe client command with:

--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -145,9 +145,9 @@ Feature: Service-catalog related scenarios
     """
     When I switch to cluster admin pseudo user
     And I use the "<%= cb.ups_broker_project %>" project
-    When I run the :new_app client command with:
-      | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml |
-      | param | UPS_BROKER_PROJECT=<%= cb.ups_broker_project %>                                                         |
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml |
+      | p | UPS_BROKER_PROJECT=<%= cb.ups_broker_project %>                                                         |
     Then the step should succeed
     And I wait for the steps to pass:
     """
@@ -219,9 +219,9 @@ Feature: Service-catalog related scenarios
 
     When I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
-    When I run the :new_app client command with:
-      | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml |
-      | param | UPS_BROKER_PROJECT=<%= project.name %>                                                                  |
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml |
+      | p | UPS_BROKER_PROJECT=<%= project.name %>                                                                  |
     Then the step should succeed
     And I wait for the steps to pass:
     """


### PR DESCRIPTION
In OCP 4.1, the new-app command has been deprecated. Like the below shows, see bug https://bugzilla.redhat.com/show_bug.cgi?id=1671528 for more details. 

By using ` When I run the :new_app client command with` we're facing the following issue:
```
STDERR:
      error: The template contained an object type unknown to `oc new-app`.  Use `oc process -f <template> | oc create -f -` instead.  Error details: no kind "ClusterServiceBroker" is registered for version "servicecatalog.k8s.io/v1beta1" in scheme "k8s.io/kubernetes/pkg/kubectl/scheme/scheme.go:28"
      
      [16:10:10] INFO> Exit Status: 1
      | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml |
      | param | UPS_BROKER_PROJECT=<%= project.name %>                                                                  |
    Then the step should succeed                                                                                # features/step_definitions/common.rb:4
      the step failed (RuntimeError)
      /home/jenkins/workspace/Runner-v3/features/step_definitions/common.rb:6:in `/^the step should( not)? (succeed|fail)$/'
      features/svc-catalog_asb/svc-catalog.feature:225:in `Then the step should succeed
```
My suggestion is to change it to `When I process and create` that will have the same expected behavior as shown below:
```
    When I process and create:                                                                                  # features/step_definitions/cli.rb:143
      [18:29:48] INFO> Shell Commands: oc process -f https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml -p UPS_BROKER_PROJECT\=up-9g --config=/home/jenkins/workspace/Runner-v3/workdir/cucushift-oc41-standard-slave-2dqdf-0/ocp4_admin.kubeconfig
      {
          "kind": "List",
          "apiVersion": "v1",
          "metadata": {},
          "items": [
              {
                  "apiVersion": "v1",
                  "kind": "Service",
                  "metadata": {
                      "labels": {
                          "app": "ups-broker",
                          "chart": "ups-broker-0.0.1",
                          "heritage": "Tiller",
                          "release": "ups-broker"
                      },
                      "name": "ups-broker"
                  },
                  "spec": {
                      "ports": [
                          {
                              "port": 80,
                              "protocol": "TCP",
                              "targetPort": 8080
                          }
                      ],
                      "selector": {
                          "app": "ups-broker"
                      },
                      "sessionAffinity": "None"
                  }
              },
              {
                  "apiVersion": "extensions/v1beta1",
                  "kind": "Deployment",
                  "metadata": {
                      "labels": {
                          "app": "ups-broker",
                          "chart": "ups-broker-0.0.1",
                          "heritage": "Tiller",
                          "release": "ups-broker"
                      },
                      "name": "ups-broker"
                  },
                  "spec": {
                      "replicas": 1,
                      "selector": {
                          "matchLabels": {
                              "app": "ups-broker"
                          }
                      },
                      "strategy": {
                          "rollingUpdate": {
                              "maxSurge": 1,
                              "maxUnavailable": 1
                          },
                          "type": "RollingUpdate"
                      },
                      "template": {
                          "metadata": {
                              "creationTimestamp": null,
                              "labels": {
                                  "app": "ups-broker",
                                  "chart": "ups-broker-0.0.1",
                                  "heritage": "Tiller",
                                  "release": "ups-broker"
                              }
                          },
                          "spec": {
                              "containers": [
                                  {
                                      "args": [
                                          "-alsologtostderr",
                                          "--port",
                                          "8080"
                                      ],
                                      "image": "quay.io/kubernetes-service-catalog/user-broker:latest",
                                      "imagePullPolicy": "Always",
                                      "livenessProbe": {
                                          "failureThreshold": 3,
                                          "initialDelaySeconds": 10,
                                          "periodSeconds": 10,
                                          "successThreshold": 1,
                                          "tcpSocket": {
                                              "port": 8080
                                          },
                                          "timeoutSeconds": 2
                                      },
                                      "name": "ups-broker",
                                      "ports": [
                                          {
                                              "containerPort": 8080,
                                              "protocol": "TCP"
                                          }
                                      ],
                                      "readinessProbe": {
                                          "failureThreshold": 1,
                                          "initialDelaySeconds": 10,
                                          "periodSeconds": 10,
                                          "successThreshold": 1,
                                          "tcpSocket": {
                                              "port": 8080
                                          },
                                          "timeoutSeconds": 2
                                      }
                                  }
                              ],
                              "dnsPolicy": "ClusterFirst",
                              "restartPolicy": "Always",
                              "terminationGracePeriodSeconds": 30
                          }
                      }
                  }
              },
              {
                  "apiVersion": "servicecatalog.k8s.io/v1beta1",
                  "kind": "ClusterServiceBroker",
                  "metadata": {
                      "name": "ups-broker"
                  },
                  "spec": {
                      "url": "http://ups-broker.up-9g.svc.cluster.local"
                  }
              }
          ]
      }
      
      [18:29:50] INFO> Exit Status: 0
```