### PR TITLE
Remove error/warning info from "oc version"

### DIFF
--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -60,7 +60,7 @@ module BushSlicer
       fake_config = Tempfile.new("kubeconfig")
       fake_config.close
 
-      res = host.exec_as(user, "oc version -o yaml --config=#{fake_config.path}")
+      res = host.exec_as(user, "oc version -o yaml --config=#{fake_config.path}" 2>/dev/null)
 
       fake_config.unlink
 


### PR DESCRIPTION
```
      [06:18:46] INFO> cleaning-up user testuser-0 projects
      [06:18:46] INFO> Shell Commands: rm  -f -- /home/jenkins/workspace/Runner-v3/workdir/ocp4_testuser-0.kubeconfig
      
      [06:18:46] INFO> Exit Status: 0
      [06:18:46] INFO> Shell Commands: oc version -o yaml --config=/tmp/kubeconfig20200211-364-1nbppq6
      Flag --config has been deprecated, use --kubeconfig instead
      clientVersion:
        buildDate: "2020-02-10T17:21:47Z"
        compiler: gc
        gitCommit: ee05f83cb8f0bee84c0a1516591437cd71befdc8
        gitTreeState: clean
        gitVersion: v4.4.0
        goVersion: go1.13.4
        major: ""
        minor: ""
        platform: linux/amd64
      
      
      [06:18:52] INFO> Exit Status: 0
      (<unknown>): mapping values are not allowed in this context at line 2 column 14 (Psych::SyntaxError)
      /home/jenkins/workspace/Runner-v3/lib/cli_executor.rb:68:in `get_version_for'
      /home/jenkins/workspace/Runner-v3/lib/cli_executor.rb:261:in `version'
      /home/jenkins/workspace/Runner-v3/lib/cli_executor.rb:251:in `executor'
      /home/jenkins/workspace/Runner-v3/lib/cli_executor.rb:293:in `user_opts'
      /home/jenkins/workspace/Runner-v3/lib/cli_executor.rb:303:in `exec'
      /home/jenkins/workspace/Runner-v3/lib/api_accessor.rb:71:in `cli_exec'
      /home/jenkins/workspace/Runner-v3/lib/api_accessor_owner.rb:28:in `public_send'
      /home/jenkins/workspace/Runner-v3/lib/api_accessor_owner.rb:28:in `block (2 levels) in <module:APIAccessorOwner>'
      /home/jenkins/workspace/Runner-v3/lib/openshift/cluster_resource.rb:162:in `get_matching'
      /home/jenkins/workspace/Runner-v3/lib/openshift/user.rb:143:in `projects'
      /home/jenkins/workspace/Runner-v3/lib/openshift/user.rb:113:in `block in clean_projects'
      /home/jenkins/workspace/Runner-v3/lib/base_helper.rb:153:in `wait_for'
      /home/jenkins/workspace/Runner-v3/lib/openshift/user.rb:112:in `clean_projects'
      /home/jenkins/workspace/Runner-v3/lib/openshift/user.rb:138:in `clean_up_on_load'
      /home/jenkins/workspace/Runner-v3/lib/user_manager.rb:107:in `[]'
      /home/jenkins/workspace/Runner-v3/lib/world.rb:150:in `user'
      /home/jenkins/workspace/Runner-v3/features/step_definitions/project.rb:21:in `/^I have a project$/'
      features/tierN/cli/allinone-volume.feature:73:in `Given I have a project'
```