### PR TITLE
Add reviewers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,10 @@
 approvers:
 - akostadinov
 - pruan-rht
+reviewers:
+- akostadinov
+- pruan-rht
+- yapei
+- yanpzhan
+- liangxia
+- chao007


### PR DESCRIPTION
Hi, I'm from a team maintaining OpenShift Prow instance which is
configured to perform some actions on this repo. One of the actions
is automatically selecting two reviewers for a repo which are not
the PR authors. This means that for OWNERS files containing just two
logins we occasionally do not have enough reviewers to choose from.

Thus, adding `reviewers` to the `OWNERS` file from the people who
seem to be already reviewing PRs in this repo. This list only controls
the automated reviewer selection, it does not change any rights or
permissions to do anything.