### PR TITLE
Update rules: Auto OCP-25802 and update OCP-24287

### DIFF
--- a/features/step_definitions/admin_console.rb
+++ b/features/step_definitions/admin_console.rb
@@ -2,6 +2,12 @@
 #   cb_name ||= :console
 #   cb[cb_name] = route('console', service('console',project('openshift-console', switch: false))).dns(by: admin)
 # end
+
+Given /^default admin-console downloads route is stored in the#{OPT_SYM} clipboard$/ do | cb_name |
+  cb_name ||= :downloads_route
+  cb[cb_name] = route('downloads', service('downloads',project('openshift-console', switch: false))).dns(by: admin)
+end
+
 Given /^I open admin console in a browser$/ do
   base_rules = BushSlicer::WebConsoleExecutor::RULES_DIR + "/base/"
   snippets_dir = BushSlicer::WebConsoleExecutor::SNIPPETS_DIR
@@ -23,3 +29,4 @@ Given /^I open admin console in a browser$/ do
   raise "cannot login to cluster console" unless @result[:success]
   browser.base_url = browser.url.sub(%r{(https://[^/]+/).*}, "\\1")
 end
+

--- a/features/step_definitions/admin_console.rb
+++ b/features/step_definitions/admin_console.rb
@@ -4,6 +4,7 @@
 # end
 
 Given /^default admin-console downloads route is stored in the#{OPT_SYM} clipboard$/ do | cb_name |
+  ensure_admin_tagged
   cb_name ||= :downloads_route
   cb[cb_name] = route('downloads', service('downloads',project('openshift-console', switch: false))).dns(by: admin)
 end

--- a/lib/rules/web/admin_console/4.2/check_links.xyaml
+++ b/lib/rules/web/admin_console/4.2/check_links.xyaml
@@ -120,6 +120,7 @@ check_default_oc_download_links:
     text: Download oc
     link_url: clients/oc/4.2
   action: check_link_and_text
+check_default_odo_download_links:
   params:
     text: Download odo
     link_url: clients/odo/latest

--- a/lib/rules/web/admin_console/4.3/check_links.xyaml
+++ b/lib/rules/web/admin_console/4.3/check_links.xyaml
@@ -149,7 +149,7 @@ check_default_oc_download_links:
   action: check_link_and_text  
 check_default_odo_download_links:
   params:
-    text: Download odo
+    text: odo
     link_url: clients/odo/latest
   action: check_link_and_text
 check_customized_oc_download_links:

--- a/lib/rules/web/admin_console/4.3/check_links.xyaml
+++ b/lib/rules/web/admin_console/4.3/check_links.xyaml
@@ -125,16 +125,29 @@ check_image_url:
 check_default_oc_download_links:
   params:
     text: Download oc for Linux for x86_64
-    link_url: amd64/linux/oc.tar
+    link_url: <downloads_route>/amd64/linux/oc.tar
   action: check_link_and_text
   params:
+    text: Download oc for Linux for ARM 64
+    link_url: <downloads_route>/arm/linux/oc.tar
+  action: check_link_and_text
+  params:
+    text: Download oc for Linux for IBM Power, little endian
+    link_url: <downloads_route>/ppc64le/linux/oc.tar
+  action: check_link_and_text 
+  params:
+    text: Download oc for Linux for IBM Z
+    link_url: <downloads_route>/s390x/linux/oc.tar
+  action: check_link_and_text 
+  params:
     text: Download oc for Mac
-    link_url: amd64/mac/oc.zip
+    link_url: <downloads_route>/amd64/mac/oc.zip
   action: check_link_and_text
   params:
     text: Download oc for Windows
-    link_url: amd64/windows/oc.zip
+    link_url: <downloads_route>/amd64/windows/oc.zip
   action: check_link_and_text  
+check_default_odo_download_links:
   params:
     text: Download odo
     link_url: clients/odo/latest


### PR DESCRIPTION
Since OCP-25802 is to check default download links across multiple OS, OCP-24287 is to check customization for oc download links, I move the step check_default_oc_download_links into OCP-25802: 
OCP-24287 is for 4.2 & 4.3, only keep `check_default_odo_download_links` and mainly check customization links.
OCP-25802 is for checking default links.
@yapei Plz review, thanks!