### PR TITLE
Fix typo of OCP-9638

### DIFF
--- a/features/storage/iscsi.feature
+++ b/features/storage/iscsi.feature
@@ -4,7 +4,7 @@ Feature: ISCSI volume plugin testing
   # @case_id OCP-9638
   @admin
   @destructive
-  Scenario: ISCCI volume security test
+  Scenario: ISCSI volume security test
     Given I have a iSCSI setup in the environment
     And I have a project
 


### PR DESCRIPTION
@akostadinov @pruan-rht 

We have fixed the typo in master branch and in Polarion, but forgot to back-port the fix to v3.