### PR TITLE
Clearer error message when BUSHSLICER_CONFIG "browser" value is bad

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -156,7 +156,7 @@ require_relative 'chrome_extension'
         driver = Selenium::WebDriver.for :safari, desired_capabilities: safari_caps
         @browser = Watir::Browser.new driver
       else
-        raise "Not implemented yet"
+        raise "Web4Cucumber: browser type '#{@browser_type}' not supported"
       end
       @browser
     end


### PR DESCRIPTION
I tried using `BUSHSLICER_CONFIG='{"global": {"browser": "chromium"}}'`
Previously printed error:
```
      Not implemented yet (RuntimeError)
```
which was vague, I thought maybe the step definition was unimplemented?
now shows:
```
      Web4Cucumber: browser type 'chromium' not supported (RuntimeError)
```
(turns out I want "chrome" not "chromium")