### PR TITLE
change default IDP to the last one

### DIFF
--- a/lib/rules/web/console/base/login.xyaml
+++ b/lib/rules/web/console/base/login.xyaml
@@ -17,7 +17,7 @@ login_sequence:
         # when idp is specified we use the correct IDP
         # otherwise we always use the first one
         # a hacking way to cover our requirements
-        xpath: //a[contains(@class, 'idp<idp>') or contains(@class, 'login-redhat<idp>') or text()='<idp>'][1]
+        xpath: //a[contains(@class, 'idp<idp>') or contains(@class, 'login-redhat<idp>') or text()='<idp>'][last()]
       timeout: 1
   action:
     ref: login_console


### PR DESCRIPTION
@akostadinov  When defaulting IDP to the first one, it's always `kube:admin` and always failed (Found in CI).  So updated to use the last one, also the changes applies to our CI (which the only and last option is `flexy-htpasswd-provider`)