### PR TITLE
Fix OCP-10467

### DIFF
--- a/features/cli/policy.feature
+++ b/features/cli/policy.feature
@@ -357,16 +357,14 @@ Feature: change the policy of user/service account
       | force | true              |
       | n     | <%= cb.project %> |
     And the step should fail
-    And the output should contain:
-      | User "<%= user.name %>" cannot delete persistentvolumeclaims |
+    And the output should contain "forbidden"
 
     When I run the :delete client command with:
       | object_type       | pvc                   |
       | object_name_or_id | pvc-<%= cb.project %> |
       | n                 | <%= cb.project %>     |
     And the step should fail
-    And the output should contain:
-      | User "<%= user.name %>" cannot delete persistentvolumeclaims |
+    And the output should contain "forbidden"
 
   # @author chaoyang@redhat.com
   # @case_id OCP-10465


### PR DESCRIPTION
@akostadinov @pruan-rht @chao007 

Error in 4.x is `Error from server (Forbidden): persistentvolumeclaims "pvc-q-lbw" is forbidden: User "testuser-24" cannot delete resource "persistentvolumeclaims" in API group "" in the namespace "q-lbw"
`