### PR TITLE
Use simpler pvc/pod name to easier debug as they are in unique project

### DIFF
--- a/features/storage/NoDiskConflict.feature
+++ b/features/storage/NoDiskConflict.feature
@@ -18,17 +18,17 @@ Feature: NoDiskConflict
 
     Given I have a 1 GB volume and save volume id in the :volumeID clipboard
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/<path_to_file>" replacing paths:
-      | ["metadata"]["name"]                                      | pod1-<%= project.name %> |
+      | ["metadata"]["name"]                                      | mypod1 |
       | ["spec"]["volumes"][0]["<storage_type>"]["<volume_name>"] | <%= cb.volumeID %>       |
     Then the step should succeed
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/<path_to_file>" replacing paths:
-      | ["metadata"]["name"]                                      | pod2-<%= project.name %> |
+      | ["metadata"]["name"]                                      | mypod2 |
       | ["spec"]["volumes"][0]["<storage_type>"]["<volume_name>"] | <%= cb.volumeID %>       |
     Then the step should succeed
 
     When I run the :describe client command with:
       | resource | pod                      |
-      | name     | pod2-<%= project.name %> |
+      | name     | mypod2 |
     Then the step should succeed
     And the output should match:
       | Pending                             |

--- a/features/storage/aws.feature
+++ b/features/storage/aws.feature
@@ -11,24 +11,24 @@ Feature: AWS specific scenarios
       | ["provisioner"]      | openshift.org/aws-efs  |
     Then the step should succeed
     When I run oc create over "https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/aws/efs/deploy/claim.yaml" replacing paths:
-      | ["metadata"]["name"]         | efspvc-<%= project.name %> |
+      | ["metadata"]["name"]         | mypvc |
       | ["spec"]["storageClassName"] | sc-<%= project.name %>     |
     Then the step should succeed
-    And the "efspvc-<%= project.name %>" PVC becomes :bound within 60 seconds
+    And the "mypvc" PVC becomes :bound within 60 seconds
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/ebs/pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                         | pod1-<%= project.name %>   |
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | efspvc-<%= project.name %> |
+      | ["metadata"]["name"]                                         | mypod1   |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc |
     Then the step should succeed
-    And the pod named "pod1-<%= project.name %>" becomes ready
+    And the pod named "mypod1" becomes ready
     When I execute on the pod:
       | touch | /tmp/file_pod1 |
     Then the step should succeed
 
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/ebs/pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                         | pod2-<%= project.name %>   |
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | efspvc-<%= project.name %> |
+      | ["metadata"]["name"]                                         | mypod2   |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc |
     Then the step should succeed
-    And the pod named "pod2-<%= project.name %>" becomes ready
+    And the pod named "mypod2" becomes ready
     When I execute on the pod:
       | touch | /tmp/file_pod2 |
     Then the step should succeed
@@ -39,7 +39,7 @@ Feature: AWS specific scenarios
       | file_pod1 |
       | file_pod2 |
 
-    And I ensure "efspvc-<%= project.name %>" pvc is deleted
+    And I ensure "mypvc" pvc is deleted
     And I switch to cluster admin pseudo user
     And I wait for the resource "pv" named "<%= pvc.volume_name %>" to disappear within 300 seconds
 

--- a/features/storage/csi.feature
+++ b/features/storage/csi.feature
@@ -14,16 +14,16 @@ Feature: CSI testing related feature
     And I checked "cinder" csi driver is running
     And I have a project
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]         | pvc-<%= project.name %> |
+      | ["metadata"]["name"]         | mypvc |
       | ["spec"]["storageClassName"] | cinder-csi              |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes :bound
+    And the "mypvc" PVC becomes :bound
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                         | pod-<%= project.name %> |
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
+      | ["metadata"]["name"]                                         | mypod |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/cinder             |
     Then the step should succeed
-    Given the pod named "pod-<%= project.name %>" becomes ready
+    Given the pod named "mypod" becomes ready
     When I execute on the pod:
       | ls | -ld | /mnt/cinder/ |
     Then the step should succeed

--- a/features/storage/dynamic_provisioning.feature
+++ b/features/storage/dynamic_provisioning.feature
@@ -17,9 +17,9 @@ Feature: Dynamic provisioning
     And I use the "<%= cb.proj_name %>" project
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"] | dynamic-pvc1-<%= project.name %> |
+      | ["metadata"]["name"] | mypvc1 |
     Then the step should succeed
-    And the "dynamic-pvc1-<%= project.name %>" PVC becomes :bound
+    And the "mypvc1" PVC becomes :bound
 
     And I save volume id from PV named "<%= pvc.volume_name %>" in the :volumeID clipboard
 
