### PR TITLE
Add more time for oauth restore step

### DIFF
--- a/features/step_definitions/oauth.rb
+++ b/features/step_definitions/oauth.rb
@@ -14,5 +14,6 @@ Given /^the #{QUOTED} oauth CRD is restored after scenario$/ do |name|
     opts = {resource: 'oauth', resource_name: name, p: patch_json, type: 'merge' }
     @result = _admin.cli_exec(:patch, **opts)
     raise "Cannot restore OAuth: #{name}" unless @result[:success]
+    sleep 60
   }
 end


### PR DESCRIPTION
Add more time for oauth restore step, in case of it not finish when next scenario started.