### PR TITLE
update the match strings to avoid case-sensitive

### DIFF
--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -348,7 +348,7 @@ Feature: Testing route
     And the output should contain:
       | Hello-OpenShift |
       | HTTP/1.1 302 Found |
-      | Location: https:// |
+      | ocation: https:// |
 
   # @author yadu@redhat.com
   # @case_id OCP-9650
@@ -502,7 +502,7 @@ Feature: Testing route
     And the output should contain:
       | Hello-OpenShift |
       | HTTP/1.1 302 Found |
-      | Location: https:// |
+      | ocation: https:// |
     """
     When I run the :patch client command with:
       | resource      | route              |
@@ -551,7 +551,7 @@ Feature: Testing route
     And the output should contain:
       | Hello-OpenShift |
       | HTTP/1.1 302 Found |
-      | Location: https:// |
+      | ocation: https:// |
     """
     When I run the :patch client command with:
       | resource      | route           |
@@ -638,7 +638,7 @@ Feature: Testing route
     And the output should contain:
       | Hello-OpenShift |
       | HTTP/1.1 302 Found |
-      | Location: https:// |
+      | ocation: https:// |
     And I execute on the pod:
       | cat |
       | /tmp/cookie |
@@ -671,7 +671,7 @@ Feature: Testing route
     And the output should contain:
       | Hello-OpenShift |
       | HTTP/1.1 302 Found |
-      | Location: https:// |
+      | ocation: https:// |
     """
     And I execute on the pod:
       | cat |


### PR DESCRIPTION
The HAProxy in router is upgrade to 2.0 in OCP 4.4 and some heads are changed to lowercase like below, so remove the capitalized "L" from match strings.

```
< HTTP/1.1 302 Found
< content-length: 0
< location: https://console-openshift-console.apps.example.com/
```
