### PR TITLE
Update regexp to match new output format.

### DIFF
--- a/features/containers/containers.feature
+++ b/features/containers/containers.feature
@@ -14,7 +14,7 @@ Feature: Container test feature
       | id |
     Then the step should succeed
     And the output should match:
-      | uid=\d+\s+gid=0\(root\)\s+groups=0\(root\),\d+ |
+      | uid=\d+(\(\d+\))?\s+gid=0\(root\)\s+groups=0\(root\),\d+ |
     And I execute on the pod:
       | bash | -c | echo redhat \| su - |
     Then the step should fail


### PR DESCRIPTION
New output looks like:
```bash
id
uid=1001520000(1001520000) gid=0(root) groups=0(root),1001520000
```