### PR TITLE
[Blocker] Replace obsoleted oadm_manage_node with oadm_cordon/uncordon_node

### DIFF
--- a/features/admin/pod.feature
+++ b/features/admin/pod.feature
@@ -69,14 +69,12 @@ Feature: pod related features
     And the pod named "pod-pull-by-tag" status becomes :running
     Given I register clean-up steps:
     """
-    I run the :oadm_manage_node admin command with:
-      | node_name   | <%= cb.pod_node %> |
-      | schedulable | true               |
+    I run the :oadm_uncordon_node admin command with:
+      | node_name | <%= cb.pod_node %> |
     the step should succeed
     """
-    When I run the :oadm_manage_node admin command with:
-      | node_name   | <%= cb.pod_node %> |
-      | schedulable | false              |
+    When I run the :oadm_cordon_node admin command with:
+      | node_name | <%= cb.pod_node %> |
     Then the step should succeed
     When I execute on the pod:
       | bash |
@@ -113,14 +111,12 @@ Feature: pod related features
     Given I store the schedulable nodes in the :nodes clipboard
     Given I register clean-up steps:
     """
-    I run the :oadm_manage_node admin command with:
-      | node_name   | noescape: <%= cb.nodes.map(&:name).join(" ") %> |
-      | schedulable | true                                                           |
+    I run the :oadm_uncordon_node admin command with:
+      | node_name | noescape: <%= cb.nodes.map(&:name).join(" ") %> |
     the step should succeed
     """
-    When I run the :oadm_manage_node admin command with:
-      | node_name   | noescape: <%= cb.nodes.map(&:name).join(" ") %> |
-      | schedulable | false                                                                                                 |
+    When I run the :oadm_cordon_node admin command with:
+      | node_name | noescape: <%= cb.nodes.map(&:name).join(" ") %> |
     Then the step should succeed
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift/origin/master/examples/hello-openshift/hello-pod.json |
@@ -152,23 +148,20 @@ Feature: pod related features
     Given I store the schedulable nodes in the :nodes clipboard
     Given I register clean-up steps:
     """
-    I run the :oadm_manage_node admin command with:
-      | node_name   | <%= cb.nodes[0].name %> |
-      | schedulable | true                    |
+    I run the :oadm_uncordon_node admin command with:
+      | node_name | <%= cb.nodes[0].name %> |
     the step should succeed
     """
-    When I run the :oadm_manage_node admin command with:
-      | node_name   | <%= cb.nodes[0].name %> |
-      | schedulable | false                   |
+    When I run the :oadm_cordon_node admin command with:
+      | node_name | <%= cb.nodes[0].name %> |
     Then the step should succeed
     Given label "os=fedora" is added to the "<%= cb.nodes[0].name %>" node
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/pod-with-nodeselector.yaml |
     Then the step should succeed
     And the pod named "hello-pod" status becomes :pending
-    When I run the :oadm_manage_node admin command with:
-      | node_name   | <%= cb.nodes[0].name %> |
-      | schedulable | true                    |
+    When I run the :oadm_uncordon_node admin command with:
+      | node_name | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "hello-pod" status becomes :running
 
@@ -210,14 +203,12 @@ Feature: pod related features
     Given I store the schedulable nodes in the :nodes clipboard
     Given I register clean-up steps:
     """
-    I run the :oadm_manage_node admin command with:
-      | node_name   | <%= cb.nodes[0].name %> |
-      | schedulable | true                    |
+    I run the :oadm_uncordon_node admin command with:
+      | node_name | <%= cb.nodes[0].name %> |
     the step should succeed
     """
-    When I run the :oadm_manage_node admin command with:
-      | node_name   | <%= cb.nodes[0].name %> |
-      | schedulable | false                   |
+    When I run the :oadm_cordon_node admin command with:
+      | node_name | <%= cb.nodes[0].name %> |
     Then the step should succeed
     Given cluster role "cluster-admin" is added to the "first" user
     When I run the :create client command with:

--- a/features/step_definitions/node.rb
+++ b/features/step_definitions/node.rb
@@ -504,8 +504,12 @@ Given /^node schedulable status should be restored after scenario$/ do
   _admin = admin
   teardown_add {
     _org_schedulable.each do |node, schedulable|
-      opts = { :node_name =>  node.name, :schedulable => schedulable  }
-      _admin.cli_exec(:oadm_manage_node, opts)
+      opts = { :node_name =>  node.name }
+      if schedulable
+        _admin.cli_exec(:oadm_uncordon_node, opts)
+      else
+        _admin.cli_exec(:oadm_cordon_node, opts)
+      end
     end
   }
 end

--- a/lib/rules/cli/4.0.yaml
+++ b/lib/rules/cli/4.0.yaml
@@ -1176,15 +1176,6 @@
   :cmd: oc adm cordon <node_name>
 :oadm_uncordon_node:
   :cmd: oc adm uncordon <node_name>
-:oadm_manage_node_evacuate:
-  :cmd: oc adm manage-node
-  :options:
-    :dry_run: --dry-run=<value>
-    :evacuate: --evacuate=<value>
-    :list_pods: --list-pods=<value>
-    :node_name: <value>
-    :pod_selector: --pod-selector=<value>
-    :selector: --selector=<value>
 :oadm_new_project:
   :cmd: oc adm new-project <project_name>
   #:expected:


### PR DESCRIPTION
Tested with features/admin/pod.feature:58 on a 4.2 Azure cluster, and the scenario itself failed, but cordon node in the step and uncordon node in the clean-up are working fine.

@chengzhang1016 Help review the changes for pod.feature, @zhaozhanqi for node.rb

@akostadinov @pruan-rht 