@@ -128,10 +128,10 @@ Feature: Dynamic provisioning
     """
     And the master service is restarted on all master nodes
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"] | dynamic-pvc-<%= project.name %> |
+      | ["metadata"]["name"] | mypvc |
     Then the step should succeed
     When 30 seconds have passed
-    Then the "dynamic-pvc-<%= project.name %>" PVC status is :pending
+    Then the "mypvc" PVC status is :pending
 
     Examples:
       | provisioner |

--- a/features/storage/fsType.feature
+++ b/features/storage/fsType.feature
@@ -9,13 +9,13 @@ Feature: testing for parameter fsType
     And I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/<type>/security/<type>-selinux-fsgroup-test.json" replacing paths:
-      | ["metadata"]["name"]                                      | pod-<%= project.name %> |
+      | ["metadata"]["name"]                                      | mypod |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"] | /mnt                    |
       | ["spec"]["securityContext"]["fsGroup"]                    | 24680                   |
       | ["spec"]["volumes"][0]["<storage_type>"]["<volume_name>"] | <%= cb.vid %>           |
       | ["spec"]["volumes"][0]["<storage_type>"]["fsType"]        | <fsType>                |
     Then the step should succeed
-    And the pod named "pod-<%= project.name %>" becomes ready
+    And the pod named "mypod" becomes ready
     When I execute on the pod:
       | mount |
     Then the step should succeed

--- a/features/storage/glusterfs.feature
+++ b/features/storage/glusterfs.feature
@@ -24,39 +24,39 @@ Feature: Storage of GlusterFS plugin testing
     Then the step should succeed
 
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/security/gluster_pod_sg.json" replacing paths:
-      | ["metadata"]["name"] | glusterpd-<%= project.name %> |
+      | ["metadata"]["name"] | mypod |
     Then the step should succeed
 
-    Given the pod named "glusterpd-<%= project.name %>" becomes ready
-    And I execute on the "glusterpd-<%= project.name %>" pod:
+    Given the pod named "mypod" becomes ready
+    And I execute on the pod:
       | ls | /mnt/glusterfs |
     Then the step should succeed
 
-    And I execute on the "glusterpd-<%= project.name %>" pod:
+    And I execute on the pod:
       | touch | /mnt/glusterfs/gluster_testfile |
     Then the step should succeed
 
     # Testing execute permission
-    Given I execute on the "glusterpd-<%= project.name %>" pod:
+    Given I execute on the pod:
       | cp | /hello | /mnt/glusterfs/hello |
-    When I execute on the "glusterpd-<%= project.name %>" pod:
+    When I execute on the pod:
       | /mnt/glusterfs/hello |
     Then the step should succeed
     And the output should contain:
       | Hello OpenShift Storage |
 
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/security/gluster_pod_sg.json" replacing paths:
-      | ["metadata"]["name"]                              | glusterpd-negative-<%= project.name %> |
+      | ["metadata"]["name"]                              | glusterpd-negative |
       | ["spec"]["securityContext"]["supplementalGroups"] | [123460]                               |
     Then the step should succeed
-    Given the pod named "glusterpd-negative-<%= project.name %>" becomes ready
-    And I execute on the "glusterpd-negative-<%= project.name %>" pod:
+    Given the pod named "glusterpd-negative" becomes ready
+    And I execute on the pod:
       | ls | /mnt/glusterfs |
     Then the step should fail
     Then the outputs should contain:
       | Permission denied  |
 
-    And I execute on the "glusterpd-negative-<%= project.name %>" pod:
+    And I execute on the pod:
       | touch | /mnt/glusterfs/gluster_testfile |
     Then the step should fail
     Then the outputs should contain:
@@ -110,17 +110,17 @@ Feature: Storage of GlusterFS plugin testing
     And I have a project
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/claim.yaml" replacing paths:
-      | ["metadata"]["name"]         | pvc-<%= project.name %> |
+      | ["metadata"]["name"]         | mypvc |
       | ["spec"]["storageClassName"] | glusterprovisioner      |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds
+    And the "mypvc" PVC becomes :bound within 120 seconds
 
     And the expression should be true> pv(pvc.volume_name).reclaim_policy == "Delete"
 
     # Test auto deleting PV
     Given I run the :delete client command with:
       | object_type       | pvc                     |
-      | object_name_or_id | pvc-<%= project.name %> |
+      | object_name_or_id | mypvc |
     And I switch to cluster admin pseudo user
     And I wait for the resource "pv" named "<%= pvc.volume_name %>" to disappear within 60 seconds
 
@@ -178,10 +178,10 @@ Feature: Storage of GlusterFS plugin testing
 
     # Verify Pod is assigned gid 3333
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/pod_gid.json" replacing paths:
-      | ["metadata"]["name"]                                         | pod-<%= project.name %> |
+      | ["metadata"]["name"]                                         | mypod |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc1                    |
     Then the step should succeed
-    Given the pod named "pod-<%= project.name %>" becomes ready
+    Given the pod named "mypod" becomes ready
     When I execute on the pod:
       | id | -G |
     Then the output should contain:
@@ -194,13 +194,13 @@ Feature: Storage of GlusterFS plugin testing
     Then the step should succeed
 
     # Pod should work as well having its supplementalGroups set to 3333 explicitly
-    Given I ensure "pod-<%= project.name %>" pod is deleted
+    Given I ensure "mypod" pod is deleted
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/pod_gid.json" replacing paths:
-      | ["metadata"]["name"]                                         | pod1-<%= project.name %> |
+      | ["metadata"]["name"]                                         | mypod1 |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc1                     |
       | ["spec"]["securityContext"]["supplementalGroups"]            | [3333]                   |
     Then the step should succeed
-    Given the pod named "pod1-<%= project.name %>" becomes ready
+    Given the pod named "mypod1" becomes ready
     When I execute on the pod:
       | id | -G |
     Then the output should contain:

--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -117,20 +117,20 @@ Feature: NFS Persistent Volume
     Then the step should succeed
 
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwx.json" replacing paths:
-      | ["metadata"]["name"]                         | nfsc-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc |
       | ["spec"]["resources"]["requests"]["storage"] | 1Gi                      |
     Then the step should succeed
-    And the "nfsc-<%= project.name %>" PVC becomes bound to the "nfs-<%= project.name %>" PV
+    And the "mypvc" PVC becomes bound to the "nfs-<%= project.name %>" PV
 
     Given I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/security/pod-supplementalgroup.json" replacing paths:
-      | ["metadata"]["name"]                                         | nfspd-<%= project.name %> |
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | nfsc-<%= project.name %>  |
+      | ["metadata"]["name"]                                         | mypod |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc  |
     Then the step should succeed
-    And the pod named "nfspd-<%= project.name %>" becomes ready
+    And the pod named "mypod" becomes ready
 
-    Given I execute on the "nfspd-<%= project.name %>" pod:
+    Given I execute on the "mypod" pod:
       | touch | /mnt/nfs/nfs_testfile |
     Then the step should fail
     And the output should contain:

--- a/features/storage/persistent_volume.feature
+++ b/features/storage/persistent_volume.feature
@@ -72,25 +72,25 @@ Feature: Persistent Volume Claim binding policies
       | ["spec"]["accessModes"][0] | ReadOnlyMany           |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc1-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc1 |
       | ["spec"]["accessModes"][0]                   | ReadOnlyMany             |
       | ["spec"]["resources"]["requests"]["storage"] | 10Gi                     |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]       | pvc2-<%= project.name %> |
+      | ["metadata"]["name"]       | mypvc2 |
       | ["spec"]["accessModes"][0] | ReadWriteOnce            |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]       | pvc3-<%= project.name %> |
+      | ["metadata"]["name"]       | mypvc3 |
       | ["spec"]["accessModes"][0] | ReadWriteMany            |
     Then the step should succeed
-    And the "pvc1-<%= project.name %>" PVC becomes :pending
-    And the "pvc2-<%= project.name %>" PVC becomes :pending
-    And the "pvc3-<%= project.name %>" PVC becomes :pending
+    And the "mypvc1" PVC becomes :pending
+    And the "mypvc2" PVC becomes :pending
+    And the "mypvc3" PVC becomes :pending
     And the "pv-<%= project.name %>" PV status is :available
-    Given I ensure "pvc1-<%= project.name %>" pvc is deleted
-    And I ensure "pvc2-<%= project.name %>" pvc is deleted
-    And I ensure "pvc3-<%= project.name %>" pvc is deleted
+    Given I ensure "mypvc1" pvc is deleted
+    And I ensure "mypvc2" pvc is deleted
+    And I ensure "mypvc3" pvc is deleted
     And admin ensures "pv-<%= project.name %>" pv is deleted
 
     When admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/auto/pv-template.json" where:
@@ -98,25 +98,25 @@ Feature: Persistent Volume Claim binding policies
       | ["spec"]["accessModes"][0] | ReadWriteOnce          |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc1-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc1 |
       | ["spec"]["accessModes"][0]                   | ReadWriteOnce            |
       | ["spec"]["resources"]["requests"]["storage"] | 10Gi                     |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]       | pvc2-<%= project.name %> |
+      | ["metadata"]["name"]       | mypvc2 |
       | ["spec"]["accessModes"][0] | ReadOnlyMany             |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]       | pvc3-<%= project.name %> |
+      | ["metadata"]["name"]       | mypvc3 |
       | ["spec"]["accessModes"][0] | ReadWriteMany            |
     Then the step should succeed
-    And the "pvc1-<%= project.name %>" PVC becomes :pending
-    And the "pvc2-<%= project.name %>" PVC becomes :pending
-    And the "pvc3-<%= project.name %>" PVC becomes :pending
+    And the "mypvc1" PVC becomes :pending
+    And the "mypvc2" PVC becomes :pending
+    And the "mypvc3" PVC becomes :pending
     And the "pv-<%= project.name %>" PV status is :available
-    Given I ensure "pvc1-<%= project.name %>" pvc is deleted
-    And I ensure "pvc2-<%= project.name %>" pvc is deleted
-    And I ensure "pvc3-<%= project.name %>" pvc is deleted
+    Given I ensure "mypvc1" pvc is deleted
+    And I ensure "mypvc2" pvc is deleted
+    And I ensure "mypvc3" pvc is deleted
     And admin ensures "pv-<%= project.name %>" pv is deleted
 
     When admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/auto/pv-template.json" where:
@@ -124,21 +124,21 @@ Feature: Persistent Volume Claim binding policies
       | ["spec"]["accessModes"][0] | ReadWriteMany          |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc1-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc1 |
       | ["spec"]["accessModes"][0]                   | ReadWriteMany            |
       | ["spec"]["resources"]["requests"]["storage"] | 10Gi                     |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]       | pvc2-<%= project.name %> |
+      | ["metadata"]["name"]       | mypvc2 |
       | ["spec"]["accessModes"][0] | ReadWriteOnce            |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]       | pvc3-<%= project.name %> |
+      | ["metadata"]["name"]       | mypvc3 |
       | ["spec"]["accessModes"][0] | ReadOnlyMany             |
     Then the step should succeed
-    And the "pvc1-<%= project.name %>" PVC becomes :pending
-    And the "pvc2-<%= project.name %>" PVC becomes :pending
-    And the "pvc3-<%= project.name %>" PVC becomes :pending
+    And the "mypvc1" PVC becomes :pending
+    And the "mypvc2" PVC becomes :pending
+    And the "mypvc3" PVC becomes :pending
     And the "pv-<%= project.name %>" PV status is :available
 
   # @author chaoyang@redhat.com

--- a/features/storage/pre-bind.feature
+++ b/features/storage/pre-bind.feature
@@ -10,13 +10,13 @@ Feature: Testing for pv and pvc pre-bind feature
       | ["metadata"]["name"]            | nfspv1-<%= project.name %> |
       | ["spec"]["capacity"]["storage"] | 1Gi                        |
     Then I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]                         | nfsc-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc |
       | ["spec"]["resources"]["requests"]["storage"] | 1Gi                      |
-    And the "nfsc-<%= project.name %>" PVC becomes bound to the "nfspv1-<%= project.name %>" PV
+    And the "mypvc" PVC becomes bound to the "nfspv1-<%= project.name %>" PV
     Then admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/preboundpv-rwo.yaml" where:
       | ["metadata"]["name"]              | nfspv2-<%= project.name %> |
       | ["spec"]["claimRef"]["namespace"] | <%= project.name %>        |
-      | ["spec"]["claimRef"]["name"]      | nfsc-<%= project.name %>   |
+      | ["spec"]["claimRef"]["name"]      | mypvc   |
     And the "nfspv2-<%= project.name %>" PV status is :available
 
   # @author chaoyang@redhat.com
@@ -27,13 +27,13 @@ Feature: Testing for pv and pvc pre-bind feature
     Given admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/preboundpv-rwo.yaml" where:
       | ["metadata"]["name"]              | nfspv-<%= project.name %> |
       | ["spec"]["claimRef"]["namespace"] | <%= project.name %>       |
-      | ["spec"]["claimRef"]["name"]      | nfsc-<%= project.name %>  |
+      | ["spec"]["claimRef"]["name"]      | mypvc  |
     Then the step should succeed
     And the "nfspv-<%= project.name %>" PV status is :available
     Then I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]       | nfsc-<%= project.name %> |
+      | ["metadata"]["name"]       | mypvc |
       | ["spec"]["accessModes"][0] | ReadWriteMany            |
-    And the "nfsc-<%= project.name %>" PVC becomes :pending
+    And the "mypvc" PVC becomes :pending
     And the "nfspv-<%= project.name %>" PV status is :available
 
   # @author chaoyang@redhat.com
@@ -46,13 +46,13 @@ Feature: Testing for pv and pvc pre-bind feature
       | ["metadata"]["name"]            | nfspv1-<%= project.name %> |
       | ["spec"]["capacity"]["storage"] | 1Gi                        |
     Then I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]                         | nfsc-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc |
       | ["spec"]["resources"]["requests"]["storage"] | 1Gi                      |
-    And the "nfsc-<%= project.name %>" PVC becomes bound to the "nfspv1-<%= project.name %>" PV
+    And the "mypvc" PVC becomes bound to the "nfspv1-<%= project.name %>" PV
     Then I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/preboundpvc-rwo.yaml" replacing paths:
-      | ["metadata"]["name"]   | nfsc-prebound-<%= project.name %> |
+      | ["metadata"]["name"]   | nfsc-prebound |
       | ["spec"]["volumeName"] | nfspv1-<%= project.name %>        |
-    And the "nfsc-prebound-<%= project.name %>" PVC becomes :pending
+    And the "nfsc-prebound" PVC becomes :pending
 
   # @author chaoyang@redhat.com
   # @case_id OCP-10113
@@ -66,10 +66,10 @@ Feature: Testing for pv and pvc pre-bind feature
     Then the step should succeed
     And the "nfspv-<%= project.name %>" PV status is :available
     Then I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/preboundpvc-rwo.yaml" replacing paths:
-      | ["metadata"]["name"]       | nfsc-<%= project.name %>   |
+      | ["metadata"]["name"]       | mypvc   |
       | ["spec"]["volumeName"]     | nfspv-<%= project.name %>  |
       | ["spec"]["accessModes"][0] | ReadWriteMany              |
-    And the "nfsc-<%= project.name %>" PVC becomes :pending
+    And the "mypvc" PVC becomes :pending
     And the "nfspv-<%= project.name %>" PV status is :available
 
   # @author chaoyang@redhat.com
@@ -84,10 +84,10 @@ Feature: Testing for pv and pvc pre-bind feature
     Then the step should succeed
     And the "nfspv-<%= project.name %>" PV status is :available
     Then I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/preboundpvc-rwo.yaml" replacing paths:
-      | ["metadata"]["name"]                         | nfsc-<%= project.name %>   |
+      | ["metadata"]["name"]                         | mypvc   |
       | ["spec"]["volumeName"]                       | nfspv-<%= project.name %>  |
       | ["spec"]["resources"]["requests"]["storage"] | 2Gi                        |
-    And the "nfsc-<%= project.name %>" PVC becomes :pending
+    And the "mypvc" PVC becomes :pending
     And the "nfspv-<%= project.name %>" PV status is :available
 
   # @author chaoyang@redhat.com
@@ -108,9 +108,9 @@ Feature: Testing for pv and pvc pre-bind feature
       | ["spec"]["capacity"]["storage"] | 1Gi                        |
     Then the step should succeed
     Then I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/preboundpvc-rwo.yaml" replacing paths:
-      | ["metadata"]["name"]   | nfsc-<%= project.name %>   |
+      | ["metadata"]["name"]   | mypvc   |
       | ["spec"]["volumeName"] | nfspv1-<%= project.name %> |
-    And the "nfsc-<%= project.name %>" PVC becomes bound to the "nfspv1-<%= project.name %>" PV
+    And the "mypvc" PVC becomes bound to the "nfspv1-<%= project.name %>" PV
     And the "nfspv2-<%= project.name %>" PV status is :available
 
   # @author chaoyang@redhat.com
@@ -141,10 +141,10 @@ Feature: Testing for pv and pvc pre-bind feature
   Scenario: PVC is bond to PV successfully when pvc is created first
     Given I have a project
     Then I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]                         | nfsc-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc |
     Then admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/nfs-recycle-rwo.json" where:
       | ["metadata"]["name"]              | nfspv-<%= project.name %> |
-    And the "nfsc-<%= project.name %>" PVC becomes bound to the "nfspv-<%= project.name %>" PV within 60 seconds
+    And the "mypvc" PVC becomes bound to the "nfspv-<%= project.name %>" PV within 60 seconds
 
   # @author chaoyang@redhat.com
   @admin
@@ -158,12 +158,12 @@ Feature: Testing for pv and pvc pre-bind feature
     Then the step should succeed
     And the "nfspv-<%= project.name %>" PV status is :available
     Then I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/preboundpvc-rwo.yaml" replacing paths:
-      | ["metadata"]["name"]   | nfsc-<%= project.name %> |
+      | ["metadata"]["name"]   | mypvc |
       | ["spec"]["volumeName"] | <pre-bind-pv>            |
-    And the "nfsc-<%= project.name %>" PVC becomes :pending
+    And the "mypvc" PVC becomes :pending
     And the "nfspv-<%= project.name %>" PV status is :available
     Examples:
-      | pre-bind-pvc              | pre-bind-pv                |
-      | nfsc-<%= project.name %>  | nfspv1-<%= project.name %> | # @case_id OCP-10108
-      | nfsc1-<%= project.name %> | nfspv-<%= project.name %>  | # @case_id OCP-10112
+      | pre-bind-pvc | pre-bind-pv                |
+      | nfsc         | nfspv1-<%= project.name %> | # @case_id OCP-10108
+      | nfsc1        | nfspv-<%= project.name %>  | # @case_id OCP-10112
 

--- a/features/storage/quota.feature
+++ b/features/storage/quota.feature
@@ -32,7 +32,7 @@ Feature: ResourceQuata for storage
 
     # Try to exceed the 12Gi storage
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                    | pvc-<%= project.name %> |
+      | ["metadata"]["name"]                                                    | mypvc |
       | ["metadata"]["annotations"]["volume.alpha.kubernetes.io/storage-class"] | foo                     |
       | ["spec"]["resources"]["requests"]["storage"]                            | 4Gi                     |
     Then the step should fail
@@ -57,7 +57,7 @@ Feature: ResourceQuata for storage
     And the pod named "mypodi-#{ cb.i }" becomes ready
     """
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                    | pvc-<%= project.name %> |
+      | ["metadata"]["name"]                                                    | mypvc |
       | ["metadata"]["annotations"]["volume.alpha.kubernetes.io/storage-class"] | foo                     |
       | ["spec"]["resources"]["requests"]["storage"]                            | 1Gi                     |
     Then the step should fail
