### PR TITLE
Remove alpha annotation storage-class (obsoleted since 3.4)

### DIFF
--- a/features/cli/secrets.feature
+++ b/features/cli/secrets.feature
@@ -245,11 +245,6 @@ Feature: secrets related scenarios
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image/gitserver/gitserver-persistent.yaml |
     Then the step should succeed
-    When I run the :patch client command with:
-      | resource      | pvc                                                                             |
-      | resource_name | git                                                                             |
-      | p             | {"metadata":{"annotations":{"volume.alpha.kubernetes.io/storage-class":"foo"}}} |
-    Then the step should succeed
     And the "git" PVC becomes :bound within 300 seconds
 
     When I run the :run client command with:
@@ -437,11 +432,6 @@ Feature: secrets related scenarios
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image/gitserver/gitserver-persistent.yaml |
-    Then the step should succeed
-    When I run the :patch client command with:
-      | resource      | pvc                                                                             |
-      | resource_name | git                                                                             |
-      | p             | {"metadata":{"annotations":{"volume.alpha.kubernetes.io/storage-class":"foo"}}} |
     Then the step should succeed
     And the "git" PVC becomes :bound within 300 seconds
 

--- a/features/images/jenkins.feature
+++ b/features/images/jenkins.feature
@@ -80,11 +80,6 @@ Feature: jenkins.feature
   Scenario Outline: Trigger build of application from jenkins job with persistent volume
     Given I have a project
     And I have a jenkins v<ver> application
-    When I run the :patch client command with:
-      | resource      | pvc                                                                             |
-      | resource_name | jenkins                                                                         |
-      | p             | {"metadata":{"annotations":{"volume.alpha.kubernetes.io/storage-class":"foo"}}} |
-    Then the step should succeed
     And the "jenkins" PVC becomes :bound within 300 seconds
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image/language-image-templates/application-template.json |

--- a/features/quickstarts/quickstarts.feature
+++ b/features/quickstarts/quickstarts.feature
@@ -28,11 +28,6 @@ Feature: quickstarts.feature
     Given I have a project
     When I run the :new_app client command with:
       | template | <template> |
-    When I run the :patch client command with:
-      | resource      | pvc                                                                             |
-      | resource_name | <pvc>                                                                           |
-      | p             | {"metadata":{"annotations":{"volume.alpha.kubernetes.io/storage-class":"foo"}}} |
-    Then the step should succeed
     And the "<pvc>" PVC becomes :bound within 300 seconds
     Then the step should succeed
     And the "<buildcfg>-1" build was created

--- a/features/storage/quota.feature
+++ b/features/storage/quota.feature
@@ -18,9 +18,8 @@ Feature: ResourceQuata for storage
     And I run the steps 3 times:
     """
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                    | pvc-#{ cb.i } |
-      | ["metadata"]["annotations"]["volume.alpha.kubernetes.io/storage-class"] | foo           |
-      | ["spec"]["resources"]["requests"]["storage"]                            | 3Gi           |
+      | ["metadata"]["name"]                         | pvc-#{ cb.i } |
+      | ["spec"]["resources"]["requests"]["storage"] | 3Gi           |
     Then the step should succeed
 
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gce/pod.json" replacing paths:
@@ -32,9 +31,8 @@ Feature: ResourceQuata for storage
 
     # Try to exceed the 12Gi storage
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                    | mypvc |
-      | ["metadata"]["annotations"]["volume.alpha.kubernetes.io/storage-class"] | foo                     |
-      | ["spec"]["resources"]["requests"]["storage"]                            | 4Gi                     |
+      | ["metadata"]["name"]                         | mypvc |
+      | ["spec"]["resources"]["requests"]["storage"] | 4Gi   |
     Then the step should fail
     And the output should contain:
       | exceeded quota                 |
@@ -46,9 +44,8 @@ Feature: ResourceQuata for storage
     And I run the steps 2 times:
     """
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                    | pvci-#{ cb.i } |
-      | ["metadata"]["annotations"]["volume.alpha.kubernetes.io/storage-class"] | foo            |
-      | ["spec"]["resources"]["requests"]["storage"]                            | 1Gi            |
+      | ["metadata"]["name"]                         | pvci-#{ cb.i } |
+      | ["spec"]["resources"]["requests"]["storage"] | 1Gi            |
     Then the step should succeed
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gce/pod.json" replacing paths:
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvci-#{ cb.i }   |
@@ -57,9 +54,8 @@ Feature: ResourceQuata for storage
     And the pod named "mypodi-#{ cb.i }" becomes ready
     """
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                                                    | mypvc |
-      | ["metadata"]["annotations"]["volume.alpha.kubernetes.io/storage-class"] | foo                     |
-      | ["spec"]["resources"]["requests"]["storage"]                            | 1Gi                     |
+      | ["metadata"]["name"]                         | mypvc |
+      | ["spec"]["resources"]["requests"]["storage"] | 1Gi   |
     Then the step should fail
     And the output should contain:
       | exceeded quota                      |
@@ -97,12 +93,12 @@ Feature: ResourceQuata for storage
 
     # Try to exceed the 10Mi storage
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                         | mypvc             |
+      | ["metadata"]["name"]                         | mypvc                  |
       | ["spec"]["storageClassName"]                 | sc-<%= project.name %> |
-      | ["spec"]["resources"]["requests"]["storage"] | 4Mi                                 |
+      | ["spec"]["resources"]["requests"]["storage"] | 4Mi                    |
     Then the step should fail
     And the output should contain:
-      | exceeded quota                                                                                  |
+      | exceeded quota                                                                     |
       | requested: sc-<%= project.name %>.storageclass.storage.k8s.io/requests.storage=4Mi |
       | used: sc-<%= project.name %>.storageclass.storage.k8s.io/requests.storage=8Mi      |
       | limited: sc-<%= project.name %>.storageclass.storage.k8s.io/requests.storage=10Mi  |
@@ -131,7 +127,7 @@ Feature: ResourceQuata for storage
     Given admin clones storage class "sc1-<%= project.name %>" from ":default" with:
       | | |
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
-      | ["metadata"]["name"]                         | mypvc1 |
+      | ["metadata"]["name"]                         | mypvc1                   |
       | ["spec"]["storageClassName"]                 | sc1-<%= project.name %>  |
       | ["spec"]["resources"]["requests"]["storage"] | 11Mi                     |
     Then the step should succeed


### PR DESCRIPTION
Alpha annotation storage-class is obsoleted since 3.4, and 3.4/3.5 reach EOL in April 2019.

@stuartchuan  for secrets.feature
@wzheng1  for jenkins.feature and quickstarts.feature
@chao007  for quota.feature

@akostadinov @pruan-rht 
