### PR TITLE
Simplify steps to query prometheus

### DIFF
--- a/features/machine/alerting.feature
+++ b/features/machine/alerting.feature
@@ -38,23 +38,13 @@ Feature: Alerting for machine-api
     Then the step should succeed
     """
 
-    And I use the "openshift-monitoring" project
-    And evaluation of `secret(service_account('prometheus-k8s').get_secret_names.find {|s| s.match('token')}).token` is stored in the :token clipboard
-
-    # verify alert is fired by querying prometheus http api
-    And I wait up to 180 seconds for the steps to pass:
+    Given I wait up to 180 seconds for the steps to pass:
     """
-    When I run the :exec admin command with:
-      | n                | openshift-monitoring                                                                                                                                                                |
-      | pod              | prometheus-k8s-0                                                                                                                                                                    |
-      | c                | prometheus                                                                                                                                                                          |
-      | oc_opts_end      |                                                                                                                                                                                     |
-      | exec_command     | sh                                                                                                                                                                                  |
-      | exec_command_arg | -c                                                                                                                                                                                  |
-      | exec_command_arg | curl -G -s -k -H "Authorization: Bearer <%= cb.token %>" --data-urlencode 'query=ALERTS{alertname="<alertname>"}' https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query |
+    When I perform the GET prometheus rest client with:
+      | path  | /api/v1/query?                  |
+      | query | ALERTS{alertname="<alertname>"} |
     Then the step should succeed
-    And the output should match:
-      | "alertstate":"pending\|firing" |
+    And the expression should be true> @result[:parsed]["data"]["result"][0]["metric"]["alertstate"] =~ /pending|firing/
     """
 
     Examples:

--- a/features/step_definitions/prometheus.rb
+++ b/features/step_definitions/prometheus.rb
@@ -1,0 +1,22 @@
+When(/^I perform the (GET|POST) prometheus rest client with:$/) do | op_type, table |
+  opts = opts_array_to_hash(table.raw)
+  raise "required parameter 'path' or 'query' is missing" unless opts[:path] && opts[:query]
+
+  # prepare prometheus dns and token
+  step %Q{I use the "openshift-monitoring" project}
+  prometheus_dns = route("prometheus-k8s").dns
+  token = secret(service_account('prometheus-k8s').get_secret_names.find {|s| s.match('token')}).token
+
+  https_opts = {}
+  https_opts[:proxy] = env.client_proxy if env.client_proxy
+  https_opts[:headers] ||= {}
+  https_opts[:headers][:accept] ||= "application/json"
+  https_opts[:headers][:content_type] ||= "application/json"
+  https_opts[:headers][:authorization] ||= "Bearer #{token}"
+
+  uri = URI.parse("https://" + prometheus_dns + opts[:path])
+  uri.query = URI.encode_www_form("query": opts[:query])
+
+  @result = BushSlicer::Http.request(url: uri.to_s, **https_opts, method: op_type)
+  @result[:parsed] = YAML.load(@result[:response]) if @result[:success]
+end


### PR DESCRIPTION
Per the [discussion](https://github.com/openshift/cucushift/pull/7356#issuecomment-577745707) with @pruan-rht and @liangxia , we'd like to simplify the prometheus queriy steps. Instead of running the `oc exec` on the `prometheus-k8s-0` or `prometheus-k8s-1` pod, we query the prometheus route, this makes sure the data is always consistent.

Verified my tests locally:
```
    [07:43:19] INFO> === End After Scenario: Alert should be fired when operator is down, Examples (#3) ===

3 scenarios (3 passed)
24 steps (24 passed)
4m25.926s
```