### PR TITLE
Fix OCP-16485

### DIFF
--- a/features/storage/regression.feature
+++ b/features/storage/regression.feature
@@ -13,14 +13,13 @@ Feature: Regression testing cases
 
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/damonset.json |
-      | n | <%= project.name %>                                                                                      |
+      | n | <%= project.name %>                                                                           |
     Then the step should succeed
 
     And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :describe client command with:
       | resource | pod |
-    Then the output should contain:
-      | already |
+    Then the output should match:
+      | (already\|conflict) |
     """
-


### PR DESCRIPTION
Previously, error msg is "volume is already exclusively attached to another node", now the error msg is "1 node(s) had volume node affinity conflict"

@chao007 @duanwei33 