### PR TITLE
Use attribute storageClassName to replace annotations

### DIFF
--- a/features/step_definitions/pv.rb
+++ b/features/step_definitions/pv.rb
@@ -82,9 +82,9 @@ Given /^I have a(?: (\d+) GB)? volume from provisioner "([^"]*)" and save volume
     })
   step %Q/the step should succeed/
   step %Q{I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/azure/azpvc-sc.yaml" replacing paths:}, table(%{
-    | ["metadata"]["name"]                                                   | <%= project.name %>-<%= cb.dynamic_pvc_name %> |
-    | ["spec"]["resources"]["requests"]["storage"]                           | #{size}Gi                                      |
-    | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | <%= project.name %>-<%=cb.storage_class_name%> |
+    | ["metadata"]["name"]                         | <%= project.name %>-<%= cb.dynamic_pvc_name %> |
+    | ["spec"]["resources"]["requests"]["storage"] | #{size}Gi                                      |
+    | ["spec"]["storageClassName"]                 | <%= project.name %>-<%=cb.storage_class_name%> |
     })
   step %Q/the step should succeed/
   step %Q/the "<%= project.name %>-<%= cb.dynamic_pvc_name %>" PVC becomes :bound within #{timeout} seconds/

--- a/features/step_definitions/secrets.rb
+++ b/features/step_definitions/secrets.rb
@@ -9,8 +9,8 @@ Given /^the azure file secret name and key are stored to the clipboard$/ do
     })
   step %Q/the step should succeed/
   step %Q{I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/azure/azpvc-sc.yaml" replacing paths:}, table(%{
-    | ["metadata"]["name"]                                                   | <%= cb.dynamic_pvc_name %>   |
-    | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | <%= cb.storage_class_name %> |
+    | ["metadata"]["name"]         | <%= cb.dynamic_pvc_name %>   |
+    | ["spec"]["storageClassName"] | <%= cb.storage_class_name %> |
     })
   step %Q/the step should succeed/
   step %Q/the "<%= cb.dynamic_pvc_name %>" PVC becomes :bound within 120 seconds/

--- a/features/storage/aws.feature
+++ b/features/storage/aws.feature
@@ -11,8 +11,8 @@ Feature: AWS specific scenarios
       | ["provisioner"]      | openshift.org/aws-efs  |
     Then the step should succeed
     When I run oc create over "https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/aws/efs/deploy/claim.yaml" replacing paths:
-      | ["metadata"]["name"]                                                   | efspvc-<%= project.name %> |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %>     |
+      | ["metadata"]["name"]         | efspvc-<%= project.name %> |
+      | ["spec"]["storageClassName"] | sc-<%= project.name %>     |
     Then the step should succeed
     And the "efspvc-<%= project.name %>" PVC becomes :bound within 60 seconds
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/ebs/pod.yaml" replacing paths:

--- a/features/storage/cloud_provider.feature
+++ b/features/storage/cloud_provider.feature
@@ -66,10 +66,10 @@ Feature: kubelet restart and node restart
     And I run the steps 3 times:
     """
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | dpvc-#{cb.i}              |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %>    |
-      | ["spec"]["accessModes"][0]                                             | #{cb.accessmodes[cb.i-1]} |
-      | ["spec"]["resources"]["requests"]["storage"]                           | #{cb.i}Gi                 |
+      | ["metadata"]["name"]                         | dpvc-#{cb.i}              |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %>    |
+      | ["spec"]["accessModes"][0]                   | #{cb.accessmodes[cb.i-1]} |
+      | ["spec"]["resources"]["requests"]["storage"] | #{cb.i}Gi                 |
     Then the step should succeed
     And the "dpvc-#{cb.i}" PVC becomes :bound
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pod.yaml" replacing paths:

--- a/features/storage/csi.feature
+++ b/features/storage/csi.feature
@@ -14,8 +14,8 @@ Feature: CSI testing related feature
     And I checked "cinder" csi driver is running
     And I have a project
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-<%= project.name %> |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | cinder-csi              |
+      | ["metadata"]["name"]         | pvc-<%= project.name %> |
+      | ["spec"]["storageClassName"] | cinder-csi              |
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes :bound
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pod.yaml" replacing paths:

--- a/features/storage/dynamic_provisioning.feature
+++ b/features/storage/dynamic_provisioning.feature
@@ -66,10 +66,10 @@ Feature: Dynamic provisioning
     And I run the steps 1 times:
     """
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/azure/azpvc-sc.yaml" replacing paths:
-      | ["metadata"]["name"]                                                   | dpvc-#{cb.i}              |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %>    |
-      | ["spec"]["accessModes"][0]                                             | #{cb.accessmodes[cb.i-1]} |
-      | ["spec"]["resources"]["requests"]["storage"]                           | #{cb.i}Gi                 |
+      | ["metadata"]["name"]                         | dpvc-#{cb.i}              |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %>    |
+      | ["spec"]["accessModes"][0]                   | #{cb.accessmodes[cb.i-1]} |
+      | ["spec"]["resources"]["requests"]["storage"] | #{cb.i}Gi                 |
     Then the step should succeed
     And the "dpvc-#{cb.i}" PVC becomes :bound within 120 seconds
     And I save volume id from PV named "#{ pvc.volume_name }" in the :disk clipboard

