### PR TITLE
Add the OCP-15603 ocp-15605

### DIFF
--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -218,7 +218,7 @@ Feature: Service-catalog related scenarios
     And evaluation of `project.name` is stored in the :user_project clipboard
 
     # Deploy ups broker
-    Given I ensures "ups-instance" serviceinstance is deleted
+    Given admin ensures "ups-instance" serviceinstance is deleted
     When I switch to cluster admin pseudo user
     And I use the "<%= cb.ups_broker_project %>" project
     When I process and create:
@@ -259,7 +259,7 @@ Feature: Service-catalog related scenarios
       | resource   | serviceinstance/ups-instance |
       | show_label | true                         |
     Then the output should contain "app=test-instance"
-    Given I ensures "ups-instance" serviceinstance is deleted
+    Given admin ensures "ups-instance" serviceinstance is deleted
 
   # @author chezhang@redhat.com
   # @case_id OCP-15605
@@ -272,7 +272,7 @@ Feature: Service-catalog related scenarios
     And evaluation of `project.name` is stored in the :user_project clipboard
 
     # Deploy ups broker
-    Given I ensures "ups-broker" clusterservicebroker is deleted
+    Given admin ensures "ups-broker" clusterservicebroker is deleted
     When I switch to cluster admin pseudo user
     And I use the "<%= cb.ups_broker_project %>" project
     When I process and create:
@@ -328,7 +328,7 @@ Feature: Service-catalog related scenarios
     Then the output should contain "app=test-binding"
 
     # Delete servicebinding
-    Given I ensures "ups-binding" servicebinding is deleted
+    Given admin ensures "ups-binding" servicebinding is deleted
     And I wait for the resource "secret" named "my-secret" to disappear within 60 seconds  
 
   # @author chezhang@redhat.com

--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -24,7 +24,7 @@ Feature: Service-catalog related scenarios
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml |
       | p | UPS_BROKER_PROJECT=<%= cb.ups_broker_project %>                                                         |
     Then the step should succeed
