### PR TITLE
update project Details tab page url for 4.4

### DIFF
--- a/lib/rules/web/admin_console/4.4/goto.xyaml
+++ b/lib/rules/web/admin_console/4.4/goto.xyaml
@@ -8,8 +8,9 @@ goto_resource_page_under_default_project:
 goto_project_resources_page:
   url: k8s/cluster/projects/<project_name>/workloads
 goto_project_details_page:
-  url: k8s/cluster/projects/<project_name>/overview
-goto_one_project_page:
+  url: k8s/cluster/projects/<project_name>/details
+# Dashboard renamed to Overview in 4.4, url is same "k8s/cluster/projects/<project_name>"
+goto_one_project_page: 
   url: k8s/cluster/projects/<project_name>
 goto_one_project_dashboard_page:
   action: goto_one_project_page


### PR DESCRIPTION
@yanpzhan   same rule name `goto_project_details_page` only changed the url for 4.4.

<img width="660" alt="project-tab-page-renamed-on-4 4" src="https://user-images.githubusercontent.com/14801299/73915592-a70ca580-48f6-11ea-9002-539a426e8e87.png">
