### PR TITLE
Add machine-healthcheck scenarios

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -16,14 +16,7 @@ Feature: MachineHealthCheck Test Scenarios
       | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]    | <%= machine_set.cluster %>  |
       | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"] | <%= machine_set.name %>     |
     Then the step should succeed
-    Given I register clean-up steps:
-    """
-    When I run the :delete admin command with:
-      | n                 | openshift-machine-api       |
-      | object_type       | machinehealthcheck          |
-      | object_name_or_id | mhc-<%= machine_set.name %> |
-    Then the step should succeed
-    """
+    And I ensure "mhc-<%= machine_set.name %>" machinehealthcheck is deleted after scenario
 
     # Create unhealthyCondition to trigger machine remediation
     When I create the 'Ready' unhealthyCondition

--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -1,0 +1,30 @@
+Feature: MachineHealthCheck Test Scenarios
+
+  # @author jhou@redhat.com
+  # @case_id OCP-25897
+  @admin
+  @destructive
+  Scenario: Remediation should be applied when the unhealthyCondition 'Ready' is met
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+
+    Given I pick a random machineset to scale
+    # Create MHC
+    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cloud/mhc/mhc1.yaml" replacing paths:
+      | n                                                                                  | openshift-machine-api       |
+      | ["metadata"]["name"]                                                               | mhc-<%= machine_set.name %> |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]    | <%= machine_set.cluster %>  |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"] | <%= machine_set.name %>     |
+    Then the step should succeed
+    Given I register clean-up steps:
+    """
+    When I run the :delete admin command with:
+      | n                 | openshift-machine-api       |
+      | object_type       | machinehealthcheck          |
+      | object_name_or_id | mhc-<%= machine_set.name %> |
+    Then the step should succeed
+    """
+
+    # Create unhealthyCondition to trigger machine remediation
+    When I create the 'Ready' unhealthyCondition
+    Then the machine should be remediated

--- a/features/step_definitions/machine_healthcheck.rb
+++ b/features/step_definitions/machine_healthcheck.rb
@@ -1,0 +1,34 @@
+When(/^I create the 'Ready' unhealthyCondition$/) do
+  ensure_destructive_tagged
+
+  # pick a random node from the machines
+  machines = BushSlicer::Machine.list(user: admin, project: project("openshift-machine-api")).
+    select { |m| m.machine_set_name == machine_set.name }
+  cache_resources *machines.shuffle
+
+  # somtimes PDB may prevent a successful node-drain thus blocks the test
+  # annnotate the machine to exclude node-drain so that test does not flake
+  step %Q{I run the :annotate client command with:}, table(%{
+    | n            | openshift-machine-api                       |
+    | resource     | machine                                     |
+    | resourcename | #{machine.name}                             |
+    | overwrite    | true                                        |
+    | keyval       | machine.openshift.io/exclude-node-draining= |
+  })
+
+  # create a priviledged pod that kills kubelet on its node
+  step %Q{I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cloud/mhc/kubelet-killer-pod.yml" replacing paths:}, table(%{
+    | n                    | openshift-machine-api |
+    | ["spec"]["nodeName"] | #{machine.node_name}  |
+  })
+  step %Q{the step should succeed}
+end
+
+Then(/^the machine should be remediated$/) do
+  # unhealthy machine and should be deleted
+  step %Q{I wait for the resource "node" named "<%= machine.node_name %>" to disappear within 600 seconds}
+  step %Q{I wait for the resource "machine" named "<%= machine.name %>" to disappear within 600 seconds}
+
+  # new machine and node should provisioned
+  step %Q{the machineset should have expected number of running machines}
+end

--- a/lib/openshift/machine_set.rb
+++ b/lib/openshift/machine_set.rb
@@ -21,5 +21,10 @@ module BushSlicer
         available_replicas(user: user, cached: cached, quiet: quiet))
       return result
     end
+
+    def cluster(user: nil, cached: true, quiet: false)
+      rr = raw_resource(user: user, cached: cached, quiet: quiet)
+      rr.dig('spec', 'selector', 'matchLabels', 'machine.openshift.io/cluster-api-cluster')
+    end
   end
 end

--- a/lib/openshift/machinehealthcheck.rb
+++ b/lib/openshift/machinehealthcheck.rb
@@ -1,0 +1,9 @@
+require 'openshift/cluster_resource'
+
+module BushSlicer
+  # represents MachineHealthCheck
+  class Machinehealthcheck < ProjectResource
+    RESOURCE = 'machinehealthcheck'
+  end
+end
+


### PR DESCRIPTION
The test verifies a machine is remediated when it has the unhealthyCondition defined in a mhc resource.