### PR TITLE
Update OCP-10466 so it cross platforms

### DIFF
--- a/features/cli/policy.feature
+++ b/features/cli/policy.feature
@@ -267,15 +267,13 @@ Feature: change the policy of user/service account
     Given I have a project
     And admin ensures "pv-<%= project.name %>" pv is deleted after scenario
     Given cluster role "storage-admin" is added to the "first" user
-    And I have a 1 GB volume and save volume id in the :volumeID clipboard
 
-    When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/ebs/pv-rwo.yaml"
-    Then I replace lines in "pv-rwo.yaml":
-      | ebs                           | pv-<%= project.name %> |
-      | 10Gi                          | 1Gi                    |
-      | aws://us-east-1d/vol-e69f0b1c | <%= cb.volumeID %>     |
+    When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/hostpath/pv-rwx-recycle.yaml"
+    Then I replace lines in "pv-rwx-recycle.yaml":
+      | local         | pv-<%= project.name %> |
+      | ReadWriteMany | ReadWriteOnce          |
     Then I run the :create client command with:
-      | f | pv-rwo.yaml |
+      | f | pv-rwx-recycle.yaml |
     And the step should succeed
 
     When I run the :get client command with:
@@ -295,12 +293,12 @@ Feature: change the policy of user/service account
       | name     | pv-<%= project.name %> |
     Then the step should succeed
 
-    Then I replace lines in "pv-rwo.yaml":
+    Then I replace lines in "pv-rwx-recycle.yaml":
       | ReadWriteOnce | ReadWriteMany |
 
     When I run the :replace client command with:
-      | f     | pv-rwo.yaml |
-      | force | true        |
+      | f     | pv-rwx-recycle.yaml |
+      | force | true                |
     And the step should succeed
 
     When I run the :describe client command with:


### PR DESCRIPTION
As the test case is checking that storage-admin can create/delete/update/get PVs, replacing aws PV with hostpath PV does no harm.

Why replacing aws PV to hostpath PV ?
Because we do volume validation now in 4.x, the test case will works on AWS only if we use aws PV.
```
    Then I run the :create client command with:                                                                              # features/step_definitions/cli.rb:13
      [06:30:53] INFO> Shell Commands: oc create -f pv-rwo.yaml --config=/home/lxia/workdir/ocp-lxia/ose_testuser-46.kubeconfig
      
      STDERR:
      Error from server (Forbidden): error when creating "pv-rwo.yaml": persistentvolumes "pv-6qvej" is forbidden: error querying AWS EBS volume qe-lxi-fzkpq-dynamic-pvc-454c9ed2-14c4-41f9-b76c-9d3bd3da261b: unable to read AWS cloud provider config file: warnings:
      can't store data at section "global", variable "project-id"
      can't store data at section "global", variable "regional"
      can't store data at section "global", variable "multizone"
      can't store data at section "global", variable "node-tags"
      can't store data at section "global", variable "node-tags"
      can't store data at section "global", variable "subnetwork-name"
      
      [06:30:59] INFO> Exit Status: 1
      | f | pv-rwo.yaml |
    And the step should succeed                                                                                              # features/step_definitions/common.rb:4
      the step failed (RuntimeError)
      /home/lxia/github.com/verification-tests/features/step_definitions/common.rb:6:in `/^the step should( not)? (succeed|fail)$/'
      features/cli/policy.feature:279:in `And the step should succeed'
```

@chao007 @duanwei33 