### PR TITLE
enable svcat in 4.1

### DIFF
--- a/lib/rules/cli/svcat-4.1.yaml
+++ b/lib/rules/cli/svcat-4.1.yaml
@@ -1,0 +1,1 @@
+svcat-3.10.yaml


### PR DESCRIPTION
Fix the error `unknown rules source 'String': /Users/jianzhang/project/verification-tests/lib/rules/cli/svcat-4.1.yaml (RuntimeError)`, details as below. @akostadinov @pruan-rht @jianzhangbjz @zihantang-rh @scolange @bandrade Please have a review, thanks!
```console
waiting for operation up to 3600 seconds..
      #get help info
    When I run the :provision admin command with:                                                 # features/step_definitions/cli.rb:31
      [08:57:11] INFO> Shell Commands: rm  -f -- /Users/jianzhang/workdir/mac-jianzhang/ocp4_admin.kubeconfig
     
      [08:57:11] INFO> Exit Status: 0
      [08:57:11] INFO> Shell Commands: oc config set-credentials admin --client-certificate=/Users/jianzhang/workdir/mac-jianzhang/clcert20190524-55066-yo6fgo --client-key=/Users/jianzhang/workdir/mac-jianzhang/clkey20190524-55066-emw83k --embed-certs=true --server=https://api.jialiu-vsphere2.qe.devcluster.openshift.com:6443 --config=/Users/jianzhang/workdir/mac-jianzhang/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      User "admin" set.
     
      [08:57:11] INFO> Exit Status: 0
      [08:57:11] INFO> Shell Commands: oc config set-cluster generated-cluster --server=https://api.jialiu-vsphere2.qe.devcluster.openshift.com:6443 --config=/Users/jianzhang/workdir/mac-jianzhang/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Cluster "generated-cluster" set.
     
      [08:57:11] INFO> Exit Status: 0
      [08:57:11] INFO> Shell Commands: oc config set-context generated --cluster=generated-cluster --user=admin --config=/Users/jianzhang/workdir/mac-jianzhang/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Context "generated" created.
     
      [08:57:11] INFO> Exit Status: 0
      [08:57:11] INFO> Shell Commands: oc config use-context generated --config=/Users/jianzhang/workdir/mac-jianzhang/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Switched to context "generated".
     
      [08:57:11] INFO> Exit Status: 0
      | _tool         | svcat  |
      | instance_name | :false |
      | h             |        |
      unknown rules source 'String': /Users/jianzhang/project/verification-tests/lib/rules/cli/svcat-4.1.yaml (RuntimeError)
      /Users/jianzhang/project/verification-tests/lib/rules_common.rb:27:in `block in load'
      /Users/jianzhang/project/verification-tests/lib/rules_common.rb:7:in `each'
      /Users/jianzhang/project/verification-tests/lib/rules_common.rb:7:in `reduce'
      /Users/jianzhang/project/verification-tests/lib/rules_common.rb:7:in `load'
      /Users/jianzhang/project/verification-tests/lib/rules_command_executor.rb:312:in `rules'
      /Users/jianzhang/project/verification-tests/lib/rules_command_executor.rb:231:in `build_command_line'
      /Users/jianzhang/project/verification-tests/lib/rules_command_executor.rb:53:in `run'
      /Users/jianzhang/project/verification-tests/lib/cli_executor.rb:304:in `exec'
      /Users/jianzhang/project/verification-tests/lib/api_accessor.rb:71:in `cli_exec'
      /Users/jianzhang/project/verification-tests/features/step_definitions/cli.rb:43:in `/^I run the :([a-z_]*?)( background)? admin command with:$/'
      features/tierN/svc-catalog_asb/svcat.feature:459:in `When I run the :provision admin command with:'
    Then the step should succeed                                                                  # features/step_definitions/common.rb:4
    And the output by order should contain:                                                       # features/step_definitions/common.rb:33
      | Usage:                                                 |
      | svcat provision NAME --plan PLAN --class CLASS [flags] |
      # Deploy ups broker
```