### PR TITLE
Ensure secret prometheus-k8s-token-xxx is returned

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -85,7 +85,7 @@ Feature: Machine features testing
   Scenario: MAO metrics is exposed on https
     Given I switch to cluster admin pseudo user
     And I use the "openshift-monitoring" project
-    And evaluation of `secret(service_account('prometheus-k8s').get_secret_names.first).token` is stored in the :token clipboard
+    And evaluation of `secret(service_account('prometheus-k8s').get_secret_names.find {|s| s.match('token')}).token` is stored in the :token clipboard
 
     When I run the :exec admin command with:
       | n                | openshift-monitoring                                                                                                         |


### PR DESCRIPTION
Occasionally, the following line returns secret `prometheus-k8s-dockercfg-g7488` where we want the secret to be `prometheus-k8s-token-*`. This PR fixes the test flake.
```
And evaluation of `secret(service_account('prometheus-k8s').get_secret_names.first).token` is stored in the :token clipboard # features/step_definitions/common.rb:128
     [22:12:26] INFO> Shell Commands: oc get secrets prometheus-k8s-dockercfg-g7488 --output=yaml --config=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig --namespace=openshift-monitoring
```

I've run the test and it had passed
```
      [10:02:26] INFO> === After Scenario: MAO metrics is exposed on https ===
      [10:02:26] INFO> Shell Commands: rm -r -f -- /Users/houjianwei/workdir/jhouMacBookPro-houjianwei

      [10:02:26] INFO> Exit Status: 0
      [10:02:26] INFO> === End After Scenario: MAO metrics is exposed on https ===

1 scenario (1 passed)
5 steps (5 passed)
```