### PR TITLE
update login flow, add IDP option

### DIFF
--- a/features/step_definitions/admin_console.rb
+++ b/features/step_definitions/admin_console.rb
@@ -18,7 +18,7 @@ Given /^I open admin console in a browser$/ do
   @result = browser.run_action(:login_admin_console,
                                username: user.auth_name,
                                password: user.password,
-                               idp: env.openshift_idp)
+                               idp: env.idp)
   raise "cannot login to cluster console" unless @result[:success]
   browser.base_url = browser.url.sub(%r{(https://[^/]+/).*}, "\\1")
 end

--- a/features/step_definitions/admin_console.rb
+++ b/features/step_definitions/admin_console.rb
@@ -17,7 +17,8 @@ Given /^I open admin console in a browser$/ do
   browser.run_action(:goto_admin_console_root)
   @result = browser.run_action(:login_admin_console,
                                username: user.auth_name,
-                               password: user.password)
+                               password: user.password,
+                               idp: env.openshift_idp)
   raise "cannot login to cluster console" unless @result[:success]
   browser.base_url = browser.url.sub(%r{(https://[^/]+/).*}, "\\1")
 end

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -164,15 +164,15 @@ module BushSlicer
       return @admin_console_url
     end
 
-    def openshift_idp
-      unless @openshift_idp
-        if opts[:openshift_idp]
-          @openshift_idp = opts[:openshift_idp]
+    def idp
+      unless @idp
+        if opts[:idp]
+          @idp = opts[:idp]
         else
-          @openshift_idp = "kube:admin"
+          @idp = ''
         end
       end
-      return @openshift_idp
+      return @idp
     end
 
     def authentication_url

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -164,6 +164,17 @@ module BushSlicer
       return @admin_console_url
     end
 
+    def openshift_idp
+      unless @openshift_idp
+        if opts[:openshift_idp]
+          @openshift_idp = opts[:openshift_idp]
+        else
+          @openshift_idp = "kube:admin"
+        end
+      end
+      return @openshift_idp
+    end
+
     def authentication_url
       unless @authentication_url
         if opts[:authentication_url]

--- a/lib/rules/web/console/base/login.xyaml
+++ b/lib/rules/web/console/base/login.xyaml
@@ -14,8 +14,10 @@ login_sequence:
     - login_page_loaded
     if_element:
       selector: &pre_login_buttons
-        # we just choose the first button per OPENSHIFTQ-12062
-        xpath: //a[text()='<idp>']
+        # when idp is specified we use the correct IDP
+        # otherwise we always use the first one
+        # a hacking way to cover our requirements
+        xpath: //a[contains(@class, 'idp<idp>') or contains(@class, 'login-redhat<idp>') or text()='<idp>'][1]
       timeout: 1
   action:
     ref: login_console

--- a/lib/rules/web/console/base/login.xyaml
+++ b/lib/rules/web/console/base/login.xyaml
@@ -15,7 +15,7 @@ login_sequence:
     if_element:
       selector: &pre_login_buttons
         # we just choose the first button per OPENSHIFTQ-12062
-        css: ".login-redhat:first-of-type, .idp:first-of-type"
+        xpath: //a[text()='<idp>']
       timeout: 1
   action:
     ref: login_console
@@ -23,7 +23,7 @@ login_sequence:
       selector:
         # title RE not working w/ ff legacy
         # text: !ruby/regexp '/Login - OpenShift/'
-        xpath: '//title[starts-with(.,"Login - O")]'
+        xpath: '//title[starts-with(.,"Login")]'
       visible: false
       timeout: 1
   action:


### PR DESCRIPTION
Using the `first` IDP blocks console automation because the first IDP is `kube:admin` on OCP clusters , running automation with `kube:admin` is dangerous and not allowed in cucushift
```
     [09:15:09] INFO> Exit Status: 0
      system projects visible to user kube:admin, clean-up too dangerous (RuntimeError)
      /Users/yapei/repo/verification-tests/lib/openshift/user.rb:119:in `clean_projects'
```
So we wonder if we can add IDP option as environment variables, that will be much easier/better.  

@yasun1 Can you please review the changes to see how online cases will be affected?
FYI @yanpzhan  @SSshahan  @xiaocwan   