### PR TITLE
private cluster proxy support

### DIFF
--- a/features/step_definitions/logging_metrics.rb
+++ b/features/step_definitions/logging_metrics.rb
@@ -107,6 +107,7 @@ When /^I perform the (GET|POST) metrics rest request with:$/ do | op_type, table
   bearer_token = opts[:token] ? opts[:token] : user.cached_tokens.first
 
   https_opts = {}
+  https_opts[:proxy] = env.client_proxy if env.client_proxy
   https_opts[:headers] ||= {}
   https_opts[:headers][:accept] ||= "application/json"
   https_opts[:headers][:content_type] ||= "application/json"

--- a/features/step_definitions/metering.rb
+++ b/features/step_definitions/metering.rb
@@ -325,6 +325,7 @@ When /^I perform the GET metering rest request with:$/ do | table |
   https_opts[:headers][:accept] ||= "application/json"
   https_opts[:headers][:content_type] ||= "application/json"
   https_opts[:headers][:authorization] ||= "Bearer #{bearer_token}"
+  https_opts[:proxy] = env.client_proxy if env.client_proxy
   # first we need to expose reporting API route if not route is found
   step %Q/I enable route for metering service/ unless route('metering').exists?
   report_name = opts[:report_name]

--- a/features/step_definitions/net.rb
+++ b/features/step_definitions/net.rb
@@ -56,14 +56,16 @@ When /^I open( secure)? web server via the(?: "(.+?)")? route$/ do |secure, rout
 end
 
 When /^I open web server via the(?: "(.+?)")? url$/ do |url|
-  @result = BushSlicer::Http.get(url: url, cookies: cb.http_cookies)
+  proxy_opt = {}
+  proxy_opt[:proxy] = env.client_proxy if env.client_proxy
+
+  @result = BushSlicer::Http.get(url: url, cookies: cb.http_cookies, **proxy_opt)
 end
 
 Given /^I download a file from "(.+?)"(?: into the "(.+?)" dir)?$/ do |url, dl_path|
   retries = 3
-  @result = BushSlicer::Http.get(url: url, cookies: cb.http_cookies)
-  # force failure
   while true
+    @result = BushSlicer::Http.get(url: url, cookies: cb.http_cookies)
     if @result[:success]
       if dl_path
         file_name = File.join(dl_path, File.basename(URI.parse(url).path))
@@ -77,7 +79,7 @@ Given /^I download a file from "(.+?)"(?: into the "(.+?)" dir)?$/ do |url, dl_p
       @result[:abs_path] = File.absolute_path(file_name)
       break
     elsif @result[:exitstatus] >= 500 && retries > 0
-      @result = BushSlicer::Http.get(url: url, cookies: cb.http_cookies)
+      # we will wait for retry
     else
       raise "Failed to download file from #{url} with HTTP status #{@result[:exitstatus]}"
     end
@@ -120,6 +122,7 @@ end
 #   """
 When /^I perform the HTTP request:$/ do |yaml_request|
   opts = YAML.load yaml_request
+  opts[:proxy] ||= env.client_proxy if env.client_proxy
   if Symbol == opts[:cookies]
     opts[:cookies] = cb[opts[:cookies]]
   end
@@ -140,6 +143,8 @@ When /^I perform (\d+) HTTP requests with concurrency (\d+):$/ do |num, concurre
   opts = YAML.load yaml_request
   opts[:count] = num.to_i
   opts[:concurrency] = concurrency.to_i
+  opts[:proxy] ||= env.client_proxy if env.client_proxy
+
   @result = BushSlicer::Http.flood_count(**opts)
 end
 

--- a/features/step_definitions/web.rb
+++ b/features/step_definitions/web.rb
@@ -77,6 +77,9 @@ Given /^I have a browser with:$/ do |table|
   if conf[:browser]
     init_params[:browser_type] ||= conf[:browser].to_sym
   end
+  if env.client_proxy
+    init_params[:http_proxy] ||= env.client_proxy
+  end
   init_params[:logger] = logger
   browser = Web4Cucumber.new(**init_params)
   cache_browser(browser)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,7 +14,6 @@ require 'common' # common code
 require 'world' # our custom bushslicer world
 require 'log' # BushSlicer::Logger
 require 'manager' # our shared global state
