### PR TITLE
fix namespaced scope for packagemanifests

### DIFF
--- a/lib/openshift/package_manifest.rb
+++ b/lib/openshift/package_manifest.rb
@@ -1,5 +1,5 @@
 module BushSlicer
-  class PackageManifest < ClusterResource
+  class PackageManifest < ProjectResource
     RESOURCE = "packagemanifests"
 
   end


### PR DESCRIPTION
```$ oc api-resources --api-group=packages.operators.coreos.com
NAME               SHORTNAMES   APIGROUP                        NAMESPACED   KIND
packagemanifests                packages.operators.coreos.com   true         PackageManifest
```
The packagemanifests should be namespaced resource.
@yapei @pruan-rht  please help to review, thanks
