### PR TITLE
Pass idp type when jenkins enables openshift oauth

### DIFF
--- a/features/step_definitions/images/jenkins.rb
+++ b/features/step_definitions/images/jenkins.rb
@@ -95,6 +95,7 @@ Given /^I log in to jenkins$/ do
     step %Q/I perform the :jenkins_multi_oauth_login web action with:/, table(%{
       | username | <%= user.name %>     |
       | password | <%= user.password %> |
+      | idp      | <%= env.idp %>       |
       })
   elsif !user.password?
     step %Q/I perform the :jenkins_standard_login web action with:/, table(%{

--- a/lib/rules/web/images/jenkins_2/jenkins_2.xyaml
+++ b/lib/rules/web/images/jenkins_2/jenkins_2.xyaml
@@ -603,9 +603,13 @@ jenkins_multi_oauth_login:
         Logtext.click();
         return true;
     expect_result: true
-  - command: return document.getElementsByClassName("idp")[1].click()
-    expect_result: ~
+ # - command: return document.getElementsByClassName("idp")[1].click()
+ #   expect_result: ~
+ # getting idp type from env var when jenkins enables openshift oauth.
   elements:
+  - selector:
+      xpath: //a[text()='<idp>']
+    op: click
   - selector:
       id: inputUsername
     op: send_keys <username>


### PR DESCRIPTION
If there are multiple idp, need pass idp type when jenkins enables openshift oauth.
@openshift/devexp-qe Please help review, thx