### PR TITLE
OCP-11286 iptables rules test updated for 4.x

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -38,7 +38,9 @@ Feature: SDN related networking scenarios
   @admin
   @destructive
   Scenario: iptables rules will be repaired automatically once it gets destroyed
-    Given the master version >= "4.1"
+    # we do not detect incomplete rule removal since ~4.3, BZ-1810316
+    # so only test on >= 4.3
+    Given the master version >= "4.3"
     Given I select a random node's host
     And the node iptables config is checked
     And the step succeeded
@@ -52,8 +54,10 @@ Feature: SDN related networking scenarios
     When the node standard iptables rules are removed
     And 35 seconds have passed
     When the node iptables config is checked
-    # we do not detect incomplete rule removal since ~4.3, BZ-1810316
-    Then the iptables partial deletion check should have succeeded depending on version
+    # Removing individual rules will not trigger automatic repair on < 4.3
+    # the check should fail
+    Then the step failed
+    # >= 4.3 we have to flush all the rules and tables to trigger a repair
     When the node standard iptables rules are completely flushed
     And 35 seconds have passed
     Then the node iptables config is checked

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -33,18 +33,32 @@ Feature: SDN related networking scenarios
     And the output should contain "Using userspace Proxier"
     """
 
-  # @author bmeng@redhat.com
+  # @author rbrattai@redhat.com
   # @case_id OCP-11286
   @admin
   @destructive
   Scenario: iptables rules will be repaired automatically once it gets destroyed
+    Given the master version >= "4.1"
     Given I select a random node's host
-    And the node iptables config is verified
+    And the node iptables config is checked
+    And the step succeeded
     And the node service is restarted on the host after scenario
+    And I register clean-up steps:
+    """
+    When the node iptables config is checked
+    Then the step succeeded
+    """
 
-    Given the node standard iptables rules are removed
-    Given 35 seconds have passed
-    Given the node iptables config is verified
+    When the node standard iptables rules are removed
+    And 35 seconds have passed
+    When the node iptables config is checked
+    # we do not detect incomplete rule removal since ~4.3, BZ-1810316
+    Then the iptables partial deletion check should have succeeded depending on version
+    When the node standard iptables rules are completely flushed
+    And 35 seconds have passed
+    Then the node iptables config is checked
+    Then the step succeeded
+
 
   # @author hongli@redhat.com
   # @case_id OCP-13847
@@ -188,7 +202,7 @@ Feature: SDN related networking scenarios
     Then the step should succeed
     And evaluation of `@result[:response].split("\n")[0]` is stored in the :sdn_pod_rules clipboard
     Then the expression should be true> cb.host_rules==cb.sdn_pod_rules
-    
+
   # @author huirwang@redhat.com
   # @case_id OCP-25707
   @admin
@@ -243,48 +257,48 @@ Feature: SDN related networking scenarios
     Then the step should succeed
     And the output should contain "Hello OpenShift"
     """
-    
-  # @author weliang@redhat.com	
-  # @case_id OCP-27655	
-  @admin	
-  Scenario: Networking should work on default namespace		
-  #Test for bug https://bugzilla.redhat.com/show_bug.cgi?id=1800324 and https://bugzilla.redhat.com/show_bug.cgi?id=1796157	
-    Given I switch to cluster admin pseudo user	
-    And I use the "default" project	
-    Given I obtain test data file "networking/list_for_pods.json"
-    When I run oc create over "list_for_pods.json" replacing paths:	
-      | ["items"][0]["spec"]["replicas"] | 4 |	
-    Then the step should succeed	
-    And 4 pods become ready with labels:	
-      | name=test-pods |	
-    And evaluation of `pod(0).name` is stored in the :pod1_name clipboard	
-    And evaluation of `pod(0).ip_url` is stored in the :pod1_ip clipboard	
-    And evaluation of `pod(1).ip_url` is stored in the :pod2_ip clipboard	
-    And evaluation of `pod(2).ip_url` is stored in the :pod3_ip clipboard	
-    And evaluation of `pod(3).ip_url` is stored in the :pod4_ip clipboard	
-    And I register clean-up steps:	
-    """	
-    Given I ensure "test-rc" replicationcontroller is deleted	
-    Given I ensure "test-service" service is deleted	
-    """	
 
