### PR TITLE
utilty to summarize instance usages for various cloud vendors

### DIFF
--- a/lib/instance_summary.rb
+++ b/lib/instance_summary.rb
@@ -1,11 +1,8 @@
 require 'text-table'
+require 'thread'
+require 'thwait'
+
 module BushSlicer
-  # represents what we want to show in the summary output
-  # 1. platform   (aws, azure, gce, openstack, and etc)
-  # 2. instance_name
-  # 3. uptime
-  # 4. link to Flexy job ID that was used to spin it up (none if nont-Fles
-  #
   class InstanceSummary
     attr_accessor :jenkins
 
@@ -15,7 +12,6 @@ module BushSlicer
 
     ## print out summary in a text table format
     def print_summary(summary)
-
       table = Text::Table.new
       table.head = ['name', 'uptime', 'flexy_job_id', 'region']
       summary.each do | s |
@@ -35,15 +31,13 @@ module BushSlicer
         total += s[:inst_count]
         table.rows << [s[:platform], s[:region], s[:inst_count]]
       end
-      table.rows << ["Total instances:", "", total]
+      table.foot = ["Total instances", "", total]
       puts table
-
     end
-
   end
 
   class AwsSummary < InstanceSummary
-    attr_accessor :amz, :summary, :table
+    attr_accessor :amz
     def initialize(jenkins: nil)
       @amz = Amz_EC2.new
       @jenkins = jenkins
@@ -98,25 +92,23 @@ module BushSlicer
       regions = amz.get_regions
       region_names =  regions.map {|r| r.region_name }
       aws_instances = {}
+      threads = []
       regions.each do | region |
-        ### for init debugging use one region only
         if target_region
           # first check name is valid
           raise "Unsupported region '#{target_region}'" unless region_names.include? target_region
-          amz = Amz_EC2.new(region: target_region)
-          instances = amz.get_instances_by_status('running')
-          aws_instances[target_region] = instances
-          break
-        else
-          amz = Amz_EC2.new(region: region.region_name)
-          inst = amz.get_instances_by_status('running')
-          aws_instances[region.region_name] = inst
+          region.region_name = target_region
         end
-
+        threads << Thread.new(Amz_EC2.new(region: region.region_name)) do |aws|
+          instances = aws.get_instances_by_status('running')
+          aws_instances[region.region_name] = instances
+          break if target_region == region.region_name
+        end
       end
+      ThreadsWait.all_waits(*threads)
       grand_summary = []
       aws_instances.each do |region, inst_list|
-        print "Getting summary for region '#{region}'\n"
+        # print "Getting summary for region '#{region}'\n"
         summary = summarize_instances(region, inst_list)
         print_summary(summary) if inst_list.count > 0
         grand_summary << {platform: 'aws', region: region, inst_count: inst_list.count}
@@ -127,11 +119,169 @@ module BushSlicer
   end
 
   class GceSummary < InstanceSummary
-    # WIP:
+    attr_accessor :gce
+
+    def initialize(jenkins: nil)
+      @gce = GCE.new
+      @jenkins = jenkins
+    end
+
+    # for GCE, group the instance by network
+    def regroup_instances(instances)
+      cluster_map = {}
+
+      instances.each do |inst|
+        rindex = inst.network_interfaces.first.network.split('/').last
+        if cluster_map[rindex]
+          cluster_map[rindex] << inst
+        else
+          cluster_map[rindex] = [inst]
+        end
+      end
+      return cluster_map
+    end
+
+    # @return <Array of Hash of summary>
+    def summarize_instances(region, instance_list)
+      summary = []
+      gce = @gce
+      project = gce.config[:project]
+      jenkins = @jenkins
+      cm = regroup_instances(instance_list)
+      cm.each do | network, inst_list |
+        inst_list.each do | inst |
+          inst_summary = {}
+          # inst_summary[:inst_obj] = inst
+          inst_summary[:region] = region
+          inst_summary[:name]= inst.name
+          inst_summary[:uptime]= gce.instance_uptime inst
+          inst_summary[:owned] = network
+          if inst_summary[:owned]
+            inst_summary[:flexy_job_id] = jenkins.get_jenkins_flexy_job_id(inst_summary[:owned][0..-9])
+          else
+            inst_summary[:flexy_job_id] = nil
+          end
+          summary << inst_summary
+        end
+      end
+      return summary
+    end
+
+    def get_summary(target_region: nil)
+      regions = gce.regions
+      gce_instances = {}
+      grand_summary = []
+      targets = {}
+      threads_zones = []
+
+      if target_region
+        targets[target_region] = regions[target_region]
+      else
+        targets = regions
+      end
+
+      targets.each do | region, zones |
+        gce_instances[region] = []
+        zone_threads = zones.each do |zone|
+          threads_zones << Thread.new(zone) do |z|
+            instances = gce.get_instances_by_status(zone: z, status: 'running')
+            if instances
+              instances.each do |inst|
+                gce_instances[region] << inst
+              end
+            end
+          end
+        end
+      end
+      ThreadsWait.all_waits(*threads_zones)
+
+      targets.each do |region, zones|
+        # print "Getting summary for region #{region}\n"
+        if gce_instances.keys.include? region
+          summary = summarize_instances(region, gce_instances[region])
+          print_summary(summary) if summary.count > 0
+          grand_summary << {platform: 'gce', region: region, inst_count: summary.count}
+        end
+      end
+      print_grand_summary(grand_summary)
+    end
   end
 
   class AzureSummary < InstanceSummary
