### PR TITLE
Simplify machine steps

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -29,55 +29,21 @@ Feature: Machine features testing
   @destructive
   Scenario: Scale up and scale down a machineSet
     Given I have an IPI deployment
-    And I store all machinesets to the :machinesets clipboard
+    And I pick a random machineset to scale
+    And evaluation of `machine_set.available_replicas` is stored in the :replicas_to_restore clipboard
 
-    Given evaluation of `machine_set.desired_replicas` is stored in the :replicas_original clipboard
-    And evaluation of `machine_set.desired_replicas.to_i + 1` is stored in the :replicas_expected clipboard
-    And I store the number of machines in the :num_machines_original clipboard
-
-    # scale up
-    When I run the :scale admin command with:
-      | resource | machineset                  |
-      | name     | <%= machine_set.name %>     |
-      | replicas | <%= cb.replicas_expected %> |
-      | n        | openshift-machine-api       |
+    Given I scale the machineset to +2
+    And I register clean-up steps:
+    """
+    And I scale the machineset to <%= cb.replicas_to_restore %>
+    """
     Then the step should succeed
+    And the machineset should have expected number of running machines
 
-    # register clean-up just in case of failure
-    Given I register clean-up steps:
-    """
-    When I run the :scale admin command with:
-      | resource | machineset                  |
-      | name     | <%= machine_set.name %>     |
-      | replicas | <%= cb.replicas_original %> |
-      | n        | openshift-machine-api       |
+    When I scale the machineset to -1
     Then the step should succeed
-    """
+    And the machineset should have expected number of running machines
 
-    # num of machines should increase
-    And I wait for the steps to pass:
-    """
-    Given I store the number of machines in the :num_machines_current clipboard
-    Then the expression should be true> cb.num_machines_current.to_i == cb.num_machines_original.to_i + 1
-    """
-
-    Given I store the last provisioned machine in the :new_machine clipboard
-    And I wait for the node of machine named "<%= cb.new_machine %>" to appear
-
-    # new node should be ready
-    And admin waits for the "<%= cb.new_node %>" node to become ready up to 600 seconds
-
-    # scale down
-    And I run the :scale admin command with:
-      | resource | machineset                  |
-      | name     | <%= machine_set.name %>     |
-      | replicas | <%= cb.replicas_original %> |
-      | n        | openshift-machine-api       |
-    Then the step should succeed
-
-    # node should be deleted
-    Given I switch to cluster admin pseudo user
-    Then I wait for the resource "node" named "<%= cb.new_node %>" to disappear within 600 seconds
 
   # @author jhou@redhat.com
   # @case_id OCP-25652

--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -8,8 +8,8 @@ Given(/^I have an IPI deployment$/) do
   end
 
   machine_sets.each do | machine_set |
-    unless machine_set.healthy?
-      raise "Not an IPI deployment, abort test."
+    unless machine_set.ready?
+      raise "Not an IPI deployment or machineSet #{machine_set.name} not fully scaled, abort test."
     end
   end
 end

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -4,3 +4,46 @@ Given /^I store all machinesets to the#{OPT_SYM} clipboard$/ do |cb_name|
   cb_name ||= :machinesets
   cb[cb_name] = BushSlicer::MachineSet.list(user: admin, project: project("openshift-machine-api"))
 end
+
+Given(/^I pick a random machineset to scale$/) do
+  ensure_admin_tagged
+  machine_sets = BushSlicer::MachineSet.list(user: admin, project: project("openshift-machine-api"))
+  cache_resources *machine_sets.shuffle
+end
+
+When(/^I scale the machineset to ([\+\-]?)#{NUMBER}$/) do | op, num |
+  ensure_destructive_tagged
+
+  case op
+  when "-"
+    replicas = machine_set.available_replicas - num.to_i
+  when "+"
+    replicas = machine_set.available_replicas + num.to_i
+  when ""
+    replicas = num.to_i
+  else
+    raise "wrong operation #{op.inspect} supplied"
+  end
+
+  step %Q/I run the :scale admin command with:/, table(%{
+    | n        | openshift-machine-api   |
+    | resource | machineset              |
+    | name     | <%= machine_set.name %> |
+    | replicas | #{replicas.to_s}        |
+  })
+end
+
+Then(/^the machineset should have expected number of running machines$/) do
+  machine_set.wait_till_ready(admin, 600)
+
+  machines_all = BushSlicer::Machine.list(user: admin, project: project("openshift-machine-api"))
+  machines = machines_all.select { |m| m.machine_set_name == machine_set.name }
+
+  # Each node should be running
+  machines.each do | machine |
+    machine.get
+    unless node(machine.node_name).ready?[:success]
+      raise "Node #{machine.node_name} has not become ready."
+    end
+  end
+end

--- a/lib/openshift/machine.rb
+++ b/lib/openshift/machine.rb
@@ -15,5 +15,10 @@ module BushSlicer
       instance_state = raw_resource(user: user, cached: cached, quiet: quiet).dig('status','providerStatus','instanceState')
       instance_state == 'running'
     end
+
+    def machine_set_name(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached, quiet: quiet).
+        dig('metadata', 'labels', 'machine.openshift.io/cluster-api-machineset')
+    end
   end
 end

--- a/lib/openshift/machine_set.rb
+++ b/lib/openshift/machine_set.rb
@@ -7,16 +7,19 @@ module BushSlicer
 
     def desired_replicas(user: nil, cached: true, quiet: false)
       rr = raw_resource(user: user, cached: cached, quiet: quiet)
-      rr.dig('spec', 'replicas')
+      rr.dig('spec', 'replicas').to_i
     end
 
-    def current_replicas(user: nil, cached: true, quiet: false)
+    def available_replicas(user: nil, cached: true, quiet: false)
       rr = raw_resource(user: user, cached: cached, quiet: quiet)
-      rr.dig('status', 'replicas')
+      rr.dig('status', 'availableReplicas').to_i
     end
 
-    def healthy?
-      return desired_replicas == current_replicas
+    def ready?(user: nil, cached: false, quiet: false)
+      result = {}
+      result[:success] = (desired_replicas(user: user, cached: cached, quiet: quiet) ==
+        available_replicas(user: user, cached: cached, quiet: quiet))
+      return result
     end
   end
 end


### PR DESCRIPTION
As a follow up of discussion at https://github.com/openshift/verification-tests/pull/423#discussion_r340892440, simplified the steps for scaling machinesets. The test is now more efficient by reducing the steps.