-require 'environment' # environment types classes
 require 'debug'
 
 ## default course of action would be to update BushSlicer files when

--- a/lib/bushslicer.rb
+++ b/lib/bushslicer.rb
@@ -25,6 +25,8 @@ module BushSlicer
   autoload :Platform, "platform/autoload"
   autoload :IAAS, "iaas/iaas"
   autoload :ResultHash, "result_hash"
+  autoload :Environment, "environment"
+  autoload :StaticEnvironment, "environment"
 
   autoload :RESOURCES, "resources"
   autoload :DockerImage, "openshift/flakes/docker_image"

--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -289,7 +289,9 @@ module BushSlicer
 
       # TODO: we may consider obtaining server CA chain and configuring it in
       #   instead of setting insecure SSL
-      config_setup(user: user, executor: executor, opts: {config: user_config, skip_tls_verify: "true"})
+      opts = {config: user_config, skip_tls_verify: "true"}
+      add_proxy_env_opt(user.env, opts)
+      config_setup(user: user, executor: executor, opts: opts)
 
       # success, set opts early to allow caching token
       logged_users[user.id] = {config: user_config}
@@ -302,6 +304,7 @@ module BushSlicer
         user_opts(user)
       end
 
+      add_proxy_env_opt(user.env, opts)
       cli_tool = tool_from_opts!(opts)
       executor(cli_tool: cli_tool).
         run(key, Common::Rules.merge_opts(logged_users[user.id], opts))

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -15,7 +15,7 @@ module BushSlicer
   class Environment
     include Common::Helper
 
-    attr_reader :opts
+    attr_reader :opts, :client_proxy
 
     # :master represents register, scheduler, etc.
     MANDATORY_OPENSHIFT_ROLES = []
@@ -435,19 +435,9 @@ module BushSlicer
     #  grep HTTP_PROXY /etc/origin/master/master-config.yaml
     #
     def proxy
-      if version_le("3.9", user: admin)
-        proxy_check_cmd = "cat /etc/sysconfig/atomic-openshift-master-api | grep HTTP_PROXY"
-      else
-        proxy_check_cmd = "cat /etc/origin/master/master.env | grep HTTP_PROXY"
-      end
-      @result = master_hosts.first.exec(proxy_check_cmd)
-      if @result[:success]
-        return @result[:response].split('HTTP_PROXY=')[1].strip
-      else
-        return nil
-      end
+      # TODO: return value from https://docs.openshift.com/container-platform/4.2/networking/enable-cluster-wide-proxy.html#nw-proxy-configure-object_config-cluster-wide-proxy
+      raise "not implemented"
     end
-
   end
 
   # a quickly made up environment class for the PoC
@@ -469,10 +459,22 @@ module BushSlicer
             missing_roles.to_s
         end
 
-        # so far masters are always also nodes but labels not always set
         hlist.each do |host|
+          # so far masters are always also nodes but labels not always set
           if host.roles.include?(:master) && !host.roles.include?(:node)
             host.roles << :node
+          end
+
+          # handle client proxy
+          proxy_spec = host.roles.find { |r| r.to_s.start_with? "proxy__" }
+          if proxy_spec
+            _role, proto, port, username, password = proxy_spec.to_s.split("__")
+            if username
+              auth_str = "#{username}:#{password}@"
+            else
+              auth_str = ""
+            end
+            @client_proxy = "#{proto}://#{auth_str}#{host.hostname}:#{port}"
           end
         end
 
@@ -481,6 +483,11 @@ module BushSlicer
         @hosts.concat hlist
       end
       return @hosts
+    end
+
+    def client_proxy
+      hosts
+      return @client_proxy
     end
 
     # add a new host to environment with defaults

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'json'
 
 require 'cli_executor'
@@ -470,7 +471,7 @@ module BushSlicer
           if proxy_spec
             _role, proto, port, username, password = proxy_spec.to_s.split("__")
             if username
