### PR TITLE
fix warnings introuduced with ruby 2.7, which warns about backward co…

### DIFF
--- a/features/step_definitions/dc.rb
+++ b/features/step_definitions/dc.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/hash/slice.rb'
-require 'active_support/core_ext/hash/transform_values.rb'
+#require 'active_support/core_ext/hash/transform_values.rb'
 
 Given /^I wait until the status of deployment "(.+)" becomes :(.+)$/ do |resource_name, status|
   ready_timeout = 10 * 60

--- a/features/step_definitions/dc.rb
+++ b/features/step_definitions/dc.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/hash/slice.rb'
-#require 'active_support/core_ext/hash/transform_values.rb'
 
 Given /^I wait until the status of deployment "(.+)" becomes :(.+)$/ do |resource_name, status|
   ready_timeout = 10 * 60
@@ -150,6 +149,15 @@ Given /^(I|admin) redeploys? #{QUOTED} dc( after scenario)?$/ do |who, dc_name, 
 end
 
 Given /^master CA is added to the#{OPT_QUOTED} dc$/ do |name|
+  ensure_admin_tagged
+
+  org_user = @user
+  org_proj_name = project.name
+  @user = admin
+  @result = secret("router-certs-default", project("openshift-ingress", switch: false)).value_of("tls.crt")
+  File.open("/tmp/openshift.crt", 'wb') { |f|
+    f.write(@result)
+  }
 
   step %Q/certification for default image registry is stored to the :reg_crt_name clipboard/
   step %Q/I run the :create_configmap client command with:/, table(%{

--- a/features/step_definitions/deployment.rb
+++ b/features/step_definitions/deployment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/hash/slice.rb'
-require 'active_support/core_ext/hash/transform_values.rb'
+#require 'active_support/core_ext/hash/transform_values.rb'
 
 ### Deployment related steps
 

--- a/features/step_definitions/deployment.rb
+++ b/features/step_definitions/deployment.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/hash/slice.rb'
-#require 'active_support/core_ext/hash/transform_values.rb'
 
 ### Deployment related steps
 

--- a/lib/environment_manager.rb
+++ b/lib/environment_manager.rb
@@ -37,7 +37,7 @@ module BushSlicer
       raise "no '#{key}' environment configuration found" if ! env_class || env_class.empty?
 
       env_opts[:key] = key # lets have it for a reference
-      return BushSlicer.const_get(env_class).new(env_opts)
+      return BushSlicer.const_get(env_class).new(**env_opts)
     end
 
     def clean_up

--- a/lib/host.rb
+++ b/lib/host.rb
@@ -529,9 +529,9 @@ module BushSlicer
       else
         exec_method = :exec
       end
-      public_send(exec_method, "rm #{r} -f -- #{file}", opts)
+      public_send(exec_method, "rm #{r} -f -- #{file}", **opts)
       opts[:quiet] = true
-      res = public_send(exec_method, "ls -d -- #{file}", opts)
+      res = public_send(exec_method, "ls -d -- #{file}", **opts)
 
       # OCDebugAccessibleHost does not return exit status of executed command
       # return ! res[:success]

--- a/tools/find_image.rb
+++ b/tools/find_image.rb
@@ -32,14 +32,14 @@ class QueryPayload
           :build_type => "nightly-",
           :url => "https://openshift-release.svc.ci.openshift.org/"
         raise "missing query string" if options.query.nil?
-        doc = Nokogiri::HTML(open(options.url).read)
+        doc = Nokogiri::HTML(URI.open(options.url).read)
         links = doc.xpath("//a[contains(text(), '#{options.build_type}')]")
 
         target_links = links.map { |l|  options.url + l.attributes['href'].value }
         threads = []
         target_links.each do |link|
           threads << Thread.new(link) do |i|
-            doc = Nokogiri::HTML(open(link).read)
+            doc = Nokogiri::HTML(URI.open(link).read)
               if doc.to_s.include? options.query
                 puts "Pattern '#{options.query}' found in payload: #{link}"
               end


### PR DESCRIPTION
…mpatiblity against ruby 3.0  for example:

> DEPRECATION WARNING: Ruby 2.5+ (required by Rails 6) provides Hash#transform_values natively, so requiring active_support/core_ext/hash/transform_values is no longer necessary. Requiring it will raise LoadError in Rails 6.1. (called from require at /home/pruan/workspace/bushslicer/features/step_definitions/dc.rb:4)
> /home/pruan/workspace/bushslicer/lib/host.rb:532: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