-    # WIP:
+    attr_accessor :azure
+
+    def initialize(jenkins: nil)
+      @azure = Azure.new
+      @jenkins = jenkins
+    end
+
+    def summarize_instances(cm)
+      summary = []
+      cm.each do |rg_name, instances|
+        instances.each do |inst|
+          inst_summary = {}
+          inst_summary[:region] = inst[:inst].location
+          inst_summary[:name]= inst[:inst].name
+          inst_summary[:uptime]= inst[:uptime]
+          inst_summary[:owned] = rg_name.downcase
+          if inst_summary[:owned]
+            inst_summary[:flexy_job_id] = jenkins.get_jenkins_flexy_job_id(inst_summary[:owned][0..-10])
+          else
+            inst_summary[:flexy_job_id] = nil
+          end
+          summary << inst_summary
+        end
+      end
+      return summary
+    end
+
+    def get_summary
+      grand_summary = []
+      # default status is 'PowerState/Running'
+      # cluster_map keyed off by resource_group_name
+      cm = azure.get_running_instances
+      summary = summarize_instances(cm)
+      print_summary(summary) if summary.count > 0
+      grand_summary << {platform: 'azure', region: summary.first[:region], inst_count: summary.count}
+      print_grand_summary(grand_summary)
+    end
   end
 
+
+  class OpenstackSummary < InstanceSummary
+    attr_accessor :os
+
+    def initialize(jenkins: nil)
+      @os = OpenStack10.new
+      @jenkins = jenkins
+    end
+
+    # instances is <Array> of server objects
+    def summarize_instances(instances)
+      summary = []
+      sorted_instances = instances.sort_by {|k, v| k}.to_h
+      sorted_instances.each do |name, inst|
+        inst_summary = {}
+        inst_summary[:region] = 'upshift'
+        inst_summary[:name]= name
+        inst_summary[:uptime]= os.instance_uptime inst["created"]
+        inst_summary[:owned] =  name
+        inst_summary[:flexy_job_id] = jenkins.get_jenkins_flexy_job_id(name[0..13])
+        summary << inst_summary
+      end
+      return summary
+    end
+
+    def get_summary
+      grand_summary = []
+      inst_details = os.get_running_instances
+      # sleep 15
+      summary = summarize_instances(inst_details)
+        # summary = summarize_instances(rg_name, instances)
+      print_summary(summary) if summary.count > 0
+      grand_summary << {platform: 'openstack', region: summary.first[:region], inst_count: summary.count}
+      print_grand_summary(grand_summary)
+    end
+  end
 end
+

