### PR TITLE
Fixing OCP-11925,picking a worker node to get unschedulable

### DIFF
--- a/features/admin/pod.feature
+++ b/features/admin/pod.feature
@@ -185,7 +185,7 @@ Feature: pod related features
   @destructive
   Scenario: Pods will still be created by DaemonSet when nodes are SchedulingDisabled
     Given I have a project
-    Given I store the schedulable nodes in the :nodes clipboard
+    Given I store the schedulable workers in the :nodes clipboard
     Given node schedulable status should be restored after scenario
     When I run the :oadm_cordon_node admin command with:
       | node_name | <%= cb.nodes[0].name %> |


### PR DESCRIPTION
 A master node is picked for getting disabled, a po will not be scheduled there by default. This will make the checking step failed.

Failed log:
`[weinliu@vm251-93 0119]$ oc get no
NAME                                        STATUS                     ROLES    AGE    VERSION
ip-10-0-58-76.us-east-2.compute.internal    Ready,SchedulingDisabled   master   3h3m   v1.14.6+cebabbf4a
ip-10-0-60-56.us-east-2.compute.internal    Ready                      worker   173m   v1.14.6+cebabbf4a
ip-10-0-61-83.us-east-2.compute.internal    Ready                      master   3h3m   v1.14.6+cebabbf4a
ip-10-0-66-137.us-east-2.compute.internal   Ready                      worker   172m   v1.14.6+cebabbf4a
ip-10-0-78-225.us-east-2.compute.internal   Ready                      master   3h3m   v1.14.6+cebabbf4a
`