### PR TITLE
update dnsmasq config file

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -805,12 +805,13 @@ Given /^a DHCP service is configured for interface "([^"]*)" on "([^"]*)" node w
   host = node.host
   dhcp_status_timeout = 30
   #Following will take dnsmasq backup and append curl contents to the dnsmasq config after
-  @result = host.exec_admin("cp /etc/dnsmasq.conf /etc/dnsmasq.conf.bak;curl https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/multus-cni/dnsmasq_for_testbridge.conf | sed s/testbr1/#{br_inf}/g | sed s/88.8.8.100,88.8.8.110,24h/#{add_lease}/g >> /etc/dnsmasq.conf;systemctl restart dnsmasq --now")
+  @result = host.exec_admin("cp /etc/dnsmasq.conf /etc/dnsmasq.conf.bak;curl https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/multus-cni/dnsmasq_for_testbridge.conf | sed s/testbr1/#{br_inf}/g | sed s/88.8.8.100,88.8.8.110,24h/#{add_lease}/g > /etc/dnsmasq.conf;systemctl restart dnsmasq --now")
   raise "Failed to configure dnsmasq service" unless @result[:success]
   wait_for(dhcp_status_timeout) {
     if host.exec_admin("systemctl status dnsmasq")[:response].include? "running"
       logger.info("dnsmasq service is running fine")
     else
+      host.exec_admin("cp /etc/dnsmasq.conf.bak /etc/dnsmasq.conf && systemctl restart dnsmasq --now")
       raise "Failed to start dnsmasq service. Check you cluster health manually"
     end
   }


### PR DESCRIPTION
we often met error : 192.168.1.1 is already used .
try to debug, found sometimes the dnsmasq.conf will be append two times.
 So update '>>' to ">'. and file the dnsmasq config with 
https://github.com/openshift-qe/v3-testfiles/pull/1234

@anuragthehatter @huiran0826 @weliang1 @rbbratta 