### PR TITLE
Use topology aware dynamic provisioning in the clouds

### DIFF
--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -171,8 +171,6 @@ Given(/^admin clones storage class #{QUOTED} from #{QUOTED} with:$/) do |target_
   sc_hash = YAML.load @result[:stdout]
 
   sc_hash["metadata"]["name"] = "#{target_sc}"
-  # Update sc to Immediate for smooth testing
-  sc_hash["volumeBindingMode"] = "Immediate"
   # Generally, make cloned storage class as non-default storage class.
   if sc_hash.dig("metadata", "annotations", "storageclass.beta.kubernetes.io/is-default-class")
     sc_hash["metadata"]["annotations"]["storageclass.beta.kubernetes.io/is-default-class"] = "false"


### PR DESCRIPTION
The code was added in https://github.com/openshift/verification-tests/pull/142 for 4.1 (as we add volumeBindingMode to WaitForFirstConsumer on AWS ).

We are now adding topology aware dynamic provisioning for more clouds (Azure, OpenStack, GCE) for 4.2 in https://github.com/openshift/cluster-storage-operator/pull/42 and https://github.com/openshift/cluster-storage-operator/pull/43

Immediate do means PV/volume is created before pod is scheduled, which can cause volume in zone1, while pod is scheduled on a node which is in zone2, sometimes.

We should fix some PVC checking steps in  following up PRs.

@akostadinov @pruan-rht @chao007 