--- a/features/storage/glusterfs.feature
+++ b/features/storage/glusterfs.feature
@@ -70,8 +70,8 @@ Feature: Storage of GlusterFS plugin testing
     And I have a project
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/claim.yaml" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc1               |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | glusterprovisioner |
+      | ["metadata"]["name"]         | pvc1               |
+      | ["spec"]["storageClassName"] | glusterprovisioner |
     Then the step should succeed
     And the "pvc1" PVC becomes :bound
     And admin ensures "<%= pvc('pvc1').volume_name %>" pv is deleted after scenario
@@ -110,8 +110,8 @@ Feature: Storage of GlusterFS plugin testing
     And I have a project
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/claim.yaml" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-<%= project.name %> |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | glusterprovisioner      |
+      | ["metadata"]["name"]         | pvc-<%= project.name %> |
+      | ["spec"]["storageClassName"] | glusterprovisioner      |
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds
 
@@ -134,8 +134,8 @@ Feature: Storage of GlusterFS plugin testing
     And I have a project
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/claim.yaml" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc1                |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | glusterprovisioner1 |
+      | ["metadata"]["name"]         | pvc1                |
+      | ["spec"]["storageClassName"] | glusterprovisioner1 |
     Then the step should succeed
     And the "pvc1" PVC becomes :bound
     And admin ensures "<%= pvc('pvc1').volume_name %>" pv is deleted after scenario
@@ -162,8 +162,8 @@ Feature: Storage of GlusterFS plugin testing
       | ["parameters"]["gidMax"]  | 33333                                                            |
     Then the step should succeed
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/claim.yaml" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc1                             |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | storageclass-<%= project.name %> |
+      | ["metadata"]["name"]         | pvc1                             |
+      | ["spec"]["storageClassName"] | storageclass-<%= project.name %> |
     Then the step should succeed
     And the "pvc1" PVC becomes :bound
     And admin ensures "<%= pvc('pvc1').volume_name %>" pv is deleted after scenario
@@ -219,8 +219,8 @@ Feature: Storage of GlusterFS plugin testing
     Given I have a StorageClass named "glusterprovisioner"
     And I have a project
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/claim.yaml" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc1               |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | glusterprovisioner |
+      | ["metadata"]["name"]         | pvc1               |
+      | ["spec"]["storageClassName"] | glusterprovisioner |
     Then the step should succeed
     And the "pvc1" PVC becomes :bound
     And admin ensures "<%= pvc('pvc1').volume_name %>" pv is deleted after scenario

