### PR TITLE
Split minor version from "-"

### DIFF
--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -87,7 +87,8 @@ module BushSlicer
         # OCP > 4.1 format  `openshift-clients-4.2.2-201910250432`
         major = v[0].split('openshift-clients-').last
       end
-      return [major, v[1]].join('.')
+      minor = v[1].split('.').first.split('-').first
+      return [major, minor].join('.')
     end
 
     # prepare kube config according to parameters


### PR DESCRIPTION
@elenagerman reported the issue with oc in slack,
```
[kni@provisionhost-0 verification-tests]$ oc version -o yaml
clientVersion:
  buildDate: "2020-01-31T08:08:24Z"
  compiler: gc
  gitCommit: e0666000dfa8cb634a6fa712dd80ecf132d162a7
  gitTreeState: clean
  gitVersion: openshift-clients-4.3-2-ge0666000
  goVersion: go1.12.12
  major: ""
  minor: ""
  platform: linux/amd64
```

/cc @akostadinov @pruan-rht 