### PR TITLE
fix warning introducted by PR 733

### DIFF
--- a/lib/openshift/cron_job.rb
+++ b/lib/openshift/cron_job.rb
@@ -39,7 +39,7 @@ module BushSlicer
       template(user: user, cached: cached, quiet: quiet).dig('spec', 'nodeSelector')
     end
 
-    def tolerations(user: user, cached: true, quiet: false)
+    def tolerations(user: nil, cached: true, quiet: false)
       template(user: user, cached: cached, quiet: quiet).dig('spec', 'tolerations')
     end
 

--- a/lib/openshift/pod_replicator.rb
+++ b/lib/openshift/pod_replicator.rb
@@ -112,7 +112,7 @@ module BushSlicer
       return props[:volume_specs]
     end
 
-    def tolerations(user: user, cached: true, quiet: false)
+    def tolerations(user: nil, cached: true, quiet: false)
       template(user: user, cached: cached, quiet: quiet).dig('spec', 'tolerations')
     end
 


### PR DESCRIPTION
PR #733 introduced the warning message 
```
/home/pruan/workspace/bushslicer/lib/openshift/pod_replicator.rb:115: warning: circular argument reference - user
/home/pruan/workspace/bushslicer/lib/openshift/cron_job.rb:42: warning: circular argument reference - user

```