### PR TITLE
Add 60s waiting to fixing the issues, when hooks pods get into "running" late

### DIFF
--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -677,13 +677,13 @@ Feature: deployment related features
     Then I wait for the "hooks-2" rc to appear
     And I wait until number of replicas match "1" for replicationController "hooks-2"
     Given I wait up to 60 seconds for the steps to pass:
-      """
-      When I run the :get client command with:
-       | resource | po   |
-      Then the step should succeed
-      And the output should match:
-       | hooks-2.*Running|
-      """
+    """
+    When I run the :get client command with:
+     | resource | po    |
+    Then the step should succeed
+    And the output should match:
+     | hooks-2.*Running |
+    """
 
   # @author yinzhou@redhat.com
   # @case_id OCP-11326

--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -676,9 +676,14 @@ Feature: deployment related features
     Given I wait until number of replicas match "0" for replicationController "hooks-1"
     Then I wait for the "hooks-2" rc to appear
     And I wait until number of replicas match "1" for replicationController "hooks-2"
-    When I get project pod
-    Then the output should match:
-      | hooks-2.*Running |
+    Given I wait up to 60 seconds for the steps to pass:
+      """
+      When I run the :get client command with:
+       | resource | po   |
+      Then the step should succeed
+      And the output should match:
+       | hooks-2.*Running|
+      """
 
   # @author yinzhou@redhat.com
   # @case_id OCP-11326


### PR DESCRIPTION
Failed log:
`
waiting for operation up to 3600 seconds..
    When I get project pod                                                              # features/step_definitions/project.rb:255
      [07:24:05] INFO> Shell Commands: oc get pod --config=/home/weinliu/workdir/vm251-93-weinliu/ocp4_testuser-0.kubeconfig -n 6jhvt
      NAME             READY   STATUS              RESTARTS   AGE
      hooks-1-wrcsm    1/1     Terminating         0          15s
      hooks-2-deploy   0/1     ContainerCreating   0          9s
      [07:24:07] INFO> Exit Status: 0
    Then the output should match:                                                       # features/step_definitions/common.rb:33
      | hooks-2.*Running |
`
The changes fix this