--- a/features/storage/quota.feature
+++ b/features/storage/quota.feature
@@ -87,9 +87,9 @@ Feature: ResourceQuata for storage
     And I run the steps 2 times:
     """
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-#{ cb.i }          |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %> |
-      | ["spec"]["resources"]["requests"]["storage"]                           | 4Mi                    |
+      | ["metadata"]["name"]                         | pvc-#{ cb.i }          |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %> |
+      | ["spec"]["resources"]["requests"]["storage"] | 4Mi                    |
     Then the step should succeed
     And the "pvc-#{ cb.i }" PVC becomes :bound
     And admin ensures "#{ pvc.volume_name }" pv is deleted after scenario
@@ -97,9 +97,9 @@ Feature: ResourceQuata for storage
 
     # Try to exceed the 10Mi storage
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-<%= project.name %>             |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %> |
-      | ["spec"]["resources"]["requests"]["storage"]                           | 4Mi                                 |
+      | ["metadata"]["name"]                         | pvc-<%= project.name %>             |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %> |
+      | ["spec"]["resources"]["requests"]["storage"] | 4Mi                                 |
     Then the step should fail
     And the output should contain:
       | exceeded quota                                                                                  |
@@ -109,17 +109,17 @@ Feature: ResourceQuata for storage
 
     # Try to exceed total number of PVCs
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvcnew                 |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %> |
-      | ["spec"]["resources"]["requests"]["storage"]                           | 1Mi                    |
+      | ["metadata"]["name"]                         | pvcnew                 |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %> |
+      | ["spec"]["resources"]["requests"]["storage"] | 1Mi                    |
     Then the step should succeed
     And the "pvcnew" PVC becomes :bound
     And admin ensures "<%= pvc('pvcnew').volume_name %>" pv is deleted after scenario
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvcnew2                |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %> |
-      | ["spec"]["resources"]["requests"]["storage"]                           | 1Mi                    |
+      | ["metadata"]["name"]                         | pvcnew2                |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %> |
+      | ["spec"]["resources"]["requests"]["storage"] | 1Mi                    |
     Then the step should fail
     And the output should contain:
       | exceeded quota                                                                         |
@@ -131,9 +131,9 @@ Feature: ResourceQuata for storage
     Given admin clones storage class "sc1-<%= project.name %>" from ":default" with:
       | | |
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc1-<%= project.name %> |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc1-<%= project.name %>  |
-      | ["spec"]["resources"]["requests"]["storage"]                           | 11Mi                     |
+      | ["metadata"]["name"]                         | pvc1-<%= project.name %> |
+      | ["spec"]["storageClassName"]                 | sc1-<%= project.name %>  |
+      | ["spec"]["resources"]["requests"]["storage"] | 11Mi                     |
     Then the step should succeed
     And the "pvc1-<%= project.name %>" PVC becomes :bound
     Given I ensure "pvc1-<%= project.name %>" pvc is deleted

--- a/features/storage/rbd.feature
+++ b/features/storage/rbd.feature
@@ -17,8 +17,8 @@ Feature: Storage of Ceph plugin testing
 
     Given I have a project
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/rbd/dynamic-provisioning/claim.yaml" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-<%= project.name %> |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | cephrbdprovisioner      |
+      | ["metadata"]["name"]         | pvc-<%= project.name %> |
+      | ["spec"]["storageClassName"] | cephrbdprovisioner      |
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds
 
@@ -58,8 +58,8 @@ Feature: Storage of Ceph plugin testing
     And I have a project
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/rbd/dynamic-provisioning/claim.yaml" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-<%= project.name %> |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | cephrbdprovisioner      |
+      | ["metadata"]["name"]         | pvc-<%= project.name %> |
+      | ["spec"]["storageClassName"] | cephrbdprovisioner      |
       | ["spec"]["resources"]["requests"]["storage"]                           | 9Gi                     |
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -86,10 +86,10 @@ Feature: storageClass related feature
     Then the step should succeed
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-<%= project.name %> |
-      | ["spec"]["accessModes"][0]                                             | ReadWriteOnce           |
-      | ["spec"]["resources"]["requests"]["storage"]                           | <size>                  |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %>  |
+      | ["metadata"]["name"]                         | pvc-<%= project.name %> |
+      | ["spec"]["accessModes"][0]                   | ReadWriteOnce           |
+      | ["spec"]["resources"]["requests"]["storage"] | <size>                  |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %>  |
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds
     And the expression should be true> pvc.capacity == "<size>"
@@ -149,12 +149,12 @@ Feature: storageClass related feature
       | Internal error occurred |
       | ([2-9]\|[1-9][0-9]+) default StorageClasses were found |
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc1-<%= project.name %> |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc1-<%= project.name %>  |
+      | ["metadata"]["name"]         | pvc1-<%= project.name %> |
+      | ["spec"]["storageClassName"] | sc1-<%= project.name %>  |
     Then the step should succeed
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc2-<%= project.name %> |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc2-<%= project.name %>  |
+      | ["metadata"]["name"]         | pvc2-<%= project.name %> |
+      | ["spec"]["storageClassName"] | sc2-<%= project.name %>  |
     Then the step should succeed
     And the "pvc1-<%= project.name %>" PVC becomes :bound within 120 seconds
     And the "pvc2-<%= project.name %>" PVC becomes :bound within 120 seconds
@@ -199,10 +199,10 @@ Feature: storageClass related feature
     Then the step should succeed
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-<%= project.name %> |
-      | ["spec"]["accessModes"][0]                                             | ReadWriteOnce           |
-      | ["spec"]["resources"]["requests"]["storage"]                           | <size>                  |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %>  |
+      | ["metadata"]["name"]                         | pvc-<%= project.name %> |
+      | ["spec"]["accessModes"][0]                   | ReadWriteOnce           |
+      | ["spec"]["resources"]["requests"]["storage"] | <size>                  |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %>  |
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds
     And the expression should be true> pvc.capacity == "<size>"
@@ -242,10 +242,10 @@ Feature: storageClass related feature
     Then the step should succeed
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-<%= project.name %> |
-      | ["spec"]["accessModes"][0]                                             | ReadWriteOnce           |
-      | ["spec"]["resources"]["requests"]["storage"]                           | <size>                  |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %>  |
+      | ["metadata"]["name"]                         | pvc-<%= project.name %> |
+      | ["spec"]["accessModes"][0]                   | ReadWriteOnce           |
+      | ["spec"]["resources"]["requests"]["storage"] | <size>                  |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %>  |
     Then the step should succeed
     And I wait up to 60 seconds for the steps to pass:
     """
