### PR TITLE
Adding various scenarios to support SDN 411 - Blocking Machine-config-server port

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -203,6 +203,7 @@ Feature: Pod related networking scenarios
     
     Given I have a project
     #pod-for-ping will be a non-hotnetwork pod
+    And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     And I have a pod-for-ping in the project
     And the pod named "hello-pod" becomes ready
 
@@ -213,11 +214,11 @@ Feature: Pod related networking scenarios
       | curl | -I | http://<%= cb.master_ip %>:22624/master/config | -k |
     Then the output should contain "Connection refused"
     
-    Given I have a project
     #hostnetwork-pod will be a hostnetwork pod
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/anuragthehatter/v3-testfiles/master/networking/hostnetwork-pod.json |
-    And the pod named "hostnetwork-pod" becomes ready
+      | n | <%= project.name %>                                                                                   |
+    Then the pod named "hostnetwork-pod" becomes ready
     When I execute on the pod:
       | curl | -I | http://<%= cb.master_ip %>:22623/master/config | -k |
     Then the output should contain "Connection refused"
@@ -233,7 +234,7 @@ Feature: Pod related networking scenarios
     And I run commands on the host:
       | ifconfig tun0 \| grep -w inet \| awk '{print $2}' |
     Then the step should succeed
-    And evaluation of `@result[:response]` is stored in the :master_tun0_ip clipboard
+    And evaluation of `@result[:response].strip` is stored in the :master_tun0_ip clipboard
     
     Given I select a random node's host
     And I have a project

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -297,7 +297,6 @@ Feature: Pod related networking scenarios
   @admin
   Scenario: User cannot access the MCS by creating a service that maps to non-MCS port to port 22623 or 22624 on the IP of a master (via manually-created ep's)
     Given evaluation of `env.master_hosts.first.local_ip` is stored in the :master_ip clipboard
-    Given I select a random node's host
     And I have a project
     #pod-for-ping will be a non-hostnetwork pod
     And I have a pod-for-ping in the project

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -265,7 +265,8 @@ Feature: Pod related networking scenarios
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/egress-http-proxy/egress-http-proxy-pod.yaml |
-    Then the pod named "egress-http-proxy" becomes ready
+    Then the step should succeed
+
     #Pod should not access MCS via an egress router pod
     When I execute on the pod:
       | curl | -I | https://<%= cb.master_ip %>:22623/config/master | -k |
@@ -300,7 +301,6 @@ Feature: Pod related networking scenarios
     Then the step should succeed
     #pod-for-ping will be a non-hostnetwork pod
     And I have a pod-for-ping in the project
-    And the pod named "hello-pod" becomes ready
     
     #Pod cannot access MCS
     When I execute on the pod:

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -231,7 +231,7 @@ Feature: Pod related networking scenarios
   Scenario: A pod cannot access the MCS port 22623 or 22624 via the SDN/tun0 address of the master
     Given I use the first master host		
     And I run commands on the host:
-      | ifconfig tun0 \| grep -w "inet" \| awk \'{print $2}\' |
+      | ifconfig | tun0 | \| | grep -w inet | \| | awk {print $2} |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :master_tun0_ip clipboard
     

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -194,13 +194,14 @@ Feature: Pod related networking scenarios
   # @case_id OCP-23890
   @admin
   Scenario: A pod with or without hostnetwork cannot access the MCS port 22623 or 22624 on the master
-    Given I select a random node's host
+    Given I use the first master host
     #Step to obtain master IP
-    When I run the :get admin command with:
-      | resource | nodes |
-      | output   | json | 
-    And evaluation of `@result[:parsed]['items'][0]['status']['addresses'][0]['address']` is stored in the :master_ip clipboard		
+    And I run commands on the host:
+      | hostname -i |
+    Then the step should succeed
+    And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
     
+    Given I select a random node's host
     Given I have a project
     #pod-for-ping will be a non-hostnetwork pod
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
@@ -254,13 +255,14 @@ Feature: Pod related networking scenarios
   # @case_id OCP-23892
   @admin
   Scenario: A pod cannot access the MCS via an egress router in http proxy mode
-    Given I select a random node's host
+    Given I use the first master host
     #Step to obtain master IP
-    When I run the :get admin command with:
-      | resource | nodes |
-      | output   | json |
-    And evaluation of `@result[:parsed]['items'][0]['status']['addresses'][0]['address']` is stored in the :master_ip clipboard
-
+    And I run commands on the host:
+      | hostname -i |
+    Then the step should succeed
+    And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
+    
+    Given I select a random node's host
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     #pod-for-ping will be a non-hotnetwork pod
@@ -280,13 +282,14 @@ Feature: Pod related networking scenarios
   # @case_id OCP-23893
   @admin
   Scenario: A pod in a namespace with an egress IP cannot access the MCS
-    Given I select a random node's host
+    Given I use the first master host
     #Step to obtain master IP
-    When I run the :get admin command with:
-      | resource | nodes |
-      | output   | json |
-    And evaluation of `@result[:parsed]['items'][0]['status']['addresses'][0]['address']` is stored in the :master_ip clipboard
-
+    And I run commands on the host:
+      | hostname -i |
+    Then the step should succeed
+    And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
+    
+    Given I select a random node's host
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     #pod-for-ping will be a non-hostnetwork pod

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -194,13 +194,7 @@ Feature: Pod related networking scenarios
   # @case_id OCP-23890
   @admin
   Scenario: A pod with or without hostnetwork cannot access the MCS port 22623 or 22624 on the master
-    Given I use the first master host
-    #Step to obtain master IP
-    And I run commands on the host:
-      | hostname -i |
-    Then the step should succeed
-    And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
-    
+    Given evaluation of `env.master_hosts.first.local_ip` is stored in the :master_ip clipboard
     Given I select a random node's host
     Given I have a project
     #pod-for-ping will be a non-hostnetwork pod
@@ -253,13 +247,7 @@ Feature: Pod related networking scenarios
   # @case_id OCP-23892
   @admin
   Scenario: A pod cannot access the MCS via an egress router in http proxy mode
-    Given I use the first master host
-    #Step to obtain master IP
-    And I run commands on the host:
-      | hostname -i |
-    Then the step should succeed
-    And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
-    
+    Given evaluation of `env.master_hosts.first.local_ip` is stored in the :master_ip clipboard
     Given I select a random node's host
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
@@ -279,13 +267,7 @@ Feature: Pod related networking scenarios
   # @case_id OCP-23893
   @admin
   Scenario: A pod in a namespace with an egress IP cannot access the MCS
-    Given I use the first master host
-    #Step to obtain master IP
-    And I run commands on the host:
-      | hostname -i |
-    Then the step should succeed
-    And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
-    
+    Given evaluation of `env.master_hosts.first.local_ip` is stored in the :master_ip clipboard
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
     #add the egress ip to the hostsubnet

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -209,10 +209,10 @@ Feature: Pod related networking scenarios
     And the pod named "hello-pod" becomes ready
 
     When I execute on the pod:
-      | curl | -I | https://<%= cb.master_ip %>:22623/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22623/config/master | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
-      | curl | -I | https://<%= cb.master_ip %>:22624/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22624/config/master | -k |
     Then the output should contain "Connection refused"
     
     #hostnetwork-pod will be a hostnetwork pod
@@ -222,10 +222,10 @@ Feature: Pod related networking scenarios
     Then the pod named "hostnetwork-pod" becomes ready
     #Pods should not access the MCS port 22623 or 22624 on the master
     When I execute on the pod:
-      | curl | -I | https://<%= cb.master_ip %>:22623/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22623/config/master | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
-      | curl | -I | https://<%= cb.master_ip %>:22624/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22624/config/master | -k |
     Then the output should contain "Connection refused"
 
   # @auther anusaxen@redhat.com
@@ -245,10 +245,10 @@ Feature: Pod related networking scenarios
     And the pod named "hello-pod" becomes ready
     #Curl on Master's tun0 IP to make sure connections are blocked to MCS via tun0
     When I execute on the pod:
-      | curl | -I | https://<%= cb.master_tun0_ip %>:22623/master/config | -k |
+      | curl | -I | https://<%= cb.master_tun0_ip %>:22623/config/master | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
-      | curl | -I | https://<%= cb.master_tun0_ip %>:22624/master/config | -k |
+      | curl | -I | https://<%= cb.master_tun0_ip %>:22624/config/master | -k |
     Then the output should contain "Connection refused"
 
   # @auther anusaxen@redhat.com
@@ -272,10 +272,10 @@ Feature: Pod related networking scenarios
     Then the pod named "egress-http-proxy" becomes ready
     #Pod should not access MCS via an egress router pod
     When I execute on the pod:
-      | curl | -I | https://<%= cb.master_ip %>:22623/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22623/config/master | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
-      | curl | -I | https://<%= cb.master_ip %>:22624/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22624/config/master | -k |
     Then the output should contain "Connection refused"
 
   # @auther anusaxen@redhat.com
@@ -294,15 +294,22 @@ Feature: Pod related networking scenarios
     #add the egress ip to the hostsubnet
     And the valid egress IP is added to the "<%= cb.egress_node %>" node
     Given I have a project
-    And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
+    And evaluation of `project.name` is stored in the :project clipboard
+    # add the egress ip to the project
+    When I run the :patch admin command with:
+    | resource      | netnamespace                         |
+    | resource_name | <%= cb.project %>                    |
+    | p             | {"egressIPs":["<%= cb.valid_ip %>"]} |
+    | type          | merge                                |
+    Then the step should succeed
     #pod-for-ping will be a non-hostnetwork pod
     And I have a pod-for-ping in the project
     And the pod named "hello-pod" becomes ready
     
     #Pod cannot access MCS
     When I execute on the pod:
-      | curl | -I | https://<%= cb.master_ip %>:22623/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22623/config/master | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
-      | curl | -I | https://<%= cb.master_ip %>:22624/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22624/config/master | -k |
     Then the output should contain "Connection refused"

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -315,7 +315,7 @@ Feature: Pod related networking scenarios
   @admin
   Scenario: User cannot access the MCS by creating a service that maps to non-MCS port to port 22623 or 22624 on the IP of a master (via manually-created ep's)
     Given I use the first master host
-    #Step to obtain master IP
+    Step to obtain master IP
     And I run commands on the host:
       | hostname -i |
     Then the step should succeed
@@ -339,4 +339,4 @@ Feature: Pod related networking scenarios
       | p             | {"subsets": [{"addresses": [{"ip": "<%= cb.master_ip %>"}],"ports": [{"port": 22623,"protocol": "TCP"}]}]} |
       | type          | merge                                                         						   |
     Then the step should fail
-    And the output should contain "endpoints "<%= cb.pind_pod.name %>" is forbidden: endpoint port TCP:22623 is not allowed"
+    And the output should contain "endpoints "<%= cb.ping_pod.name %>" is forbidden: endpoint port TCP:22623 is not allowed"

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -219,6 +219,7 @@ Feature: Pod related networking scenarios
       | f | https://raw.githubusercontent.com/anuragthehatter/v3-testfiles/master/networking/hostnetwork-pod.json |
       | n | <%= project.name %>                                                                                   |
     Then the pod named "hostnetwork-pod" becomes ready
+    #Pods should not access the MCS port 22623 or 22624 on the master
     When I execute on the pod:
       | curl | -I | http://<%= cb.master_ip %>:22623/master/config | -k |
     Then the output should contain "Connection refused"
@@ -267,7 +268,7 @@ Feature: Pod related networking scenarios
       | f | https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/egress-http-proxy/egress-http-proxy-pod.yaml |
       | n | <%= project.name %>                                                                                   |
     Then the pod named "egress-http-proxy" becomes ready
-
+    #Pod should not access MCS via an egress router pod
     When I execute on the pod:
       | curl | -I | http://<%= cb.master_ip %>:22623/master/config | -k |
     Then the output should contain "Connection refused"
@@ -293,17 +294,17 @@ Feature: Pod related networking scenarios
     And the pod named "hello-pod" becomes ready
     
     When I run the :patch admin command with:
-      | resource      | netnamespace |
-      | resource_name | <%= cb.project %> |
+      | resource      | netnamespace                         |
+      | resource_name | <%= project.name %>                  |
       | p             | {"egressIPs":["<%= cb.valid_ip %>"]} |
+      | type          | merge                                |
     Then the step should succeed
     
     Given I use the "<%= project.name %>" project
+    #Pod cannot access MCS
     When I execute on the pod:
       | curl | -I | http://<%= cb.master_ip %>:22623/master/config | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
       | curl | -I | http://<%= cb.master_ip %>:22624/master/config | -k |
     Then the output should contain "Connection refused"
-
-

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -235,17 +235,12 @@ Feature: Pod related networking scenarios
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :master_tun0_ip clipboard
     
-    #Step to obtain master IP
-    When I run the :get admin command with:
-      | resource | nodes |
-      | output   | json | 
-    And evaluation of `@result[:parsed]['items'][0]['status']['addresses'][0]['address']` is stored in the :master_ip clipboard		
-    
-    Given I have a project
+    Given I select a random node's host
+    And I have a project
     #pod-for-ping will be a non-hotnetwork pod
     And I have a pod-for-ping in the project
     And the pod named "hello-pod" becomes ready
-
+    #Curl on Master's tun0 IP to make sure connections are blocked to MCS via tun0
     When I execute on the pod:
       | curl | -I | http://<%= cb.master_tun0_ip %>:22623/master/config | -k |
     Then the output should contain "Connection refused"

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -314,13 +314,7 @@ Feature: Pod related networking scenarios
   # @case_id OCP-23894
   @admin
   Scenario: User cannot access the MCS by creating a service that maps to non-MCS port to port 22623 or 22624 on the IP of a master (via manually-created ep's)
-    Given I use the first master host
-    #Step to obtain master IP
-    And I run commands on the host:
-      | hostname -i |
-    Then the step should succeed
-    And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
-    
+    Given evaluation of `env.master_hosts.first.local_ip` is stored in the :master_ip clipboard
     Given I select a random node's host
     And I have a project
     #pod-for-ping will be a non-hostnetwork pod

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -244,26 +244,6 @@ Feature: Pod related networking scenarios
     Then the output should contain "Connection refused"
 
   # @auther anusaxen@redhat.com
-  # @case_id OCP-23892
-  @admin
-  Scenario: A pod cannot access the MCS via an egress router in http proxy mode
-    Given evaluation of `env.master_hosts.first.local_ip` is stored in the :master_ip clipboard
-    Given I select a random node's host
-    Given I have a project
-    And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
-    When I run the :create client command with:
-      | f | https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/egress-http-proxy/egress-http-proxy-pod.yaml |
-    Then the pod named "egress-http-proxy" becomes ready
-
-    #Pod should not access MCS via an egress router pod
-    When I execute on the pod:
-      | curl | -I | https://<%= cb.master_ip %>:22623/config/master | -k |
-    Then the output should contain "Connection refused"
-    When I execute on the pod:
-      | curl | -I | https://<%= cb.master_ip %>:22624/config/master | -k |
-    Then the output should contain "Connection refused"
-
-  # @auther anusaxen@redhat.com
   # @case_id OCP-23893
   @admin
   Scenario: A pod in a namespace with an egress IP cannot access the MCS

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -231,7 +231,7 @@ Feature: Pod related networking scenarios
   Scenario: A pod cannot access the MCS port 22623 or 22624 via the SDN/tun0 address of the master
     Given I use the first master host		
     And I run commands on the host:
-      | ifconfig | tun0 | \| | grep -w inet | \| | awk {print $2} |
+      | ifconfig tun0 \| grep -w inet \| awk '{print $2}' |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :master_tun0_ip clipboard
     

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -282,33 +282,23 @@ Feature: Pod related networking scenarios
   # @case_id OCP-23893
   @admin
   Scenario: A pod in a namespace with an egress IP cannot access the MCS
-    #Given I use the first master host
+    Given I use the first master host
     #Step to obtain master IP
-    #And I run commands on the host:
-    #  | hostname -i |
-    #Then the step should succeed
-    #And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
+    And I run commands on the host:
+      | hostname -i |
+    Then the step should succeed
+    And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
     
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
     #add the egress ip to the hostsubnet
     And the valid egress IP is added to the "<%= cb.egress_node %>" node
-    #Given I select a random node's host
-    
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     #pod-for-ping will be a non-hostnetwork pod
     And I have a pod-for-ping in the project
     And the pod named "hello-pod" becomes ready
     
-    #When I run the :patch admin command with:
-    #  | resource      | netnamespace                         |
-    #  | resource_name | <%= project.name %>                  |
-    #  | p             | {"egressIPs":["<%= cb.valid_ip %>"]} |
-    #  | type          | merge                                |
-    #Then the step should succeed
-    
-    #Given I use the "<%= project.name %>" project
     #Pod cannot access MCS
     When I execute on the pod:
       | curl | -I | https://<%= cb.master_ip %>:22623/master/config | -k |

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -206,7 +206,6 @@ Feature: Pod related networking scenarios
     #pod-for-ping will be a non-hostnetwork pod
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     And I have a pod-for-ping in the project
-    And the pod named "hello-pod" becomes ready
 
     When I execute on the pod:
       | curl | -I | https://<%= cb.master_ip %>:22623/config/master | -k |
@@ -242,7 +241,6 @@ Feature: Pod related networking scenarios
     And I have a project
     #pod-for-ping will be a non-hostnetwork pod
     And I have a pod-for-ping in the project
-    And the pod named "hello-pod" becomes ready
     #Curl on Master's tun0 IP to make sure connections are blocked to MCS via tun0
     When I execute on the pod:
       | curl | -I | https://<%= cb.master_tun0_ip %>:22623/config/master | -k |
@@ -265,7 +263,7 @@ Feature: Pod related networking scenarios
     Given I select a random node's host
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
-    #pod-for-ping will be a non-hotnetwork pod
+    #pod-for-ping will be a non-hostnetwork pod
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/egress-http-proxy/egress-http-proxy-pod.yaml |
       | n | <%= project.name %>                                                                                   |
@@ -294,11 +292,11 @@ Feature: Pod related networking scenarios
     #add the egress ip to the hostsubnet
     And the valid egress IP is added to the "<%= cb.egress_node %>" node
     Given I have a project
-    And evaluation of `project.name` is stored in the :project clipboard
+    And evaluation of `project.name` is stored in the clipboard
     # add the egress ip to the project
     When I run the :patch admin command with:
     | resource      | netnamespace                         |
-    | resource_name | <%= cb.project %>                    |
+    | resource_name | <%= project.name %>                    |
     | p             | {"egressIPs":["<%= cb.valid_ip %>"]} |
     | type          | merge                                |
     Then the step should succeed

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -263,10 +263,8 @@ Feature: Pod related networking scenarios
     Given I select a random node's host
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
-    #pod-for-ping will be a non-hostnetwork pod
-    When I run the :create admin command with:
+    When I run the :create client command with:
       | f | https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/egress-http-proxy/egress-http-proxy-pod.yaml |
-      | n | <%= project.name %>                                                                                   |
     Then the pod named "egress-http-proxy" becomes ready
     #Pod should not access MCS via an egress router pod
     When I execute on the pod:

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -315,7 +315,7 @@ Feature: Pod related networking scenarios
   @admin
   Scenario: User cannot access the MCS by creating a service that maps to non-MCS port to port 22623 or 22624 on the IP of a master (via manually-created ep's)
     Given I use the first master host
-    Step to obtain master IP
+    #Step to obtain master IP
     And I run commands on the host:
       | hostname -i |
     Then the step should succeed

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -235,7 +235,6 @@ Feature: Pod related networking scenarios
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :master_tun0_ip clipboard
     
-    Given I select a random node's host
     #Step to obtain master IP
     When I run the :get admin command with:
       | resource | nodes |

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -209,10 +209,10 @@ Feature: Pod related networking scenarios
     And the pod named "hello-pod" becomes ready
 
     When I execute on the pod:
-      | curl | -I | http://<%= cb.master_ip %>:22623/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22623/master/config | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
-      | curl | -I | http://<%= cb.master_ip %>:22624/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22624/master/config | -k |
     Then the output should contain "Connection refused"
     
     #hostnetwork-pod will be a hostnetwork pod
@@ -222,10 +222,10 @@ Feature: Pod related networking scenarios
     Then the pod named "hostnetwork-pod" becomes ready
     #Pods should not access the MCS port 22623 or 22624 on the master
     When I execute on the pod:
-      | curl | -I | http://<%= cb.master_ip %>:22623/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22623/master/config | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
-      | curl | -I | http://<%= cb.master_ip %>:22624/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22624/master/config | -k |
     Then the output should contain "Connection refused"
 
   # @auther anusaxen@redhat.com
@@ -245,10 +245,10 @@ Feature: Pod related networking scenarios
     And the pod named "hello-pod" becomes ready
     #Curl on Master's tun0 IP to make sure connections are blocked to MCS via tun0
     When I execute on the pod:
-      | curl | -I | http://<%= cb.master_tun0_ip %>:22623/master/config | -k |
+      | curl | -I | https://<%= cb.master_tun0_ip %>:22623/master/config | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
-      | curl | -I | http://<%= cb.master_tun0_ip %>:22624/master/config | -k |
+      | curl | -I | https://<%= cb.master_tun0_ip %>:22624/master/config | -k |
     Then the output should contain "Connection refused"
 
   # @auther anusaxen@redhat.com
@@ -272,10 +272,10 @@ Feature: Pod related networking scenarios
     Then the pod named "egress-http-proxy" becomes ready
     #Pod should not access MCS via an egress router pod
     When I execute on the pod:
-      | curl | -I | http://<%= cb.master_ip %>:22623/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22623/master/config | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
-      | curl | -I | http://<%= cb.master_ip %>:22624/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22624/master/config | -k |
     Then the output should contain "Connection refused"
 
   # @auther anusaxen@redhat.com
@@ -290,24 +290,29 @@ Feature: Pod related networking scenarios
     And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
     
     Given I select a random node's host
+    And evaluation of `node.name` is stored in the :egress_node clipboard
+    #add the egress ip to the hostsubnet
+    And the valid egress IP is added to the "<%= cb.egress_node %>" node
+    #Given I select a random node's host
+    
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     #pod-for-ping will be a non-hostnetwork pod
     And I have a pod-for-ping in the project
     And the pod named "hello-pod" becomes ready
     
-    When I run the :patch admin command with:
-      | resource      | netnamespace                         |
-      | resource_name | <%= project.name %>                  |
-      | p             | {"egressIPs":["<%= cb.valid_ip %>"]} |
-      | type          | merge                                |
-    Then the step should succeed
+    #When I run the :patch admin command with:
+    #  | resource      | netnamespace                         |
+    #  | resource_name | <%= project.name %>                  |
+    #  | p             | {"egressIPs":["<%= cb.valid_ip %>"]} |
+    #  | type          | merge                                |
+    #Then the step should succeed
     
-    Given I use the "<%= project.name %>" project
+    #Given I use the "<%= project.name %>" project
     #Pod cannot access MCS
     When I execute on the pod:
-      | curl | -I | http://<%= cb.master_ip %>:22623/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22623/master/config | -k |
     Then the output should contain "Connection refused"
     When I execute on the pod:
-      | curl | -I | http://<%= cb.master_ip %>:22624/master/config | -k |
+      | curl | -I | https://<%= cb.master_ip %>:22624/master/config | -k |
     Then the output should contain "Connection refused"

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -282,12 +282,12 @@ Feature: Pod related networking scenarios
   # @case_id OCP-23893
   @admin
   Scenario: A pod in a namespace with an egress IP cannot access the MCS
-    Given I use the first master host
+    #Given I use the first master host
     #Step to obtain master IP
-    And I run commands on the host:
-      | hostname -i |
-    Then the step should succeed
-    And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
+    #And I run commands on the host:
+    #  | hostname -i |
+    #Then the step should succeed
+    #And evaluation of `@result[:response].strip` is stored in the :master_ip clipboard
     
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -265,7 +265,7 @@ Feature: Pod related networking scenarios
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/egress-http-proxy/egress-http-proxy-pod.yaml |
-    Then the step should succeed
+    Then the pod named "egress-http-proxy" becomes ready
 
     #Pod should not access MCS via an egress router pod
     When I execute on the pod:

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -329,7 +329,7 @@ Feature: Pod related networking scenarios
     When I run the :expose client command with:
       | resource      | pod                     |
       | resource_name | <%= cb.ping_pod.name %> |
-      | target-port   | 22623                   |
+      | target_port   | 22623                   |
       | port          | 8080                    |
     Then the step should succeed
     # Editing endpoint created above during expose to point to master ip and the step should fail

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -127,5 +127,5 @@ Feature: Service related networking scenarios
     And evaluation of `@result[:response].strip` is stored in the :svc_lb_ip clipboard
     #Make sure user cannot access the MCS by creating a LoadBalancer service that points to the MCS 
     When I execute on the pod:
-      | curl | -I | http://<%= cb.svc_lb_ip %>:22623/master/config | -k |
+      | curl | -I | http://<%= cb.svc_lb_ip %>:22623/config/master | -k |
     Then the output should contain "Connection refused"

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -140,6 +140,14 @@ Feature: Service related networking scenarios
       | p             | {"subsets": [{"addresses": [{"ip": "<%= cb.master_ip %>"}]}]} |
       | type          | merge                                			      |
     Then the step should succeed
+    And evaluation of `@result[:response].strip` is stored in the :ep_ip clipboard
+    #Make sure ep points to master ip
+    Then the expression should be true> cb.master_ip==cb.ep_ip
+    When I run the :get client command with:
+      | resource      | ep                            |
+      | resource_name | <%= cb.ping_pod.name %>       |
+      | output        | {.subsets[*].addresses[*].ip} |
+    And evaluation of `@result[:response].strip` is stored in the :svc_lb_ip clipboard
 
     #Make sure user cannot access the MCS by creating a LoadBalancer service that points to the MCS 
     When I execute on the pod:

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -133,22 +133,20 @@ Feature: Service related networking scenarios
       | n        | <%= project.name %>                 |
     And evaluation of `@result[:response].strip` is stored in the :svc_lb_ip clipboard
     
-    # Editing endpoint to point to mastr ip
+    # Editing endpoint to point to master ip
     When I run the :patch client command with:
       | resource      | ep                         				      |
       | resource_name | <%= cb.ping_pod.name %>                  		      |
       | p             | {"subsets": [{"addresses": [{"ip": "<%= cb.master_ip %>"}]}]} |
       | type          | merge                                			      |
     Then the step should succeed
-    And evaluation of `@result[:response].strip` is stored in the :ep_ip clipboard
     #Make sure ep points to master ip
-    Then the expression should be true> cb.master_ip==cb.ep_ip
     When I run the :get client command with:
       | resource      | ep                            |
       | resource_name | <%= cb.ping_pod.name %>       |
       | output        | {.subsets[*].addresses[*].ip} |
-    And evaluation of `@result[:response].strip` is stored in the :svc_lb_ip clipboard
-
+    And evaluation of `@result[:response].strip` is stored in the :ep_ip clipboard
+    Then the expression should be true> cb.master_ip==cb.ep_ip
     #Make sure user cannot access the MCS by creating a LoadBalancer service that points to the MCS 
     When I execute on the pod:
       | curl | -I | http://<%= cb.svc_lb_ip %>:22623/config/master | -k |

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -142,9 +142,9 @@ Feature: Service related networking scenarios
     Then the step should succeed
     #Make sure ep points to master ip
     When I run the :get client command with:
-      | resource      | ep                            |
-      | resource_name | <%= cb.ping_pod.name %>       |
-      | output        | {.subsets[*].addresses[*].ip} |
+      | resource      | ep                            	       |
+      | resource_name | <%= cb.ping_pod.name %>       	       |
+      | output        | jsonpath={.subsets[*].addresses[*].ip} |
     And evaluation of `@result[:response].strip` is stored in the :ep_ip clipboard
     Then the expression should be true> cb.master_ip==cb.ep_ip
     #Make sure user cannot access the MCS by creating a LoadBalancer service that points to the MCS 

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -113,7 +113,6 @@ Feature: Service related networking scenarios
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     And I have a pod-for-ping in the project
-    And the pod named "hello-pod" becomes ready
     #Creating laodbalancer service that points to MCS IP
     When I run the :create_service_loadbalancer client command with: 
       | name | hello-pod  |

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -603,7 +603,7 @@ Given /^the valid egress IP is added to the#{OPT_QUOTED} node$/ do |node_name|
   ensure_admin_tagged
   step "I store a random unused IP address from the reserved range to the clipboard"
 
-  @result = admin.cli_exec(:patch, resource: "hostsubnet", resource_name: "#{node_name}", p: "{\"egressIPs\":[\"#{cb.valid_ip}\"]}")
+  @result = admin.cli_exec(:patch, resource: "hostsubnet", resource_name: "#{node_name}", p: "{\"egressIPs\":[\"#{cb.valid_ip}\"]} --type=merge")
   raise "Failed to patch hostsubnet!" unless @result[:success]
   logger.info "The free IP #{cb.valid_ip} added to egress node #{node_name}."
 

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -603,7 +603,7 @@ Given /^the valid egress IP is added to the#{OPT_QUOTED} node$/ do |node_name|
   ensure_admin_tagged
   step "I store a random unused IP address from the reserved range to the clipboard"
 
-  @result = admin.cli_exec(:patch, resource: "hostsubnet", resource_name: "#{node_name}", p: "{\"egressIPs\":[\"#{cb.valid_ip}\"]} --type=merge")
+  @result = admin.cli_exec(:patch, resource: "hostsubnet", resource_name: "#{node_name}", p: "{\"egressIPs\":[\"#{cb.valid_ip}\"]}", type: "merge")
   raise "Failed to patch hostsubnet!" unless @result[:success]
   logger.info "The free IP #{cb.valid_ip} added to egress node #{node_name}."
 

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -608,7 +608,7 @@ Given /^the valid egress IP is added to the#{OPT_QUOTED} node$/ do |node_name|
   logger.info "The free IP #{cb.valid_ip} added to egress node #{node_name}."
 
   teardown_add {
-    @result = admin.cli_exec(:patch, resource: "hostsubnet", resource_name: "#{node_name}", p: "{\"egressIPs\":[]}")
+    @result = admin.cli_exec(:patch, resource: "hostsubnet", resource_name: "#{node_name}", p: "{\"egressIPs\":[]}", type: "merge")
     raise "Failed to clear egress IP on node #{node_name}" unless @result[:success]
   }
 end


### PR DESCRIPTION
These tests are required to cover Cases connected to Blocking Machine-config-server port
Pass logs:
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/366/console
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/365/console
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/364/console
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/363/console
OCP-23893 needs a valid_ip as an input variable during the test
@zhaozhanqi  PTAL