-              auth_str = "#{username}:#{password}@"
+              auth_str = "#{username}:#{Base64.decode64 password}@"
             else
               auth_str = ""
             end

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -72,7 +72,10 @@ module BushSlicer
       rc_opts[:open_timeout] = open_timeout
 
       # RestClient.proxy = proxy if proxy && ! proxy.empty?
-      rc_opts[:proxy] = proxy if proxy && ! proxy.empty?
+      if proxy && ! proxy.empty?
+        proxy = "http://#{proxy}" unless proxy.include?("://")
+        rc_opts[:proxy] = proxy
+      end
 
       userstr = user ? "#{user}@" : ""
       result ||= {}

--- a/lib/openshift/route.rb
+++ b/lib/openshift/route.rb
@@ -30,8 +30,8 @@ module BushSlicer
 
     def http_get(by:, proto: "http", port: nil, **http_opts)
       portstr = port ? ":#{port}" : ""
-      BushSlicer::Http.get(url: proto + "://" + dns(by: by) + portstr,
-                          **http_opts)
+      http_opts[:proxy] ||= env.client_proxy if env.client_proxy
+      BushSlicer::Http.get(url: proto + "://" + dns(by: by) + portstr, **http_opts)
     end
 
     def wait_http_accessible(by:, proto: "http", port: nil,

--- a/lib/platform/master_service.rb
+++ b/lib/platform/master_service.rb
@@ -35,8 +35,10 @@ module BushSlicer
 
       private def wait_start(**opts)
         res = {}
+        proxy_opt = {}
+        proxy_opt[:proxy] = env.client_proxy if env.client_proxy
         success = wait_for(expected_load_time, interval: 5) {
-          (res = Http.get(url: api_url))[:success]
+          (res = Http.get(url: api_url, **proxy_opt))[:success]
         }
         if opts[:raise] && !success
           raise "API did not start responding on #{host.hostname}"

--- a/lib/rest.rb
+++ b/lib/rest.rb
@@ -42,6 +42,8 @@ module BushSlicer
         opts[:headers]["Accept"] = "<accept>"
         opts[:headers]["Content-Type"] = "<content_type>"
 
+        opts[:proxy] = user.env.client_proxy if user.env.client_proxy
+
         auth ||= user.rest_preferences[:auth]
         auth ||= user.known_cert? ? :client_cert : :bearer_token
 

--- a/lib/rules/cli/4.0.yaml
+++ b/lib/rules/cli/4.0.yaml
@@ -1017,9 +1017,10 @@
   :expected:
     - Client Version
   :properties:
-    :oc_version: !ruby/regexp '/^Client.*GitVersion:"v(.+?)"/'
+    :oc_version: !ruby/regexp '/^Client(?:.*Git| )Version:[" ]v(.+?)["\s]/'
   :optional_properties:
-    :kubernetes_server_version: !ruby/regexp '/^Server.*GitVersion:"v(.+?)"/'
+    :server_version: !ruby/regexp '/^Server Version: (.+?)\s/'
+    :kubernetes_server_version: !ruby/regexp '/^Kubernetes(?:.*Git| )Version:[" ]v(.+?)["\s]/'
 :wait:
   :cmd: oc wait
   :options:

--- a/lib/webauto/chrome_extension.rb
+++ b/lib/webauto/chrome_extension.rb
@@ -1,0 +1,109 @@
+require 'erb'
+require 'find'
+require 'openssl'
+require 'zip'
+
+require_relative 'resource/chrome_crx3/crx3.pb.rb'
+
+class ChromeExtension
+  def self.gen_rsa_key(len=2048)
+    OpenSSL::PKey::RSA.generate(len)
+  end
+
+  #  @note original crx2 format description https://web.archive.org/web/20180114090616/https://developer.chrome.com/extensions/crx
+  def self.header_v2_extension(data, key: nil)
+    key ||= gen_rsa_key()
+    digest = OpenSSL::Digest.new('sha1')
+    header = String.new(encoding: "ASCII-8BIT")
+
+    # it is exactly same signature as `ssh_do_sign(data)` from net/ssh does
+    signature = key.sign(digest, data)
+    signature_length = signature.length
+    pubkey_length = key.public_key.to_der.length
+
+    header << "Cr24"
+    header << [ 2 ].pack("V") # version
+    header << [ pubkey_length ].pack("V")
+    header << [ signature_length ].pack("V")
+    header << key.public_key.to_der
+    header << signature
+
+    return header
+  end
+
+  #  @note file format spec pointers:
+  #    https://groups.google.com/a/chromium.org/d/msgid/chromium-extensions/977b9b99-2bb9-476b-992f-97a3e37bf20c%40chromium.org
+  def self.header_v3_extension(data, key: nil)
+    key ||= gen_rsa_key()
+
+    digest = OpenSSL::Digest.new('sha256')
+    signed_data = Crx_file::SignedData.new
+    signed_data.crx_id = digest.digest(key.public_key.to_der)[0...16]
+    signed_data = signed_data.encode
+
+    signature_data = String.new(encoding: "ASCII-8BIT")
+    signature_data << "CRX3 SignedData\00"
+    signature_data << [ signed_data.size ].pack("V")
+    signature_data << signed_data
+
+    signature = key.sign(digest, signature_data)
+
+    proof = Crx_file::AsymmetricKeyProof.new
+    proof.public_key = key.public_key.to_der
+    proof.signature = signature
+
+    header_struct = Crx_file::CrxFileHeader.new
+    header_struct.sha256_with_rsa = [proof]
+    header_struct.signed_header_data = signed_data
+    header_struct = header_struct.encode
+
+    header = String.new(encoding: "ASCII-8BIT")
+    header << "Cr24"
+    header << [ 3 ].pack("V") # version
+    header << [ header_struct.size ].pack("V")
+    header << header_struct
+
+    return header
+  end
+
+  # @param file [String] to write result to
+  # @param dir [String] to read extension from
+  # @param key [OpenSSL::PKey]
+  # @param crxv [String] version of CRX file to create
+  # @param erb_binding [Binding] optional if you want to process ERB files
+  # @return undefined
+  def self.pack_extension (file:, dir:, key: nil, crxv: "v3", erb_binding: nil)
+    zip = zip(dir: dir, erb_binding: erb_binding)
+
+    File.open(file, 'wb') do |io|
+      io.write self.send(:"header_#{crxv}_extension", zip, key: key)
+      io.write zip
+    end
+  end
+
+  # @param dir [String] to read extension from
+  # @param erb_binding [Binding] optional if you want to process ERB files
+  # @return [String] the zip file content
+  def self.zip(dir:, erb_binding: nil)
+    dir_prefix_len = dir.end_with?("/") ? dir.length : dir.length + 1
+    zip = StringIO.new
+    zip.set_encoding "ASCII-8BIT"
+    Zip::OutputStream::write_buffer(zip) do |zio|
+      Find.find(dir) do |file|
+        if File.file? file
+          if erb_binding && file.end_with?(".erb")
+            zio.put_next_entry(file[dir_prefix_len...-4])
+            erb = ERB.new(File.read file)
+            erb.location = file
+            zio.write(erb.result(erb_binding))
+            Kernel.puts erb.result(erb_binding)
+          else
+            zio.put_next_entry(file[dir_prefix_len..-1])
+            zio.write(File.read(file))
+          end
+        end
+      end
+    end
+    return zip.string
+  end
+end

--- a/lib/webauto/resource/chrome_crx3/README
+++ b/lib/webauto/resource/chrome_crx3/README
@@ -1,0 +1,9 @@
+* Generated pb file is with command:
+
+ protoc --plugin=protoc-gen-ruby-protobuf=`ls ~/bin/protoc-gen-ruby` --ruby-protobuf_out=./ lib/webauto/resource/chrome_crx3/crx3.proto
+
+* gem used https://github.com/ruby-protobuf/protobuf
+
+* proto file from:
+
+ https://cs.chromium.org/chromium/src/components/crx_file/crx3.proto

--- a/lib/webauto/resource/chrome_crx3/crx3.pb.rb
+++ b/lib/webauto/resource/chrome_crx3/crx3.pb.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+module Crx_file
+  ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+  ##
+  # Message Classes
+  #
+  class CrxFileHeader < ::Protobuf::Message; end
+  class AsymmetricKeyProof < ::Protobuf::Message; end
+  class SignedData < ::Protobuf::Message; end
+
+
+  ##
+  # File Options
+  #
+  set_option :optimize_for, ::Google::Protobuf::FileOptions::OptimizeMode::LITE_RUNTIME
+
+
+  ##
+  # Message Fields
+  #
+  class CrxFileHeader
+    repeated ::Crx_file::AsymmetricKeyProof, :sha256_with_rsa, 2
+    repeated ::Crx_file::AsymmetricKeyProof, :sha256_with_ecdsa, 3
+    optional :bytes, :signed_header_data, 10000
+  end
+
+  class AsymmetricKeyProof
+    optional :bytes, :public_key, 1
+    optional :bytes, :signature, 2
+  end
+
+  class SignedData
+    optional :bytes, :crx_id, 1
+  end
+
+end
+

--- a/lib/webauto/resource/chrome_crx3/crx3.proto
+++ b/lib/webauto/resource/chrome_crx3/crx3.proto
@@ -1,0 +1,56 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file
+
+syntax = "proto2";
+
+option optimize_for = LITE_RUNTIME;
+
+package crx_file;
+
+// A CRX₃ file is a binary file of the following format:
+// [4 octets]: "Cr24", a magic number.
+// [4 octets]: The version of the *.crx file format used (currently 3).
+// [4 octets]: N, little-endian, the length of the header section.
+// [N octets]: The header (the binary encoding of a CrxFileHeader).
+// [M octets]: The ZIP archive.
+// Clients should reject CRX₃ files that contain an N that is too large for the
+// client to safely handle in memory.
+
+message CrxFileHeader {
+  // PSS signature with RSA public key. The public key is formatted as a
+  // X.509 SubjectPublicKeyInfo block, as in CRX₂. In the common case of a
+  // developer key proof, the first 128 bits of the SHA-256 hash of the
+  // public key must equal the crx_id.
+  repeated AsymmetricKeyProof sha256_with_rsa = 2;
+
+  // ECDSA signature, using the NIST P-256 curve. Public key appears in
+  // named-curve format.
+  // The pinned algorithm will be this, at least on 2017-01-01.
+  repeated AsymmetricKeyProof sha256_with_ecdsa = 3;
+
+  // The binary form of a SignedData message. We do not use a nested
+  // SignedData message, as handlers of this message must verify the proofs
+  // on exactly these bytes, so it is convenient to parse in two steps.
+  //
+  // All proofs in this CrxFile message are on the value
+  // "CRX3 SignedData\x00" + signed_header_size + signed_header_data +
+  // archive, where "\x00" indicates an octet with value 0, "CRX3 SignedData"
+  // is encoded using UTF-8, signed_header_size is the size in octets of the
+  // contents of this field and is encoded using 4 octets in little-endian
+  // order, signed_header_data is exactly the content of this field, and
+  // archive is the remaining contents of the file following the header.
+  optional bytes signed_header_data = 10000;
+}
+
+message AsymmetricKeyProof {
+  optional bytes public_key = 1;
+  optional bytes signature = 2;
+}
+
+message SignedData {
+  // This is simple binary, not UTF-8 encoded mpdecimal; i.e. it is exactly
+  // 16 bytes long.
+  optional bytes crx_id = 1;
+}
+

--- a/lib/webauto/resource/chrome_proxy/background.js.erb
+++ b/lib/webauto/resource/chrome_proxy/background.js.erb
@@ -1,0 +1,28 @@
+var config = {
+  mode: "fixed_servers",
+  rules: {
+    singleProxy: {
+      scheme: "<%= proxy_proto %>",
+      host: "<%= proxy_host %>",
+      port: parseInt(<%= proxy_port %>)
+    },
+    bypassList: <%= proxy_bypass.split(/[ ,]/).delete_if(&:empty?).to_json %>
+  }
+};
+
+chrome.proxy.settings.set({value: config, scope: "regular"}, function() {});
+
+function callbackFn(details) {
+  return {
+    authCredentials: {
+      username: "<%= proxy_user %>",
+      password: "<%= proxy_pass %>"
+    }
+  };
+}
+
+chrome.webRequest.onAuthRequired.addListener(
+  callbackFn,
+  {urls: ["<all_urls>"]},
+  ['blocking']
+);

--- a/lib/webauto/resource/chrome_proxy/manifest.json
+++ b/lib/webauto/resource/chrome_proxy/manifest.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.0.1",
+    "manifest_version": 2,
+    "name": "Authenticated Proxy",
+    "permissions": [
+        "<all_urls>",
+        "proxy",
+        "unlimitedStorage",
+        "webRequest",
+        "webRequestBlocking",
+        "storage",
+        "tabs"
+    ],
+    "background": {
+        "scripts": ["background.js"]
+    },
+    "minimum_chrome_version":"23.0.0"
+}

