### PR TITLE
Default storage class can not be deleted in 4.x

### DIFF
--- a/features/step_definitions/cluster_configuration/csi.rb
+++ b/features/step_definitions/cluster_configuration/csi.rb
@@ -118,7 +118,7 @@ Given /^I create (default )?storage class for #{QUOTED} csi driver$/ do |default
   filepath = @result[:abs_path]
 
   if default_sc
-    step %Q/default storage class is deleted/
+    step %Q/default storage class is patched to non-default/
     sc["metadata"]["annotations"]["storageclass.kubernetes.io/is-default-class"] = "true"
   end
   File.write(filepath, sc.to_yaml)

--- a/features/storage/persistent_volume.feature
+++ b/features/storage/persistent_volume.feature
@@ -146,7 +146,7 @@ Feature: Persistent Volume Claim binding policies
   @admin
   @destructive
   Scenario: PV and PVC bound and unbound many times
-    Given default storage class is deleted
+    Given default storage class is patched to non-default
     Given I have a project
     And I have a NFS service in the project
 

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -42,7 +42,7 @@ Feature: storageClass related feature
   @destructive
   Scenario Outline: No dynamic provision when no default storage class
     Given I have a project
-    And default storage class is deleted
+    And default storage class is patched to non-default
     When admin creates a StorageClass from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/storageClass.yaml" where:
       | ["metadata"]["name"] | sc-<%= project.name %>      |
       | ["provisioner"]      | kubernetes.io/<provisioner> |

--- a/features/web/pvc.feature
+++ b/features/web/pvc.feature
@@ -7,7 +7,7 @@ Feature: Add pvc to pod from web related
   Scenario: Attach pvc to pod with multiple containers from web console
     Given I have a project
     And I have a NFS service in the project
-    And default storage class is deleted
+    And default storage class is patched to non-default
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/dc-with-two-containers.yaml |
     Then the step should succeed


### PR DESCRIPTION
The step `default storage class is deleted` will recover the storage class in after hooks. As default storage class will be automatically recovered by cluster-storage-operator, the after hook will fail, which will cause auto execution quit prematurely.

@chao007 @qinpingli @jhou1 @akostadinov @pruan-rht 