### PR TITLE
Fix clone from storage class without parameters

### DIFF
--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -198,6 +198,7 @@ Given(/^admin clones storage class #{QUOTED} from #{QUOTED} with:$/) do |target_
   # Add/update any key/value pair.
   # Specially, add below line to make it a default storage class.
   # | ["metadata"]["annotations"]["storageclass.kubernetes.io/is-default-class"] | true |
+  sc_hash["parameters"] ||= {}
   table.raw.each do |path, value|
     eval "sc_hash#{path} = YAML.load value" unless path == ''
   end


### PR DESCRIPTION
When we use below step to clone from storage class which does not have parameters(E.g, on OpenStack), it will fail.
```
And admin clones storage class "storageclass-<%= project.name %>" from ":default" with:
  | ["parameters"]["fstype"] | <fstype> |
```

Pass [log](https://privatebin-it-iso.int.open.paas.redhat.com/?9c771e5fc0409aa7#mIAssdpGUnPIA8ALPWQSyPplA5UTYpJnHvtqzyZA1eM=) on OpenStack.

@chao007 @duanwei33 @pruan-rht @akostadinov 
