### PR TITLE
WIP admin console must read browser_opts.yml

### DIFF
--- a/features/step_definitions/admin_console.rb
+++ b/features/step_definitions/admin_console.rb
@@ -8,9 +8,9 @@ Given /^I open admin console in a browser$/ do
 
   version = env.webconsole_executor.get_master_version(user, via_rest: true)
   step "I have a browser with:", table(%{
+    | rules        | lib/rules/web/admin_console/#{version}/  |
     | rules        | #{base_rules}                            |
     | rules        | lib/rules/web/admin_console/base/        |
-    | rules        | lib/rules/web/admin_console/#{version}/  |
     | base_url     | <%= env.admin_console_url %>             |
     | snippets_dir | #{snippets_dir}                          |
   })


### PR DESCRIPTION
@yapei, please see if this will get you browser.yml respected. Order in which rules are specified is important to find the additional opts.