@@ -97,7 +97,7 @@ Feature: ResourceQuata for storage
 
     # Try to exceed the 10Mi storage
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc-<%= project.name %>             |
+      | ["metadata"]["name"]                         | mypvc             |
       | ["spec"]["storageClassName"]                 | sc-<%= project.name %> |
       | ["spec"]["resources"]["requests"]["storage"] | 4Mi                                 |
     Then the step should fail
@@ -131,12 +131,12 @@ Feature: ResourceQuata for storage
     Given admin clones storage class "sc1-<%= project.name %>" from ":default" with:
       | | |
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc1-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc1 |
       | ["spec"]["storageClassName"]                 | sc1-<%= project.name %>  |
       | ["spec"]["resources"]["requests"]["storage"] | 11Mi                     |
     Then the step should succeed
-    And the "pvc1-<%= project.name %>" PVC becomes :bound
-    Given I ensure "pvc1-<%= project.name %>" pvc is deleted
+    And the "mypvc1" PVC becomes :bound
+    Given I ensure "mypvc1" pvc is deleted
     Given I switch to cluster admin pseudo user
     And I wait for the resource "pv" named "<%= pvc.volume_name %>" to disappear within 300 seconds
 

--- a/features/storage/rbd.feature
+++ b/features/storage/rbd.feature
@@ -17,10 +17,10 @@ Feature: Storage of Ceph plugin testing
 
     Given I have a project
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/rbd/dynamic-provisioning/claim.yaml" replacing paths:
-      | ["metadata"]["name"]         | pvc-<%= project.name %> |
+      | ["metadata"]["name"]         | mypvc |
       | ["spec"]["storageClassName"] | cephrbdprovisioner      |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds
+    And the "mypvc" PVC becomes :bound within 120 seconds
 
     # Switch to admin so as to create pod with desired FSGroup and SElinux levels
     Given I switch to cluster admin pseudo user
@@ -28,7 +28,7 @@ Feature: Storage of Ceph plugin testing
     And I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/rbd/dynamic-provisioning/user_secret.yaml" replacing paths:
       | ["data"]["key"] | <%= cb.secret_key %> |
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/rbd/dynamic-provisioning/pod.json" replacing paths:
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc |
     Then the step should succeed
     And the pod named "rbdpd" becomes ready
 
@@ -58,11 +58,11 @@ Feature: Storage of Ceph plugin testing
     And I have a project
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/rbd/dynamic-provisioning/claim.yaml" replacing paths:
-      | ["metadata"]["name"]         | pvc-<%= project.name %> |
+      | ["metadata"]["name"]         | mypvc |
       | ["spec"]["storageClassName"] | cephrbdprovisioner      |
       | ["spec"]["resources"]["requests"]["storage"]                           | 9Gi                     |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds
+    And the "mypvc" PVC becomes :bound within 120 seconds
 
     And the expression should be true> pvc.capacity == "9Gi"
 

--- a/features/storage/reclaim_policy.feature
+++ b/features/storage/reclaim_policy.feature
@@ -15,25 +15,25 @@ Feature: Persistent Volume reclaim policy tests
       | ["spec"]["persistentVolumeReclaimPolicy"]   | Default                |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gce/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc |
       | ["spec"]["volumeName"]                       | pv-<%= project.name %>  |
       | ["spec"]["accessModes"][0]                   | ReadWriteOnce           |
       | ["spec"]["resources"]["requests"]["storage"] | 1Gi                     |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes bound to the "pv-<%= project.name %>" PV
