### PR TITLE
Update default sub-team reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 approvers:
-- akostadinov
-- pruan-rht
+  - akostadinov
+  - pruan-rht
+
 reviewers:
-- akostadinov
-- pruan-rht
-- yapei
-- yanpzhan
-- liangxia
-- chao007
+  - akostadinov
+  - liangxia
+  - pruan-rht
+  - yanpzhan
+  - yapei

--- a/features/admin/OWNERS
+++ b/features/admin/OWNERS
@@ -1,6 +1,8 @@
 approvers:
+#  - chengzhang1016
+#  - xingxingxia
 
 reviewers:
-- chengzhang1016
-- pruan-rht
-- xingxingxia
+  - chengzhang1016
+  - pruan-rht
+  - xingxingxia

--- a/features/build/OWNERS
+++ b/features/build/OWNERS
@@ -1,5 +1,7 @@
 approvers:
+#  - yapei
+
 reviewers:
-- wewang58
-- wzheng1
-- xiuwang
+  - wewang58
+  - wzheng1
+  - xiuwang

--- a/features/cli/OWNERS
+++ b/features/cli/OWNERS
@@ -1,7 +1,10 @@
 approvers:
+#  - chengzhang1016
+#  - xingxingxia
+#  - yapei
 
 reviewers:
-- chengzhang1016
-- zhouying7780
-- xiuwang
-- xiaocwan
+  - chengzhang1016
+  - xiaocwan
+  - xiuwang
+  - zhouying7780

--- a/features/cluster_configuration/OWNERS
+++ b/features/cluster_configuration/OWNERS
@@ -1,6 +1,6 @@
 approvers:
 
 reviewers:
-- qinpingli
-- pruan-rht
-- liangxia
+  - liangxia
+  - pruan-rht
+  - qinpingli

--- a/features/images/OWNERS
+++ b/features/images/OWNERS
@@ -1,5 +1,7 @@
 approvers:
+#  - yapei
+
 reviewers:
-- wewang58
-- wzheng1
-- xiuwang
+  - wewang58
+  - wzheng1
+  - xiuwang

--- a/features/infrastructure/OWNERS
+++ b/features/infrastructure/OWNERS
@@ -1,4 +1,4 @@
 approvers:
 
 reviewers:
-- wjiangjay
+  - wjiangjay

--- a/features/logging/OWNERS
+++ b/features/logging/OWNERS
@@ -1,5 +1,6 @@
 approvers:
+#  - yapei
 
 reviewers:
-- anpingli
-- QiaolingTang
+  - anpingli
+  - QiaolingTang

--- a/features/machine/OWNERS
+++ b/features/machine/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+#  - jhou1
 
 reviewers:
-- jhou1
+  - jhou1

--- a/features/metrics/OWNERS
+++ b/features/metrics/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+#  - yapei
 
 reviewers:
-- pruan-rht
+  - pruan-rht

--- a/features/networking/OWNERS
+++ b/features/networking/OWNERS
@@ -1,5 +1,6 @@
 approvers:
+#  - qinpingli
 
 reviewers:
-- anuragthehatter
-- lihongan
+  - anuragthehatter
+  - lihongan

--- a/features/ocm/OWNERS
+++ b/features/ocm/OWNERS
@@ -1,7 +1,8 @@
 approvers:
+#  - xueli181114
 #  - yasun1
 
 reviewers:
-  - xiaocwan
-  - yasun1
+  - xueli181114
   - yuwang-RH
+  - tzhou5

--- a/features/quickstarts/OWNERS
+++ b/features/quickstarts/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+#  - yapei
 
 reviewers:
-- xiuwang
+  - xiuwang

--- a/features/registry/OWNERS
+++ b/features/registry/OWNERS
@@ -1,5 +1,7 @@
 approvers:
+#  - xingxingxia
+#  - yapei
 
 reviewers:
-- zhouying7780
-- pruan-rht
+  - pruan-rht
+  - zhouying7780

--- a/features/routing/OWNERS
+++ b/features/routing/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+#  - qinpingli
 
 reviewers:
-- lihongan
+  - lihongan

--- a/features/storage/OWNERS
+++ b/features/storage/OWNERS
@@ -1,5 +1,7 @@
 approvers:
+#  - qinpingli
+
 reviewers:
-- chao007
-- duanwei33
-- liangxia
+  - chao007
+  - duanwei33
+  - liangxia

--- a/features/svc-catalog_asb/OWNERS
+++ b/features/svc-catalog_asb/OWNERS
@@ -1,6 +1,7 @@
 approvers:
+#  - chengzhang1016
 
 reviewers:
-- chengzhang1016
-- emmajiafan
-- jianzhangbjz
+  - chengzhang1016
+  - emmajiafan
+  - jianzhangbjz

--- a/features/upgrade/OWNERS
+++ b/features/upgrade/OWNERS
@@ -1,4 +1,4 @@
 approvers:
 
 reviewers:
-- geliu2016
+  - geliu2016

--- a/features/upgrade/etcd/OWNERS
+++ b/features/upgrade/etcd/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+#  - xingxingxia
 
 reviewers:
-- geliu2016
+  - geliu2016

--- a/features/web/OWNERS
+++ b/features/web/OWNERS
@@ -1,7 +1,8 @@
 approvers:
+#  - yapei
 
 reviewers:
-- yapei
-- yanpzhan
-- SSshahan
-- xiaocwan
+  - SSshahan
+  - xiaocwan
+  - yanpzhan
+  - yapei

--- a/features/web/service-catalog/OWNERS
+++ b/features/web/service-catalog/OWNERS
@@ -1,6 +1,8 @@
 approvers:
+#  - chengzhang1016
+#  - yapei
 
 reviewers:
-- emmajiafan
-- SSshahan
-- jianzhangbjz
+  - emmajiafan
+  - jianzhangbjz
+  - SSshahan

--- a/lib/rules/web/admin_console/OWNERS
+++ b/lib/rules/web/admin_console/OWNERS
@@ -1,6 +1,8 @@
 approvers:
+#  - yapei
+
 reviewers:
-- SSshahan
-- xiaocwan
-- yanpzhan
-- yapei
+  - SSshahan
+  - xiaocwan
+  - yanpzhan
+  - yapei


### PR DESCRIPTION
1. Add group-lead as approver for sub-teams.
2. Sort approvers/reviewers.

@jhou1 @wsun1 @xltian @akostadinov @pruan-rht  Please help review the PR.

@xingxingxia  @yapei @chengzhang1016 @jhou1 @qinpingli @yasun1 for awareness that you can merge PR by adding /lgtm in specific sub-folders/teams.