### PR TITLE
More waiting time in case slow env as CI flaky failure hits

### DIFF
--- a/features/step_definitions/meta_steps.rb
+++ b/features/step_definitions/meta_steps.rb
@@ -37,7 +37,7 @@ Given /^I wait(?: up to #{NUMBER} seconds)? for the steps to pass:$/ do |seconds
       steps_string = steps_string.raw.flatten.join("\n")
     end
     logger.dedup_start
-    seconds = Integer(seconds) rescue 60
+    seconds = Integer(seconds) rescue 180
     # repetitions = 0
     error = nil
     success = wait_for(seconds) {


### PR DESCRIPTION
Why fix: https://url.corp.redhat.com/qe-ci-tracker-slow-env-flaky-failure (RH internal)
@yapei @akostadinov please review/merge, thanks!