### PR TITLE
Removing unnecessary step for cheking pods

### DIFF
--- a/features/cli/hpa.feature
+++ b/features/cli/hpa.feature
@@ -1,6 +1,7 @@
 Feature: hpa scale
 
   # @author chezhang@redhat.com
+  # @author weinliu@redhat.com
   # @case_id OCP-10931
   Scenario: HPA shouldn't scale up target if the replicas of dc is 0
     Given I have a project
@@ -32,7 +33,6 @@ Feature: hpa scale
       | deployment=hello-openshift-1 |
     When I get project pods
     Then the step should succeed
-    And the output should not contain "hello-openshift-"
 
   # @author chezhang@redhat.com
   # @case_id OCP-11338


### PR DESCRIPTION
Failed log: http://pastebin.test.redhat.com/834392

The script tried to check if pods get cleaned by checking if any `hello-openshift-*` pods left, however, `hello-openshift-1-deploy` is there with status Completed.
Removing this checkpoint is still good enough, since the last check point checked all pods with the label have died

```
 Given all existing pods die with labels:
      [09:03:28] INFO> Shell Commands: oc get pods --output=yaml -l deployment\=hello-openshift-1 --config=/home/weinliu/workdir/vm251-93-weinliu/ocp4_testuser-0.kubeconfig -n z275p
      apiVersion: v1
      items: []
      kind: List
      metadata:
        resourceVersion: ""
        selfLink: ""

```

Log after script updated: http://pastebin.test.redhat.com/834402


@jhou1 @sunilcio @lyman9966 ,could you guys help to take a look? Thanks.