-    And I wait for the steps to pass:
+    And I wait up to 360 seconds for the steps to pass:
     """
     When I run the :describe client command with:
       | resource | clusterservicebroker/ups-broker |
@@ -131,7 +131,7 @@ Feature: Service-catalog related scenarios
   # @case_id OCP-15604
   @admin
   @destructive
-  Scenario: Create/get/update/delete for ClusterServiceBroker resource	
+  Scenario: Create/get/update/delete for ClusterServiceBroker resource  
     Given I have a project
     And evaluation of `project.name` is stored in the :ups_broker_project clipboard
 
@@ -208,6 +208,152 @@ Feature: Service-catalog related scenarios
     Then the output should not contain "user-provided"
 
   # @author chezhang@redhat.com
+  # @case_id OCP-15603
+  @admin
+  @destructive
+  Scenario: Create/get/update/delete for ServiceInstance resource
+    Given I have a project
+    And evaluation of `project.name` is stored in the :ups_broker_project clipboard
+    And I create a new project
+    And evaluation of `project.name` is stored in the :user_project clipboard
+
+    # Deploy ups broker
+    Given I register clean-up steps:
+    """
+    I run the :delete admin command with:
+      | object_type       | clusterservicebroker |
+      | object_name_or_id | ups-broker           |
+    the step should succeed
+    """
+    When I switch to cluster admin pseudo user
+    And I use the "<%= cb.ups_broker_project %>" project
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml |
+      | p | UPS_BROKER_PROJECT=<%= cb.ups_broker_project %>                                                         |
+    Then the step should succeed
+    And I wait up to 300 seconds for the steps to pass:
+    """
+    When I run the :describe client command with:
+      | resource | clusterservicebroker/ups-broker |
+    Then the output should contain "Successfully fetched catalog entries from broker"
+    When I run the :get client command with:
+      | resource | clusterserviceclass                                                       |
+      | o        | custom-columns=CLASSNAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName |
+    Then the output should contain "user-provided"
+    """
+
+    #Provision a serviceinstance
+    Given I switch to the first user
+    And I use the "<%= cb.user_project %>" project
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-instance-template.yaml |
+      | p | USER_PROJECT=<%= cb.user_project %>                                                                       |
+    Then the step should succeed
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    When I run the :describe client command with:
+      | resource | serviceinstance/ups-instance |
+    Then the output should match "Message.*The instance was provisioned successfully"
+    """
+
+    #Update serviceinstance
+    When I run the :patch client command with:
+      | resource | serviceinstance/ups-instance                    |
+      | p        | {"metadata":{"labels":{"app":"test-instance"}}} |
+    Then the step should succeed
+    When I run the :get client command with:
+      | resource   | serviceinstance/ups-instance |
+      | show_label | true                         |
+    Then the output should contain "app=test-instance"
+
+    #Delete serviceinstance
+    When I run the :delete client command with:
+      | object_type       | serviceinstance |
+      | object_name_or_id | ups-instance    |
+    Then the step should succeed
+    And I ensure "ups-instance" serviceinstance is deleted
+
+  # @author chezhang@redhat.com
+  # @case_id OCP-15605
+  @admin
+  @destructive
+  Scenario: Create/get/update/delete for ServiceBinding resource
+    Given I have a project
+    And evaluation of `project.name` is stored in the :ups_broker_project clipboard
+    And I create a new project
+    And evaluation of `project.name` is stored in the :user_project clipboard
+
+    # Deploy ups broker
+    Given I register clean-up steps:
+    """
+    I run the :delete admin command with:
+      | object_type       | clusterservicebroker |
+      | object_name_or_id | ups-broker           |
+    the step should succeed
+    """
+    When I switch to cluster admin pseudo user
+    And I use the "<%= cb.ups_broker_project %>" project
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml |
+      | p | UPS_BROKER_PROJECT=<%= cb.ups_broker_project %>                                                         |
+    Then the step should succeed
+    And I wait up to 300 seconds for the steps to pass:
+    """
+    When I run the :describe client command with:
+      | resource | clusterservicebroker/ups-broker |
+    Then the output should contain "Successfully fetched catalog entries from broker"
+    When I run the :get client command with:
+      | resource | clusterserviceclass                                                       |
+      | o        | custom-columns=CLASSNAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName |
+    Then the output should contain "user-provided"
+    """
+
+    #Provision a serviceinstance
+    Given I switch to the first user
+    And I use the "<%= cb.user_project %>" project
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-instance-template.yaml |
+      | p | USER_PROJECT=<%= cb.user_project %>                                                                       |
+    Then the step should succeed
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    When I run the :describe client command with:
+      | resource | serviceinstance/ups-instance |
+    Then the output should match "Message.*The instance was provisioned successfully"
+    """
+
+    # Create servicebinding
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-binding-template.yaml |
+      | p | USER_PROJECT=<%= cb.user_project %>                                                                      |
+    Then the step should succeed
+    Given I check that the "my-secret" secret exists
+    And I wait up to 10 seconds for the steps to pass:
+    """
+    When I run the :describe client command with:
+      | resource | servicebinding |
+    Then the output should match "Message.*Injected bind result"
+    """
+
+    #Update servicebinding
+    When I run the :patch client command with:
+      | resource | servicebinding/ups-binding                     |
+      | p        | {"metadata":{"labels":{"app":"test-binding"}}} |
+    Then the step should succeed
+    When I run the :get client command with:
+      | resource   | servicebinding/ups-binding |
+      | show_label | true                       |
+    Then the output should contain "app=test-binding"
+
+    # Delete servicebinding
+    When I run the :delete client command with:
+      | object_type       | servicebinding |
+      | object_name_or_id | ups-binding    |
+    Then the step should succeed
+    Given I ensure "ups-binding" servicebinding is deleted
+    And I wait for the resource "secret" named "my-secret" to disappear within 60 seconds  
+
+  # @author chezhang@redhat.com
   # @case_id OCP-15602
   @admin
   @destructive
@@ -223,7 +369,7 @@ Feature: Service-catalog related scenarios
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml |
       | p | UPS_BROKER_PROJECT=<%= project.name %>                                                                  |
     Then the step should succeed
-    And I wait for the steps to pass:
+    And I wait up to 300 seconds for the steps to pass:
     """
     When I run the :describe client command with:
       | resource | clusterservicebroker/ups-broker |
@@ -279,4 +425,3 @@ Feature: Service-catalog related scenarios
       | resource | clusterserviceplan                                         |
       | o        | custom-columns=BROKER\ NAME:.spec.clusterServiceBrokerName |
     Then the output should not contain "ups-broker"
