### PR TITLE
update step run command on node's sdn pod

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -671,7 +671,6 @@ Given /^I run command on the#{OPT_QUOTED} node's sdn pod:$/ do |node_name, table
   }.first
   cache_resources sdn_pod
   @result = sdn_pod.exec(network_cmd, as: admin)
-  raise "Failed to execute network command!" unless @result[:success]
 end
 
 Given /^the default interface on nodes is stored in the#{OPT_SYM} clipboard$/ do |cb_name|


### PR DESCRIPTION
As there is one step in case OCP-9753 need run command fails, so update the file to remove the raise error if not success.

Any comments will be welcomed, thanks!
@zhaozhanqi @anuragthehatter @lihongan

The log is for PR https://github.com/openshift/cucushift/pull/7116 and this PR.
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/44963/console