### PR TITLE
auto OCP-9767

### DIFF
--- a/features/routing/ipfailover.feature
+++ b/features/routing/ipfailover.feature
@@ -1,0 +1,30 @@
+Feature: Testing ipfailover scenarios
+
+  # @author hongli@redhat.com
+  # @case_id OCP-9767
+  @admin
+  @destructive
+  Scenario: Configure a highly available network service
+    Given the cluster is running on OpenStack
+    And I switch to cluster admin pseudo user
+    And I use the "default" project
+    And default router image is stored into the :router_image clipboard
+    And SCC "privileged" is added to the "ipfailover" service account
+    And admin ensures "ipf-9767" dc is deleted after scenario
+
+    When I run the :oadm_ipfailover admin command with:
+      | name        | ipf-9767                                                              |
+      | images      | <%= cb.router_image.gsub("haproxy-router","keepalived-ipfailover") %> |
+      | virtual_ips | 192.168.1.1                                                           |
+      | watch_port  | 53                                                                    |
+    Then a pod becomes ready with labels:
+      | deploymentconfig=ipf-9767 |
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I run the :logs admin command with:
+      | resource_name | <%= pod.name %> |
+      | namespace     | default         |
+    Then the step should succeed
+    And the output should contain:
+      | Entering MASTER STATE |
+    """

--- a/lib/rules/cli/3.3.yaml
+++ b/lib/rules/cli/3.3.yaml
@@ -1174,6 +1174,12 @@
     :confirm: --confirm
     :type: --type=<value>
     :sort_by: --sort-by=<value>
+:oadm_ipfailover:
+  :cmd: oc adm ipfailover <name>
+  :options:
+    :images: --images=<value>
+    :virtual_ips: --virtual-ips=<value>
+    :watch_port: --watch-port=<value>
 :oadm_manage_node:
   :cmd: oc adm manage-node <node_name>
   :options:


### PR DESCRIPTION
This case is for CVP in 3.x release and just ensure no issue with ipfailover image and the pod can be `Running`.
@zhaozhanqi Please help review. Thanks.

log: https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/42475/consoleFull