### PR TITLE
Ensure machines and nodes are restored after scenario

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -35,7 +35,8 @@ Feature: Machine features testing
     Given I scale the machineset to +2
     And I register clean-up steps:
     """
-    And I scale the machineset to <%= cb.replicas_to_restore %>
+    When I scale the machineset to <%= cb.replicas_to_restore %>
+    Then the machineset should have expected number of running machines
     """
     Then the step should succeed
     And the machineset should have expected number of running machines


### PR DESCRIPTION
The machine number is restored after scenario, but we did not wait for the node number to be restored. This PR address the enhancement.

@qinpingli Will you PTAL?