--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -48,7 +48,8 @@ require "base64"
         browser: nil,
         scroll_strategy: nil,
         size: nil,
-        hooks: nil
+        hooks: nil,
+        http_proxy: nil
       )
       @browser_type = browser_type
       @rules = Web4Cucumber.load_rules [rules]
@@ -58,6 +59,7 @@ require "base64"
       @logger = logger
       @scroll_strategy = scroll_strategy
       @size = size
+      @http_proxy = http_proxy
       set_hooks(hooks)
     end
 
@@ -71,8 +73,9 @@ require "base64"
       chrome_caps = Selenium::WebDriver::Remote::Capabilities.chrome()
       safari_caps = Selenium::WebDriver::Remote::Capabilities.safari()
       chrome_switches = []
-      if ENV.has_key? "http_proxy"
-        proxy = ENV["http_proxy"].scan(/[\w\.\d\_\-]+\:\d+/)[0] # to get rid of the heading "http://" that breaks the profile
+      if ENV.has_key?("http_proxy") || @http_proxy
+        # get rid of the heading "http://" that breaks the profile
+        proxy = (@http_proxy || ENV["http_proxy"]).scan(/[\w\.\d\_\-]+\:\d+/)[0]
         firefox_profile.proxy = chrome_caps.proxy = safari_caps.proxy = Selenium::WebDriver::Proxy.new({:http => proxy, :ssl => proxy})
         firefox_profile['network.proxy.no_proxies_on'] = "localhost, 127.0.0.1"
         chrome_switches.concat %w[--proxy-bypass-list=127.0.0.1]