-    When I execute on the "<%= cb.pod1_name %>" pod:	
-      | curl | --connect-timeout | 5 | <%= cb.pod1_ip %>:8080 |	
-    Then the step should succeed	
-    And the output should contain "Hello OpenShift"	
-    When I execute on the "<%= cb.pod1_name %>" pod:	
-      | curl | --connect-timeout | 5 | <%= cb.pod2_ip %>:8080 |	
-    Then the step should succeed	
-    And the output should contain "Hello OpenShift"	
-    When I execute on the "<%= cb.pod1_name %>" pod:	
-      | curl | --connect-timeout | 5 | <%= cb.pod3_ip %>:8080 |	
-    Then the step should succeed	
-    And the output should contain "Hello OpenShift"	
-    When I execute on the "<%= cb.pod1_name %>" pod:	
-      | curl | --connect-timeout | 5 | <%= cb.pod4_ip %>:8080 |	
-    Then the step should succeed	
+  # @author weliang@redhat.com
+  # @case_id OCP-27655
+  @admin
+  Scenario: Networking should work on default namespace
+  #Test for bug https://bugzilla.redhat.com/show_bug.cgi?id=1800324 and https://bugzilla.redhat.com/show_bug.cgi?id=1796157
+    Given I switch to cluster admin pseudo user
+    And I use the "default" project
+    Given I obtain test data file "networking/list_for_pods.json"
+    When I run oc create over "list_for_pods.json" replacing paths:
+      | ["items"][0]["spec"]["replicas"] | 4 |
+    Then the step should succeed
+    And 4 pods become ready with labels:
+      | name=test-pods |
+    And evaluation of `pod(0).name` is stored in the :pod1_name clipboard
+    And evaluation of `pod(0).ip_url` is stored in the :pod1_ip clipboard
+    And evaluation of `pod(1).ip_url` is stored in the :pod2_ip clipboard
+    And evaluation of `pod(2).ip_url` is stored in the :pod3_ip clipboard
+    And evaluation of `pod(3).ip_url` is stored in the :pod4_ip clipboard
+    And I register clean-up steps:
+    """
+    Given I ensure "test-rc" replicationcontroller is deleted
+    Given I ensure "test-service" service is deleted
+    """
+
+    When I execute on the "<%= cb.pod1_name %>" pod:
+      | curl | --connect-timeout | 5 | <%= cb.pod1_ip %>:8080 |
+    Then the step should succeed
     And the output should contain "Hello OpenShift"
-    
+    When I execute on the "<%= cb.pod1_name %>" pod:
+      | curl | --connect-timeout | 5 | <%= cb.pod2_ip %>:8080 |
+    Then the step should succeed
+    And the output should contain "Hello OpenShift"
+    When I execute on the "<%= cb.pod1_name %>" pod:
+      | curl | --connect-timeout | 5 | <%= cb.pod3_ip %>:8080 |
+    Then the step should succeed
+    And the output should contain "Hello OpenShift"
+    When I execute on the "<%= cb.pod1_name %>" pod:
+      | curl | --connect-timeout | 5 | <%= cb.pod4_ip %>:8080 |
+    Then the step should succeed
+    And the output should contain "Hello OpenShift"
+
   # @author anusaxen@redhat.com
   # @case_id OCP-25787
   @admin
@@ -294,7 +308,7 @@ Feature: SDN related networking scenarios
     And I store "<%= cb.master[0].name %>" node's corresponding default networkType pod name in the :ovnkube_pod clipboard
     Given I switch to cluster admin pseudo user
     And I use the "openshift-ovn-kubernetes" project
-    #Fetching ovn master pod name to be used later 
+    #Fetching ovn master pod name to be used later
     When I run the :get client command with:
       | resource      | pods                                   |
       | fieldSelector | spec.nodeName=<%= cb.master[0].name %> |
@@ -302,7 +316,7 @@ Feature: SDN related networking scenarios
       | output        | json                                   |
     Then the step should succeed
     And evaluation of `@result[:parsed]['items'][0]['metadata']['name']` is stored in the :ovn_master_pod clipboard
-    #Checking controller iteration 1. Need to execute under ovn-contoller container 
+    #Checking controller iteration 1. Need to execute under ovn-contoller container
     When I run the :exec client command with:
       | pod              | <%= cb.ovnkube_pod %> |
       | c                | ovn-controller        |

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -52,6 +52,8 @@ Feature: SDN related networking scenarios
     """
 
     When the node standard iptables rules are removed
+    # wait full iptablesSyncPeriod, which is 30 seconds by default
+    # This step is a negative check, so we have to wait the full period to make sure the rules were not restored.
     And 35 seconds have passed
     When the node iptables config is checked
     # Removing individual rules will not trigger automatic repair on < 4.3
@@ -59,9 +61,11 @@ Feature: SDN related networking scenarios
     Then the step failed
     # >= 4.3 we have to flush all the rules and tables to trigger a repair
     When the node standard iptables rules are completely flushed
-    And 35 seconds have passed
-    Then the node iptables config is checked
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    Given the node iptables config is checked
     Then the step succeeded
+    """
 
 
   # @author hongli@redhat.com

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -136,26 +136,6 @@ Given /^the subnet from the clusternetwork resource is stored in the clipboard$/
 end
 
 