--- a/lib/instance_summary.rb
+++ b/lib/instance_summary.rb
@@ -1,0 +1,137 @@
+require 'text-table'
+module BushSlicer
+  # represents what we want to show in the summary output
+  # 1. platform   (aws, azure, gce, openstack, and etc)
+  # 2. instance_name
+  # 3. uptime
+  # 4. link to Flexy job ID that was used to spin it up (none if nont-Fles
+  #
+  class InstanceSummary
+    attr_accessor :jenkins
+
+    def initialize(jenkins: nil)
+      @jenkins = jenkins
+    end
+
+    ## print out summary in a text table format
+    def print_summary(summary)
+
+      table = Text::Table.new
+      table.head = ['name', 'uptime', 'flexy_job_id', 'region']
+      summary.each do | s |
+        row = [s[:name], s[:uptime], s[:flexy_job_id], s[:region]]
+        table.rows << row
+      end
+      puts table
+      print "There are #{summary.count} running instances in #{summary.first[:region]}\n"
+    end
+
+    # print a table of summary of all of the instances grouped by region
+    def print_grand_summary(summary)
+      table = Text::Table.new
+      table.head = ['platform', 'region', 'total instances']
+      total = 0
+      summary.each do |s|
+        total += s[:inst_count]
+        table.rows << [s[:platform], s[:region], s[:inst_count]]
+      end
+      table.rows << ["Total instances:", "", total]
+      puts table
+
+    end
+
+  end
+
+  class AwsSummary < InstanceSummary
+    attr_accessor :amz, :summary, :table
+    def initialize(jenkins: nil)
+      @amz = Amz_EC2.new
+      @jenkins = jenkins
+      @table = Text::Table.new
+    end
+
+    # @return <Hashed Array of Instances> with each hash key being keyed on the `owned` tag.
+    def regroup_instances(instances)
+      cluster_map = {}
+      instances.each do |r|
+        owned =   r.tags.select {|t| t['value'] == "owned" }
+        if owned.count > 0
+          rindex = owned.first['key'].split('kubernetes.io/cluster/')[-1]
+        else
+          rindex = "no_owner"
+        end
+        if cluster_map[rindex]
+          cluster_map[rindex] << r
+        else
+          cluster_map[rindex] = [r]
+        end
+      end
+      return cluster_map
+    end
+
+    # @instances <Array of unordered Instance obj>
+    def summarize_instances(region, instances)
+      summary = []
+      amz = @amz
+      jenkins = @jenkins
+      cm = regroup_instances(instances)
+      cm.each do | owned, inst_list |
+        inst_list.each do | inst |
+          inst_summary = {}
+          # inst_summary[:inst_obj] = inst
+          inst_summary[:region] = region
+          inst_summary[:name]= amz.instance_name inst
+          inst_summary[:uptime]= amz.instance_uptime inst
+          inst_summary[:owned] = amz.instance_owned inst
+          if inst_summary[:owned]
+            inst_summary[:flexy_job_id] = jenkins.get_jenkins_flexy_job_id(inst_summary[:owned][0..-7])
+          else
+            inst_summary[:flexy_job_id] = nil
+          end
+          summary << inst_summary
+        end
+      end
+      return summary
+    end
+
+    def get_summary(target_region: nil)
+      regions = amz.get_regions
+      region_names =  regions.map {|r| r.region_name }
+      aws_instances = {}
+      regions.each do | region |
+        ### for init debugging use one region only
+        if target_region
+          # first check name is valid
+          raise "Unsupported region '#{target_region}'" unless region_names.include? target_region
+          amz = Amz_EC2.new(region: target_region)
+          instances = amz.get_instances_by_status('running')
+          aws_instances[target_region] = instances
+          break
+        else
+          amz = Amz_EC2.new(region: region.region_name)
+          inst = amz.get_instances_by_status('running')
+          aws_instances[region.region_name] = inst
+        end
+
+      end
+      grand_summary = []
+      aws_instances.each do |region, inst_list|
+        print "Getting summary for region '#{region}'\n"
+        summary = summarize_instances(region, inst_list)
+        print_summary(summary) if inst_list.count > 0
+        grand_summary << {platform: 'aws', region: region, inst_count: inst_list.count}
+      end
+      print_grand_summary(grand_summary)
+    end
+
+  end
+
+  class GceSummary < InstanceSummary
+    # WIP:
+  end
+
+  class AzureSummary < InstanceSummary
+    # WIP:
+  end
+
+end

--- a/lib/jenkins.rb
+++ b/lib/jenkins.rb
@@ -7,6 +7,14 @@ module BushSlicer
     def initialize
       @client = JenkinsApi::Client.new(:server_url => 'https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com',
          :username => ENV['JENKINS_USER'], :password => ENV['JENKINS_PASSWORD'])
