### PR TITLE
Bug fix for OCP-21814

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -143,8 +143,8 @@ Feature: Service related networking scenarios
     When I run the :get client command with:
       | resource      | pod                     |
     Then the step should succeed
-    And the output should contain 2 times:
-      | ImagePullBackOff |
+    And the output should match 2 times:
+      | (Err)?ImagePull(BackOff)?\\s+0 |
     """
 
     When I run the :get client command with:


### PR DESCRIPTION
Some times the pod with an invalid image is not in `ImagePullBackOff` status, maybe in `ErrImagePull` status too.
So I updated the test scripts to involve this situation.

The test log is: https://privatebin-it-iso.int.open.paas.redhat.com/?82dcf601db52f206#TVnG/4SXlgXIK5fuTiD+q61F/LCKBS822M1TI8nfrWY=

@zhaozhanqi @huiran0826 Please help reveiw.