### PR TITLE
Update to run cucushift on oc 4.4 using --kubeconfig instead of --config

### DIFF
--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -60,7 +60,7 @@ module BushSlicer
       fake_config = Tempfile.new("kubeconfig")
       fake_config.close
 
-      res = host.exec_as(user, "oc version -o yaml --config=#{fake_config.path}")
+      res = host.exec_as(user, "oc version -o yaml --kubeconfig=#{fake_config.path}")
 
       fake_config.unlink
 

--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -6,7 +6,7 @@
   :api_version: --api-version=<value>
   :ca: --certificate-authority=<value>
   :cluster: --cluster=<value>
-  :config: --config=<value>
+  :config: --kubeconfig=<value>
   :context: --context=<value>
   :h: -h
   :help: --help
@@ -1103,7 +1103,7 @@
   :cmd: oc adm diagnostics
   :options:
     :cluster-context: --cluster-context=<value>
-    :config: --config=<value>
+    :config: --kubeconfig=<value>
     :context: --context=<value>
     :diaglevel: --diaglevel=<value>
     :diagnostics_name: <value>


### PR DESCRIPTION
Hi @akostadinov and @pruan-rht 
Could we use `--kubeconfig` instead of `--config` since `--config` has been deprecated? I suggest to switch to the right flag for the oc 4.4.

$ oc version
Client Version: openshift-clients-4.4-23-g37623bc8
Server Version: 4.4.0-0.nightly-2020-02-05-181112

Mac using the latest oc version failed to run cucushift unless change `--config` to `--kubeconfig` as this PR did.
