### PR TITLE
fix for oc version output change

### DIFF
--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -65,7 +65,7 @@ module BushSlicer
       fake_config.unlink
 
       raise "cannot execute on host #{host.hostname} as user '#{user}'" unless res[:success]
-      return res[:response].scan(/^os?c v(.+)$|GitVersion:"v([^"]+)"/)[0].find{|v| v != nil}
+      return res[:response].scan(/GitVersion:"v([^"]+)"|^Client Version: v(.+)$/)[0].find{|v| v != nil}
     end
 
     # try to map ocp and origin cli version to a comparable integer value


### PR DESCRIPTION
Now latest 4.2 oc version output changed:
$ oc version
Client Version: v4.2.0
Server Version: 4.2.0-0.nightly-2019-09-17-232025
Kubernetes Version: v1.14.6+e353665
Pass log: http://pastebin.test.redhat.com/798708
@akostadinov  @pruan-rht , pls help to review, thanks!