### PR TITLE
add set_floating_ip function for IPI on OSP routes record

### DIFF
--- a/lib/launchers/openstack10.rb
+++ b/lib/launchers/openstack10.rb
@@ -767,7 +767,7 @@ module BushSlicer
       end
     end
 
-    def set_floating_ip(floatingip_id, **opts)
+    def assign_ip_to_port(floatingip_id, port_id)
       fips = get_floating_ips
       unless fips.find { |fip| fip["id"] == floatingip_id }
         raise "given floatingip_id #{floatingip_id} is not existed"
@@ -775,7 +775,9 @@ module BushSlicer
       request_url = self.os_network_url + "/v2.0/floatingips/#{floatingip_id}"
       method = "PUT"
       payload = {
-        floatingip: opts
+        floatingip: {
+          port_id: port_id
+        }
       }
       res = self.rest_run(request_url, method, payload, self.os_token)
       logger.debug(res[:response])

--- a/lib/launchers/openstack10.rb
+++ b/lib/launchers/openstack10.rb
@@ -768,10 +768,6 @@ module BushSlicer
     end
 
     def assign_ip_to_port(floatingip_id, port_id)
-      fips = get_floating_ips
-      unless fips.find { |fip| fip["id"] == floatingip_id }
-        raise "given floatingip_id #{floatingip_id} is not existed"
-      end
       request_url = self.os_network_url + "/v2.0/floatingips/#{floatingip_id}"
       method = "PUT"
       payload = {

--- a/lib/launchers/openstack10.rb
+++ b/lib/launchers/openstack10.rb
@@ -715,6 +715,15 @@ module BushSlicer
       end
     end
     
+    def get_floating_ips()
+      res = self.rest_run(self.os_network_url + "/v2.0/floatingips", "GET", {}, self.os_token)
+      if res[:success]
+        return res.dig(:parsed, "floatingips")
+      else
+        raise "Could not get all existing floating ips\n#{res[:response]}"
+      end
+    end
+
     def allocate_floating_ip(network_name, reuse: true)
       network = floating_ip_networks.find { |n| n["name"] == network_name }
       unless network
@@ -722,12 +731,7 @@ module BushSlicer
       end
 
       if reuse
-        fipsres = self.rest_run(self.os_network_url + "/v2.0/floatingips", "GET", {}, self.os_token)
-        if fipsres[:success]
-          fips = fipsres.dig(:parsed, "floatingips")
-        else
-          raise "Could not get all existing floating ips\n#{fipsres[:response]}"
-        end  
+        fips = get_floating_ips()
         # filter condition is
         # 1, floating ip is not belong to given network_name and
         # 2, floating ip is not preserved
@@ -760,6 +764,25 @@ module BushSlicer
         return res.dig(:parsed, "floatingip")
       else
         raise "could not allocate new floating ip:\n#{res[:response]}"
+      end
+    end
+
+    def set_floating_ip(floatingip_id, **opts)
+      fips = get_floating_ips
+      unless fips.find { |fip| fip["id"] == floatingip_id }
+        raise "given floatingip_id #{floatingip_id} is not existed"
+      end
+      request_url = self.os_network_url + "/v2.0/floatingips/#{floatingip_id}"
+      method = "PUT"
+      payload = {
+        floatingip: opts
+      }
+      res = self.rest_run(request_url, method, payload, self.os_token)
+      logger.debug(res[:response])
+      if res[:success]
+        return res.dig(:parsed, "floatingip")
+      else
+        raise "failed to set properties for floating ip:\n#{res[:response]}"
       end
     end
 


### PR DESCRIPTION
```
[1] pry(#<BushSlicer::DefaultWorld>)> iaas = iaas_by_service("openstack_upshift")
[2] pry(#<BushSlicer::DefaultWorld>)> iaas.get_floating_ips
[3] pry(#<BushSlicer::DefaultWorld>)> iaas.allocate_floating_ip("provider_net_shared_2")
=> {"router_id"=>nil,
 "status"=>"DOWN",
 "description"=>"IP allocated automatically by OpenShift verification-tests",
 "tags"=>[],
 "tenant_id"=>"542c6ebd48bf40fa857fc245c7572e30",
 "created_at"=>"2019-08-26T22:36:46Z",
 "updated_at"=>"2019-08-26T22:36:46Z",
 "floating_network_id"=>"14c15d33-175c-424e-88ba-361a875e0c5c",
 "fixed_ip_address"=>nil,
 "floating_ip_address"=>"10.0.79.234",
 "revision_number"=>0,
 "project_id"=>"542c6ebd48bf40fa857fc245c7572e30",
 "port_id"=>nil,
 "id"=>"d9a898a3-7767-4ace-8315-608974ca10da",
 "qos_policy_id"=>nil}
[4] pry(#<BushSlicer::DefaultWorld>)> iaas.set_floating_ip("8d981842-700e-4ce1-9d26-8c62907b0cb", port_id: "3bfa79aa-8c24-4669-8e34-aba6c63d10ef")
RuntimeError: given floatingip_id 8d981842-700e-4ce1-9d26-8c62907b0cb is not existed
from /home/wjiang/git/automationFW/BushSlicer/lib/launchers/openstack10.rb:773:in `set_floating_ip'
[5] pry(#<BushSlicer::DefaultWorld>)> iaas.set_floating_ip("8d981842-700e-4ce1-9d26-8c62907b0cb1", port_id: "3bfa79aa-8c24-4669-8e34-aba6c63d10ef")
=> {"router_id"=>"945f82a2-df99-43b6-8e7d-4776653d94a6",
 "status"=>"ACTIVE",
 "description"=>"IP allocated automatically by OpenShift verification-tests",
 "tags"=>[],
 "tenant_id"=>"542c6ebd48bf40fa857fc245c7572e30",
 "created_at"=>"2019-08-30T00:42:58Z",
 "updated_at"=>"2019-08-30T04:54:15Z",
 "floating_network_id"=>"25ec4907-36fc-4035-b8d5-b797246330f2",
 "fixed_ip_address"=>"192.168.0.7",
 "floating_ip_address"=>"10.0.151.188",
 "revision_number"=>4,
 "project_id"=>"542c6ebd48bf40fa857fc245c7572e30",
 "port_id"=>"3bfa79aa-8c24-4669-8e34-aba6c63d10ef",
 "id"=>"8d981842-700e-4ce1-9d26-8c62907b0cb1",
 "qos_policy_id"=>nil}

```