### PR TITLE
ocp 23543 - iptables binary and rules on sdn containers should be the same as host

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -229,7 +229,7 @@ Feature: SDN related networking scenarios
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :iptables_version_host clipboard
     
-    When I run command on the  node's sdn pod:
+    When I run command on the node's sdn pod:
       | iptables-save --version |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :iptables_version_pod clipboard

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -234,7 +234,8 @@ Feature: SDN related networking scenarios
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :iptables_version_pod clipboard
     Then the expression should be true> cb.iptables_version_host==cb.iptables_version_pod
-
+    
+    Given I switch to cluster admin pseudo user
     When I run commands on the host:
       | iptables --list \| wc -l |
     Then the step should succeed

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -228,9 +228,20 @@ Feature: SDN related networking scenarios
       | iptables-save --version |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :iptables_version_host clipboard
-    
+    #Comparing host and sdn container version for iptables binary
     When I run command on the node's sdn pod:
       | iptables-save | --version |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :iptables_version_pod clipboard
     Then the expression should be true> cb.iptables_version_host==cb.iptables_version_pod
+
+    When I run commands on the host:
+      | iptables --list --line-numbers \| wc -l |
+    Then the step should succeed
+    And evaluation of `@result[:response]` is stored in the :host_rules clipboard
+    #Comparing host and sdn container rules for iptables
+    When I run command on the node's sdn pod:
+      | iptables | --list | --line-numbers \| wc -l|
+    Then the step should succeed
+    And evaluation of `@result[:response]` is stored in the :sdn_pod_rules clipboard
+    Then the expression should be true> cb.host_rules==cb.sdn_pod_rules

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -236,9 +236,9 @@ Feature: SDN related networking scenarios
     Then the expression should be true> cb.iptables_version_host==cb.iptables_version_pod
     
     When I run commands on the host:
-      | sudo iptables --list \| wc -l |
+      | sudo iptables --list |
     Then the step should succeed
-    And evaluation of `@result[:response]` is stored in the :host_rules clipboard
+    And evaluation of `@result[:response].lines.count` is stored in the :host_rules clipboard
     #Comparing host and sdn container rules for iptables
     When I run command on the node's sdn pod:
       | iptables | --list |

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -236,12 +236,12 @@ Feature: SDN related networking scenarios
     Then the expression should be true> cb.iptables_version_host==cb.iptables_version_pod
 
     When I run commands on the host:
-      | iptables --list --line-numbers \| wc -l |
+      | iptables --list \| wc -l |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :host_rules clipboard
     #Comparing host and sdn container rules for iptables
     When I run command on the node's sdn pod:
-      | iptables | --list | --line-numbers \| wc -l|
+      | iptables | --list \| wc -l|
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :sdn_pod_rules clipboard
     Then the expression should be true> cb.host_rules==cb.sdn_pod_rules

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -241,7 +241,7 @@ Feature: SDN related networking scenarios
     And evaluation of `@result[:response]` is stored in the :host_rules clipboard
     #Comparing host and sdn container rules for iptables
     When I run command on the node's sdn pod:
-      | iptables | --list\|wc -l|
+      | iptables | --list | \| | wc -l |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :sdn_pod_rules clipboard
     Then the expression should be true> cb.host_rules==cb.sdn_pod_rules

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -235,14 +235,13 @@ Feature: SDN related networking scenarios
     And evaluation of `@result[:response]` is stored in the :iptables_version_pod clipboard
     Then the expression should be true> cb.iptables_version_host==cb.iptables_version_pod
     
-    Given I switch to cluster admin pseudo user
     When I run commands on the host:
-      | iptables --list \| wc -l |
+      | sudo iptables --list \| wc -l |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :host_rules clipboard
     #Comparing host and sdn container rules for iptables
     When I run command on the node's sdn pod:
-      | iptables | --list \| wc -l|
+      | iptables --list \| wc -l |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :sdn_pod_rules clipboard
     Then the expression should be true> cb.host_rules==cb.sdn_pod_rules

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -241,7 +241,7 @@ Feature: SDN related networking scenarios
     And evaluation of `@result[:response]` is stored in the :host_rules clipboard
     #Comparing host and sdn container rules for iptables
     When I run command on the node's sdn pod:
-      | iptables | --list | \| | wc -l |
+      | iptables | --list |
     Then the step should succeed
-    And evaluation of `@result[:response]` is stored in the :sdn_pod_rules clipboard
+    And evaluation of `@result[:response].lines.count` is stored in the :sdn_pod_rules clipboard
     Then the expression should be true> cb.host_rules==cb.sdn_pod_rules

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -241,7 +241,7 @@ Feature: SDN related networking scenarios
     And evaluation of `@result[:response]` is stored in the :host_rules clipboard
     #Comparing host and sdn container rules for iptables
     When I run command on the node's sdn pod:
-      | iptables --list\| wc -l|
+      | iptables | --list\|wc -l|
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :sdn_pod_rules clipboard
     Then the expression should be true> cb.host_rules==cb.sdn_pod_rules

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -241,7 +241,7 @@ Feature: SDN related networking scenarios
     And evaluation of `@result[:response]` is stored in the :host_rules clipboard
     #Comparing host and sdn container rules for iptables
     When I run command on the node's sdn pod:
-      | iptables --list \| wc -l |
+      | iptables --list\| wc -l|
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :sdn_pod_rules clipboard
     Then the expression should be true> cb.host_rules==cb.sdn_pod_rules

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -219,3 +219,20 @@ Feature: SDN related networking scenarios
     Then the step should succeed
     And the output should not contain "No such device"
 
+  # @author anusaxen@redhat.com
+  # @case_id OCP-23543
+  @admin
+  Scenario: The iptables binary and rules on sdn containers should be the same as host
+    Given I select a random node's host
+    When I run commands on the host:
+      | iptables-save --version |
+    Then the step should succeed
+    And evaluation of `@result[:response]` is stored in the :iptables_version_host clipboard
+    
+    When I run command on the  node's sdn pod:
+      | iptables-save --version |
+    Then the step should succeed
+    And evaluation of `@result[:response]` is stored in the :iptables_version_pod clipboard
+    Then the expression should be true> cb.iptables_version_host==cb.iptables_version_pod
+
+

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -230,9 +230,7 @@ Feature: SDN related networking scenarios
     And evaluation of `@result[:response]` is stored in the :iptables_version_host clipboard
     
     When I run command on the node's sdn pod:
-      | iptables-save --version |
+      | iptables-save | --version |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :iptables_version_pod clipboard
     Then the expression should be true> cb.iptables_version_host==cb.iptables_version_pod
-
-


### PR DESCRIPTION
This was a test case created for SDN-341.
Logs: https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/410/console
Not sure if :239 is right way to define sudo or if there is a step which can facilitate that. Pleas advise
Thanks.
@zhaozhanqi  