### PR TITLE
Fix OCP-11943

### DIFF
--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -223,7 +223,7 @@ Feature: build 'apps' with CLI
   Scenario: Using a docker image as source input using new-build cmd
     Given I have a project
     When I run the :tag client command with:
-      | source | openshift/python:latest |
+      | source | docker.io/python:latest |
       | dest   | python:latest |
     Then the step should succeed
     And the "python" image stream becomes ready


### PR DESCRIPTION
Need authentication when pull image from registry.redhat.io,  after tag openshift images into user project  image streams, so using docker.io image. 
[pass log](https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/41355/console)
@openshift/devexp-qe pls help to review it, thx