### PR TITLE
add new steps to get `opsrc` name

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -47,7 +47,7 @@ Given /^logging operators are installed successfully$/ do
       step %Q/I use the "openshift-marketplace" project/
       # first check packagemanifest exists for cluster-logging
       raise "Required packagemanifest 'cluster-logging' no found!" unless package_manifest('cluster-logging').exists?
-
+      step %Q/I use the "openshift-logging" project/
       if cb.ocp_cluster_version.include? "4.1."
         # create catalogsourceconfig and subscription for cluster-logging-operator
         catsrc_logging_yaml ||= "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/logging/clusterlogging/deploy_clo_via_olm/4.1/03_clo_csc.yaml"
@@ -58,8 +58,12 @@ Given /^logging operators are installed successfully$/ do
         raise "Error creating subscription for cluster_logging" unless @result[:success]
       else
         # create subscription in `openshift-logging` namespace:
-        sub_logging_yaml ||= "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/logging/clusterlogging/deploy_clo_via_olm/4.2/03_clo_sub.yaml"
-        @result = admin.cli_exec(:create, f: sub_logging_yaml)
+        sub_logging_yaml ||= "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/logging/clusterlogging/deploy_clo_via_olm/4.2/clo-sub-template.yaml"
+        step %Q/I process and create:/, table(%{
+          | f | #{sub_logging_yaml}                          |
+          | p | SOURCE=#{env.subscription_opsrc_name}        |
+          | p | CHANNEL=#{env.get_version(user: user).first} |
+        })
         raise "Error creating subscription for cluster_logging" unless @result[:success]
       end
     end
@@ -91,7 +95,7 @@ Given /^logging operators are installed successfully$/ do
       step %Q/I use the "openshift-marketplace" project/
       # first check packagemanifest exists for elasticsearch-operator
       raise "Required packagemanifest 'elasticsearch-operator' no found!" unless package_manifest('elasticsearch-operator').exists?
-
+      step %Q/I use the "openshift-operators-redhat" project/
       if cb.ocp_cluster_version.include? "4.1."
         # create catalogsourceconfig and subscription for elasticsearch-operator
         catsrc_elasticsearch_yaml ||= "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/logging/eleasticsearch/deploy_via_olm/4.1/04_eo-csc.yaml"
@@ -102,8 +106,12 @@ Given /^logging operators are installed successfully$/ do
         raise "Error creating subscription for elasticsearch" unless @result[:success]
       else
         # create subscription in "openshift-operators-redhat" namespace:
-        sub_elasticsearch_yaml ||= "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/logging/eleasticsearch/deploy_via_olm/4.2/04_eo-sub.yaml"
-        @result = admin.cli_exec(:create, f: sub_elasticsearch_yaml)
+        sub_elasticsearch_yaml ||= "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/logging/eleasticsearch/deploy_via_olm/4.2/eo-sub-template.yaml"
+        step %Q/I process and create:/, table(%{
+          | f | #{sub_elasticsearch_yaml}                    |
+          | p | SOURCE=#{env.subscription_opsrc_name}        |
+          | p | CHANNEL=#{env.get_version(user: user).first} |
+        })
         raise "Error creating subscription for elasticsearch" unless @result[:success]
       end
     end

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -229,18 +229,6 @@ module BushSlicer
       return @system_docker_repo
     end
 
-    # the opsrc used to create subscription, default to "redhat-operators"
-    def subscription_opsrc_name
-      unless @subscription_opsrc_name
-        if opts[:subscription_opsrc_name]
-          @subscription_opsrc_name = opts[:subscription_opsrc_name]
-        else
-          @subscription_opsrc_name = "redhat-operators"
-        end
-      end
-      return @subscription_opsrc_name
-    end
-
     # helper parser
     def parse_version(ver_str)
       ver = ver_str.sub(/^v/,"")

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -229,6 +229,18 @@ module BushSlicer
       return @system_docker_repo
     end
 
+    # the opsrc used to create subscription, default to "redhat-operators"
+    def subscription_opsrc_name
+      unless @subscription_opsrc_name
+        if opts[:subscription_opsrc_name]
+          @subscription_opsrc_name = opts[:subscription_opsrc_name]
+        else
+          @subscription_opsrc_name = "redhat-operators"
+        end
+      end
+      return @subscription_opsrc_name
+    end
+
     # helper parser
     def parse_version(ver_str)
       ver = ver_str.sub(/^v/,"")


### PR DESCRIPTION
@anpingli @akostadinov @pruan-rht  PTAL, thanks.

I'm adding a new environment variable `subscription_opsrc_name`, I add this because when running logging test, the opsrc we used to create subscription can be changed due to a lot of reasons.
And this variable could be used for all the testing related to creating subscriptions via OLM. I set the default value to `redhat-operators`.

Here is an example:
```
export BUSHSLICER_CONFIG='                                                        
environments:
  ocp4:
    version: "4.3"
    subscription_opsrc_name: "redhat-operators-art"
'
```
Log: https://url.corp.redhat.com/d7f0207