### PR TITLE
helper for pr731

### DIFF
--- a/lib/openshift/machine.rb
+++ b/lib/openshift/machine.rb
@@ -26,6 +26,16 @@ module BushSlicer
         dig('status','phase')
     end
 
+    def instance_state(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached, quiet: quiet).
+          dig('status', 'providerStatus', 'instanceState')
+    end
+
+    def annotation_instance_state(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached, quiet: quiet).
+          dig('metadata', 'annotations', 'machine.openshift.io/instance-state')
+    end
+
     def ready?(user: nil, cached: true, quiet: false)
       instance_state = raw_resource(user: user, cached: cached, quiet: quiet).
         dig('status','providerStatus','instanceState')


### PR DESCRIPTION
@miyadav once this PR is merged, then you can reduce your scenario to these two lines
```
   And evaluation of `BushSlicer::Machine.list(user: admin, project: project('openshift-machine-api'))` is stored in the :machines clipboard
   Then the expression should be true> cb.machines.select {|m| m.instance_state == m.annotation_instance_state }.count == cb.machines.count
```