-Given /^the iptables partial deletion check should have succeeded depending on version$/ do
-  ensure_admin_tagged
-  if env.version_ge("4.3", user: user)
-    # we expect the check to fail on 4.4 and above, because we only detect full flush
-    # it looks like 4.3 was fixed as well, so maybe only 4.2 will fail
-    if @result[:success]
-      raise "sync check should not have succeded"
-    else
-      logger.info("sync check failed as expected: #{@result[:message]}")
-    end
-  else
-    if @result[:success]
-      logger.info("sync check succedded as expected")
-    else
-      raise "sync check failed #{@result[:message]}"
-    end
-  end
-
-end
-
 Given /^the#{OPT_QUOTED} node iptables config is checked$/ do |node_name|
   ensure_admin_tagged
   _node = node(node_name)

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -123,212 +123,104 @@ Given /^the#{OPT_QUOTED} node network is verified$/ do |node_name|
   teardown_add net_verify
 end
 
-Given /^the#{OPT_QUOTED} node iptables config is verified$/ do |node_name|
+
+Given /^The subnet from the clusternetwork resource is stored in the clipboard$/ do
+  ensure_admin_tagged
+  _admin = admin
+  @result = _admin.cli_exec(:get, resource: "clusternetwork", resource_name: "default", template: '{{index .clusterNetworks 0 "CIDR"}}')
+  unless @result[:success]
+    raise "Can not get clusternetwork resource!"
+  end
+  cb.clusternetwork = @result[:response].chomp
+  logger.info "Cluster network #{cb.clusternetwork} saved into the :clusternetwork clipboard"
+end
+
+
+Given /^the iptables partial deletion check should have succeeded depending on version$/ do
+  ensure_admin_tagged
+  if env.version_ge("4.3", user: user)
+    # we expect the check to fail on 4.4 and above, because we only detect full flush
+    # it looks like 4.3 was fixed as well, so maybe only 4.2 will fail
+    if @result[:success]
+      raise "sync check should not have succeded"
+    else
+      logger.info("sync check failed as expected: #{@result[:message]}")
+    end
+  else
+    if @result[:success]
+      logger.info("sync check succedded as expected")
+    else
+      raise "sync check failed #{@result[:message]}"
+    end
+  end
+
+end
+
+Given /^the#{OPT_QUOTED} node iptables config is checked$/ do |node_name|
   ensure_admin_tagged
   _node = node(node_name)
   _host = _node.host
   _admin = admin
 
-  if env.version_lt("3.7", user: user)
-    @result = _admin.cli_exec(:get, resource: "clusternetwork", resource_name: "default", template: "{{.network}}")
-  else
-    @result = _admin.cli_exec(:get, resource: "clusternetwork", resource_name: "default", template: '{{index .clusterNetworks 0 "CIDR"}}')
-  end
-  unless @result[:success]
-    raise "Can not get clusternetwork resource!"
-  end
+  step "The subnet from the clusternetwork resource is stored in the clipboard"
+  subnet = cb.clusternetwork
 
-  subnet = @result[:response]
-  cb.clusternetwork = subnet
-
+  plugin_type = ""
   @result = _admin.cli_exec(:get, resource: "clusternetwork", resource_name: "default")
   if @result[:success]
     plugin_type = @result[:response]
   end
 
