### PR TITLE
Add a step for rsh command in pod

### DIFF
--- a/features/step_definitions/pod.rb
+++ b/features/step_definitions/pod.rb
@@ -226,6 +226,19 @@ When /^(I execute|admin executes) on the(?: "(.+?)")? pod:$/ do |by, pod_name, r
   @result = pod(pod_name).exec(*args, as: _user)
 end
 
+When /^(I|admin) rsh on the(?: "(.+?)")? pod:$/ do |by, pod_name, raw_args|
+  _user = by.split.first == "admin" ? admin : user
+  if raw_args.respond_to? :raw
+    # this is table, we don't mind dimentions used by user
+    args = raw_args.raw.flatten
+  else
+    # multi-line string; useful when piping is needed
+    args = raw_args.split("\n").map(&:strip)
+  end
+
+  @result = pod(pod_name).rsh(*args, as: _user)
+end
+
 # wrapper around  oc logs, keep executing the command until we have an non-empty response
 # There are few occassion that the 'oc logs' cmd returned empty response
 #   this step should address those situations

--- a/lib/openshift/pod.rb
+++ b/lib/openshift/pod.rb
@@ -303,5 +303,12 @@ module BushSlicer
                exec_command_arg: args,
                _stdin: stdin)
     end
+
+    def rsh(command, *args, as:, container:nil, stdin: nil)
+      default_user(as).cli_exec(:rsh, pod: name, n: project.name,
+               c: container,
+               command: command,
+               command_arg: args)
+    end
   end
 end


### PR DESCRIPTION
@xingxingxia @xiaojiey Please check is that what you need? Any param needs to add?
Tested with a simple test as below and PASS locally: http://pastebin.test.redhat.com/828646
```
Feature: test rsh
  # @author xiaocwan@redhat.com
  # @case_id OCP-test
  @admin
  Scenario: test pod rsh
    Given I have a project
    When I run the :new_app client command with:
      | template | django-psql-example     | 
    Given the "django-psql-example-1" build completes
    Given 1 pods become ready with labels:
      | deployment=postgresql-1 |
    When I rsh on the pod:
      | ls | -al |
    Then the step should succeed
```