### PR TITLE
Replace obsoleted "oc env" with "oc set env"

### DIFF
--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -666,7 +666,7 @@ Feature: deployment related features
     Then the step should succeed
     Given status becomes :succeeded of exactly 1 pods labeled:
       | name=hello-openshift |
-    When I run the :env client command with:
+    When I run the :set_env client command with:
       | resource | dc/hooks                   |
       | e        | MYSQL_PASSWORD=update12345 |
     Then the step should succeed

--- a/features/cli/oc_env.feature
+++ b/features/cli/oc_env.feature
@@ -15,7 +15,7 @@ Feature: oc_env.feature
       | name=cakephp-mysql-example |
     Given I store in the clipboard the pods labeled:
       | name=cakephp-mysql-example |
-    When I run the :env client command with:
+    When I run the :set_env client command with:
       | resource | pods/<%= cb.pods[0].name%> |
       | list     | true                       |
     And the output should contain:

--- a/features/cli/oc_set_env.feature
+++ b/features/cli/oc_set_env.feature
@@ -46,7 +46,7 @@ Feature: oc_set_env.feature
       | key2=value2    |
       | key3=value3    |
     # set invalid enviroment variable
-    When I run the :env client command with:
+    When I run the :set_env client command with:
       | resource | bc/ruby-sample-build |
       | e        | pe#cial%=1234 |
     Then the step should fail

--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -296,7 +296,7 @@ Feature: Testing haproxy router
     Given default router is disabled and replaced by a duplicate
     And I switch to cluster admin pseudo user
     And I use the router project
-    When I run the :env admin command with:
+    When I run the :set_env admin command with:
       | resource | dc/<%= cb.new_router_dc.name %>         |
       | e        | RELOAD_INTERVAL=90s                     |
     Then the step should succeed

--- a/features/routing/logging.feature
+++ b/features/routing/logging.feature
@@ -29,7 +29,7 @@ Feature: Testing HAProxy router logging related scenarios
       | deploymentconfig=ocp-19830 |
     Then evaluation of `pod.name` is stored in the :router_pod clipboard
 
-    When I run the :env client command with:
+    When I run the :set_env client command with:
       | resource | dc/ocp-19830 |
       | e        | ROUTER_LOG_LEVEL=debug |
     Then the step should succeed

--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -293,19 +293,6 @@
   :options:
     :filename: --filename=<value>
     :output: --output=<value>
-# The cmd :env can be removed after 3.1 EOL (nov 2018).
-# We have both :env and :set_env since 3.2.
-# Removed :env in 3.11.
-:env:
-  :cmd: oc set env
-  :options:
-    :all: --all=<value>
-    :e: -e <value>
-    :env_name: <value>
-    :keyval: <value>
-    :list: --list=<value>
-    :o: -o <value>
-    :resource: <value>
 :exec:
   # reorder global_options and options to allow specifying exec command
   :cmd: oc exec <pod> <global_options> <options>
@@ -862,6 +849,7 @@
     :post: --post
     :pre: --pre
     :remove: --remove
+# We have :set_env since 3.2.
 :set_env:
   :cmd: oc set env
   :options:


### PR DESCRIPTION
\# The cmd :env can be removed after 3.1 EOL (nov 2018).
\# We have both :env and :set_env since 3.2.
\# Removed :env in 3.11.

@pruan-rht @akostadinov @zhouying7780