-  if env.version_ge("3.9", user: user) && plugin_type.include?("openshift-ovs-networkpolicy")
-    puts "OpenShift version >= 3.9 and uses networkpolicy plugin."
-    filter_matches = [
-      'INPUT -m comment --comment "Ensure that non-local NodePort traffic can flow" -j KUBE-NODEPORT-NON-LOCAL',
-      'INPUT -m conntrack --ctstate NEW -m comment --comment "kubernetes externally-visible service portals" -j KUBE-EXTERNAL-SERVICES',
-      'INPUT -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-ALLOW',
-      'FORWARD -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-FORWARD',
-      'FORWARD -i tun0 ! -o tun0 -m comment --comment "administrator overrides" -j OPENSHIFT-ADMIN-OUTPUT-RULES',
-      'OPENSHIFT-FIREWALL-ALLOW -p udp -m udp --dport 4789 -m comment --comment "VXLAN incoming" -j ACCEPT',
-      'OPENSHIFT-FIREWALL-ALLOW -i tun0 -m comment --comment "from SDN to localhost" -j ACCEPT',
-      'OPENSHIFT-FIREWALL-ALLOW -i docker0 -m comment --comment "from docker to localhost" -j ACCEPT',
-      "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"attempted resend after connection close\" -m conntrack --ctstate INVALID -j DROP",
-      "OPENSHIFT-FIREWALL-FORWARD -d #{subnet} -m comment --comment \"forward traffic from SDN\" -j ACCEPT",
-      "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"forward traffic to SDN\" -j ACCEPT"
-    ]
-    nat_matches = [
-      "PREROUTING -m comment --comment \".*\" -j KUBE-SERVICES",
-      "OUTPUT -m comment --comment \"kubernetes service portals\" -j KUBE-SERVICES",
-      "POSTROUTING -m comment --comment \"rules for masquerading OpenShift traffic\" -j OPENSHIFT-MASQUERADE",
-      "OPENSHIFT-MASQUERADE -s #{subnet} -m comment --comment \"masquerade .* traffic\" -j OPENSHIFT-MASQUERADE-2",
-      "OPENSHIFT-MASQUERADE-2 -d #{subnet} -m comment --comment \"masquerade pod-to-external traffic\" -j RETURN",
-      "OPENSHIFT-MASQUERADE-2 -j MASQUERADE"
-    ]
-  elsif env.version_ge("3.9", user: user)
-    puts "OpenShift version >= 3.9 and uses multitenant or subnet plugin."
-    filter_matches = [
-      'INPUT -m comment --comment "Ensure that non-local NodePort traffic can flow" -j KUBE-NODEPORT-NON-LOCAL',
-      'INPUT -m conntrack --ctstate NEW -m comment --comment "kubernetes externally-visible service portals" -j KUBE-EXTERNAL-SERVICES',
-      'INPUT -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-ALLOW',
-      'FORWARD -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-FORWARD',
-      'FORWARD -i tun0 ! -o tun0 -m comment --comment "administrator overrides" -j OPENSHIFT-ADMIN-OUTPUT-RULES',
-      'OPENSHIFT-FIREWALL-ALLOW -p udp -m udp --dport 4789 -m comment --comment "VXLAN incoming" -j ACCEPT',
-      'OPENSHIFT-FIREWALL-ALLOW -i tun0 -m comment --comment "from SDN to localhost" -j ACCEPT',
-      'OPENSHIFT-FIREWALL-ALLOW -i docker0 -m comment --comment "from docker to localhost" -j ACCEPT',
-      "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"attempted resend after connection close\" -m conntrack --ctstate INVALID -j DROP",
-      "OPENSHIFT-FIREWALL-FORWARD -d #{subnet} -m comment --comment \"forward traffic from SDN\" -j ACCEPT",
-      "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"forward traffic to SDN\" -j ACCEPT"
-    ]
-    nat_matches = [
-      "PREROUTING -m comment --comment \".*\" -j KUBE-SERVICES",
-      "OUTPUT -m comment --comment \"kubernetes service portals\" -j KUBE-SERVICES",
-      "POSTROUTING -m comment --comment \"rules for masquerading OpenShift traffic\" -j OPENSHIFT-MASQUERADE",
-      "OPENSHIFT-MASQUERADE -s #{subnet} -m comment --comment \"masquerade .* traffic\" -j MASQUERADE",
-    ]
-  elsif env.version_ge("3.7", user: user) && plugin_type.include?("openshift-ovs-networkpolicy")
-    puts "OpenShift version >= 3.7 and uses networkpolicy plugin."
-    filter_matches = [
-      'INPUT -m comment --comment "Ensure that non-local NodePort traffic can flow" -j KUBE-NODEPORT-NON-LOCAL',
-      'INPUT -m comment --comment "kubernetes service portals" -j KUBE-SERVICES',
-      'INPUT -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-ALLOW',
-      'FORWARD -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-FORWARD',
-      'FORWARD -i tun0 ! -o tun0 -m comment --comment "administrator overrides" -j OPENSHIFT-ADMIN-OUTPUT-RULES',
-      'OPENSHIFT-FIREWALL-ALLOW -p udp -m udp --dport 4789 -m comment --comment "VXLAN incoming" -j ACCEPT',
-      'OPENSHIFT-FIREWALL-ALLOW -i tun0 -m comment --comment "from SDN to localhost" -j ACCEPT',
-      'OPENSHIFT-FIREWALL-ALLOW -i docker0 -m comment --comment "from docker to localhost" -j ACCEPT',
-      "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"attempted resend after connection close\" -m conntrack --ctstate INVALID -j DROP",
-      "OPENSHIFT-FIREWALL-FORWARD -d #{subnet} -m comment --comment \"forward traffic from SDN\" -j ACCEPT",
-      "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"forward traffic to SDN\" -j ACCEPT"
-    ]
-    nat_matches = [
-      "PREROUTING -m comment --comment \".*\" -j KUBE-SERVICES",
-      "OUTPUT -m comment --comment \"kubernetes service portals\" -j KUBE-SERVICES",
-      "POSTROUTING -m comment --comment \"rules for masquerading OpenShift traffic\" -j OPENSHIFT-MASQUERADE",
-      "OPENSHIFT-MASQUERADE -s #{subnet} -m comment --comment \"masquerade .* traffic\" -j OPENSHIFT-MASQUERADE-2",
-      "OPENSHIFT-MASQUERADE-2 -d #{subnet} -m comment --comment \"masquerade pod-to-external traffic\" -j RETURN",
-      "OPENSHIFT-MASQUERADE-2 -j MASQUERADE"
-    ]
-  elsif env.version_ge("3.7", user: user)
-    puts "OpenShift version >= 3.7 and uses multitenant or subnet plugin."
-    filter_matches = [
-      'INPUT -m comment --comment "Ensure that non-local NodePort traffic can flow" -j KUBE-NODEPORT-NON-LOCAL',
-      'INPUT -m comment --comment "kubernetes service portals" -j KUBE-SERVICES',
-      'INPUT -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-ALLOW',
-      'FORWARD -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-FORWARD',
-      'FORWARD -i tun0 ! -o tun0 -m comment --comment "administrator overrides" -j OPENSHIFT-ADMIN-OUTPUT-RULES',
-      'OPENSHIFT-FIREWALL-ALLOW -p udp -m udp --dport 4789 -m comment --comment "VXLAN incoming" -j ACCEPT',
-      'OPENSHIFT-FIREWALL-ALLOW -i tun0 -m comment --comment "from SDN to localhost" -j ACCEPT',
-      'OPENSHIFT-FIREWALL-ALLOW -i docker0 -m comment --comment "from docker to localhost" -j ACCEPT',
-      "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"attempted resend after connection close\" -m conntrack --ctstate INVALID -j DROP",
-      "OPENSHIFT-FIREWALL-FORWARD -d #{subnet} -m comment --comment \"forward traffic from SDN\" -j ACCEPT",
-      "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"forward traffic to SDN\" -j ACCEPT"
-    ]
-    nat_matches = [
-      "PREROUTING -m comment --comment \".*\" -j KUBE-SERVICES",
-      "OUTPUT -m comment --comment \"kubernetes service portals\" -j KUBE-SERVICES",
-      "POSTROUTING -m comment --comment \"rules for masquerading OpenShift traffic\" -j OPENSHIFT-MASQUERADE",
-      "OPENSHIFT-MASQUERADE -s #{subnet} -m comment --comment \"masquerade .* traffic\" -j MASQUERADE",
-    ]
-  elsif env.version_eq("3.6", user: user)
-    puts "OpenShift version is 3.6"
-    filter_matches = [
-      'INPUT -m comment --comment "Ensure that non-local NodePort traffic can flow" -j KUBE-NODEPORT-NON-LOCAL',
-      'INPUT -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-ALLOW',
-      'OUTPUT -m comment --comment "kubernetes service portals" -j KUBE-SERVICES',
-      'FORWARD -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-FORWARD',
-      'FORWARD -i tun0 ! -o tun0 -m comment --comment "administrator overrides" -j OPENSHIFT-ADMIN-OUTPUT-RULES',
-      'OPENSHIFT-FIREWALL-ALLOW -p udp -m udp --dport 4789 -m comment --comment "VXLAN incoming" -j ACCEPT',
-      'OPENSHIFT-FIREWALL-ALLOW -i tun0 -m comment --comment "from SDN to localhost" -j ACCEPT',
-      'OPENSHIFT-FIREWALL-ALLOW -i docker0 -m comment --comment "from docker to localhost" -j ACCEPT',
-      "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"attempted resend after connection close\" -m conntrack --ctstate INVALID -j DROP",
-      "OPENSHIFT-FIREWALL-FORWARD -d #{subnet} -m comment --comment \"forward traffic from SDN\" -j ACCEPT",
-      "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"forward traffic to SDN\" -j ACCEPT"
-    ]
-    # different MASQUERADE rules for networkpolicy plugin and multitenant/subnet plugin, for example:
-    #   with networkpolicy plugin it should be:
-    #   "OPENSHIFT-MASQUERADE -s #{subnet} ! -d #{subnet} -m comment --comment "masquerade pod-to-external traffic" -j MASQUERADE"
-    #   with multitenant or subnet plugin it should be:
-    #   "OPENSHIFT-MASQUERADE -s #{subnet} -m comment --comment "masquerade pod-to-service and pod-to-external traffic" -j MASQUERADE"
-    #   so use fuzzy matching in nat_matches.
-    nat_matches = [
-      'PREROUTING -m comment --comment "kubernetes service portals" -j KUBE-SERVICES',
-      "OUTPUT -m comment --comment \"kubernetes service portals\" -j KUBE-SERVICES",
-      'POSTROUTING -m comment --comment "kubernetes postrouting rules" -j KUBE-POSTROUTING',
-      "OPENSHIFT-MASQUERADE -s #{subnet} .*--comment \"masquerade .*pod-to-external traffic\" -j MASQUERADE"
-    ]
-  else
-    puts "OpenShift version < 3.6"
-    filter_matches = [
-      'INPUT -i tun0 -m comment --comment "traffic from(.*)" -j ACCEPT',
-      'INPUT -p udp -m multiport --dports 4789 -m comment --comment "001 vxlan incoming" -j ACCEPT',
-      'OUTPUT -m comment --comment "kubernetes service portals" -j KUBE-SERVICES',
-      "FORWARD -s #{subnet} -j ACCEPT",
-      "FORWARD -d #{subnet} -j ACCEPT"
-    ]
-    nat_matches = [
-      'PREROUTING -m comment --comment "kubernetes service portals" -j KUBE-SERVICES',
-      'POSTROUTING -m comment --comment "kubernetes postrouting rules" -j KUBE-POSTROUTING',
-      "POSTROUTING -s #{subnet} -j MASQUERADE"
-    ]
+  unless plugin_type.include?("openshift-ovs-networkpolicy")
+    raise "#{plugin_type} != openshift-ovs-networkpolicy.  This is unsupported?"
   end
 
