### PR TITLE
Fix PV gid type (from int to string)

### DIFF
--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -58,7 +58,7 @@ Feature: NFS Persistent Volume
       | ["spec"]["nfs"]["path"]                                  | /                                |
       | ["spec"]["capacity"]["storage"]                          | 1Gi                              |
       | ["metadata"]["name"]                                     | nfs-<%= project.name %>          |
-      | ["metadata"]["annotations"]["pv.beta.kubernetes.io/gid"] | <pv-gid>                         |
+      | ["metadata"]["annotations"]["pv.beta.kubernetes.io/gid"] | "<pv-gid>"                       |
 
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwx.json" replacing paths:
       | ["metadata"]["name"]                         | nfsc-<%= project.name %> |


### PR DESCRIPTION
@chao007 

```
09:05:28 INFO> HTTP GET https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/pv-gid.json
09:05:28 INFO> HTTP GET took 0.499 sec: 200 OK | text/plain 392 bytes
09:05:28 INFO> Creating PV:
---
apiVersion: v1
kind: PersistentVolume
metadata:
  name: nfs-il9xm
  annotations:
    pv.beta.kubernetes.io/gid: 1234
spec:
  capacity:
    storage: 1Gi
  accessModes:
  - ReadWriteMany
  nfs:
    path: "/"
    server: 172.30.155.32
  persistentVolumeReclaimPolicy: Retain
09:05:28 INFO> Shell Commands: oc create -f - --config=/home/jenkins/workspace/Runner-v3/workdir/ose_admin.kubeconfig

STDERR:
Error from server (BadRequest): error when creating "STDIN": PersistentVolume in version "v1" cannot be handled as a PersistentVolume: [pos 101]: json: expect char '"' but got char '1'
09:05:29 INFO> Exit Status: 1
09:05:29 ERROR> 
STDERR:
Error from server (BadRequest): error when creating "STDIN": PersistentVolume in version "v1" cannot be handled as a PersistentVolume: [pos 101]: json: expect char '"' but got char '1'
```