-

--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -218,7 +218,7 @@ Feature: Service-catalog related scenarios
     And evaluation of `project.name` is stored in the :user_project clipboard
 
     # Deploy ups broker
-    Given admin ensures "ups-instance" serviceinstance is deleted
+    Given I ensures "ups-instance" serviceinstance is deleted
     When I switch to cluster admin pseudo user
     And I use the "<%= cb.ups_broker_project %>" project
     When I process and create:
@@ -259,7 +259,7 @@ Feature: Service-catalog related scenarios
       | resource   | serviceinstance/ups-instance |
       | show_label | true                         |
     Then the output should contain "app=test-instance"
-    Given I ensure "ups-instance" serviceinstance is deleted
+    Given I ensures "ups-instance" serviceinstance is deleted
 
   # @author chezhang@redhat.com
   # @case_id OCP-15605
@@ -272,7 +272,7 @@ Feature: Service-catalog related scenarios
     And evaluation of `project.name` is stored in the :user_project clipboard
 
     # Deploy ups broker
-    And admin ensures "ups-broker" clusterservicebroker is deleted
+    Given I ensures "ups-broker" clusterservicebroker is deleted
     When I switch to cluster admin pseudo user
     And I use the "<%= cb.ups_broker_project %>" project
     When I process and create:
@@ -328,7 +328,7 @@ Feature: Service-catalog related scenarios
     Then the output should contain "app=test-binding"
 
     # Delete servicebinding
-    Given I ensure "ups-binding" servicebinding is deleted
+    Given I ensures "ups-binding" servicebinding is deleted
     And I wait for the resource "secret" named "my-secret" to disappear within 60 seconds  
 
   # @author chezhang@redhat.com
@@ -339,7 +339,7 @@ Feature: Service-catalog related scenarios
     Given I have a project
 
     # Deploy ups broker
-    Given admin ensures "ups-broker" clusterservicebroker is deleted after scenario
+    Given I ensures "ups-broker" clusterservicebroker is deleted after scenario
 
     When I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project

--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -219,6 +219,7 @@ Feature: Service-catalog related scenarios
 
     # Deploy ups broker
     Given admin ensures "ups-instance" serviceinstance is deleted
+    Given admin ensures "ups-broker" clusterservicebroker is deleted
     When I switch to cluster admin pseudo user
     And I use the "<%= cb.ups_broker_project %>" project
     When I process and create:
@@ -309,7 +310,6 @@ Feature: Service-catalog related scenarios
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-binding-template.yaml |
       | p | USER_PROJECT=<%= cb.user_project %>                                                                      |
     Then the step should succeed
