### PR TITLE
Ensure machine/node consistency after scenario

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -29,16 +29,17 @@ Feature: Machine features testing
   @destructive
   Scenario: Scale up and scale down a machineSet
     Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
     And I pick a random machineset to scale
     And evaluation of `machine_set.available_replicas` is stored in the :replicas_to_restore clipboard
 
     Given I scale the machineset to +2
+    Then the step should succeed
     And I register clean-up steps:
     """
     When I scale the machineset to <%= cb.replicas_to_restore %>
     Then the machineset should have expected number of running machines
     """
-    Then the step should succeed
     And the machineset should have expected number of running machines
 
     When I scale the machineset to -1

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -32,14 +32,30 @@ end
 Then(/^the machineset should have expected number of running machines$/) do
   machine_set.wait_till_ready(admin, 600)
 
-  machines_all = BushSlicer::Machine.list(user: admin, project: project("openshift-machine-api"))
-  machines = machines_all.select { |m| m.machine_set_name == machine_set.name }
+  machines = BushSlicer::Machine.list(user: admin, project: project("openshift-machine-api"))
 
-  # Each node should be running
+  num_running_machines = 0
   machines.each do | machine |
+    next if machine.machine_set_name != machine_set.name
+
+    # if machine phase is 'Deleting' then wait for its node to disappear
+    if machine.phase == 'Deleting'
+      step %Q{I wait for the resource "node" named "#{machine.node_name}" to disappear within 600 seconds}
+      step %Q{I wait for the resource "machine" named "#{machine.name}" to disappear within 600 seconds}
+      next
+    end
+    
+    # wait till machine's node is ready
     machine.get
     unless node(machine.node_name).ready?[:success]
-      raise "Node #{machine.node_name} has not become ready."
+      raise "Node #{machine.node_name} has not become ready"
     end
+
+    num_running_machines+=1
+  end
+
+  available_replicas = machine_set.available_replicas(user: nil, cached: false, quiet: false)
+  if available_replicas != num_running_machines
+    raise "Machineset #{machine_set.name} has #{num_running_machines} running machines, expected #{available_replicas}"
   end
 end

--- a/lib/openshift/machine.rb
+++ b/lib/openshift/machine.rb
@@ -5,20 +5,26 @@ module BushSlicer
   class Machine < ProjectResource
     RESOURCE = 'machines'
 
+    def machine_set_name(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached, quiet: quiet).
+        dig('metadata', 'labels', 'machine.openshift.io/cluster-api-machineset')
+    end
+
     # returns the node name the machine linked to
     def node_name(user: nil, cached: true, quiet: false)
       raw_resource(user: user, cached: cached, quiet: quiet).
         dig('status', 'nodeRef', 'name')
     end
 
-    def ready?(user: nil, cached: true, quiet: false)
-      instance_state = raw_resource(user: user, cached: cached, quiet: quiet).dig('status','providerStatus','instanceState')
-      instance_state == 'running'
+    def phase(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached, quiet: quiet).
+        dig('status','phase')
     end
 
-    def machine_set_name(user: nil, cached: true, quiet: false)
-      raw_resource(user: user, cached: cached, quiet: quiet).
-        dig('metadata', 'labels', 'machine.openshift.io/cluster-api-machineset')
+    def ready?(user: nil, cached: true, quiet: false)
+      instance_state = raw_resource(user: user, cached: cached, quiet: quiet).
+        dig('status','providerStatus','instanceState')
+      instance_state == 'running'
     end
   end
 end


### PR DESCRIPTION
This enhancement makes sure that if there were machine in 'Deleting' phase, the machine and its node must disappear. If machine phase is not 'Deleting', the machine must have a nodeRef and the node must be 'Running'.
This guarantees a consistent environment during test and after test tear down.

@sunzhaohua2 @miyadav Please review. @qinpingli FYI.