### PR TITLE
Changing definition to support mixed nodes

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -881,10 +881,9 @@ end
 Given /^the Internal IP of node "([^"]*)" is stored in the#{OPT_SYM} clipboard$/ do |node_name,cb_ipaddr|
   ensure_admin_tagged
   node = node(node_name)
-  _admin = admin
   host = node.host
   cb_ipaddr ||= "ip_address"
-  @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.defaultNetwork.type}")
+  @result = admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.defaultNetwork.type}")
   if @result[:success] then
      networkType = @result[:response].strip
   end


### PR DESCRIPTION
The existing definition is breaking on a cluster with mixed nodes as noted in CI runs. The reason is cluster with rhel7+rhcos nodes might have different master interface names on them respectively. Existing definition calls another step in it which changes course from existing node to a different one. We need to make sure the definition should execute on a single node itself from starting to end.

We could have shortened this definition by executing on host but i prefer to get inf names via network pods due to sometime we get STDERR on host commands.

Confirmed via logs that this whole def is executing on a single node now http://pastebin.test.redhat.com/830405

@pruan-rht Can you help merging it? 