### PR TITLE
new step to get available router ip

### DIFF
--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -90,7 +90,7 @@ Feature: Testing route
   @smoke
   Scenario: Edge terminated route with custom cert
     Given I have a project
-    And I store default router IPs in the :router_ip clipboard
+    And I store an available router IP in the :router_ip clipboard
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/caddy-docker.json |
     Then the step should succeed


### PR DESCRIPTION
The step `I store default router IPs in the#{OPT_SYM} clipboard` cannot work for private cluster since no public DNS for route.
In the new step, we execute curl command on the pod inside the cluster so can solve above problem.
Actually, nslookup command can be used here but using curl can workaround the DNS misconfiguration issue for few clusters (vSphere/Baremetal and adding RHEL worker). When the DNS issue resolved then we can change back to use nslookup command.
 
 