### PR TITLE
Automate test case OCP-25628

### DIFF
--- a/features/machine/alerting.feature
+++ b/features/machine/alerting.feature
@@ -62,3 +62,57 @@ Feature: Alerting for machine-api
       | cluster-autoscaler-operator | openshift-machine-api              | ClusterAutoscalerOperatorDown | # @case_id OCP-26250
       | machine-api-operator        | openshift-machine-api              | MachineAPIOperatorDown        | # @case_id OCP-26248
       | machine-approver            | openshift-cluster-machine-approver | ClusterMachineApproverDown    | # @case_id OCP-26110
+
+  # @author jhou@redhat.com
+  # case_id OCP-25628
+  @admin
+  @destructive
+  Scenario: Alert should be fired when machine is in 'Deleting' state for too long
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    And I pick a random machineset to scale
+
+    Given I create the 'Ready' unhealthyCondition
+    And I run the :annotate client command with:
+      | n            | openshift-machine-api                       |
+      | resource     | machine                                     |
+      | resourcename | <%= machine.name %>                         |
+      | overwrite    | true                                        |
+      | keyval       | machine.openshift.io/exclude-node-draining- |
+    Then the step should succeed
+    And I register clean-up steps:
+    """
+    When I run the :annotate client command with:
+      | n            | openshift-machine-api                       |
+      | resource     | machine                                     |
+      | resourcename | <%= machine.name %>                         |
+      | overwrite    | true                                        |
+      | keyval       | machine.openshift.io/exclude-node-draining= |
+    Then the step should succeed
+    """
+
+    Given I run the :delete admin command with:
+      | object_type       | machine               |
+      | object_name_or_id | <%= machine.name %>   |
+      | n                 | openshift-machine-api |
+      | wait              | false                 |
+    And I use the "openshift-monitoring" project
+    And evaluation of `secret(service_account('prometheus-k8s').get_secret_names.find {|s| s.match('token')}).token` is stored in the :token clipboard
+
+    # verify alert is fired by querying prometheus http api
+    And I wait up to 180 seconds for the steps to pass:
+    """
+    When I run the :exec admin command with:
+      | n                | openshift-monitoring                                                                                                                                                                |
+      | pod              | prometheus-k8s-0                                                                                                                                                                    |
+      | c                | prometheus                                                                                                                                                                          |
+      | oc_opts_end      |                                                                                                                                                                                     |
+      | exec_command     | sh                                                                                                                                                                                  |
+      | exec_command_arg | -c                                                                                                                                                                                  |
+      | exec_command_arg | curl -G -s -k -H "Authorization: Bearer <%= cb.token %>" --data-urlencode 'query=ALERTS{alertname="MachineWithNoRunningPhase"}' https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query |
+    Then the step should succeed
+    And the output should match:
+      | "alertstate":"pending\|firing" |
+    """
+
+    And admin ensures "<%= machine.name %>" machine is deleted from the "openshift-machine-api" project after scenario

--- a/features/step_definitions/machine_healthcheck.rb
+++ b/features/step_definitions/machine_healthcheck.rb
@@ -22,6 +22,7 @@ When(/^I create the 'Ready' unhealthyCondition$/) do
     | ["spec"]["nodeName"] | #{machine.node_name}  |
   })
   step %Q{the step should succeed}
+  step %Q{admin ensures "kubelet-killer" pod is deleted from the "openshift-machine-api" project after scenario}
 end
 
 Then(/^the machine should be remediated$/) do

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -7,7 +7,8 @@ end
 
 Given(/^I pick a random machineset to scale$/) do
   ensure_admin_tagged
-  machine_sets = BushSlicer::MachineSet.list(user: admin, project: project("openshift-machine-api"))
+  machine_sets = BushSlicer::MachineSet.list(user: admin, project: project("openshift-machine-api")).
+    select { |m| m.available_replicas > 0 }
   cache_resources *machine_sets.shuffle
 end
 


### PR DESCRIPTION
Automate test case OCP-25628.

The test covers that when a machine is start at Deleting state, an alert is fired. Tested locally

```
      [10:08:38] INFO> === End After Scenario: Alert should be fired when machine is in 'Deleting' state for too long ===

1 scenario (1 passed)
12 steps (12 passed)
1m18.511s
```

@liangxia @pruan-rht can you please review?