@@ -269,10 +269,10 @@ Feature: storageClass related feature
     Given I have a project
     # No sc exists
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc1-<%= project.name %> |
-      | ["spec"]["accessModes"][0]                                             | ReadWriteOnce            |
-      | ["spec"]["resources"]["requests"]["storage"]                           | 1Gi                      |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc1-<%= project.name %>  |
+      | ["metadata"]["name"]                         | pvc1-<%= project.name %> |
+      | ["spec"]["accessModes"][0]                   | ReadWriteOnce            |
+      | ["spec"]["resources"]["requests"]["storage"] | 1Gi                      |
+      | ["spec"]["storageClassName"]                 | sc1-<%= project.name %>  |
     Then the step should succeed
     And I wait up to 60 seconds for the steps to pass:
     """

--- a/features/storage/vsphere.feature
+++ b/features/storage/vsphere.feature
@@ -9,8 +9,8 @@ Feature: vSphere test scenarios
       | ["parameters"]["diskformat"] | <disk_format>                    |
     Then the step should succeed
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/vsphere/pvc.json" replacing paths:
-        | ["metadata"]["name"]                                                   | pvc-<%= project.name %>          |
-        | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | storageclass-<%= project.name %> |
+        | ["metadata"]["name"]         | pvc-<%= project.name %>          |
+        | ["spec"]["storageClassName"] | storageclass-<%= project.name %> |
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes :bound
 
@@ -67,8 +67,8 @@ Feature: vSphere test scenarios
     Then the step should succeed
 
     Given I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/vsphere/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-<%= project.name %>          |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | storageclass-<%= project.name %> |
+      | ["metadata"]["name"]         | pvc-<%= project.name %>          |
+      | ["spec"]["storageClassName"] | storageclass-<%= project.name %> |
     And I wait up to 30 seconds for the steps to pass:
     """
     When I run the :describe client command with:

--- a/features/test/pvc.feature
+++ b/features/test/pvc.feature
@@ -9,8 +9,8 @@ Feature: pvc testing scenarios
   Scenario: check pvc.storage_class
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                   | pvc-<%= project.name %> |
-      | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %>  |
+      | ["metadata"]["name"]         | pvc-<%= project.name %> |
+      | ["spec"]["storageClassName"] | sc-<%= project.name %>  |
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes :pending
     And the expression should be true> pvc.storage_class(user: user) == "sc-<%= project.name %>"


### PR DESCRIPTION
From k8s [docs](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class),
In the past, the annotation volume.beta.kubernetes.io/storage-class was used instead of the storageClassName attribute. This annotation is still working, however it will become fully deprecated in a future Kubernetes release.

@chao007 This should addressed your concern in https://github.com/openshift/verification-tests/pull/228#issuecomment-499010882
@pruan-rht @akostadinov