+    And the "mypvc" PVC becomes bound to the "pv-<%= project.name %>" PV
 
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gce/pod.json" replacing paths:
-      | ["metadata"]["name"]                                         | pod-<%= project.name %> |
+      | ["metadata"]["name"]                                         | mypod |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt                    |
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc |
     Then the step should succeed
-    Given the pod named "pod-<%= project.name %>" becomes ready
+    Given the pod named "mypod" becomes ready
     When I execute on the pod:
       | touch | /mnt/testfile |
     Then the step should succeed
 
-    Given I ensure "pod-<%= project.name %>" pod is deleted
-    And I ensure "pvc-<%= project.name %>" pvc is deleted
+    Given I ensure "mypod" pod is deleted
+    And I ensure "mypvc" pvc is deleted
     And the PV becomes :released
 
     Examples:
@@ -57,25 +57,25 @@ Feature: Persistent Volume reclaim policy tests
       | ["spec"]["persistentVolumeReclaimPolicy"]   | Delete                 |
     Then the step should succeed
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gce/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc |
       | ["spec"]["volumeName"]                       | pv-<%= project.name %>  |
       | ["spec"]["accessModes"][0]                   | ReadWriteOnce           |
       | ["spec"]["resources"]["requests"]["storage"] | 1Gi                     |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes bound to the "pv-<%= project.name %>" PV
