### PR TITLE
add a rule to make sure kebab actions list open before next click

### DIFF
--- a/lib/rules/web/admin_console/4.3/actions.xyaml
+++ b/lib/rules/web/admin_console/4.3/actions.xyaml
@@ -8,9 +8,10 @@ click_resource_action_button:
     op: click
     timeout: 30
 choose_action_item_from_list:
-  action: check_actions_items_open
-  element:
-    selector:
+  elements:
+  - selector:
+      xpath: //*[@data-test-id="action-items"] 
+  - selector:
       xpath: //button[@data-test-action='<item>' and not(@disabled)]
     op: click
 choose_item_from_list:

--- a/lib/rules/web/admin_console/4.3/actions.xyaml
+++ b/lib/rules/web/admin_console/4.3/actions.xyaml
@@ -8,6 +8,7 @@ click_resource_action_button:
     op: click
     timeout: 30
 choose_action_item_from_list:
+  action: check_actions_items_open
   element:
     selector:
       xpath: //button[@data-test-action='<item>' and not(@disabled)]

--- a/lib/rules/web/admin_console/4.3/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.3/common_ui_elements.xyaml
@@ -275,8 +275,6 @@ submit_changes:
   elements:
   - selector:
       xpath: //button[@type='submit' and not(@disabled)]
-  - selector:
-      xpath: //button[@type='submit' and not(@disabled)]
     op: click
 click_add_more_button:
   element:

--- a/lib/rules/web/admin_console/4.3/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.3/common_ui_elements.xyaml
@@ -167,11 +167,7 @@ check_resource_item:
 check_resources_title_on_page:
   elements:
   - selector:
-      xpath: //span[text()='<resource_title>']
-check_actions_items_open:
-  elements:
-  - selector:
-      xpath: //*[@data-test-id="action-items"]      
+      xpath: //span[text()='<resource_title>']     
 click_kebab_of_one_resource:
   elements:
   - selector:

--- a/lib/rules/web/admin_console/4.3/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.3/common_ui_elements.xyaml
@@ -168,6 +168,10 @@ check_resources_title_on_page:
   elements:
   - selector:
       xpath: //span[text()='<resource_title>']
+check_actions_items_open:
+  elements:
+  - selector:
+      xpath: //*[@data-test-id="action-items"]      
 click_kebab_of_one_resource:
   elements:
   - selector:
@@ -272,8 +276,10 @@ check_page_not_match:
     selector: *page_content
     missing: true
 submit_changes:
-  element:
-    selector:
+  elements:
+  - selector:
+      xpath: //button[@type='submit' and not(@disabled)]
+  - selector:
       xpath: //button[@type='submit' and not(@disabled)]
     op: click
 click_add_more_button:

--- a/lib/rules/web/admin_console/4.4/actions.xyaml
+++ b/lib/rules/web/admin_console/4.4/actions.xyaml
@@ -8,6 +8,7 @@ click_resource_action_button:
     op: click
     timeout: 30
 choose_action_item_from_list:
+  action: check_actions_items_open
   element:
     selector:
       xpath: //button[@data-test-action='<item>' and not(@disabled)]

--- a/lib/rules/web/admin_console/4.4/actions.xyaml
+++ b/lib/rules/web/admin_console/4.4/actions.xyaml
@@ -8,9 +8,10 @@ click_resource_action_button:
     op: click
     timeout: 30
 choose_action_item_from_list:
-  action: check_actions_items_open
-  element:
-    selector:
+  elements:
+  - selector:
+      xpath: //*[@data-test-id="action-items"]
+  - selector:
       xpath: //button[@data-test-action='<item>' and not(@disabled)]
     op: click
 choose_item_from_list:

--- a/lib/rules/web/admin_console/4.4/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.4/common_ui_elements.xyaml
@@ -275,8 +275,6 @@ submit_changes:
   elements:
   - selector:
       xpath: //button[@type='submit' and not(@disabled)]
-  - selector:
-      xpath: //button[@type='submit' and not(@disabled)]
     op: click
 click_add_more_button:
   element:

--- a/lib/rules/web/admin_console/4.4/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.4/common_ui_elements.xyaml
@@ -168,10 +168,6 @@ check_resources_title_on_page:
   elements:
   - selector:
       xpath: //span[text()='<resource_title>']
-check_actions_items_open:
-  elements:
-  - selector:
-      xpath: //*[@data-test-id="action-items"]
 click_kebab_of_one_resource:
   elements:
   - selector:

--- a/lib/rules/web/admin_console/4.4/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.4/common_ui_elements.xyaml
@@ -168,6 +168,10 @@ check_resources_title_on_page:
   elements:
   - selector:
       xpath: //span[text()='<resource_title>']
+check_actions_items_open:
+  elements:
+  - selector:
+      xpath: //*[@data-test-id="action-items"]
 click_kebab_of_one_resource:
   elements:
   - selector:
@@ -272,8 +276,10 @@ check_page_not_match:
     selector: *page_content
     missing: true
 submit_changes:
-  element:
-    selector:
+  elements:
+  - selector:
+      xpath: //button[@type='submit' and not(@disabled)]
+  - selector:
       xpath: //button[@type='submit' and not(@disabled)]
     op: click
 click_add_more_button:


### PR DESCRIPTION
Update for both 4.3 and 4.4 for stable:
1) expect the kebab actions list open then choose the item
2) submit_changes actually existed then click it

Console 4.x framework is using ::after and ::before a lot, which makes our xpath unstable.
Refer to https://css-tricks.com/almanac/selectors/a/after-and-before/

Suggest solutions:
1) use expect before the click option (or before the next move, such as goto actions)
2) use CSS instead of xpath for more stable
Either one is okay.

This affects **OCP-25763** and **OCP-25800**, used to be failed: http://pastebin.test.redhat.com/835297
So I update it by 1st solution.
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/68535/console

@yapei @SSshahan @yanpzhan I suggest to have a discussion about this.
@yapei For this case, please review the change, thanks！