-    Given I check that the "my-secret" secret exists
     And I wait up to 10 seconds for the steps to pass:
     """
     When I run the :describe client command with:
@@ -403,3 +403,4 @@ Feature: Service-catalog related scenarios
       | resource | clusterserviceplan                                         |
       | o        | custom-columns=BROKER\ NAME:.spec.clusterServiceBrokerName |
     Then the output should not contain "ups-broker"
+

--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -218,13 +218,7 @@ Feature: Service-catalog related scenarios
     And evaluation of `project.name` is stored in the :user_project clipboard
 
     # Deploy ups broker
-    Given I register clean-up steps:
-    """
-    I run the :delete admin command with:
-      | object_type       | clusterservicebroker |
-      | object_name_or_id | ups-broker           |
-    the step should succeed
-    """
+    Given admin ensures "ups-instance" serviceinstance is deleted
     When I switch to cluster admin pseudo user
     And I use the "<%= cb.ups_broker_project %>" project
     When I process and create:
@@ -265,13 +259,7 @@ Feature: Service-catalog related scenarios
       | resource   | serviceinstance/ups-instance |
       | show_label | true                         |
     Then the output should contain "app=test-instance"
-
-    #Delete serviceinstance
-    When I run the :delete client command with:
-      | object_type       | serviceinstance |
-      | object_name_or_id | ups-instance    |
-    Then the step should succeed
-    And I ensure "ups-instance" serviceinstance is deleted
+    Given I ensure "ups-instance" serviceinstance is deleted
 
   # @author chezhang@redhat.com
   # @case_id OCP-15605
@@ -284,13 +272,7 @@ Feature: Service-catalog related scenarios
     And evaluation of `project.name` is stored in the :user_project clipboard
 
     # Deploy ups broker
-    Given I register clean-up steps:
-    """
-    I run the :delete admin command with:
-      | object_type       | clusterservicebroker |
-      | object_name_or_id | ups-broker           |
-    the step should succeed
-    """
+    And admin ensures "ups-broker" clusterservicebroker is deleted
     When I switch to cluster admin pseudo user
     And I use the "<%= cb.ups_broker_project %>" project
     When I process and create:
@@ -346,10 +328,6 @@ Feature: Service-catalog related scenarios
     Then the output should contain "app=test-binding"
 
     # Delete servicebinding
-    When I run the :delete client command with:
-      | object_type       | servicebinding |
-      | object_name_or_id | ups-binding    |
-    Then the step should succeed
     Given I ensure "ups-binding" servicebinding is deleted
     And I wait for the resource "secret" named "my-secret" to disappear within 60 seconds  
 

--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -339,7 +339,7 @@ Feature: Service-catalog related scenarios
     Given I have a project
 
     # Deploy ups broker
-    Given I ensures "ups-broker" clusterservicebroker is deleted after scenario
+    Given admin ensures "ups-broker" clusterservicebroker is deleted after scenario
 
     When I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project


### PR DESCRIPTION
Add the auto scrip OCP-15603 ocp-15605 to verification-tests.
runner v3 test log:
 # @case_id OCP-15605
  @admin @destructive
  Scenario: Create/get/update/delete for ServiceBinding resource                          # features/svc-catalog_asb/svc-catalog.feature:280
      [05:06:33] INFO> === Before Scenario: Create/get/update/delete for ServiceBinding resource ===
      [05:06:33] INFO> === End Before Scenario: Create/get/update/delete for ServiceBinding resource ===
...
      [05:07:53] INFO> HTTP DELETE took 0.402 sec: 200 OK | application/json 235 bytes
      
      [05:07:53] INFO> Shell Commands: rm -r -f -- /home/jenkins/workspace/Runner-v3/workdir
      
      [05:07:53] INFO> Exit Status: 0
      [05:07:53] INFO> === End After Scenario: Create/get/update/delete for ServiceBinding resource ===

waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
  
  # @case_id OCP-15603
  @admin @destructive
  Scenario: Create/get/update/delete for ServiceInstance resource                   # features/svc-catalog_asb/svc-catalog.feature:214
      [05:07:56] INFO> === Before Scenario: Create/get/update/delete for ServiceInstance resource ===
      [05:07:56] INFO> Shell Commands: mkdir -v -p '/home/jenkins/workspace/Runner-v3/workdir'
      mkdir: created directory '/home/jenkins/workspace/Runner-v3/workdir'
      ...
      [05:08:59] INFO> Exit Status: 0
      [05:08:59] INFO> waiting up to 30 seconds for user clean-up to take place
      [05:09:06] INFO> REST delete_oauthaccesstoken for user 'BushSlicer::APIAccessor:testuser-38@ocp4', base_opts: {:options=>{:api_version=>"v1", :accept=>"application/json", :content_type=>"application/json", :oauth_token=>"uJDBTj1IHrPuBxZjkWyCb-_588re4CYF48XuIBJZqw8"}, :base_url=>"https://api.yinzhou.qe.devcluster.openshift.com:6443", :headers=>{"Accept"=>"<accept>", "Content-Type"=>"<content_type>", "Authorization"=>"Bearer <oauth_token>"}}, opts: {:token_to_delete=>"uJDBTj1IHrPuBxZjkWyCb-_588re4CYF48XuIBJZqw8"}
      [05:09:06] INFO> HTTP DELETE https://api.yinzhou.qe.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthaccesstokens/uJDBTj1IHrPuBxZjkWyCb-_588re4CYF48XuIBJZqw8
      [05:09:07] INFO> HTTP DELETE took 0.422 sec: 200 OK | application/json 235 bytes
      
      [05:09:07] INFO> Shell Commands: rm -r -f -- /home/jenkins/workspace/Runner-v3/workdir
      
      [05:09:07] INFO> Exit Status: 0
      [05:09:07] INFO> === End After Scenario: Create/get/update/delete for ServiceInstance resource ===

2 scenarios (2 passed)
49 steps (49 passed)
2m33.634s