### PR TITLE
Remove jenkins login steps from pipeline cases

### DIFF
--- a/features/build/buildconfig.feature
+++ b/features/build/buildconfig.feature
@@ -92,6 +92,8 @@ Feature: buildconfig.feature
     When I run the :new_app client command with:
      | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/templates/OCP-12057/application-template-stibuild_pull_private_sourceimage.json |
     Then the step should succeed
+    And the "ruby-sample-build-1" build was created
+    And the "ruby-sample-build-1" build completed
     Given a pod becomes ready with labels:
      | name=frontend |
     When I execute on the pod:

--- a/features/build/env.feature
+++ b/features/build/env.feature
@@ -8,6 +8,8 @@ Feature: env.feature
       | app_repo | ruby:latest~https://github.com/openshift/ruby-hello-world |
       | env      | DB_USER=test                                              |
     Then the step should succeed
+    And the "ruby-hello-world-1" build was created
+    Given the "ruby-hello-world-1" build completed
     Given a pod becomes ready with labels:
       |deployment=ruby-hello-world-1|
     When I run the :set_env client command with:
@@ -20,6 +22,8 @@ Feature: env.feature
       | app_repo | ruby:latest~https://github.com/openshift/ruby-hello-world |
       | env      | RACK_ENV=development                                      |
     Then the step should succeed
+    And the "ruby-hello-world-1" build was created
+    Given the "ruby-hello-world-1" build completed
     Given a pod becomes ready with labels:
       |deployment=ruby-hello-world-1|
     When I run the :set_env client command with:
@@ -36,6 +40,8 @@ Feature: env.feature
       | app_repo | ruby:2.5~https://github.com/openshift/ruby-hello-world |
       | env_file | test                                                   |
     Then the step should succeed
+    And the "ruby-hello-world-1" build was created
+    Given the "ruby-hello-world-1" build completed
     Given a pod becomes ready with labels:
       |deployment=ruby-hello-world-1|
     When I run the :set_env client command with:
@@ -52,6 +58,8 @@ Feature: env.feature
       | app_repo | ruby:2.5~https://github.com/openshift/ruby-hello-world |
       | env_file | test                                                   |
     Then the step should succeed
+    And the "ruby-hello-world-1" build was created
+    Given the "ruby-hello-world-1" build completed
     Given a pod becomes ready with labels:
       |deployment=ruby-hello-world-1|
     When I run the :set_env client command with:

--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -152,7 +152,7 @@ Feature: build 'apps' with CLI
     And I wait up to 120 seconds for the steps to pass:
     """
     When I execute on the pod:
-      | bash | -c | mysql  -h $MYSQL_SERVICE_HOST -u root -ptest -e "show databases" |
+      | bash | -c | mysql  -h $HOSTNAME -u root -ptest -e "show databases" |
     Then the step should succeed
     """
     And the output should contain "mysql"

--- a/features/images/jenkins.feature
+++ b/features/images/jenkins.feature
@@ -158,44 +158,12 @@ Feature: jenkins.feature
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift/origin/master/examples/jenkins/pipeline/maven-pipeline.yaml |
     Then the step should succeed
-    Given I have a jenkins browser
-    And I log in to jenkins
-    Given I update "maven" slave image for jenkins <version> server
     When I run the :start_build client command with:
       | buildconfig | openshift-jee-sample |
     Then the step should succeed
     Given a pod becomes ready with labels:
       | jenkins/maven=true |
     Given the "openshift-jee-sample-1" build completes
-    When I perform the :goto_jenkins_buildlog_page web action with:
-      | namespace|<%= project.name %>                      |
-      | job_name| <%= project.name %>-openshift-jee-sample |
-      | job_num | 1                                        |
-    Then the step should succeed
-    When I get the visible text on web html page
-    Then the output should contain:
-      | Building SampleApp 1.0 |
-      | BUILD SUCCESS          |
-    When I run the :patch client command with:
-      | resource      | bc                                                                                                                                       |
-      | resource_name | openshift-jee-sample                                                                                                                     |
-      | p             | {"spec" : {"strategy": {"jenkinsPipelineStrategy": {"jenkinsfile": "node('unexist') {\\nstage 'Check mvn version'\\nsh 'mvn -v'\\n}"}}}} |
-    Then the step should succeed
-    When I perform the :jenkins_add_pod_template web action with:
-      | slave_name  | unexist        |
-      | slave_label | unexist        |
-      | slave_image | unexist:latest |
-    Then the step should succeed
-    When I run the :start_build client command with:
-      | buildconfig | openshift-jee-sample |
-    Then the step should succeed
-    When I perform the :jenkins_verify_job_text web action with:
-      | namespace  | <%= project.name %>                      |
-      | job_name   | <%= project.name %>-openshift-jee-sample |
-      | checktext  | unexist         |
-      | job_num    | 2               |
-      | time_out   | 300             |
-    Then the step should succeed
 
     Examples:
       | version |


### PR DESCRIPTION
@openshift/devexp-qe Please help review, thanks~
Since 4.x, no need update the slave image on the jenkins console managed page, so remove the login steps for the pipeline build cases.