### PR TITLE
support resources with dots in their Kind field

### DIFF
--- a/lib/admin_credentials.rb
+++ b/lib/admin_credentials.rb
@@ -68,12 +68,12 @@ module BushSlicer
       end
     end
   end
- 
+
   class URLKubeconfigCredentials < AdminCredentials
     def get
       # export OPENSHIFT_ENV_OCP4_ADMIN_CREDS_SPEC=file:///~/.kube/config
       if opts[:spec].start_with? 'file:///'
-        path = File.expand_path(opts[:spec].split("file:///")[1])
+        path = File.expand_path(opts[:spec].split("file://")[1])
         raise "kubeconfig does not exists" unless File.exists? File.expand_path(path)
         config = File.open(path).read
       else
@@ -84,7 +84,7 @@ module BushSlicer
       return accessor_from_kubeconfig(config)
     end
   end
-  
+
   class AutoKubeconfigCredentials < AdminCredentials
     def get
       case opts[:spec]

--- a/lib/openshift/cluster_role.rb
+++ b/lib/openshift/cluster_role.rb
@@ -10,15 +10,6 @@ module BushSlicer
     def update_from_api_object(hash)
       super
 
-      m = hash["metadata"]
-
-      unless hash["kind"] == shortclass
-        raise "hash not from a #{shortclass}: #{hash["kind"]}"
-      end
-      unless name == m["name"]
-        raise "hash from a different #{shortclass}: #{name} vs #{m["name"]}"
-      end
-
       props[:role_ref] = hash["roleRef"]
       props[:subjects] = hash["subjects"]
       props[:user_names] = hash["userNames"]

--- a/lib/openshift/config_samples_operator_openshift_io.rb
+++ b/lib/openshift/config_samples_operator_openshift_io.rb
@@ -1,0 +1,7 @@
+require 'openshift/cluster_resource'
+
+module BushSlicer
+  class ConfigSamplesOperatorOpenshiftIo < ClusterResource
+    RESOURCE = 'configs.samples.operator.openshift.io'
+  end
+end

--- a/lib/openshift/resource.rb
+++ b/lib/openshift/resource.rb
@@ -136,10 +136,11 @@ module BushSlicer
 
     def update_from_api_object(hash)
       case
-      when hash["kind"] != shortclass
-        raise "hash not from a #{shortclass}: #{hash["kind"]}"
+      when hash["kind"] != type
+        raise "hash not from a #{shortclass}: expected #{type} but was #{hash["kind"]}"
       when name != hash["metadata"]["name"]
         raise "hash from a different #{shortclass}: #{name} vs #{hash["metadata"]["name"]}"
+      # TODO: check API name/version
       when self.respond_to?(:project) &&
            hash["metadata"]&.has_key?("namespace") &&
            project.name != hash["metadata"]["namespace"]
@@ -404,6 +405,22 @@ module BushSlicer
 
     def shortclass
       self.class.shortclass
+    end
+
+    # @return [String] the type of resource as would appear in YAML output
+    # @note we need to handle resources where api name part is significant and
+    #   RESOURCE contains dots
+    def self.type
+      unless @type
+        count_words = self::RESOURCE[/^[^.]*/].count("_") + 1
+        @type = shortclass.sub(/^((?:[A-Z][a-z0-9]*){#{count_words}}).*$/, "\\1")
+      end
+
+      return @type
+    end
+
+    def type
+      self.class.type
     end
 
     def self.struct_iso8601_time(struct)

--- a/lib/openshift/security_context_constraints.rb
+++ b/lib/openshift/security_context_constraints.rb
@@ -6,14 +6,7 @@ module BushSlicer
     RESOURCE = 'securitycontextconstraints'
 
     def update_from_api_object(hash)
-      m = hash["metadata"]
-
-      unless hash["kind"] == shortclass
-        raise "hash not from a #{shortclass}: #{hash["kind"]}"
-      end
-      unless name == m["name"]
-        raise "hash from a different #{shortclass}: #{name} vs #{m["name"]}"
-      end
+      super
 
       props[:role_ref] = hash["roleRef"]
       props[:subjects] = hash["subjects"]

--- a/lib/world.rb
+++ b/lib/world.rb
@@ -299,7 +299,7 @@ module BushSlicer
     def cluster_resource(clazz, name = nil, env = nil, switch: nil)
       env ||= self.env
 
-      varname = "@#{clazz::RESOURCE}"
+      varname = "@#{clazz::RESOURCE}".tr(".","_")
       clazzname = clazz.shortclass
       var = instance_variable_get(varname) ||
               instance_variable_set(varname, [])


### PR DESCRIPTION
@xiuwang, please test whether this will help #308

you can refer to the name "cluster" of kind "config.samples.operator.openshift.io" by `config_samples_operator_openshift_io("cluster")`. And let me know!

@pruan-rht, notice file URL change here