### PR TITLE
update cases ocp-22202

### DIFF
--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -121,44 +121,23 @@ Feature: Operator related networking scenarios
     """
 
   # @author bmeng@redhat.com
+  # @author zzhao@redhat.com
   # @case_id OCP-22202
   @admin
   @destructive
   Scenario: The clusteroperator should be able to reflect the realtime status of the network when a new node added
-    Given the master version >= "4.1"
+    Given I have an IPI deployment
     # Check that the operator is not progressing
     Given the expression should be true> cluster_operator('network').condition(type: 'Progressing')['status'] == "False"
 
     # Record the original machine replica and scale it up to number +1
-    When I run the :get admin command with:
-      | resource | machineset                         |
-      | n        | openshift-machine-api              |
-      | template | {{(index .items 0).metadata.name}} |
-    Then the step should succeed
-    And evaluation of `@result[:stdout]` is stored in the :machineset clipboard
-    When I run the :get admin command with:
-      | resource      | machineset            |
-      | n             | openshift-machine-api |
-      | resource_name | <%= cb.machineset %>  |
-      | template      | {{.spec.replicas}}    |
-    Then the step should succeed
-    And evaluation of `@result[:response].to_i` is stored in the :original_replicas clipboard
-    And evaluation of `@result[:response].to_i + 1` is stored in the :desired_replicas clipboard
-    When I run the :scale admin command with:
-      | resource | machineset                 |
-      | name     | <%= cb.machineset %>       |
-      | replicas | <%= cb.desired_replicas %> |
-      | n        | openshift-machine-api      |
-    Then the step should succeed
+    Given I pick a random machineset to scale
+    And evaluation of `machine_set.available_replicas` is stored in the :replicas_to_restore clipboard
+    Given I scale the machineset to +1
     # Scale down the machine after the scenario
     Given I register clean-up steps:
     """
-    When I run the :scale admin command with:
-      | resource | machineset                  |
-      | name     | <%= cb.machineset %>        |
-      | replicas | <%= cb.original_replicas %> |
-      | n        | openshift-machine-api       |
-    Then the step should succeed
+    When I scale the machineset to <%= cb.replicas_to_restore %>
     Then the machineset should have expected number of running machines
     """
 
@@ -168,16 +147,7 @@ Feature: Operator related networking scenarios
     Given the status of condition "Progressing" for network operator is :True
     """
 
-    And I wait up to 60 seconds for the steps to pass:
-    """
-    When I run the :get admin command with:
-      | resource      | machineset                |
-      | resource_name | <%= cb.machineset %>      |
-      | n             | openshift-machine-api     |
-      | template      | {{.status.readyReplicas}} |
-    Then the expression should be true> @result[:response].to_i == cb.desired_replicas
-    """
-
+    And the machineset should have expected number of running machines
     # Check that the status of Progressing is back to False once the node provision finished
     And I wait up to 120 seconds for the steps to pass:
     """


### PR DESCRIPTION
the old steps often caused error: 
```
   [08:17:03] INFO> === After Scenario: The clusteroperator should be able to reflect the realtime status of the network when a new node added ===
      [08:17:03] INFO> Step: I run the :scale admin command with:
      | resource | machineset                  |
      | name     | qeci-2891-2jv2j-worker-us-east-2a        |
      | replicas | 1 |
      | n        | openshift-machine-api       |
      [08:17:03] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@ec2-3-15-229-24.us-east-2.compute.amazonaws.com:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@ec2-3-15-229-24.us-east-2.compute.amazonaws.com:3128
      oc scale machineset qeci-2891-2jv2j-worker-us-east-2a --replicas=1 --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig -n openshift-machine-api
      machineset.machine.openshift.io/qeci-2891-2jv2j-worker-us-east-2a scaled
      
      [08:17:04] INFO> Exit Status: 0
      [08:17:04] INFO> Step: the step should succeed
      [08:17:04] INFO> Step: the machineset should have expected number of running machines
      [08:17:04] ERROR> Test Execution will finish prematurely.
      no projects in cache (RuntimeError)
      /home/jenkins/workspace/Runner-v3/lib/world.rb:187:in `project'
      /home/jenkins/workspace/Runner-v3/lib/world.rb:264:in `project_resource'
      /home/jenkins/workspace/Runner-v3/lib/world.rb:117:in `machine_set'
      /home/jenkins/workspace/Runner-v3/features/step_definitions/machine_set.rb:33:in `/^the machineset should have expected number of running machines$/'
      /opt/rh/rh-ruby26/root/usr/share/ruby/forwardable.rb:230:in `invoke_dynamic_step'
      /home/jenkins/workspace/Runner-v3/lib/world.rb:509:in `block (3 levels) in to_step_procs'
      /home/jenkins/workspace/Runner-v3/lib/world.rb:431:in `block in after_scenario'
      /home/jenkins/workspace/Runner-v3/lib/world.rb:431:in `reverse_each'
      /home/jenkins/workspace/Runner-v3/lib/world.rb:431:in `after_scenario'
      /home/jenkins/workspace/Runner-v3/lib/manager.rb:35:in `clean_up'
      /home/jenkins/workspace/Runner-v3/features/support/env.rb:67:in `block (2 levels) in <top (required)>'
      /home/jenkins/workspace/Runner-v3/lib/base_helper.rb:131:in `capture_error'
      /home/jenkins/workspace/Runner-v3/features/support/env.rb:65:in `After'
```

@huiran0826 @anuragthehatter @rbbratta @weliang1 