+      # # xxx for debugging you can set @build_map manually and disable to
+      # init call in cloud_cop.rb to save time querying jenkins server
+      # repeatedly
+      #
+      #  @build_map =  {"qeci-293"=>69641,
+      #  ...
+      #  "juzhao-1023"=>69559}
+
     end
 
     # @return <Array of builds>

--- a/lib/jenkins.rb
+++ b/lib/jenkins.rb
@@ -1,0 +1,66 @@
+require 'net/https'
+require 'thread'
+
+module BushSlicer
+  class Jenkins
+    attr_accessor :client, :build_map
+    def initialize
+      @client = JenkinsApi::Client.new(:server_url => 'https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com',
+         :username => ENV['JENKINS_USER'], :password => ENV['JENKINS_PASSWORD'])
+    end
+
+    # @return <Array of builds>
+    def get_builds(job_name)
+      return client.job.get_builds(job_name)
+    end
+
+    def get_build_details(build_id: nil, job_name: "Launch Environment Flexy")
+      return client.job.get_build_details(job_name, build_id)
+    end
+
+    # @return INSTANCE_NAME_PREFIX information from a build detail
+    # actions[action_index]['parameters'][param_index]['name'] == "INSTANCE_NAME_PREFIX"
+    def get_instance_prefix_from_build(build_id: nil)
+      bd = self.get_build_details(build_id: build_id)
+      instance_name_prefix = ""
+      bd['actions'].each do |action|
+        action.each do |a|
+          if a.include? "hudson.model.ParametersAction"
+          	instance_name_prefix = action['parameters'].map { |p| p['value'] if p['name']== "INSTANCE_NAME_PREFIX" }.compact.first
+          	break
+          end
+        end
+      end
+      return instance_name_prefix
+    end
+
+    def construct_jenkins_build_map
+      threads = []
+      # API only limits at 100 at the moment...should be sufficient
+      builds = get_builds('Launch Environment Flexy')
+      build_map = {}
+      builds.each do | build |
+        threads << Thread.new(build) do |b|
+          instance_build_prefix = get_instance_prefix_from_build(build_id: build['number'])
+          build_map[instance_build_prefix] = build['number']
+        end
+      end
+      self.build_map = build_map
+      return build_map
+    end
+
+    # @return <Array> of job id or 'Not found is none is matched'
+    def get_jenkins_flexy_job_id(inst_group_name)
+      index = self.build_map.keys.select { |b|
+        b.include? inst_group_name
+      }.first
+      if index
+        self.build_map[index]
+      else
+        "not found"
+      end
+    end
+
+  end
+
+end

--- a/lib/launchers/amz.rb
+++ b/lib/launchers/amz.rb
@@ -4,7 +4,7 @@ require 'aws-sdk'
 require 'common'
 require 'host'
 require 'launchers/cloud_helper'
-require 'pry-byebug'
+
 module BushSlicer
 
   class Amz_EC2

--- a/lib/launchers/amz.rb
+++ b/lib/launchers/amz.rb
@@ -4,7 +4,7 @@ require 'aws-sdk'
 require 'common'
 require 'host'
 require 'launchers/cloud_helper'
-
+require 'pry-byebug'
 module BushSlicer
 
   class Amz_EC2
@@ -13,7 +13,7 @@ module BushSlicer
 
     attr_reader :config
 
-    def initialize(access_key: nil, secret_key: nil, service_name: nil)
+    def initialize(access_key: nil, secret_key: nil, service_name: nil, region: nil)
       service_name ||= :AWS
       @config = conf[:services, service_name]
       @can_terminate = true
@@ -40,13 +40,13 @@ module BushSlicer
       end
 
       raise "no readable credentials file or external credentials config found" unless awscred
-
       Aws.config.update( config[:config_opts].merge({
         credentials: Aws::Credentials.new(
           awscred["AWSAccessKeyId"],
           awscred["AWSSecretKey"]
         )
       }) )
+      Aws.config.update( config[:config_opts].merge({region: region})) if region
     end
 
     private def client_ec2
@@ -281,6 +281,17 @@ module BushSlicer
       }).to_a
     end
 
