### PR TITLE
Fix CLI format of "oc secrets new"

### DIFF
--- a/features/build/buildlogic.feature
+++ b/features/build/buildlogic.feature
@@ -153,7 +153,7 @@ Feature: buildlogic.feature
     And I have an ssh-git service in the project
     And the "secret" file is created with the following lines:
       | <%= cb.ssh_private_key.to_pem %> |
-    And I run the :oc_secrets_new_sshauth client command with:
+    And I run the :secrets_new_sshauth client command with:
       | ssh_privatekey | secret   |
       | secret_name    | mysecret |
     Then the step should succeed
@@ -201,7 +201,7 @@ Feature: buildlogic.feature
     And I have an ssh-git service in the project
     And the "secret" file is created with the following lines:
       | <%= cb.ssh_private_key.to_pem %> |
-    And I run the :oc_secrets_new_sshauth client command with:
+    And I run the :secrets_new_sshauth client command with:
       | ssh_privatekey | secret   |
       | secret_name    | mysecret |
     When I execute on the pod:

--- a/features/cli/secrets.feature
+++ b/features/cli/secrets.feature
@@ -30,7 +30,7 @@ Feature: secrets related scenarios
   Scenario: Create new secrets for ssh authentication
     Given I have a project
     When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cases/508971/id_rsa"
-    When I run the :oc_secrets_new_sshauth client command with:
+    When I run the :secrets_new_sshauth client command with:
       |secret_name    |testsecret |
       |ssh_privatekey |id_rsa     |
     Then the step should succeed
@@ -42,7 +42,7 @@ Feature: secrets related scenarios
     And the output should contain:
       |ssh-privatekey:|
     When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cases/508970/ca.crt"
-    When I run the :oc_secrets_new_sshauth client command with:
+    When I run the :secrets_new_sshauth client command with:
       |secret_name    |testsecret2 |
       |ssh_privatekey |id_rsa      |
       |cafile         |ca.crt      |
@@ -323,7 +323,7 @@ Feature: secrets related scenarios
       | resource | dc/git                    |
       | e        | ALLOW_ANON_GIT_PULL=false |
     Then the step should succeed
-    When I run the :oc_secrets_new_basicauth client command with:
+    When I run the :secrets_new_basicauth client command with:
       |secret_name |mysecret                          |
       |password    |<%= user.cached_tokens.first %>|
     Then the step should succeed
@@ -513,7 +513,7 @@ Feature: secrets related scenarios
       | e        | ALLOW_ANON_GIT_PULL=false |
     Then the step should succeed
     When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cases/508964/.gitconfig"
-    When I run the :oc_secrets_new_basicauth client command with:
+    When I run the :secrets_new_basicauth client command with:
       |secret_name|mysecret  |
       |username   |openshift |
       |password   |redhat    |
@@ -547,7 +547,7 @@ Feature: secrets related scenarios
     Given the "ruby-hello-world-2" build completes
 
     #Trigger third build automaticlly with secret which only contain a pair correct secret
-    When I run the :oc_secrets_new_basicauth client command with:
+    When I run the :secrets_new_basicauth client command with:
       |secret_name|mysecret1 |
       |username   |invaild   |
       |password   |invaild   |
@@ -706,7 +706,7 @@ Feature: secrets related scenarios
     When I run the :new_app client command with:
       | app_repo | ruby~http://<%= cb.git_route %>/ruby-hello-world.git |
     Then the step should succeed
-    When I run the :oc_secrets_new_basicauth client command with:
+    When I run the :secrets_new_basicauth client command with:
       | secret_name | mysecret  |
       | username    | openshift |
       | password    | redhat    |
@@ -733,7 +733,7 @@ Feature: secrets related scenarios
     When I have an ssh-git service in the project
     And the "secret" file is created with the following lines:
       | <%= cb.ssh_private_key.to_pem %> |
-    And I run the :oc_secrets_new_sshauth client command with:
+    And I run the :secrets_new_sshauth client command with:
       | ssh_privatekey | secret    |
       | secret_name    | sshsecret |
     Then the step should succeed
@@ -780,7 +780,7 @@ Feature: secrets related scenarios
       | -c                                                                                                      |
       | cd /var/lib/git/ && git clone --bare https://github.com/openshift/ruby-hello-world ruby-hello-world.git |
     Then the step should succeed
-    When I run the :oc_secrets_new_basicauth client command with:
+    When I run the :secrets_new_basicauth client command with:
       | secret_name | mysecret  |
       | username    | openshift |
       | password    | redhat    |
@@ -819,7 +819,7 @@ Feature: secrets related scenarios
       | l           | app=newapp2 |
     Then the step should succeed
 
-    When I run the :oc_secrets_new_basicauth client command with:
+    When I run the :secrets_new_basicauth client command with:
       | secret_name | override  |
       | username    | openshift |
       | password    | redhat    |

--- a/features/web/secrets.feature
+++ b/features/web/secrets.feature
@@ -4,7 +4,7 @@ Feature: web secrets related
   # @case_id OCP-11386
   Scenario: Add secret on Create From Image page
     Given I have a project
-    When I run the :oc_secrets_new_basicauth client command with:
+    When I run the :secrets_new_basicauth client command with:
       | secret_name | gitsecret |
       | username    | user      |
       | password    | 12345678  |

--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -806,6 +806,39 @@
   :cmd: oc secrets new <secret_name>
   :options:
     :source: <value>
+:secrets_new_basicauth:
+  :cmd: oc secrets new-basicauth <secret_name>
+  :options:
+    :cafile: --ca-cert=<value>
+    :gitconfig: --gitconfig=<value>
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>
+    :output_version: --output-version=<value>
+    :password: --password=<value>
+    :prompt: --prompt=<value>
+    :template: --template=<value>
+    :username: --username=<value>
+:secrets_new_dockercfg:
+  :cmd: oc secrets new-dockercfg <secret_name>
+  :options:
+    :docker_email: --docker-email=<value>
+    :docker_password: --docker-password=<value>
+    :docker_server: --docker-server=<value>
+    :docker_username: --docker-username=<value>
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>  # One of: json|yaml|template|templatefile|wide
+    :output_version: --output-version=<value>
+    :template: --template=<value>
+:secrets_new_sshauth:
+  :cmd: oc secrets new-sshauth <secret_name>
+  :options:
+    :cafile: --ca-cert=<value>
+    :gitconfig: --gitconfig=<value>
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>
+    :prompt: --prompt=<value>
+    :ssh_privatekey: --ssh-privatekey=<value>
+    :template: --template=<value>
 :secret_unlink:
   :cmd: oc secrets unlink serviceaccount/<sa_name> secrets/<secret_name>
 :serviceaccounts_get_token:


### PR DESCRIPTION
@pruan-rht @xiuwang 

Following the CLI rules, replace `oc_secrets_new_sshauth` with `secrets_new_sshauth`.

Will remove CLI rule `oc_secrets_new_sshauth` in another PR after all commands are replaced.