### PR TITLE
Uncordon node so pods are schedulable

### DIFF
--- a/features/storage/node_operations.feature
+++ b/features/storage/node_operations.feature
@@ -25,6 +25,9 @@ Feature: Node operations test scenarios
     # Verify old pod is deleted
     And I wait for the resource "pod" named "<%= pod.name %>" to disappear
 
+    When I run the :oadm_uncordon_node admin command with:
+      | node_name | <%= pod.node_name %> |
+    Then the step should succeed
     # After draining, new Pod becomes available
     And a pod becomes ready with labels:
       | name=jenkins |


### PR DESCRIPTION
In 4.x cluster, generally there are 3 nodes in 3 zones. When we drain node (node in zone1 with persistent volume in zone1 ), those pods are not schedulable as there are no available node in zone1.
This PR uncordon the node so that pods are back after drain-node.

@chao007 @duanwei33 