### PR TITLE
update rules create_project for OCP-19577

### DIFF
--- a/lib/rules/web/admin_console/4.2/projects.xyaml
+++ b/lib/rules/web/admin_console/4.2/projects.xyaml
@@ -11,7 +11,7 @@ create_project:
   action: submit_changes
   element:
     selector:
-      xpath: //span[contains(text(),'<project_name>')]
+      xpath: //*[contains(text(),'<project_name>')]
     timeout: 30
 set_project_name:
   element:

--- a/lib/rules/web/admin_console/4.3/projects.xyaml
+++ b/lib/rules/web/admin_console/4.3/projects.xyaml
@@ -11,7 +11,7 @@ create_project:
   action: submit_changes
   element:
     selector:
-      xpath: //span[contains(text(),'<project_name>')]
+      xpath: //*[contains(text(),'<project_name>')]
     timeout: 30
 set_project_name:
   element:


### PR DESCRIPTION
This rule should reuse for the negative scenario such as this case. No-matter project created successfully or not, need to check the Complete status for creating project, not only check for the Success status. (Success status has `//span` but the Error status need to check `//div`)
So update the rule in this PR.

@yanpzhan Please help to review, thanks!