### PR TITLE
update OCP-18482 and OCP-9650

### DIFF
--- a/features/routing/rate-limit.feature
+++ b/features/routing/rate-limit.feature
@@ -2,13 +2,20 @@ Feature: Testing haproxy rate limit related features
 
   # @author hongli@redhat.com
   # @case_id OCP-18482
+  @admin
   Scenario Outline: limits backend pod max concurrent connections for unsecure, edge, reen route
-    Given I have a project
-    And I store an available router IP in the :router_ip clipboard
+    Given I switch to cluster admin pseudo user
+    And I use the router project
+    Given all default router pods become ready
+    Then evaluation of `pod.name` is stored in the :router_pod clipboard
+
+    Given I switch to the first user
+    And I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/routetimeout/httpbin-pod.json |
     Then the step should succeed
     And the pod named "httpbin-pod" becomes ready
+    And evaluation of `pod.ip` is stored in the :pod_ip clipboard
 
     When I run the :create client command with:
       | f | <service> |
@@ -16,25 +23,21 @@ Feature: Testing haproxy rate limit related features
     When I run the :create client command with:
       | f | <route> |
     Then the step should succeed
-    Given I have a pod-for-ping in the project
-    When I execute on the pod:
-      | bash | -c | for i in {1..4} ; do curl -sS --resolve <resolve_str>:<%= cb.router_ip[0] %> <url>/delay/6 -k -I & done |
-    Then the step should succeed
-    And the output should contain 4 times:
-      | 200 OK |
-
     When I run the :annotate client command with:
       | resource     | route        |
       | resourcename | <route_name> |
       | keyval       | haproxy.router.openshift.io/pod-concurrent-connections=<pass_num> |
     Then the step should succeed
-    When I execute on the pod:
-      | bash | -c | for i in {1..4} ; do curl -sS --resolve <resolve_str>:<%= cb.router_ip[0] %> <url>/delay/6 -k -I & done |
-    Then the step should succeed
-    And the output should contain <pass_num> times:
-      | 200 OK |
-    And the output should contain <fail_num> times:
-      | 503 Service Unavailable |
+
+    Given I switch to cluster admin pseudo user
+    And I use the router project
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    When I execute on the "<%=cb.router_pod %>" pod:
+      | grep | <%=cb.pod_ip %> | /var/lib/haproxy/conf/haproxy.config |
+    Then the output should contain:
+      | maxconn <pass_num> |
+    """
 
     Examples:
       | route_type | route_name | service | route | resolve_str | url | pass_num | fail_num |

--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -388,7 +388,6 @@ Feature: Testing route
     Then the step should succeed
     And the output should contain:
       | Hello-OpenShift |
-      | HTTP/1.1 200    |
     And the output should not contain:
       | HTTP/1.1 302 Found |
     When I execute on the pod:
@@ -402,7 +401,6 @@ Feature: Testing route
     Then the step should succeed
     And the output should contain:
       | Hello-OpenShift |
-      | HTTP/1.1 200    |
     And the output should not contain:
       | HTTP/1.1 302 Found |
     And I execute on the pod:


### PR DESCRIPTION
OCP-18482: Since the max concurrent connections is related the number of router pods as well as the clould LB, we cannot tested it with `curl` anymore. The new solution is more straightforward and just check haproxy.conf in router pod. 

OCP-9650: remove the redundant matching string, if the output contains `Hello-OpenShift` then that means the HTTP status code should be `200`. 