### PR TITLE
add one f5 router case

### DIFF
--- a/features/routing/f5-router.feature
+++ b/features/routing/f5-router.feature
@@ -1,0 +1,33 @@
+Feature: F5 router related scenarios
+
+  # @author hongli@redhat.com
+  # @case_id OCP-24080
+  @admin
+  @destructive
+  Scenario: the f5 router image should contains openssh-clients package
+    Given I switch to cluster admin pseudo user
+    And I use the router project
+    And default router image is stored into the :router_image clipboard
+    And default router replica count is restored after scenario
+    When I run the :scale client command with:
+      | resource | dc     |
+      | name     | router |
+      | replicas | 0      |
+    Then the step should succeed
+    Given admin ensures "f5router" dc is deleted after scenario
+    And admin ensures "f5router" service is deleted after scenario
+    And admin ensures "external-host-private-key-secret" secret is deleted after scenario
+    And I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/fake_id_rsa"
+    When I run the :oadm_router admin command with:
+      | name                      | f5router                                    |
+      | type                      | f5-router                                   |
+      | images                    | <%= cb.router_image.gsub("haproxy","f5") %> |
+      | external_host             | 10.66.144.115                               |
+      | external_host_username    | username                                    |
+      | external_host_password    | password                                    |
+      | external_host_private_key | fake_id_rsa                                 |
+    And a pod becomes ready with labels:
+      | deploymentconfig=f5router |
+    When I execute on the pod:
+      | which | scp |
+    Then the step should succeed

--- a/lib/rules/cli/3.3.yaml
+++ b/lib/rules/cli/3.3.yaml
@@ -1300,6 +1300,10 @@
     :canonical_hostname: --router-canonical-hostname=<value>
     :default_cert: --default-cert=<value>
     :extended_logging: --extended-logging=<value>
+    :external_host: --external-host=<value>
+    :external_host_password: --external-host-password=<value>
+    :external_host_private_key: --external-host-private-key=<value>
+    :external_host_username: --external-host-username=<value>
     :force_subdomain: --force-subdomain=<value>
     :host_network: --host-network=<value>
     :host_ports: --host-ports=<value>
@@ -1311,6 +1315,7 @@
     :stats_passwd: --stats-password=<value>
     :stats_port: --stats-port=<value>
     :stats_user: --stats-user=<value>
+    :type: --type=<value>
     :n: -n <value>
 :oadm_taint_nodes:
   :cmd: oc adm taint nodes


### PR DESCRIPTION
Since f5 router is deprecated since 3.11 so I'd like to merge this to branch v3 only.
This case is for smoke testing and ose-f5-router image testing as well.
 
logs:
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/41784/consoleFull
