### PR TITLE
Add packet support

### DIFF
--- a/lib/bushslicer.rb
+++ b/lib/bushslicer.rb
@@ -15,6 +15,7 @@ module BushSlicer
   autoload :Azure, 'launchers/azure'
   autoload :OpenStack, "launchers/openstack"
   autoload :VSphere, "launchers/v_sphere"
+  autoload :Packet, "launchers/packet"
   autoload :EnvironmentLauncher, "launchers/environment_launcher"
   autoload :PolarShift, "polarshift/autoload"
 

--- a/lib/launchers/cloud_helper.rb
+++ b/lib/launchers/cloud_helper.rb
@@ -37,6 +37,8 @@ module BushSlicer
           BushSlicer::VSphere.new(service_name: service_name)
         when "alibaba"
           BushSlicer::Alicloud.new(service_name: service_name)
+        when "packet"
+          BushSlicer::Packet.new(service_name: service_name)
         else
           raise "unknown service type " \
             "#{conf[:services, service_name, :cloud_type]} for cloud " \

--- a/lib/launchers/packet.rb
+++ b/lib/launchers/packet.rb
@@ -1,0 +1,21 @@
+
+
+lib_path = File.expand_path(File.dirname(File.dirname(__FILE__)))
+unless $LOAD_PATH.any? {|p| File.expand_path(p) == lib_path}
+  $LOAD_PATH.unshift(lib_path)
+end
+
+require 'collections'
+require 'common'
+
+module BushSlicer
+  class Packet
+    include Common::Helper
+    include CollectionsIncl
+    attr_reader :config
+
+    def initialize(**opts)
+      @config = conf[:services, opts.delete(:service_name) || :packet]
+    end
+  end
+end


### PR DESCRIPTION
packet support for upi on baremetel

Since the provision and destroy part will be implemented by launch template, so no `terminate_by_launch_opts` for packet and also `launch_instances`