### PR TITLE
Auto OCP-25608

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -77,15 +77,8 @@ Feature: Machine features testing
   Scenario: Machine should have immutable field providerID and nodeRef
     Given I have an IPI deployment
     Given I store the last provisioned machine in the :machine clipboard
-
-    When I run the :get admin command with:
-      | resource      | machine                                |
-      | resource_name | <%= cb.machine %>                      |
-      | o             | yaml                                   |
-      | n             | openshift-machine-api                  |
-    Then the step should succeed
-    And evaluation of `@result[:parsed]["status"]["nodeRef"]["name"]` is stored in the :nodeRef_name clipboard
-    And evaluation of `@result[:parsed]["spec"]["providerID"]` is stored in the :providerID clipboard
+    And evaluation of `machine(cb.machine).node_name` is stored in the :nodeRef_name clipboard
+    And evaluation of `machine(cb.machine).provider_id` is stored in the :providerID clipboard
 
     When I run the :patch admin command with:
       | resource      | machine                                |

--- a/lib/openshift/machine.rb
+++ b/lib/openshift/machine.rb
@@ -16,6 +16,11 @@ module BushSlicer
         dig('status', 'nodeRef', 'name')
     end
 
+    def provider_id(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached, quiet: quiet).
+        dig('spec', 'providerID')
+    end
+
     def phase(user: nil, cached: true, quiet: false)
       raw_resource(user: user, cached: cached, quiet: quiet).
         dig('status','phase')


### PR DESCRIPTION
Automate test case OCP-25608: Machine should have immutable field providerID and nodeRef.
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/70717/console
@jhou1 @miyadav please help to review, thanks.


