### PR TITLE
Revert part of #PR579

### DIFF
--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -141,8 +141,8 @@
     :c: -c=<value>
     :source: <value>
     :dest: <value>
-:create: 
-  :cmd: oc create <reource_type> <resouce_name>
+:create:
+  :cmd: oc create
   :options:
     :f: -f <value>
     :filename: --filename=<value>


### PR DESCRIPTION
@jhou1 @pruan-rht @yapei @xiaocwan 
```
      required command option not supplied: resource_type (RuntimeError)
      /home/lxia/github.com/verification-tests/lib/rules_command_executor.rb:280:in `block in build_command_line'
      /home/lxia/github.com/verification-tests/lib/rules_command_executor.rb:268:in `gsub!'
      /home/lxia/github.com/verification-tests/lib/rules_command_executor.rb:268:in `build_command_line'
      /home/lxia/github.com/verification-tests/lib/rules_command_executor.rb:53:in `run'
      /home/lxia/github.com/verification-tests/lib/cli_executor.rb:314:in `exec'
      /home/lxia/github.com/verification-tests/lib/api_accessor.rb:71:in `cli_exec'
      /home/lxia/github.com/verification-tests/lib/openshift/cluster_resource.rb:41:in `create'
      /home/lxia/github.com/verification-tests/features/step_definitions/pv.rb:167:in `/^admin creates a PV from "([^"]*)" where:$/'
      features/storage/persistent_volume.feature:85:in `When admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/auto/pv-template.json" where:'
      features/storage/persistent_volume.feature:68:in `When admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/auto/pv-template.json" where:'
```