### PR TITLE
Ensure goto action complete loading current page

### DIFF
--- a/lib/rules/web/admin_console/4.4/goto.xyaml
+++ b/lib/rules/web/admin_console/4.4/goto.xyaml
@@ -150,8 +150,10 @@ goto_catalog_page:
   url: catalog/ns/<project_name>
 goto_create_app_from_imagestream_page:
   url: catalog/source-to-image?imagestream=<is_name>&imagestream-ns=openshift&preselected-ns=<project_name>
+  action: wait_form_loaded
 goto_create_app_from_template_page:
   url: catalog/instantiate-template?template==<template_name>&template-ns=openshift&preselected-ns=<project_name>
+  action: wait_form_loaded
 
 # monitoring
 goto_monitoring_metrics_page:
@@ -180,6 +182,7 @@ goto_one_namespace_page:
 # operator hub
 goto_operator_hub_page:
   url: operatorhub/ns/default
+  action: wait_box_loaded
 goto_installed_operators_page:
   url: k8s/ns/<project_name>/operators.coreos.com~v1alpha1~ClusterServiceVersion
 goto_operator_subscription_page:

--- a/lib/rules/web/admin_console/4.4/goto.xyaml
+++ b/lib/rules/web/admin_console/4.4/goto.xyaml
@@ -1,6 +1,7 @@
 # projects
 goto_projects_list_page:
   url: k8s/cluster/projects
+  action: wait_box_loaded
 goto_project_status:
   url: status/ns/<project>
 goto_resource_page_under_default_project:
@@ -9,6 +10,7 @@ goto_project_resources_page:
   url: k8s/cluster/projects/<project_name>/workloads
 goto_project_details_page:
   url: k8s/cluster/projects/<project_name>/details
+
 # Dashboard renamed to Overview in 4.4, url is same "k8s/cluster/projects/<project_name>"
 goto_one_project_page: 
   url: k8s/cluster/projects/<project_name>
@@ -150,10 +152,8 @@ goto_catalog_page:
   url: catalog/ns/<project_name>
 goto_create_app_from_imagestream_page:
   url: catalog/source-to-image?imagestream=<is_name>&imagestream-ns=openshift&preselected-ns=<project_name>
-  action: wait_form_loaded
 goto_create_app_from_template_page:
   url: catalog/instantiate-template?template==<template_name>&template-ns=openshift&preselected-ns=<project_name>
-  action: wait_form_loaded
 
 # monitoring
 goto_monitoring_metrics_page:
@@ -182,7 +182,6 @@ goto_one_namespace_page:
 # operator hub
 goto_operator_hub_page:
   url: operatorhub/ns/default
-  action: wait_box_loaded
 goto_installed_operators_page:
   url: k8s/ns/<project_name>/operators.coreos.com~v1alpha1~ClusterServiceVersion
 goto_operator_subscription_page:


### PR DESCRIPTION
I've been wanting to suggest the change since 3.x. Since 4.x has some changes on console rendering, automation sometimes fail when page is directing and automation is doing some operation(like click) simultaneously.

The reason I update goto rules:
Test step itself should ensure the current action succeed, not the following step wait for the following checkpoint, it’s not clear for debug.
The wait_box_loaded (_css: .loading-box__loaded_) will be succeed even when the page has no item (but not a total empty crashed page), it makes sure the current page finished loading, that's the complete operation for goto action. IMO this can not rely on following steps, also the timeout for next step may not be enough.

I tested each page updated for the goto action.

So far I only update the goto_xxx_list page, will also update the goto_one_resource_xxx_page, this css selector does also work on this page. [Here comes an example, error should raise on goto_one_dc_page, not check_popover_info. Also the error page may raised by click action is VERY closed to goto action when page is still loading](http://ci-qe-openshift.usersys.redhat.com/userContent/cucushift/v3/2020/02/17/01:27:39/Check_popover_help_on_resource_detail_page/console.html) (refer to the [doc for pseudo-elements](https://www.w3.org/TR/CSS2/generate.html#before-after-content) )
@akostadinov @pruan-rht  Please tell me your thought and concern, thanks!