+    And the "mypvc" PVC becomes bound to the "pv-<%= project.name %>" PV
 
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gce/pod.json" replacing paths:
-      | ["metadata"]["name"]                                         | pod-<%= project.name %> |
+      | ["metadata"]["name"]                                         | mypod |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt                    |
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc |
     Then the step should succeed
-    Given the pod named "pod-<%= project.name %>" becomes ready
+    Given the pod named "mypod" becomes ready
     When I execute on the pod:
       | touch | /mnt/testfile |
     Then the step should succeed
 
-    Given I ensure "pod-<%= project.name %>" pod is deleted
-    And I ensure "pvc-<%= project.name %>" pvc is deleted
+    Given I ensure "mypod" pod is deleted
+    And I ensure "mypvc" pvc is deleted
     Given I switch to cluster admin pseudo user
     And I wait for the resource "pv" named "<%= pv.name %>" to disappear within 1200 seconds
 

--- a/features/storage/security.feature
+++ b/features/storage/security.feature
@@ -9,14 +9,14 @@ Feature: storage security check
     Given I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/<type>/security/<type>-selinux-fsgroup-test.json" replacing paths:
-      | ["metadata"]["name"]                                      | pod-<%= project.name %> |
+      | ["metadata"]["name"]                                      | mypod |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"] | /mnt                    |
       | ["spec"]["securityContext"]["seLinuxOptions"]["level"]    | s0:c13,c2               |
       | ["spec"]["securityContext"]["fsGroup"]                    | 24680                   |
       | ["spec"]["securityContext"]["runAsUser"]                  | 1000160000              |
       | ["spec"]["volumes"][0]["<storage_type>"]["<volume_name>"] | <%= cb.vid %>           |
     Then the step should succeed
-    And the pod named "pod-<%= project.name %>" becomes ready
+    And the pod named "mypod" becomes ready
     When I execute on the pod:
       | id | -u |
     Then the step should succeed