+    # @return [Array<Instance>]
+    def get_instances_by_status(status)
+      res = ec2.instances({
+        filters: [
+          {
+            name: "instance-state-name",
+            values: [status]
+          },
+        ]
+      }).to_a
+    end
     # @param [String] ami_id the EC2 AMI-ID
     # @return [Array<String>, Array<Object>] the array of IP address with array of instances object
     def get_instance_ip_by_ami_id(ami_id)
@@ -443,6 +454,25 @@ module BushSlicer
         return volume.state
     end
 
+    # @return [Array <Region>]
+    def get_regions
+      client_ec2.describe_regions.to_a[0][0]
+    end
+
+    def instance_uptime(instance)
+      ((Time.now.utc - instance.launch_time) / (60 * 60)).round(2)
+    end
+
+    def instance_name(instance)
+      instance.tags.select { |i| i['value'] if i['key'] == "Name" }.first['value']
+    end
+    # @return group of instances that belong to the same `owned`
+    def instance_owned(instance)
+      res = instance.tags.select { |i| i['key'] if i['value'] == "owned" }
+      if res.count > 0
+        res.first['key'].split('/').last
+      end
+    end
 
     # returns ssh connection
     def get_host(instance, host_opts={}, wait: false)

--- a/lib/launchers/azure.rb
+++ b/lib/launchers/azure.rb
@@ -63,6 +63,16 @@ module BushSlicer
       return @compute_clients[subs_id]
     end
 
+    # @return [ResourceManagementClient] for the provided subscription id
+    def resource_mgmt_client(subs_id = default_subscription_id)
+      return @resource_mgmt_clients[subs_id] if @resource_mgmt_clients&.dig(subs_id)
+
+      @resource_mgmt_clients ||= {}
+      @resource_mgmt_clients[subs_id] = Resource::ResourceManagementClient.new(credentials)
+      @resource_mgmt_clients[subs_id].subscription_id = subs_id
+      return @resource_mgmt_clients[subs_id]
+    end
+
     def net_client(subs_id = default_subscription_id)
       return @net_clients[subs_id] if @net_clients&.dig(subs_id)
 
@@ -103,6 +113,10 @@ module BushSlicer
       return object_storage_client(*key).blob_client
     end
 
+    def resource_groups
+      @resource_groups ||= resource_mgmt_client.resource_groups.list
+    end
+
     # @return [String, StorageAccount] where the String is the name of the
     #   new account
     # @note MS recommends using separate acconut for each VM:
@@ -127,6 +141,60 @@ module BushSlicer
       end
 
       return storage_account_name, storage_client(subs_id).storage_accounts.create(res_group, storage_account_name, storage_create_params)
+    end
+
+    # @return <Array of VirtualMachine>
+    def instances
+      compute_client.virtual_machines.list_all
+    end
+
+    # call instance_view method with ResourceGroup name and instance_name
+    def instance_view(vm_obj)
+      rg_name = BushSlicer::Azure.resource_group_from_id(vm_obj.id)
+      inst_view = compute_client.virtual_machines.instance_view(rg_name, vm_obj.name)
+      return rg_name, inst_view
+    end
+
+    def instance_view_time(inst_view)
+      inst_view.statuses.first.time.strftime
+    end
+
+    def vm_disk_creation_time(inst_view)
+      inst_view.disks.first.statuses.first.time.strftime
+    end
+    # use of vm_disk time is more accurate than instance_view (which resets if a user stops and restart the instance)
+    def instance_uptime(inst_view, src: "vm_disk")
+      time_src = nil
+      if src == 'vm_disk'
+        time_src = vm_disk_creation_time(inst_view)
+      else
+        time_src = instance_view_time(inst_view)
+      end
+      ((Time.now - Time.parse(time_src))/ (60 * 60)).round(2)
+    end
+
+    def running? (inst_view)
+      inst_view.statuses[1].code == 'PowerState/running'
+    end
+
+    def get_running_instances
+      vms = {}
+      instances = self.instances
+      instances.each do |inst|
+        rg_name, iv = instance_view(inst)
+        vms[rg_name] = [] if vms[rg_name].nil?
+        if running? iv
+          uptime = instance_uptime(iv)
+          vms[rg_name] << {:inst => inst,
+            :inst_view => iv,
+            :uptime => uptime }
+        end
+      end
+      # cleanup Hash if the value is an empty array.
+      vms.each do |k,v|
+        vms.delete k if v.empty?
+      end
+      return vms
     end
 
     def get_volume_by_openshift_metadata(pv_name, project_name)

