### PR TITLE
helper for https://github.com/openshift/cucushift/pull/7083

### DIFF
--- a/features/test/new_api.feature
+++ b/features/test/new_api.feature
@@ -20,3 +20,9 @@ Feature: test new api methods
     Given I switch to cluster admin pseudo user
     And I use the "openshift-logging" project
     And I wait for clusterlogging to be functional in the project
+
+  @admin
+  Scenario: test new route apis
+    Given I switch to cluster admin pseudo user
+    And I use the "openshift-monitoring" project
+    And evaluation of `route('prometheus-k8s').spec.host` is stored in the clipboard

--- a/lib/openshift/flakes/route_spec.rb
+++ b/lib/openshift/flakes/route_spec.rb
@@ -15,6 +15,10 @@ module BushSlicer
       return struct['host']
     end
 
+    def path
+      struct['path']
+    def
+
     def target_port
       return struct.dig('port', 'targetPort')
     end

--- a/lib/openshift/flakes/route_spec.rb
+++ b/lib/openshift/flakes/route_spec.rb
@@ -4,8 +4,6 @@ module BushSlicer
 
   # this class should help with parsing route specifications
   class RouteSpec
-    include Common::Helper
-
     attr_reader :struct
     private :struct
 
@@ -13,46 +11,56 @@ module BushSlicer
       @struct = struct
     end
 
-    module ExportMethods
-      def  host
-        return struct['host']
-      end
-
-      def targetPort
-        return struct.dig('port', 'targetPort')
-      end
-
-      def subdomain
-        return struct['subdomain']
-      end
-
-      def tls_insecureEdgeTerminationPolicy
-        return struct.dig('tls', 'insecureEdgeTerminationPolicy')
-      end
-
-      def tls_termination
-        return struct.dig('tls', 'termination')
-      end
-
-      def to_kind
-        return struct.dig('to', 'kind')
-      end
-
-      def to_name
-        return struct.dig('to', 'name')
-      end
-
-      def to_weight
-        return struct.dig('to', 'weight')
-      end
-
-      def wildcardPolicy
-        return struct['wildcardPolicy']
-      end
-
+    def  host
+      return struct['host']
     end
 
-    include ExportMethods
+    def target_port
+      return struct.dig('port', 'targetPort')
+    end
 
+    def subdomain
+      return struct['subdomain']
+    end
+
+    def tls_insecure_edge_termination_policy
+      return struct.dig('tls', 'insecureEdgeTerminationPolicy')
+    end
+
+    def tls_termination
+      return struct.dig('tls', 'termination')
+    end
+
+    def tls_certificate
+      return struct.dig('tls', 'certificate')
+    end
+
+    def tls_key
+      return struct.dig('tls', 'key')
+    end
+
+    def tls_ca_certificate
+      return struct.dig('tls', 'caCertificate')
+    end
+
+    def tls_destination_ca_certificate
+      return struct.dig('tls', 'destinationCACertificate')
+    end
+
+    def to_kind
+      return struct.dig('to', 'kind')
+    end
+
+    def to_name
+      return struct.dig('to', 'name')
+    end
+
+    def to_weight
+      return struct.dig('to', 'weight')
+    end
+
+    def wildcard_policy
+      return struct['wildcardPolicy']
+    end
   end
 end

--- a/lib/openshift/flakes/route_spec.rb
+++ b/lib/openshift/flakes/route_spec.rb
@@ -47,15 +47,15 @@ module BushSlicer
       return struct.dig('tls', 'destinationCACertificate')
     end
 
-    def to_kind
+    def target_kind
       return struct.dig('to', 'kind')
     end
 
-    def to_name
+    def target_name
       return struct.dig('to', 'name')
     end
 
-    def to_weight
+    def target_weight
       return struct.dig('to', 'weight')
     end
 

--- a/lib/openshift/flakes/route_spec.rb
+++ b/lib/openshift/flakes/route_spec.rb
@@ -1,0 +1,58 @@
+require 'base_helper'
+
+module BushSlicer
+
+  # this class should help with parsing route specifications
+  class RouteSpec
+    include Common::Helper
+
+    attr_reader :struct
+    private :struct
+
+    def initialize(struct)
+      @struct = struct
+    end
+
+    module ExportMethods
+      def  host
+        return struct['host']
+      end
+
+      def targetPort
+        return struct.dig('port', 'targetPort')
+      end
+
+      def subdomain
+        return struct['subdomain']
+      end
+
+      def tls_insecureEdgeTerminationPolicy
+        return struct.dig('tls', 'insecureEdgeTerminationPolicy')
+      end
+
+      def tls_termination
+        return struct.dig('tls', 'termination')
+      end
+
+      def to_kind
+        return struct.dig('to', 'kind')
+      end
+
+      def to_name
+        return struct.dig('to', 'name')
+      end
+
+      def to_weight
+        return struct.dig('to', 'weight')
+      end
+
+      def wildcardPolicy
+        return struct['wildcardPolicy']
+      end
+
+    end
+
+    include ExportMethods
+
+  end
+end

--- a/lib/openshift/route.rb
+++ b/lib/openshift/route.rb
@@ -1,5 +1,6 @@
 require 'common'
 require 'openshift/project_resource'
+require 'openshift/flakes/route_spec'
 
 module BushSlicer
   # @note represents an OpenShift route to a service
@@ -114,5 +115,12 @@ module BushSlicer
       end
       return ready
     end
+
+    # @return a RouteSpec object instead of just a raw hash
+    def spec(user: nil, cached: true, quiet: false)
+      rr = raw_resource(user: user, cached: cached, quiet: quiet).dig("spec")
+      RouteSpec.new rr
+    end
+
   end
 end


### PR DESCRIPTION
@yanpzhan, this PR adds route spec property support.  Example usage is `route('grafana').spec.host`.  There's a similar PR (#346 by @yapei).  Both PRs accomplishes the same end result (different ways of calling methods) but with different internal implementation.  @akostadinov, can you PTAL both and see which one you prefer?  Thanks!