-  iptables_verify = proc {
-    @result = _host.exec_admin("systemctl status iptables")
-    unless @result[:success] && @result[:response] =~ /Active:\s+?active/
-      raise "The iptables deamon verification failed. The deamon is not active!"
-    end
+  puts "OpenShift version >= 3.9 and uses networkpolicy plugin."
+  filter_matches = [
+    'INPUT -m comment --comment "Ensure that non-local NodePort traffic can flow" -j KUBE-NODEPORT-NON-LOCAL',
+    'INPUT -m conntrack --ctstate NEW -m comment --comment "kubernetes externally-visible service portals" -j KUBE-EXTERNAL-SERVICES',
+    'INPUT -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-ALLOW',
+    'FORWARD -m comment --comment "firewall overrides" -j OPENSHIFT-FIREWALL-FORWARD',
+    'FORWARD -i tun0 ! -o tun0 -m comment --comment "administrator overrides" -j OPENSHIFT-ADMIN-OUTPUT-RULES',
+    'OPENSHIFT-FIREWALL-ALLOW -p udp -m udp --dport 4789 -m comment --comment "VXLAN incoming" -j ACCEPT',
+    'OPENSHIFT-FIREWALL-ALLOW -i tun0 -m comment --comment "from SDN to localhost" -j ACCEPT',
+    'OPENSHIFT-FIREWALL-ALLOW -i docker0 -m comment --comment "from docker to localhost" -j ACCEPT',
+    "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"attempted resend after connection close\" -m conntrack --ctstate INVALID -j DROP",
+    "OPENSHIFT-FIREWALL-FORWARD -d #{subnet} -m comment --comment \"forward traffic from SDN\" -j ACCEPT",
+    "OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"forward traffic to SDN\" -j ACCEPT"
+  ]
+  nat_matches = [
+    "PREROUTING -m comment --comment \".*\" -j KUBE-SERVICES",
+    "OUTPUT -m comment --comment \"kubernetes service portals\" -j KUBE-SERVICES",
+    "POSTROUTING -m comment --comment \"rules for masquerading OpenShift traffic\" -j OPENSHIFT-MASQUERADE",
+    "OPENSHIFT-MASQUERADE -s #{subnet} -m comment --comment \"masquerade .* traffic\" -j OPENSHIFT-MASQUERADE-2",
+    "OPENSHIFT-MASQUERADE-2 -d #{subnet} -m comment --comment \"masquerade pod-to-external traffic\" -j RETURN",
+    "OPENSHIFT-MASQUERADE-2 -j MASQUERADE"
+  ]
 
+  # use a lambda so we can exit early
+  iptables_verify = -> {
     @result = _host.exec_admin("iptables-save -t filter")
     filter_matches.each { |match|
       unless @result[:success] && @result[:response] =~ /#{match}/
-        raise "The filter table verification failed!"
+        @result[:success] = false
+        @result[:message] = "The filter table verification failed, missing [#{match}]"
+        return
       end
     }
 
     @result = _host.exec_admin("iptables-save -t nat")
     nat_matches.each { |match|
       unless @result[:success] && @result[:response] =~ /#{match}/
-        raise "The nat table verification failed!"
+        @result[:success] = false
+        @result[:message] = "The nat table verification failed, missing [#{match}]"
+        return
       end
     }
   }
 
-  firewalld_verify = proc {
-    @result = _host.exec_admin("systemctl status firewalld")
-    unless @result[:success] && @result[:response] =~ /Active:\s+?active/
-      raise "The firewalld deamon verification failed. The deamon is not active!"
-    end
+  iptables_verify.call
 
-    @result = _host.exec_admin("iptables-save -t filter")
-    filter_matches.each { |match|
-      unless @result[:success] && @result[:response] =~ /#{match}/
-        raise "The filter table verification failed!"
-      end
-    }
-
-    @result = _host.exec_admin("iptables-save -t nat")
-    nat_matches.each { |match|
-      unless @result[:success] && @result[:response] =~ /#{match}/
-        raise "The nat table verification failed!"
-      end
-    }
-  }
-
-  @result = _host.exec_admin("firewall-cmd --state")
-  if @result[:success] && @result[:response] =~ /running/
-    firewalld_verify.call
-    logger.info "Cluster network #{subnet} saved into the :clusternetwork clipboard"
-    teardown_add firewalld_verify
-  else
-    iptables_verify.call
-    logger.info "Cluster network #{subnet} saved into the :clusternetwork clipboard"
-    teardown_add iptables_verify
-  end
 end
 
 Given /^the#{OPT_QUOTED} node standard iptables rules are removed$/ do |node_name|
@@ -337,46 +229,45 @@ Given /^the#{OPT_QUOTED} node standard iptables rules are removed$/ do |node_nam
   _host = _node.host
   _admin = admin
 
-  if env.version_lt("3.7", user: user)
-    @result = _admin.cli_exec(:get, resource: "clusternetwork", resource_name: "default", template: "{{.network}}")
-  else
-    @result = _admin.cli_exec(:get, resource: "clusternetwork", resource_name: "default", template: '{{index .clusterNetworks 0 "CIDR"}}')
-  end
-  unless @result[:success]
-    raise "Can not get clusternetwork resource!"
-  end
+  step "The subnet from the clusternetwork resource is stored in the clipboard"
+  subnet = cb.clusternetwork
 
-  subnet = @result[:response]
+  @result = _host.exec('iptables -D OPENSHIFT-FIREWALL-ALLOW -p udp -m udp --dport 4789 -m comment --comment "VXLAN incoming" -j ACCEPT')
+  raise "failed to delete iptables rule #1" unless @result[:success]
+  @result = _host.exec('iptables -D OPENSHIFT-FIREWALL-ALLOW -i tun0 -m comment --comment "from SDN to localhost" -j ACCEPT')
+  raise "failed to delete iptables rule #2" unless @result[:success]
+  @result = _host.exec("iptables -D OPENSHIFT-FIREWALL-FORWARD -d #{subnet} -m comment --comment \"forward traffic from SDN\" -j ACCEPT")
+  raise "failed to delete iptables rule #3" unless @result[:success]
+  @result = _host.exec("iptables -D OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"forward traffic to SDN\" -j ACCEPT")
+  raise "failed to delete iptables rule #4" unless @result[:success]
 
-  if env.version_lt("3.6", user: user)
-    @result = _host.exec('iptables -D INPUT -p udp -m multiport --dports 4789 -m comment --comment "001 vxlan incoming" -j ACCEPT')
-    raise "failed to delete iptables rule #1" unless @result[:success]
-    @result = _host.exec('iptables -D INPUT -i tun0 -m comment --comment "traffic from SDN" -j ACCEPT')
-    raise "failed to delete iptables rule #2" unless @result[:success]
-    @result = _host.exec("iptables -D FORWARD -d #{subnet} -j ACCEPT")
-    raise "failed to delete iptables rule #3" unless @result[:success]
-    @result = _host.exec("iptables -D FORWARD -s #{subnet} -j ACCEPT")
-    raise "failed to delete iptables rule #4" unless @result[:success]
-    @result = _host.exec("iptables -t nat -D POSTROUTING -s #{subnet} -j MASQUERADE")
-    raise "failed to delete iptables nat rule" unless @result[:success]
-  else
-    @resule = _host.exec('iptables -D OPENSHIFT-FIREWALL-ALLOW -p udp -m udp --dport 4789 -m comment --comment "VXLAN incoming" -j ACCEPT')
-    raise "failed to delete iptables rule #1" unless @result[:success]
-    @resule = _host.exec('iptables -D OPENSHIFT-FIREWALL-ALLOW -i tun0 -m comment --comment "from SDN to localhost" -j ACCEPT')
-    raise "failed to delete iptables rule #2" unless @result[:success]
-    @resule = _host.exec("iptables -D OPENSHIFT-FIREWALL-FORWARD -d #{subnet} -m comment --comment \"forward traffic from SDN\" -j ACCEPT")
-    raise "failed to delete iptables rule #3" unless @result[:success]
-    @resule = _host.exec("iptables -D OPENSHIFT-FIREWALL-FORWARD -s #{subnet} -m comment --comment \"forward traffic to SDN\" -j ACCEPT")
-    raise "failed to delete iptables rule #4" unless @result[:success]
+  # compatible with different network plugin
+  # limit the match to the main OPENSHIFT-MASQUERADE rule
+  @result = _host.exec("iptables -S -t nat \| grep -e 'OPENSHIFT-MASQUERADE -s #{subnet}' \| cut -d ' ' -f 2-")
+  raise "failed to grep rule from the iptables nat table!" unless @result[:success]
+  # don't use :response because for oc debug :response includes STDERR appended
+  nat_rule = @result[:stdout].to_s
 
-    # compatible with different network plugin
-    @result = _host.exec("iptables -S -t nat \| grep '#{subnet}' \| cut -d ' ' -f 2-")
-    raise "failed to grep rule from the iptables nat table!" unless @result[:success]
-    nat_rule = @result[:response]
+  @result = _host.exec("iptables -t nat -D #{nat_rule}")
+  raise "failed to delete iptables nat rule" unless @result[:success]
+end
 
-    @resule = _host.exec("iptables -t nat -D #{nat_rule}")
-    raise "failed to delete iptables nat rule" unless @result[:success]
-  end
+Given /^the#{OPT_QUOTED} node standard iptables rules are completely flushed$/ do |node_name|
+  ensure_admin_tagged
+  _node = node(node_name)
+  _host = _node.host
+  _admin = admin
+
+  tables = %w(filter mangle nat raw security)
+  tables.each { |table|
+
+    @result = _host.exec("iptables -t #{table} -F")
+    raise "failed to flush iptables table #{table}" unless @result[:success]
+    @result = _host.exec("iptables -t #{table} -X")
+    # ignore any chain delete errors for now and just see if it triggers the iptableSync
+    # raise "failed to delete iptables chain #{table}" unless @result[:success]
+    # iptables v1.8.4 (nf_tables):  CHAIN_USER_DEL failed (Device or resource busy): chain KUBE-MARK-MASQ
+  }
 end
 
 Given /^admin adds( and overwrites)? following annotations to the "(.+?)" netnamespace:$/ do |overwrite, netnamespace, table|

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -124,7 +124,7 @@ Given /^the#{OPT_QUOTED} node network is verified$/ do |node_name|
 end
 
 
-Given /^The subnet from the clusternetwork resource is stored in the clipboard$/ do
+Given /^the subnet from the clusternetwork resource is stored in the clipboard$/ do
   ensure_admin_tagged
   _admin = admin
   @result = _admin.cli_exec(:get, resource: "clusternetwork", resource_name: "default", template: '{{index .clusterNetworks 0 "CIDR"}}')
@@ -162,7 +162,7 @@ Given /^the#{OPT_QUOTED} node iptables config is checked$/ do |node_name|
   _host = _node.host
   _admin = admin
 
-  step "The subnet from the clusternetwork resource is stored in the clipboard"
+  step "the subnet from the clusternetwork resource is stored in the clipboard"
   subnet = cb.clusternetwork
 
   plugin_type = ""
@@ -229,7 +229,7 @@ Given /^the#{OPT_QUOTED} node standard iptables rules are removed$/ do |node_nam
   _host = _node.host
   _admin = admin
 
-  step "The subnet from the clusternetwork resource is stored in the clipboard"
+  step "the subnet from the clusternetwork resource is stored in the clipboard"
   subnet = cb.clusternetwork
 
   @result = _host.exec('iptables -D OPENSHIFT-FIREWALL-ALLOW -p udp -m udp --dport 4789 -m comment --comment "VXLAN incoming" -j ACCEPT')


### PR DESCRIPTION
For 4.4 if we partially remove rules it does not
trigger an iptablesSync (BZ-1810316)

Check if the partial removal works and then
do a full table flush and chain deletion.

This requires breaking the iptable verification step into two parts,
checking the rules and then deciding if the rule check should fail
depending on version

General fixes

`"openshift-ovs-networkpolicy"` is now the default in 4.x

Remove 3.x version specific iptables rules

When using oc debug commands the `:response` seems to always include
`STDERR` appended which doesn't work for matching the `MASQUERADE` rule so use
`:stdout.to_s` instead