### PR TITLE
[Blocker] Switch to --kubeconfig only in 4.4 as some cmd in 4.3 does not support it.

### DIFF
--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -6,7 +6,7 @@
   :api_version: --api-version=<value>
   :ca: --certificate-authority=<value>
   :cluster: --cluster=<value>
-  :config: --kubeconfig=<value>
+  :config: --config=<value>
   :context: --context=<value>
   :h: -h
   :help: --help
@@ -1110,7 +1110,7 @@
   :cmd: oc adm diagnostics
   :options:
     :cluster-context: --cluster-context=<value>
-    :config: --kubeconfig=<value>
+    :config: --config=<value>
     :context: --context=<value>
     :diaglevel: --diaglevel=<value>
     :diagnostics_name: <value>

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -1,1 +1,1346 @@
-4.3.yaml
+---
+:global_options:
+  # these are options as seen by `oc options`
+  :as: --as=<value>
+  :as_group: --as-group=<value>
+  :api_version: --api-version=<value>
+  :ca: --certificate-authority=<value>
+  :cluster: --cluster=<value>
+  :config: --kubeconfig=<value>
+  :context: --context=<value>
+  :h: -h
+  :help: --help
+  :log_dir: --log_dir=<value>
+  :log_flush_frequency: --log_flush_frequency=<value>
+  :loglevel: --loglevel=<value>
+  :logtostderr: --logtostderr=<value>
+  :match-server-version: --match-server-version=<value>
+  :n: -n <value>
+  :namespace: --namespace=<value>
+  :request-timeout: --request-timeout=<value>
+  :server: --server=<value>
+  :skip_tls_verify: --insecure-skip-tls-verify=<value>
+  :stderrthreshold: --stderrthreshold=<value>
+  :token: --token=<value>
+  :user: --user=<value>
+:annotate:
+  :cmd: oc annotate
+  :options:
+    :all: --all=<value>
+    :keyval: <value>
+    :noheadersfalse: --no-headers=<value>
+    :o: -o <value>
+    :output: --output=<value>
+    :outputversion: --output-version=<value>
+    :overwrite: --overwrite=<value>
+    :resource: <value>
+    :resourcename: <value>
+    :resourceversion: --resource-version=<value>
+    :t: -t <value>
+    :template: --template=<value>
+:apply:
+  :cmd: oc apply
+  :options:
+    :f: -f <value>
+    :force: --force=<value>
+    :grace-period: --grace-period=<value>
+    :overwrite: --overwrite=<value>
+:apply_set_last_applied:
+  :cmd: oc apply set-last-applied
+  :options:
+    :f: -f <value>
+:apply_view_last_applied:
+  :cmd: oc apply view-last-applied
+  :options:
+    :resource: <value>
+    :resource_name: <value>
+:attach:
+  :cmd: oc attach
+  :options:
+    :c: -c <value>
+    :cmd_name: <value>
+    :container: --container=<value>
+    :i: -i
+    :pod: <value>
+    :stdin: --stdin=<value>
+    :t: -t
+    :tty: --tty=<value>
+:autoscale:
+  :cmd: oc autoscale <name>
+  :options:
+    :cpu-percent: --cpu-percent=<value>
+    :max: --max=<value>
+    :min: --min=<value>
+:build_logs:
+  :cmd: oc build-logs <build_name>
+  :options:
+    :follow: --follow=<value>
+    :nowait: --nowait=<value>
+:cancel_build:
+  :cmd: oc cancel-build
+  :options:
+    :bc_name: <value>
+    :build_name: <value>
+    :dump_logs: --dump-logs=<value>
+    :restart: --restart=<value>
+    :state: --state=<value>
+:config:
+  :cmd: oc config
+  :options:
+    :subcommand: <value>
+:config_set:
+  :cmd: oc config set <prop_name> <prop_value>
+:config_set_cluster:
+  :cmd: oc config set-cluster <name>
+  :options:
+    :cert: --certificate-authority=<value>
+    :embed: --embed-certs=<value>
+    :server: --server=<value>
+:config_set_context:
+  :cmd: oc config set-context <name>
+  :options:
+    :cluster: --cluster=<value>
+    :namespace: --namespace=<value>
+    :user: --user=<value>
+:config_set_creds:
+  :cmd: oc config set-credentials <name>
+  :options:
+    :cert:  --client-certificate=<value>
+    :embed:  --embed-certs=<value>
+    :key:  --client-key=<value>
+    :password:  --password=<value>
+    :token: --token=<value>
+    :user:  --username=<value>
+:config_unset:
+  :cmd: oc config unset <prop_name>
+:config_use_context:
+  :cmd: oc config use-context <name>
+:config_view:
+  :cmd: oc config view
+  :options:
+    :flatten: --flatten
+    :minify: --minify
+    :output: --output=<value>
+    :raw: --raw
+  :expected:
+    - "apiVersion: v"
+    - "kind: Config"
+  :optional_properties:
+    :current_context: !ruby/regexp '/^current-context: (.+)/'
+:convert:
+  :cmd: oc convert
+  :options:
+    :file: -f <value>
+    :local: --local=<value>
+    :o: -o <value>
+    :output_version: --output-version=<value>
+    :recursive: --recursive=<value>
+:cp:
+  :cmd: oc cp
+  :options:
+    :c: -c=<value>
+    :dest: <value>
+    :source: <value>
+:create:
+  :cmd: oc create
+  :options:
+    :f: -f <value>
+    :filename: --filename=<value>
+    :record: --record=<value>
+    :resource_name: <resource_name>
+    :resource_type: <resource_type>
+:create_clusterresourcequota:
+  :cmd: oc create clusterresourcequota <name>
+  :options:
+    :annotation-selector: --project-annotation-selector=<value>
+    :hard: --hard=<value>
+    :label-selector: --project-label-selector=<value>
+:create_clusterrole:
+  :cmd: oc create clusterrole <name>
+  :options:
+    :resource: --resource=<value>
+    :resource-name: --resource-name=<value>
+    :verb: --verb=<value>
+:create_clusterrolebinding:
+  :cmd: oc create clusterrolebinding <name>
+  :options:
+    :clusterrole: --clusterrole=<value>
+    :group: --group=<value>
+:create_configmap:
+  :cmd: oc create configmap
+  :options:
+    :from_file: --from-file=<value>
+    :from_literal: --from-literal=<value>
+    :name: <value>
+:create_namespace:
+  :cmd: oc create namespace <name>
+:create_quota:
+  :cmd: oc create quota <name>
+  :options:
+    :dry-run: --dry-run=<value>
+    :hard: --hard=<value>
+    :scopes: --scopes=<value>
+    :output: --output=<value>
+:create_rolebinding:
+  :cmd: oc create rolebinding <name>
+  :options:
+    :role: --role=<value>
+:create_route_edge:
+  :cmd: oc create route edge <name>
+  :options:
+    :cacert: --ca-cert=<value>
+    :cert: --cert=<value>
+    :help: --help
+    :hostname: --hostname=<value>
+    :insecure_policy: --insecure-policy=<value>
+    :key: --key=<value>
+    :path: --path=<value>
+    :service: --service=<value>
+    :wildcardpolicy: --wildcard-policy=<value>
+:create_route_passthrough:
+  :cmd: oc create route passthrough <name>
+  :options:
+    :help: --help
+    :hostname: --hostname=<value>
+    :service: --service=<value>
+    :wildcardpolicy: --wildcard-policy=<value>
+:create_route_reencrypt:
+  :cmd: oc create route reencrypt <name>
+  :options:
+    :cacert: --ca-cert=<value>
+    :cert: --cert=<value>
+    :destcacert: --dest-ca-cert=<value>
+    :help: --help
+    :hostname: --hostname=<value>
+    :insecure_policy: --insecure-policy=<value>
+    :key: --key=<value>
+    :path: --path=<value>
+    :service: --service=<value>
+    :wildcardpolicy: --wildcard-policy=<value>
+:create_secret:
+  :cmd: oc create secret <secret_type>
+  :options:
+    :cert: --cert=<value>
+    :docker_email: --docker-email=<value>
+    :docker_password: --docker-password=<value>
+    :docker_server: --docker-server=<value>
+    :docker_username: --docker-username=<value>
+    :dry_run: --dry-run=<value>
+    :from_file: --from-file=<value>
+    :from_literal: --from-literal=<value>
+    :generator: --generator=<value>
+    :key: --key=<value>
+    :name: <value>
+    :output: --output=<value>
+    :save_config: --save-config=<value>
+    :template: --template=<value>
+    :type: --type=<value>
+    :validate: --validate=<value>
+:create_service:
+  :cmd: oc create service <createservice_type>
+  :options:
+      :clusterip: --clusterip=<value>
+      :dry_run: --dry-run=<value>
+      :name: <value>
+      :nodeport: --node-port=<value>
+      :tcp: --tcp=<value>
+:create_service_loadbalancer:
+  :cmd: oc create service loadbalancer <name>
+  :options:
+    :tcp: --tcp=<value>
+:create_serviceaccount:
+  :cmd: oc create serviceaccount <serviceaccount_name>
+:create_user:
+  :cmd: oc create user <username>
+  :options:
+     :allow_missing_template_keys: --allow-missing-template-keys=<value>
+     :dry_run: --dry-run=<value>
+     :full_name: --full-name=<value>
+     :o: -o <value>
+     :output: --output=<value>
+     :template: --template=<value>
+:debug:
+  :cmd: oc debug <global_options>
+  :options:
+     :c: -c <value>
+     :dry_run: --dry-run
+     :exec_command: <value>
+     :exec_command_arg: <value>
+     :f: -f <value>
+     :keep_annotations: --keep-annotations
+     :keep_init_containers: --keep-init-containers=<value>
+     :keep_liveness: --keep-liveness
+     :keep_readiness: --keep-readiness
+     :node_name: --node-name=<value>
+     :o: -o <value>
+     :oc_opts_end: --
+     :one_container: --one-container=<value>
+     :resource: <value>
+     :t: -t
+:delete:
+  :cmd: oc delete
+  :options:
+    :all: --all
+    #The following 'all' can be used with selectors, like the -l flag.
+    :all_no_dash: all
+    :cascade: --cascade=<value>
+    :f: -f <value>
+    :force: --force=<value>
+    :grace_period: --grace-period=<value>
+    :l: -l <value>
+    :object_name_or_id: <value>
+    :object_type: <value>
+    :wait: --wait=<value>
+:deploy:
+  :cmd: oc deploy <deployment_config>
+  :options:
+    :cancel: --cancel
+    :enable_triggers: --enable-triggers
+    :latest: --latest
+    :retry: --retry
+:describe:
+  :cmd: oc describe <resource>
+  :options:
+    :f: -f <value>
+    :l: -l <value>
+    :name: <value>
+    :selector: --selector=<value>
+:edit:
+  :cmd: oc edit
+  :options:
+    :filename: --filename=<value>
+    :output: --output=<value>
+:exec:
+  # reorder global_options and options to allow specifying exec command
+  :cmd: oc exec <pod> <global_options> <options>
+  :options:
+    :c: -c <value>
+    :container: --container=<value>
+    :exec_command: <value>
+    :exec_command_arg: <value>
+    :i: -i
+    :oc_opts_end: --
+    :stdin: --stdin=<value>
+    :t: -t
+    :tty: --tty=<value>
+:exec_raw_oc_cmd_for_neg_tests:   # used for negative testing in which we want to deviate from yaml
+  :cmd: oc
+  :options:
+    :arg: <value>
+    :test_do_not_use: <value>
+:explain:
+  :cmd: oc explain
+  :options:
+    :api_version: --api-version=<value>
+    :resource: <value>
+:export:
+  :cmd: oc export
+  :options:
+    :all: --all=<value>
+    :as_template: --as-template=<value>
+    :exact: --exact=<value>
+    :f: -f <value>
+    :filename: --filename=<value>
+    :l: -l <value>
+    :name: <value>
+    :o: -o <value>
+    :output_format: --output=<value>
+    :output_version: --output-version=<value>
+    :resource: <value>
+    :t: -t <value>
+:expose:
+  :cmd: oc expose <resource> <resource_name>
+  :options:
+    :external_ip: --external-ip=<value>
+    :generator: --generator=<value>
+    :help: --help
+    :hostname: --hostname=<value>
+    :name: --name=<value>
+    :o: -o <value>
+    :output: --output=<value>
+    :path: --path=<value>
+    :port: --port=<value>
+    :protocol: --protocol=<value>
+    :selector: --selector=<value>
+    :target_port: --target-port=<value>
+    :template: --template=<value>
+    :type: --type=<value>
+    :wildcardpolicy: --wildcard-policy=<value>
+:extract:
+  :cmd: oc extract
+  :options:
+    :confirm: --confirm=<value>
+    :f: -f <value>
+    :filename: --filename=<value>
+    :keys: --keys=<value>
+    :resource: <value>
+    :to: --to=<value>
+:get:
+  :cmd: oc get <resource>
+  :options:
+    :a: --show-all=<value>
+    :all_namespaces: --all-namespaces=<value>
+    :export: --export=<value>
+    :f: --filename=<value>
+    :fieldSelector: --field-selector=<value>
+    :L: -L <value>
+    :l: -l <value>
+    :no_headers: --no-headers=<value>
+    :o: -o <value>
+    :output: --output=<value>
+    :raw: --raw=<value>
+    :resource_name: <value>
+    :show_label: --show-labels=<value>
+    :sort_by: --sort-by=<value>
+    :template: --template=<value>
+    :w: --watch=<value>
+:help:
+  :cmd: oc help
+  :options:
+    :command_name: <value>
+    # use global `h` and `help` options if needed
+:idle:
+  :cmd: oc idle
+  :options:
+    :all: --all=<value>
+    :dry-run: --dry-run=<value>
+    :l: -l <value>
+    :resource-names-file: --resource-names-file=<value>
+    :svc_name: <value>
+:image_mirror:
+  :cmd: oc image mirror <source_image> <dest_image>
+  :options:
+    :a: --registry-config=<value>
+    :dry_run: --dry-run=<value>
+    :f: --filename=<value>
+    :force: --force=<value>
+    :from_dir: --from-dir=<value>
+    :insecure: --insecure=<value>
+    :s3_source_bucket: --s3-source-bucket=<value>
+    :skip_verification: --skip-verification=<value>
+:import:
+  :cmd: oc import <command>
+  :options:
+    :as_template: --as-template=<value>
+    :dry_run: --dry-run=<value>
+    :f: -f <value>
+    :o: -o <value>
+:import_image:
+  :cmd: oc import-image
+  :options:
+    :all: --all=<value>
+    :confirm: --confirm=<value>
+    :from: --from=<value>
+    :image_name: <value>
+    :insecure: --insecure=<value>
+    :reference-policy: --reference-policy=<value>
+:label:
+  :cmd: oc label <resource>
+  :options:
+    :all: --all=<value>
+    :key_val: <value>
+    :l: -l <value>
+    :name: <value>
+    :o: -o <value>
+    :overwrite: --overwrite=<value>
+:login:
+  :cmd: oc login
+  :options:
+    :p: -p <value>
+    :password: --password=<value>
+    :token: --token=<value>
+    :u: -u <value>
+    :username: --username=<value>
+  :optional_properties:
+    :username: !ruby/regexp '/ogged into ".+?" as "(.+?)"/'
+  :expected:
+    # strange, sometimes "Already logged into..." is printed to console, and
+    #   sometimes when run multiple times - not (oc v3.0.0.0)
+    #   e.g. run multiple times `oc login --username=joe`
+    - !ruby/regexp '/Login successful.|ogged into|sing project|new project/'
+:logout:
+  :cmd: oc logout
+  :expected:
+    - !ruby/regexp '/Logged ".+" out on/'
+:logs:
+  :cmd: oc logs <resource_name>
+  :options:
+    :c: -c <value>
+    :f: -f
+    :limit-bytes: --limit-bytes <value>
+    :p: -p
+    :since: --since <value>
+    :since-time: --since-time <value>
+    :tail: --tail <value>
+    :timestamps: --timestamps
+    :version: --version <value>
+:new_app:
+  :cmd: oc new-app
+  :options:
+    :allow_missing_images: --allow-missing-images=<value>
+    :allow_missing_imagestream_tags: --allow-missing-imagestream-tags=<value>
+    :app_repo: <value>
+    :as_test: --as-test=<value>
+    :build_env: --build-env=<value>
+    :build_env_file: --build-env-file=<value>
+    :code: --code=<value>
+    :context_dir: --context-dir=<value>
+    :docker_image: --docker-image=<value>
+    :dry_run: --dry-run=<value>
+    :e: -e <value>
+    :env: --env=<value>
+    :env_file: --env-file=<value>
+    :file: --file=<value>
+    :group: --group=<value>
+    :image: --image=<value>
+    :image_stream: --image-stream=<value>
+    :insecure_registry: --insecure-registry=<value>
+    :l: -l <value>
+    :labels: --labels=<value>
+    :name: --name=<value>
+    :output: --output=<value>
+    :p: -p <value>
+    :param: --param=<value>
+    :param_file: --param-file=<value>
+    :search: --search=<value>
+    :search_raw: --search <value>
+    :source_secret: --source-secret=<value>
+    :source_spec: <value>
+    :strategy: --strategy=<value>
+    :template: --template=<value>
+:new_build:
+  :cmd: oc new-build
+  :options:
+    :allow_missing_imagestream_tags: --allow-missing-imagestream-tags=<value>
+    :app_repo: <value>
+    :binary: --binary <value>
+    :build_arg: --build-arg=<value>
+    :build_config_map: --build-config-map=<value>
+    :build_env: --build-env=<value>
+    :build_env_file: --build-env-file=<value>
+    :build_secret: --build-secret=<value>
+    :code: --code=<value>
+    :context_dir: --context-dir=<value>
+    :docker_image: --docker-image=<value>
+    :D : -D <value>
+    :e: -e <value>
+    :env_file: --env-file=<value>
+    :image: --image=<value>
+    :image_stream: --image-stream=<value>
+    :l: -l <value>
+    :name: --name=<value>
+    :no-output: --no-output=<value>
+    :output: --output=<value>
+    :source_image: --source-image=<value>
+    :source_image_path: --source-image-path=<value>
+    :source_secret: --source-secret=<value>
+    :strategy: --strategy=<value>
+    :template: --template=<value>
+    :to : --to=<value>
+    :to_docker: --to-docker=<value>
+:new_project:
+  :cmd: oc new-project <project_name>
+  #:expected:
+  #  - Created project <project_name>
+  :options:
+    :admin: --admin=<value>
+    :description: --description=<value>
+    :display_name: --display-name=<value>
+:new_secret:
+  :cmd: oc secrets new <secret_name> <credential_file>
+  :options:
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>  # One of: json|yaml|template|templatefile|wide
+    :output_version: --output-version=<value>
+    :quiet: --quiet=<value>
+    :template: --template=<value>
+    :type: --type=<value>
+:observe:
+  :cmd: oc observe <resource> <global_options> <options>
+  :options:
+    :a: -a=<value>
+    :command: <value>
+    :delete: --delete=<value>
+    :maximum_errors: --maximum-errors=<value>
+    :names: --names=<value>
+    :no_headers: --no-headers=<value>
+    :oc_opts_end: --
+    :once: --once=<value>
+    :resync_period: --resync-period=<value>
+:options:
+  :cmd: oc options
+:patch:
+  :cmd: oc patch <resource>
+  :options:
+    :p: -p <value>
+    :resource_name: <value>
+    :type: --type=<value>
+:plugin:
+  :cmd: oc plugin
+  :options:
+    :cmd_flag: <value>
+    :cmd_flag_val: <value>
+    :cmd_name: <value>
+:policy_add_role_to_group:
+  :cmd: oc policy add-role-to-group <role> <group_name>
+  :options:
+    :role_namespace: --role-namespace=<value>
+:policy_add_role_to_user:
+  :cmd: oc policy add-role-to-user <role>
+  :options:
+    :role_namespace: --role-namespace=<value>
+    :rolebinding_name: --rolebinding-name=<value>
+    :serviceaccount: -z=<value>
+    :serviceaccountraw: <value>
+    :user_name: <value>
+:policy_can_i:
+  :cmd: oc policy can-i <verb> <resource>
+  :options:
+    :q: -q
+:policy_remove_group:
+  :cmd: oc policy remove-group <group_name>
+:policy_remove_role_from_group:
+  :cmd: oc policy remove-role-from-group <role> <group_name>
+  :options:
+    :role_namespace: --role-namespace=<value>
+:policy_remove_role_from_user:
+  :cmd: oc policy remove-role-from-user <role>
+  :options:
+    :role_namespace: --role-namespace=<value>
+    :serviceaccount: -z <value>
+    :user_name: <value>
+:policy_scc_review:
+  :cmd: oc policy scc-review
+  :options:
+    :f: -f <value>
+    :serviceaccount: -z <value>
+:policy_scc_subject_review:
+  :cmd: oc policy scc-subject-review
+  :options:
+    :f: -f <value>
+    :group: -g <value>
+    :serviceaccount: -z <value>
+    :user: -u <value>
+:policy_who_can:
+  :cmd: oc policy who-can <verb> <resource>
+:port_forward:
+  :cmd: oc port-forward
+  :options:
+    :pod: <value>
+    :port_spec: <value>
+:process:
+  :cmd: oc process
+  :options:
+    :f: -f <value>
+    :l: -l <value>
+    :p: -p <value>
+    :parameters: --parameters=<value>
+    :param_file: --param-file=<value>
+    :template: <value>
+    :v: --value=<value>
+:project:
+  :cmd: oc project
+  :options:
+    :project_name: <value>
+    :short:  --short=<value>
+:projects:
+  :cmd: oc projects
+  :options:
+    :short:  --short=<value>
+:proxy:
+  :cmd: oc proxy
+  :options:
+    :accept_hosts: --accept-hosts=<value>
+    :accept_paths: --accept-paths=<value>
+    :address: --address=<value>
+    :api_prefix: --api-prefix=<value>
+    :disable_filter: --disable-filter=<value>
+    :port: --port=<value>
+    :reject_methods: --reject-methods=<value>
+    :reject_paths: --reject-paths=<value>
+    :unix_socket: --unix-socket=<value>
+    :www: --www=<value>
+    :www_prefix: --www-prefix=<value>
+:replace:
+  :cmd: oc replace
+  :options:
+    :cascade: --cascade
+    :f: -f <value>
+    :force: --force
+    :grace_period: --grace-period=<value>
+    :output: --output=<value>
+:rollback:
+  :cmd: oc rollback <deployment_name>
+  :options:
+    :change_scaling_settings: --change-scaling-settings
+    :change_strategy: --change-strategy
+    :change_triggers: --change-triggers
+    :dry_run: --dry-run
+    :output: --output=<value>
+    :template: --template=<value>
+    :to_version: --to-version=<value>
+:rollout_cancel:
+  :cmd: oc rollout cancel <resource> <name>
+  :options:
+    :f: -f <value>
+    :output: --output=<value>
+:rollout_history:
+  :cmd: oc rollout history <resource>
+  :options:
+    :resource_name: <value>
+    :revision: --revision=<value>
+:rollout_latest:
+  :cmd: oc rollout latest <resource>
+  :options:
+      :f: -f <value>
+:rollout_pause:
+  :cmd: oc rollout pause <resource> <name>
+  :options:
+    :f: -f <value>
+:rollout_resume:
+  :cmd: oc rollout resume <resource> <name>
+  :options:
+    :f: -f <value>
+:rollout_retry:
+  :cmd: oc rollout retry <resource> <name>
+  :options:
+    :f: -f <value>
+    :output: --output=<value>
+:rollout_status:
+  :cmd: oc rollout status <resource> <name>
+  :options:
+    :f: -f <value>
+    :w: --watch=<value>
+:rollout_undo:
+  :cmd: oc rollout undo <resource>
+  :options:
+    :resource_name: <value>
+    :to_revision: --to-revision=<value>
+:rsh:
+  :cmd: oc rsh <global_options> <options>
+  :options:
+    :app_name: <value>
+    :c: --container=<value>
+    :command: <value>
+    :command_arg: <value>
+    :no_tty: --no-tty=<value>
+    :pod: <value>
+    :shell: --shell=<value>
+:rsync:
+  #either source or destination must be in to format POD:/remote/dir/, i.e.
+  #oc rsync ./local/dir/ POD:/remote/dir
+  #oc rsync POD:/remote/dir/ ./local/dir
+  #Please reference TC 510666 in features/cli/oc_rsync.feature for an example.
+  :cmd: oc rsync <source> <destination>
+  :options:
+    :c: --container=<value>
+    :delete: --delete=<value>
+    :strategy: --strategy=<value>
+    :w: --watch=<value>
+:run:
+  :cmd: oc run <name> <global_options> <options>
+  :options:
+    :attach: --attach=<value>
+    :cmd: <value>
+    :command: --command=<value>
+    :dry_run: --dry-run
+    :env: --env=<value>
+    :generator: --generator=<value>
+    :image: --image=<value>
+    :limits: --limits=<value>
+    :oc_opt_end: --
+    :overrides: --overrides=<value>
+    :port: --port <value>
+    :replicas: --replicas <value>
+    :requests: --requests=<value>
+    :restart: --restart=<value>
+    :schedule: --schedule=<value>
+    :serviceaccount: --serviceaccount=<value>
+    :sleep:  -- sleep <value>
+    :tty: --tty=<value>
+    :-i: --stdin=<value>
+    :-l: --labels=<value>
+    :-t: --template=<value>
+    :-o: --output=<value>
+:scale:
+  :cmd: oc scale <resource> <name>
+  :options:
+    :current_replicas: --current-replicas=<value>
+    :replicas:  --replicas=<value>
+    :resource_ver: --resource-version=<value>
+    :timeout: --timeout=<value>
+:secrets:
+  :cmd: oc secrets <action>
+  :options:
+    :for: --for=<value>
+    :name: <value>
+    :password: --password=<value>
+    :secrets_name: <value>
+    :serviceaccount: <value>
+    :source: <value>
+    :username: --username=<value>
+:secret_add:
+  :cmd: oc secrets add serviceaccount/<sa_name> secrets/<secret_name>
+  :options:
+    :for: --for=<value>
+:secret_link:
+  :cmd: oc secrets link serviceaccount/<sa_name> secrets/<secret_name>
+  :options:
+    :for: --for=<value>
+:secret_new:
+  :cmd: oc secrets new <secret_name>
+  :options:
+    :source: <value>
+:secrets_new_basicauth:
+  :cmd: oc secrets new-basicauth <secret_name>
+  :options:
+    :cafile: --ca-cert=<value>
+    :gitconfig: --gitconfig=<value>
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>
+    :output_version: --output-version=<value>
+    :password: --password=<value>
+    :prompt: --prompt=<value>
+    :template: --template=<value>
+    :username: --username=<value>
+:secrets_new_dockercfg:
+  :cmd: oc secrets new-dockercfg <secret_name>
+  :options:
+    :docker_email: --docker-email=<value>
+    :docker_password: --docker-password=<value>
+    :docker_server: --docker-server=<value>
+    :docker_username: --docker-username=<value>
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>  # One of: json|yaml|template|templatefile|wide
+    :output_version: --output-version=<value>
+    :template: --template=<value>
+:secrets_new_sshauth:
+  :cmd: oc secrets new-sshauth <secret_name>
+  :options:
+    :cafile: --ca-cert=<value>
+    :gitconfig: --gitconfig=<value>
+    :no_headers: --no-headers=<value>
+    :output: --output=<value>
+    :prompt: --prompt=<value>
+    :ssh_privatekey: --ssh-privatekey=<value>
+    :template: --template=<value>
+:secret_unlink:
+  :cmd: oc secrets unlink serviceaccount/<sa_name> secrets/<secret_name>
+:serviceaccounts_get_token:
+  :cmd: oc serviceaccounts get-token <serviceaccount_name>
+:serviceaccounts_new_token:
+  :cmd: oc serviceaccounts new-token <serviceaccount_name>
+  :options:
+    :labels: --labels=<labels>
+    :timeout: --timeout=<timeout_seconds>
+:set_backends:
+  :cmd: oc set route-backends
+  :options:
+    :adjust: --adjust
+    :routename: <value>
+    :service: <value>
+    :zero: --zero
+:set_build_hook:
+  :cmd: oc set build-hook <global_options> <options>
+  :options:
+    :args: <value>
+    :buildconfig: <value>
+    :command: --command
+    :f: -f <value>
+    :o: -o <value>
+    :oc_opts_end: --
+    :post_commit: --post-commit=<value>
+    :remove: --remove=<value>
+    :script: --script=<value>
+:set_build_secret:
+  :cmd: oc set build-secret <options> <bc_name> <secret_name>
+  :options:
+    :l: --selector=<value>
+    :pull: --pull=<value>
+    :push: --push=<value>
+    :remove: --remove=<value>
+    :source: --source=<value>
+:set_deployment_hook:
+  :cmd: oc set deployment-hook <global_options> <options>
+  :options:
+    :all: --all
+    :args: <value>
+    :c: -c <value>
+    :deploymentconfig: <value>
+    :e: -e <value>
+    :f: -f <value>
+    :failure_policy: --failure-policy=<value>
+    :l: -l <value>
+    :mid: --mid
+    :o: -o <value>
+    :oc_opts_end: --
+    :post: --post
+    :pre: --pre
+    :remove: --remove
+# We have :set_env since 3.2.
+:set_env:
+  :cmd: oc set env
+  :options:
+    :all: --all=<value>
+    :c: -c <value>
+    :e: -e <value>
+    :env_name: <value>
+    :f: -f <value>
+    :from: --from=<value>
+    :keyval: <value>
+    :list: --list=<value>
+    :o: -o <value>
+    :overwrite: --overwrite=<value>
+    :prefix: --prefix=<value>
+    :resource: <value>
+:set_image:
+  :cmd: oc set image
+  :options:
+    :all: --all=<value>
+    :container_image: <value>
+    :filename: --filename=<value>
+    :keyval: <value>
+    :l: -l <value>
+    :local: --local=<value>
+    :output: --output=<value>
+    :record: --record=<value>
+    :resource: <value>
+    :selector: --selector=<value>
+    :source: --source=<value>
+    :type_name: <value>
+:set_image_lookup:
+  :cmd: oc set image-lookup
+  :options:
+    :deployment: <value>
+    :image_stream: <value>
+:set_probe:
+  :cmd: oc set probe <global_options> <options>
+  :options:
+    :all: --all
+    :c: -c <value>
+    :exec_command: <value>
+    :f: -f <value>
+    :failure_threshold: --failure-threshold=<value>
+    :get_url: --get-url=<value>
+    :initial_delay_seconds: --initial-delay-seconds=<value>
+    :l: -l <value>
+    :liveness: --liveness
+    :no_headers: --no-headers
+    :o: -o <value>
+    :oc_opts_end: --
+    :open_tcp: --open-tcp=<value>
+    :output_version: --output-version=<value>
+    :period_seconds: --period-seconds=<value>
+    :readiness: --readiness
+    :remove: --remove
+    :resource: <value>
+    :success_threshold: --success-threshold=<value>
+    :timeout_seconds: --timeout-seconds=<value>
+:set_resources:
+  :cmd: oc set resources
+  :options:
+    :c: -c <value>
+    :dryrun: --dry-run
+    :f: -f <value>
+    :limits: --limits=<value>
+    :local: --local
+    :o: -o <value>
+    :requests: --requests=<value>
+    :resource: <value>
+    :resourcename: <value>
+:set_triggers:
+  :cmd: oc set triggers
+  :options:
+    :all: --all=<value>
+    :auto: --auto=<value>
+    :containers: --containers=<value>
+    :f: --filename=<value>
+    :from_config: --from-config=<value>
+    :from_github: --from-github=<value>
+    :from_image: --from-image=<value>
+    :from_webhook: --from-webhook=<value>
+    :l: -l <value>
+    :manual: --manual=<value>
+    :o: --output=<value>
+    :remove: --remove=<value>
+    :remove_all: --remove-all=<value>
+    :resource: <value>
+    :t: --template=<value>
+:set_volume:
+  :cmd: oc set volume
+  :options:
+    :action: <value>
+    :add: --add=<value>
+    :all: --all=<value>
+    :claim-class: --claim-class=<value>
+    :claim-mode: --claim-mode=<value>
+    :claim-name: --claim-name=<value>
+    :claim-size: --claim-size=<value>
+    :configmap-name: --configmap-name=<value>
+    :confirm: --confirm=<value>
+    :f: --filename=<value>
+    :mount-path: --mount-path=<value>
+    :name: --name=<value>
+    :o: --output=<value>
+    :overwrite: --overwrite
+    :path: --path=<value>
+    :resource: <value>
+    :resource_name: <value>
+    :secret-name: --secret-name=<value>
+    :selector: --selector=<value>
+    :source: --source=<value>
+    :type: --type=<value>
+:start_build:
+  :cmd: oc start-build
+  :options:
+    :buildconfig: <value>
+    :build_arg: --build-arg=<value>
+    :commit: --commit=<value>
+    :env: --env=<value>
+    :follow: --follow=<value>
+    :from_archive: --from-archive=<value>
+    :from_build: --from-build=<value>
+    :from_dir: --from-dir=<value>
+    :from_file: --from-file=<value>
+    :from_repo: --from-repo=<value>
+    :from_webhook: --from-webhook=<value>
+    :git_post: --git-post-receive=<value>
+    :git_repository: --git-repository=<value>
+    :incremental: --incremental=<value>
+    :list_webhooks: --list-webhooks=<value>
+    :no-cache: --no-cache=<value>
+    :o: --output=<value>
+    :wait: --wait=<value>
+:status:
+  :cmd: oc status
+  :options:
+    :suggest: --suggest
+    :v: -v
+:stop:
+  :cmd: oc stop <resource>
+  :options:
+    :f: --filename=<value>
+    :name: <value>
+:tag:
+  :cmd: oc tag <source>
+  :options:
+    :alias: --alias=<value>
+    :d: --delete=<value>
+    :dest: <value>
+    :insecure: --insecure=<value>
+    :reference: --reference=<value>
+    :reference_policy: --reference-policy=<value>
+    :scheduled: --scheduled=<value>
+    :source_type: --source=<value>
+:test_do_not_use:
+  :cmd: <command>
+  :options:
+    :opt: <value>
+:types:
+  :cmd: oc types
+:version:
+  :cmd: oc version
+  :expected:
+    - Client Version
+  :properties:
+    :oc_version: !ruby/regexp '/^Client(?:.*Git| )Version:[" ]v(.+?)["\s]/'
+  :optional_properties:
+    :server_version: !ruby/regexp '/^Server Version: (.+?)\s/'
+    :kubernetes_server_version: !ruby/regexp '/^Kubernetes(?:.*Git| )Version:[" ]v(.+?)["\s]/'
+  :options:
+    :o: --output=<value>
+:wait:
+  :cmd: oc wait
+  :options:
+    :for:  --for=<value>
+    :l:  -l=<value>
+    :resource: <value>
+    :resource_name: <value>
+    :timeout: --timeout=<value>
+:whoami:
+  :cmd: oc whoami
+  :options:
+    :c: -c
+    :invalid_option: -b   # for negative testing
+    :t: -t
+#################### admin commands section
+:oadm_build_chain:
+  :cmd: oc adm build-chain
+  :options:
+    :all: --all=<value>
+    :imagestreamtag: <value>
+    :invalid_option: <value>   # for negative testing
+    :o: -o <value>
+    :trigger_only: --trigger-only=<value>
+:oadm_ca_create_key_pair:
+  :cmd: oc adm ca create-key-pair
+  :options:
+    :overwrite: --overwrite=<value>
+    :private_key: --private-key=<value>
+    :public_key: --public-key=<value>
+:oadm_ca_create_master_cert:
+  :cmd: oc adm ca create-master-certs
+  :options:
+    :certificate-authority: --certificate-authority=<value>
+    :cert-dir: --cert-dir=<value>
+    :expire-days: --expire-days=<value>
+    :hostnames: --hostnames=<value>
+    :master: --master=<value>
+    :overwrite: --overwrite=<value>
+    :public-master: --public-master=<value>
+    :signer-expire-days: --signer-expire-days=<value>
+    :signer-name: --signer-name=<value>
+:oadm_ca_create_signer_cert:
+  :cmd: oc adm ca create-signer-cert
+  :options:
+    :cert: --cert=<value>
+    :key: --key=<value>
+    :name: --name=<value>
+    :overwrite: --overwrite=<value>
+    :serial: --serial=<value>
+:oadm_config_view:
+  :cmd: oc adm config view
+  :options:
+    :flatten: --flatten
+    :minify: --minify
+    :raw: --raw
+:oadm_cordon_node:
+  :cmd: oc adm cordon <node_name>
+:oadm_diagnostics:
+  :cmd: oc adm diagnostics
+  :options:
+    :cluster-context: --cluster-context=<value>
+    :config: --kubeconfig=<value>
+    :context: --context=<value>
+    :diaglevel: --diaglevel=<value>
+    :diagnostics_name: <value>
+    :host: --host=<value>
+    :images: --images=<value>
+    :latest-images: --latest-images=<value>
+    :loglevel: --loglevel=<value>
+    :master-config: --master-config=<value>
+    :node-config: --node-config=<value>
+    :prevent-modification: --prevent-modification=<value>
+:oadm_drain:
+  :cmd: oc adm drain
+  :options:
+    :-l: --selector=<value>
+    :delete-local-data: --delete-local-data=<value>
+    :force: --force=<value>
+    :grace-period: --grace-period=<value>
+    :ignore-daemonsets: --ignore-daemonsets=<value>
+    :node_name: <value>
+    :pod-selector: --pod-selector=<value>
+    :selector: --selector=<value>
+    :timeout: --timeout=<value>
+:oadm_groups_add_users:
+  :cmd: oc adm groups add-users
+  :options:
+    :group_name: <value>
+    :user_name:  <value>
+:oadm_groups_new:
+  :cmd: oc adm groups new
+  :options:
+    :group_name: <value>
+    :user_name: <value>
+:oadm_groups_prune:
+  :cmd: oc adm groups prune
+  :options:
+    :blacklist: --blacklist=<value>
+    :confirm: --confirm
+    :sync_config: --sync-config=<value>
+    :whitelist: --whitelist=<value>
+:oadm_groups_remove_users:
+  :cmd: oc adm groups remove-users
+  :options:
+    :group_name: <value>
+    :user_name:  <value>
+:oadm_groups_sync:
+  :cmd: oc adm groups sync
+  :options:
+    :blacklist: --blacklist=<value>
+    :confirm: --confirm
+    :group_names: <value>
+    :sort_by: --sort-by=<value>
+    :sync_config: --sync-config=<value>
+    :type: --type=<value>
+    :whitelist: --whitelist=<value>
+:oadm_new_project:
+  :cmd: oc adm new-project <project_name>
+  #:expected:
+  #  - Created project <project_name>
+  :options:
+    :admin: --admin=<value>
+    :description: --description=<value>
+    :display_name: --display-name=<value>
+    :node_selector: --node-selector=<value>
+:oadm_node_logs:
+  :cmd: oc adm node-logs <options>
+  :options:
+    :path: --path=<value>
+    :role: --role=<value>    
+:oadm_pod_network_join_projects:
+  :cmd: oc adm pod-network join-projects
+  :options:
+    :project: <value>
+    :selector: --selector=<value>
+    :to: --to=<value>
+:oadm_pod_network_make_projects_global:
+  :cmd: oc adm pod-network make-projects-global
+  :options:
+    :project: <value>
+    :selector: --selector=<value>
+:oadm_pod_network_isolate_projects:
+  :cmd: oc adm pod-network isolate-projects
+  :options:
+    :project: <value>
+    :selector: --selector=<value>
+:oadm_policy_add_cluster_role_to_group:
+  :cmd: oc adm policy add-cluster-role-to-group <role_name> <group_name>
+:oadm_policy_add_cluster_role_to_user:
+  :cmd: oc adm policy add-cluster-role-to-user <role_name>
+  :options:
+    :serviceaccount: --serviceaccount=<value>
+    :user_name: <value>
+    :z:  -z <value>
+:oadm_policy_add_role_to_group:
+  :cmd: oc adm policy add-role-to-group <role_name> <group_name>
+  :options:
+    :rolebinding_name: --rolebinding-name=<value>
+:oadm_policy_add_role_to_user:
+  :cmd: oc adm policy add-role-to-user <role_name> <user_name>
+  :options:
+    :role_namespace: --role-namespace=<value>
+    :rolebinding_name: --rolebinding-name=<value>
+:oadm_policy_add_scc_to_group:
+  :cmd: oc adm policy add-scc-to-group <scc> <group_name>
+:oadm_policy_add_scc_to_user:
+  :cmd: oc adm policy add-scc-to-user <scc>
+  :options:
+    :serviceaccount: --serviceaccount=<value>
+    :user_name: <value>
+:oadm_policy_reconcile_cluster_roles:
+  :cmd: oc adm policy reconcile-cluster-roles
+  :options:
+    :confirm: --confirm=<value>
+:oadm_policy_reconcile_sccs:
+  :cmd: oc adm policy reconcile-sccs
+  :options:
+    :additive_only: --additive-only=<value>
+    :confirm: --confirm
+:oadm_policy_remove_cluster_role_from_group:
+  :cmd: oc adm policy remove-cluster-role-from-group <role_name> <group_name>
+:oadm_policy_remove_cluster_role_from_user:
+  :cmd: oc adm policy remove-cluster-role-from-user <role_name>
+  :options:
+    :serviceaccount: --serviceaccount=<value>
+    :user_name: <value>
+    :z:  -z <value>
+:oadm_policy_remove_role_from_group:
+  :cmd: oc adm policy remove-role-from-group <role_name> <group_name>
+:oadm_policy_remove_role_from_user:
+  :cmd: oc adm policy remove-role-from-user <role_name> <user_name>
+:oadm_policy_remove_scc_from_group:
+  :cmd: oc adm policy remove-scc-from-group <scc> <group_name>
+:oadm_policy_remove_scc_from_user:
+  :cmd: oc adm policy remove-scc-from-user <scc>
+  :options:
+    :serviceaccount: --serviceaccount=<value>
+    :user_name: <value>
+:oadm_policy_who_can:
+  :cmd: oc adm policy who-can <verb> <resource>
+  :options:
+    :all_namespaces: --all-namespaces=<value>
+:oadm_prune_builds:
+  :cmd: oc adm prune builds
+  :options:
+    :confirm: --confirm=<value>
+    :keep_complete: --keep-complete=<value>
+    :keep_failed: --keep-failed=<value>
+    :keep_younger_than: --keep-younger-than=<value>
+    :orphans: --orphans=<value>
+    :orphans_noopt: --orphans
+:oadm_prune_deployments:
+  :cmd: oc adm prune deployments
+  :options:
+    :confirm: --confirm=<value>
+    :keep_complete: --keep-complete=<value>
+    :keep_failed: --keep-failed=<value>
+    :keep_younger_than: --keep-younger-than=<value>
+    :orphans: --orphans=<value>
+    :orphans_noopt: --orphans
+:oadm_prune_images:
+  :cmd: oc adm prune images
+  :options:
+    :confirm: --confirm=<value>
+    :ignore_invalid_refs: --ignore-invalid-refs=<value>
+    :keep_tag_revisions: --keep-tag-revisions=<value>
+    :keep_younger_than: --keep-younger-than=<value>
+    :prune_over_size_limit: --prune-over-size-limit=<value>
+    :prune_registry: --prune-registry=<value>
+    :registry_url: --registry-url=<value>
+:oadm_registry:
+  :cmd: oc adm registry
+  :options:
+    :daemonset: --daemonset=<value>
+    :images: --images=<value>
+    :mount_host: --mount-host=<value>
+    :ports: --ports=<value>
+    :serviceaccount: --service-account=<value>
+:oadm_router:
+  :cmd: oc adm router <name>
+  :options:
+    :canonical_hostname: --router-canonical-hostname=<value>
+    :default_cert: --default-cert=<value>
+    :extended_logging: --extended-logging=<value>
+    :force_subdomain: --force-subdomain=<value>
+    :host_network: --host-network=<value>
+    :host_ports: --host-ports=<value>
+    :images: --images=<value>
+    :n: -n <value>
+    :ports: --ports=<value>
+    :replicas: --replicas=<value>
+    :selector: --selector=<value>
+    :service_account: --service-account=<value>
+    :stats_passwd: --stats-password=<value>
+    :stats_port: --stats-port=<value>
+    :stats_user: --stats-user=<value>
+:oadm_taint_nodes:
+  :cmd: oc adm taint nodes
+  :options:
+    :all: --all=<value>
+    :key_val: <value>
+    :node_name: <value>
+    :output: --output <value>
+    :overwrite: --overwrite=<value>
+:oadm_top_images:
+  :cmd: oc adm top images
+:oadm_uncordon_node:
+  :cmd: oc adm uncordon <node_name>
+:oadm_upgrade:
+  :cmd: oc adm upgrade
+  :options:
+    :allow_explicit_upgrade: --allow-explicit-upgrade=<value>
+    :clear: --clear=<value>
+    :force: --force=<value>
+    :to: --to=<value>
+    :to_image: --to-image=<value>
+    :to_latest: --to-latest=<value>
+:oadm_version:
+  :cmd: oc version
+  :expected:
+    - oc v
+    - kubernetes v
+  :properties:
+    :oadm_version: !ruby/regexp '/^oc v(.+)$/'
+    :kubernetes_version: !ruby/regexp '/kubernetes v(.+)$/'
+:openshift_version:
+  :cmd: openshift version
+  :expected:
+    - openshift v
+    - kubernetes v
+    - etcd
+  :properties:
+    :openshift_version: !ruby/regexp '/^openshift v(.+)$/'
+    :kubernetes_version: !ruby/regexp '/kubernetes v(.+)$/'
+    :etcd_version: !ruby/regexp '/etcd (.+)$/'


### PR DESCRIPTION
For 4.1/4.2/4.3, `oc config --kubeconfig` does not generate kubeconfig , then automation will fail with error,
error: stat /home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig: no such file or directory

For 4.4, when --config is used, there is a waring message which will cause an issue describe in https://github.com/openshift/verification-tests/pull/694

So we copy 4.1 to 4.4, and switch to --kubeconfig in 4.4