### PR TITLE
Use common PVC template to get rid of beta annotations

### DIFF
--- a/features/step_definitions/secrets.rb
+++ b/features/step_definitions/secrets.rb
@@ -8,7 +8,7 @@ Given /^the azure file secret name and key are stored to the clipboard$/ do
     | ["parameters"]["storageAccount"] | #{azsac}                     |
     })
   step %Q/the step should succeed/
-  step %Q{I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/azure/azpvc-sc.yaml" replacing paths:}, table(%{
+  step %Q{I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:}, table(%{
     | ["metadata"]["name"]         | <%= cb.dynamic_pvc_name %>   |
     | ["spec"]["storageClassName"] | <%= cb.storage_class_name %> |
     })


### PR DESCRIPTION
Fail [log](http://ci-qe-openshift.usersys.redhat.com/userContent/cucushift/v3/2020/01/08/04:58:02/Azure_file_with_secretNamespace_parameter_of_different_project/console.html)

The main diff is that pvc.json do not use beta annotations (replaced by spec.storageClassName).

@duanwei33 @chao007 