### PR TITLE
Make sure storageClassName is a string

### DIFF
--- a/features/storage/pre-bind.feature
+++ b/features/storage/pre-bind.feature
@@ -122,15 +122,15 @@ Feature: Testing for pv and pvc pre-bind feature
       | ["metadata"]["name"]              | nfspv-<%= project.name %> |
       | ["spec"]["claimRef"]["namespace"] | <%= project.name %>       |
       | ["spec"]["claimRef"]["name"]      | nfsc2                     |
-      | ["spec"]["storageClassName"]      | <%= project.name %>       |
+      | ["spec"]["storageClassName"]      | sc-<%= project.name %>    |
     Then I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]                         | nfsc1               |
-      | ["spec"]["resources"]["requests"]["storage"] | 1Gi                 |
-      | ["spec"]["storageClassName"]                 | <%= project.name %> |
+      | ["metadata"]["name"]                         | nfsc1                  |
+      | ["spec"]["resources"]["requests"]["storage"] | 1Gi                    |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %> |
     Then I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
-      | ["metadata"]["name"]                         | nfsc2               |
-      | ["spec"]["resources"]["requests"]["storage"] | 1Gi                 |
-      | ["spec"]["storageClassName"]                 | <%= project.name %> |
+      | ["metadata"]["name"]                         | nfsc2                  |
+      | ["spec"]["resources"]["requests"]["storage"] | 1Gi                    |
+      | ["spec"]["storageClassName"]                 | sc-<%= project.name %> |
     And the "nfsc2" PVC becomes bound to the "nfspv-<%= project.name %>" PV
     And the "nfsc1" PVC becomes :pending
 


### PR DESCRIPTION
Once the project name is numeric, the creation of PV will fail due to type check failed.
```
23:44:11 INFO> Creating PV:
---
kind: PersistentVolume
apiVersion: v1
metadata:
  name: pv-10631
  annotations:
    volume.beta.kubernetes.io/storage-class: 10631
  labels:
    type: local
spec:
  capacity:
    storage: 5Gi
  accessModes:
  - ReadWriteOnce
  hostPath:
    path: "/tmp/data01"
  persistentVolumeReclaimPolicy: Retain

23:44:12 INFO> Shell Commands: oc create -f - --config=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig

STDERR:
Error from server (BadRequest): error when creating "STDIN": PersistentVolume in version "v1" cannot be handled as a PersistentVolume: v1.PersistentVolume.ObjectMeta: v1.ObjectMeta.Annotations: ReadString: expects " or n, but found 1, error found in #10 byte of ...|e-class":10631},"lab|..., bigger context ...|ions":{"volume.beta.kubernetes.io/storage-class":10631},"labels":{"type":"local"},"name":"pv-10631"}|...
23:44:12 INFO> Exit Status: 1
23:44:12 ERROR> 
STDERR:
Error from server (BadRequest): error when creating "STDIN": PersistentVolume in version "v1" cannot be handled as a PersistentVolume: v1.PersistentVolume.ObjectMeta: v1.ObjectMeta.Annotations: ReadString: expects " or n, but found 1, error found in #10 byte of ...|e-class":10631},"lab|..., bigger context ...|ions":{"volume.beta.kubernetes.io/storage-class":10631},"labels":{"type":"local"},"name":"pv-10631"}|...
```

@chao007 @duanwei33 