@@ -49,16 +49,16 @@ Feature: storage security check
       | /mnt/hello |
     Then the step should succeed
     And the output should contain "Hello OpenShift Storage"
-    Given I ensure "pod-<%= project.name %>" pod is deleted
+    Given I ensure "mypod" pod is deleted
 
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/<type>/security/<type>-privileged-test.json" replacing paths:
-      | ["metadata"]["name"]                                      | pod2-<%= project.name %> |
+      | ["metadata"]["name"]                                      | mypod2 |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"] | /mnt                     |
       | ["spec"]["securityContext"]["seLinuxOptions"]["level"]    | s0:c13,c2                |
       | ["spec"]["securityContext"]["fsGroup"]                    | 24680                    |
       | ["spec"]["volumes"][0]["<storage_type>"]["<volume_name>"] | <%= cb.vid %>            |
     Then the step should succeed
-    And the pod named "pod2-<%= project.name %>" becomes ready
+    And the pod named "mypod2" becomes ready
     When I execute on the pod:
       | id |
     Then the step should succeed

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -6,11 +6,11 @@ Feature: storageClass related feature
   Scenario Outline: PVC modification after creating storage class
     Given I have a project
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc-without-annotations.json" replacing paths:
-      | ["metadata"]["name"] | pvc-<%= project.name %> |
+      | ["metadata"]["name"] | mypvc |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes :pending
+    And the "mypvc" PVC becomes :pending
     Given 30 seconds have passed
-    And the "pvc-<%= project.name %>" PVC status is :pending
+    And the "mypvc" PVC status is :pending
 
     When admin creates a StorageClass from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/storageClass.yaml" where:
       | ["metadata"]["name"]                                                       | sc-<%= project.name %>      |
@@ -19,14 +19,14 @@ Feature: storageClass related feature
     Then the step should succeed
     When I run the :patch client command with:
       | resource      | pvc                                                    |
-      | resource_name | pvc-<%= project.name %>                                |
+      | resource_name | mypvc                                |
       | p             | {"metadata":{"labels":{"<%= project.name %>":"test"}}} |
     Then the step should succeed
     Given 30 seconds have passed
-    And the "pvc-<%= project.name %>" PVC status is :pending
+    And the "mypvc" PVC status is :pending
     When I run the :patch client command with:
       | resource      | pvc                                                                                               |
-      | resource_name | pvc-<%= project.name %>                                                                           |
+      | resource_name | mypvc                                                                           |
       | p             | {"metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"sc-<%= project.name %>"}}} |
     Then the expression should be true> @result[:success] == env.version_le("3.5", user: user)
 
@@ -58,11 +58,11 @@ Feature: storageClass related feature
     And the output should not contain:
       | is-default-class: "true" |
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc-without-annotations.json" replacing paths:
-      | ["metadata"]["name"] | pvc-<%= project.name %> |
+      | ["metadata"]["name"] | mypvc |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes :pending
+    And the "mypvc" PVC becomes :pending
     Given 30 seconds have passed
-    And the "pvc-<%= project.name %>" PVC status is :pending
+    And the "mypvc" PVC status is :pending
 
     Examples:
       | provisioner |
@@ -133,21 +133,21 @@ Feature: storageClass related feature
     Then the step should succeed
 
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc-without-annotations.json" replacing paths:
-      | ["metadata"]["name"] | should-fail-<%= project.name %> |
+      | ["metadata"]["name"] | should-fail |
     Then the step should fail
     And the output should match:
       | Internal error occurred |
       | ([2-9]\|[1-9][0-9]+) default StorageClasses were found |
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]         | pvc1-<%= project.name %> |
+      | ["metadata"]["name"]         | mypvc1 |
       | ["spec"]["storageClassName"] | sc1-<%= project.name %>  |
     Then the step should succeed
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]         | pvc2-<%= project.name %> |
+      | ["metadata"]["name"]         | mypvc2 |
       | ["spec"]["storageClassName"] | sc2-<%= project.name %>  |
     Then the step should succeed
-    And the "pvc1-<%= project.name %>" PVC becomes :bound within 120 seconds
-    And the "pvc2-<%= project.name %>" PVC becomes :bound within 120 seconds
+    And the "mypvc1" PVC becomes :bound within 120 seconds
+    And the "mypvc2" PVC becomes :bound within 120 seconds
 
     Examples:
       | provisioner    |
@@ -161,9 +161,9 @@ Feature: storageClass related feature
   Scenario Outline: New created PVC without specifying storage class use default class when only one class is marked as default
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc-without-annotations.json" replacing paths:
-      | ["metadata"]["name"] | pvc-<%= project.name %> |
+      | ["metadata"]["name"] | mypvc |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds
+    And the "mypvc" PVC becomes :bound within 120 seconds
 
     Examples:
       | provisioner |
@@ -181,30 +181,30 @@ Feature: storageClass related feature
     Then the step should succeed
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc |
       | ["spec"]["accessModes"][0]                   | ReadWriteOnce           |
       | ["spec"]["resources"]["requests"]["storage"] | <size>                  |
       | ["spec"]["storageClassName"]                 | sc-<%= project.name %>  |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds
+    And the "mypvc" PVC becomes :bound within 120 seconds
     And the expression should be true> pvc.capacity == "<size>"
     And the expression should be true> pvc.access_modes[0] == "ReadWriteOnce"
     And the expression should be true> pv(pvc.volume_name).reclaim_policy == "Delete"
 
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                         | pod-<%= project.name %> |
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
+      | ["metadata"]["name"]                                         | mypod |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/iaas               |
     Then the step should succeed
-    Given the pod named "pod-<%= project.name %>" becomes ready
+    Given the pod named "mypod" becomes ready
     When I execute on the pod:
       | ls | -ld | /mnt/iaas/ |
     Then the step should succeed
     When I execute on the pod:
       | touch | /mnt/iaas/testfile |
     Then the step should succeed
-    Given I ensure "pod-<%= project.name %>" pod is deleted
-    Given I ensure "pvc-<%= project.name %>" pvc is deleted
+    Given I ensure "mypod" pod is deleted
+    Given I ensure "mypvc" pvc is deleted
     Given I switch to cluster admin pseudo user
     And I wait for the resource "pv" named "<%= pvc.volume_name %>" to disappear within 300 seconds
 
@@ -224,7 +224,7 @@ Feature: storageClass related feature
     Then the step should succeed
 
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc |
       | ["spec"]["accessModes"][0]                   | ReadWriteOnce           |
       | ["spec"]["resources"]["requests"]["storage"] | <size>                  |
       | ["spec"]["storageClassName"]                 | sc-<%= project.name %>  |
@@ -232,7 +232,7 @@ Feature: storageClass related feature
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :describe client command with:
-      | resource | pvc/pvc-<%= project.name %> |
+      | resource | pvc/mypvc |
     Then the output should contain:
       | ProvisioningFailed    |
       | InvalidParameterValue |
@@ -251,7 +251,7 @@ Feature: storageClass related feature
     Given I have a project
     # No sc exists
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc1-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc |
       | ["spec"]["accessModes"][0]                   | ReadWriteOnce            |
       | ["spec"]["resources"]["requests"]["storage"] | 1Gi                      |
       | ["spec"]["storageClassName"]                 | sc1-<%= project.name %>  |
@@ -259,7 +259,7 @@ Feature: storageClass related feature
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :describe client command with:
-      | resource | pvc/pvc1-<%= project.name %> |
+      | resource | pvc/mypvc |
     And the output should contain:
       | ProvisioningFailed                  |
       | "sc1-<%= project.name %>" not found |
@@ -270,16 +270,16 @@ Feature: storageClass related feature
   Scenario: AWS ebs volume is dynamic provisioned with default storageclass
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/ebs/pvc-retain.json" replacing paths:
-      | ["metadata"]["name"]                         | pvc-<%= project.name %> |
+      | ["metadata"]["name"]                         | mypvc |
       | ["spec"]["resources"]["requests"]["storage"] | 1Gi                     |
     Then the step should succeed
 
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                         | pod-<%= project.name %> |
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
+      | ["metadata"]["name"]                                         | mypod |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/iaas               |
     Then the step should succeed
-    And the pod named "pod-<%= project.name %>" becomes ready
+    And the pod named "mypod" becomes ready
 
 
 

--- a/features/storage/vsphere.feature
+++ b/features/storage/vsphere.feature
@@ -9,16 +9,16 @@ Feature: vSphere test scenarios
       | ["parameters"]["diskformat"] | <disk_format>                    |
     Then the step should succeed
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/vsphere/pvc.json" replacing paths:
-        | ["metadata"]["name"]         | pvc-<%= project.name %>          |
+        | ["metadata"]["name"]         | mypvc          |
         | ["spec"]["storageClassName"] | storageclass-<%= project.name %> |
     Then the step should succeed
-    And the "pvc-<%= project.name %>" PVC becomes :bound
+    And the "mypvc" PVC becomes :bound
 
     # Testing volume mount and read/write
     Given I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/vsphere/pod.json" replacing paths:
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc |
       | ["metadata"]["name"]                                         | mypod                   |
     Then the step should succeed
     Given the pod named "mypod" becomes ready
@@ -46,7 +46,7 @@ Feature: vSphere test scenarios
 
     # Testing reclaim policy
     Given I ensure "mypod" pod is deleted
-    And I ensure "pvc-<%= project.name %>" pvc is deleted
+    And I ensure "mypvc" pvc is deleted
     Given I switch to cluster admin pseudo user
     And I wait for the resource "pv" named "<%= pvc.volume_name %>" to disappear within 60 seconds
 
@@ -67,12 +67,12 @@ Feature: vSphere test scenarios
     Then the step should succeed
 
     Given I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/vsphere/pvc.json" replacing paths:
-      | ["metadata"]["name"]         | pvc-<%= project.name %>          |
+      | ["metadata"]["name"]         | mypvc          |
       | ["spec"]["storageClassName"] | storageclass-<%= project.name %> |
     And I wait up to 30 seconds for the steps to pass:
     """
     When I run the :describe client command with:
-      | resource | pvc/pvc-<%= project.name %> |
+      | resource | pvc/mypvc |
     Then the output should contain:
       | Pending |
       | Failed  |


### PR DESCRIPTION
@akostadinov @pruan-rht @chao007 

Since project name is unique, and pvc/pod are resources in project. Use simpler pvc/pod name can save a lot of typing when debugging failures. Saving more typing when using command history.