--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -4,6 +4,8 @@ require 'uri'
 require 'watir'
 require "base64"
 
+require_relative 'chrome_extension'
+
   class Web4Cucumber
     attr_reader :browser_type, :logger, :rules
     attr_accessor :base_url
@@ -75,11 +77,31 @@ require "base64"
       chrome_switches = []
       if ENV.has_key?("http_proxy") || @http_proxy
         # get rid of the heading "http://" that breaks the profile
-        proxy = (@http_proxy || ENV["http_proxy"]).scan(/[\w\.\d\_\-]+\:\d+/)[0]
-        firefox_profile.proxy = chrome_caps.proxy = safari_caps.proxy = Selenium::WebDriver::Proxy.new({:http => proxy, :ssl => proxy})
-        firefox_profile['network.proxy.no_proxies_on'] = "localhost, 127.0.0.1"
-        chrome_switches.concat %w[--proxy-bypass-list=127.0.0.1]
-        ENV['no_proxy'] = '127.0.0.1'
+        proxy_raw = @http_proxy || ENV["http_proxy"]
+        proxy = proxy_raw.sub(%r{^.+?://}, "")
+        proxy_bypass = "localhost,127.0.0.1"
+        firefox_profile.proxy = chrome_caps.proxy = safari_caps.proxy = Selenium::WebDriver::Proxy.new({:http => proxy.sub(%r{^.+?@}, ""), :ssl => proxy.sub(%r{^.+?@}, "")})
+        firefox_profile['network.proxy.no_proxies_on'] = proxy_bypass
+        chrome_switches << "--proxy-bypass-list=#{proxy_bypass}"
+        if proxy.include? "@"
+          # Generic solution for auth proxy support not available yet. Hope is:
+          #   https://github.com/w3c/webdriver/issues/385
+
+          # For firefox current status is that a custom profile with saved
+          #   password is needed and autologin setting
+          # firefox_profile["network.http.phishy-userpass-length"] = 255
+          # firefox_profile["signon.autologin.proxy"] = true
+
+          proxy_proto, proxy_user, proxy_pass, proxy_host, proxy_port =
+            proxy_raw.scan(%r{^(?:(.+?)://)?(.+?):(.+)@(.+?):([\d]+)$}).first
+          proxy_proto ||= "http"
+          proxy_chrome_ext_file = File.expand_path("chrome-proxy.crx")
+          ChromeExtension.pack_extension(
+            file: proxy_chrome_ext_file,
+            dir: File.dirname(__FILE__) + "/resource/chrome_proxy",
+            erb_binding: binding
+          )
+        end
       end
       client = Selenium::WebDriver::Remote::Http::Default.new
       client.open_timeout = 180
@@ -88,6 +110,7 @@ require "base64"
       # Selenium::WebDriver.logger.level = :debug
       if @browser_type == :firefox
         logger.info "Launching Firefox Marionette/Geckodriver"
+        raise "auth proxy not implemented for Firefox" if proxy_pass
         caps = Selenium::WebDriver::Remote::Capabilities.firefox accept_insecure_certs: true
         if Integer === @scroll_strategy
           caps[:element_scroll_behavior] = @scroll_strategy
@@ -115,9 +138,14 @@ require "base64"
         if self.class.container?
           chrome_switches.concat %w[--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-infobars]
         end
-        @browser = Watir::Browser.new :chrome, desired_capabilities: chrome_caps, switches: chrome_switches
+        # options = Selenium::WebDriver::Chrome::Options.new
+        # options.add_extension proxy_chrome_ext_file if proxy_chrome_ext_file
+        options = {}
+        options[:extensions] = [proxy_chrome_ext_file] if proxy_chrome_ext_file
+        @browser = Watir::Browser.new :chrome, desired_capabilities: chrome_caps, switches: chrome_switches, options: options
       elsif @browser_type == :safari
         logger.info "Launching Safari"
+        raise "auth proxy not implemented for Safari" if proxy_pass
         safari_caps[:accept_insecure_certs] = true
         if Integer === @scroll_strategy
           safari_caps[:element_scroll_behavior] = @scroll_strategy

--- a/lib/webauto/webconsole_executor.rb
+++ b/lib/webauto/webconsole_executor.rb
@@ -33,7 +33,8 @@ module BushSlicer
         base_url: env.web_console_url,
         browser_type: conf[:browser] ? conf[:browser].to_sym : :firefox,
         rules: RULES_DIR +  "base/", # will be updated after version is found
-        snippets_dir: SNIPPETS_DIR
+        snippets_dir: SNIPPETS_DIR,
+        http_proxy: env.client_proxy
       }
 
       logger.debug "initializing web console browser for user #{user.name}"

--- a/tools/shell_proxy.sh
+++ b/tools/shell_proxy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+## Source this file to setup proxy according to HOSTS spec
+
+proxy=`ruby -e '
+#!/usr/bin/env ruby
+$LOAD_PATH.unshift(File.expand_path "'$BASH_SOURCE'/../../lib")
+
+# STDERR.puts $LOAD_PATH
+
+require "common"
+manager = BushSlicer::Manager.instance
+puts manager.environments[manager.conf[:default_environment]].client_proxy
+'`
+
+echo Proxy server: "$proxy"
+
+if [[ "$proxy" ]]; then
+  export http_proxy="$proxy"
+  export https_proxy="$proxy"
+fi


### PR DESCRIPTION
/hold until complete and tested

Example scenario with private cluster using cli, REST and route access:
https://privatebin-it-iso.int.open.paas.redhat.com/?e8cc6f863af24aaf#YQbVi+LCNs0Rgfbjum+Uje7W+Ui7LnWmCTbY+cfKqWU=

Web scenarios seem to request password for proxy even though it is in uri already. But I don't see them working presently so we can leave that for later PR. If proxy does not require passowrd it is fine. This is *not* a regression.