--- a/lib/launchers/gce.rb
+++ b/lib/launchers/gce.rb
@@ -135,7 +135,7 @@ module BushSlicer
     # @input status: filter to be used when calling the list_instances method, default to RUNNING
     # @return <Array> of instance, if
     def get_instances_by_status(zone: nil, status: 'RUNNING')
-      compute.list_instances(@config[:project], zone, filter: "status eq 'RUNNING'").items
+      compute.list_instances(@config[:project], zone, filter: "status eq '#{status.upcase}'").items
     end
 
     # @return Hash of zones keyed by region name

--- a/lib/launchers/gce.rb
+++ b/lib/launchers/gce.rb
@@ -131,6 +131,26 @@ module BushSlicer
       end
     end
 
+    # @input region_name
+    # @input status: filter to be used when calling the list_instances method, default to RUNNING
+    # @return <Array> of instance, if
+    def get_instances_by_status(zone: nil, status: 'RUNNING')
+      compute.list_instances(@config[:project], zone, filter: "status eq 'RUNNING'").items
+    end
+
+    # @return Hash of zones keyed by region name
+    def regions
+      r = {}
+      res = compute.list_regions(@config[:project])
+      res.items.each { |i| r[i.name] = i.zones.map {|z| z.split('/')[-1]} }
+      return r
+    end
+
+    # @return <Float>
+    def instance_uptime(inst)
+      return (Time.now - Time.parse(inst.creation_timestamp)) / (60*60).round(2)
+    end
+
 
     # @param names [String, Array<String>] one or more names to launch
     # @param project [String] project name we work with

--- a/tools/cloud_cop.rb
+++ b/tools/cloud_cop.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+$LOAD_PATH.unshift("#{File.dirname(__FILE__)}/../lib")
+
+"""
+Helper utility to interact with AWS services on the command-line
+"""
+
+require 'commander'
+
+require 'launchers/amz'
+
+require 'collections'
+require 'common'
+require 'http'
+require 'thread'
+require 'jenkins_api_client'
+require 'text-table'
+# GCE specific
+require 'google/apis/compute_v1'
+require 'googleauth'
+
+# user libs
+require 'instance_summary'
+require 'jenkins'
+
+module BushSlicer
+  class CloudCop
+    include Commander::Methods
+    include Common::Helper
+    include Common::CloudHelper
+    attr_accessor :jenkins, :jenkins_build_map, :summary, :amz, :gce, :azure
+    def initialize
+      @jenkins = Jenkins.new
+      @jenkins.construct_jenkins_build_map
+      always_trace!
+    end
+
+    def run
+      program :name, 'CloudCop'
+      program :version, '0.0.1'
+      program :description, 'Helper utility to display summary of running instances in supported cloud platforms'
+
+      #Commander::Runner.instance.default_command(:gui)
+      default_command :help
+
+
+      command :"aws" do |c|
+        c.syntax = "#{File.basename __FILE__} -r <aws_region_name> [--all]"
+        c.description = 'display summary of running instances'
+        c.option("-r", "--region region_name", "report on this region only")
+        c.action do |args, options|
+          ps = AwsSummary.new(jenkins: @jenkins)
+          say 'Getting summary...'
+          ps.get_summary(target_region: options.region)
+
+        end
+      end
+
+      command :"gce" do |c|
+        c.syntax = "#{File.basename __FILE__} -r <gce_region_name> [--all]"
+        c.description = 'display summary of running instances'
+        c.option("-r", "--region region_name", "report on this region only")
+        c.action do |args, options|
+          say 'WIP, please check back later'
+        end
+      end
+
+      run!
+    end
+  end
+end
+
+if __FILE__ == $0
+  BushSlicer::CloudCop.new.run
+end


### PR DESCRIPTION
usage is `./tools/cloud_cop.rb aws` to get summary of all regions or `./tools/cloud_cop.rb aws --region=us-east-2` to just get the summary for that region.  Currently only support AWS, will add other cloud providers later.  Here's an example output
http://pastebin.test.redhat.com/804638