### PR TITLE
Auto the upgrade of svcat

### DIFF
--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -21,6 +21,7 @@ Feature: Service Catalog related scenarios
     Given the status of condition "Available" for "service-catalog-controller-manager" operator is: True
     Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
     #enable the svcat
+    Given I switch to cluster admin pseudo user
     When I run the :patch client command with:
       | resource      | ServiceCatalogAPIServer                 |
       | resource_name | cluster                                 |

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -22,16 +22,16 @@ Feature: Service Catalog related scenarios
     Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
     #enable the svcat
     When I run the :patch client command with:
-      | resource      | ServiceCatalogAPIServer          |
-      | resource_name | cluster                          |
-      | p             | spec:\n  managementState:Managed |
-      | type          | merge                            |
+      | resource      | ServiceCatalogAPIServer                 |
+      | resource_name | cluster                                 |
+      | p             | {"spec":{"managementState": "Managed"}} |
+      | type          | merge                                   |
     Then the step should succeed
     When I run the :patch client command with:
-      | resource      | ServiceCatalogControllerManager  |
-      | resource_name | cluster                          |
-      | p             | spec:\n  managementState:Managed |
-      | type          | merge                            |
+      | resource      | ServiceCatalogControllerManager         |
+      | resource_name | cluster                                 |
+      | p             | {"spec":{"managementState": "Managed"}} |
+      | type          | merge                                   |
     Then the step should succeed
     
   @admin

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -70,7 +70,7 @@ Feature: Service Catalog related scenarios
       | resource | clusterserviceclass                                                       |
       | o        | custom-columns=CLASSNAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName |
     Then the output should contain "user-provided"
-    """
+
     #Provision a serviceinstance
     Given I switch to the first user
     And I use the "<%= cb.user_project %>" project

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -95,15 +95,3 @@ Feature: Service Catalog related scenarios
       | object_name_or_id | ups-instance    |
     Then the step should succeed
     Given I wait for the resource "serviceinstance" named "ups-instance" to disappear within 60 seconds
-
-    # Delete ups broker
-    When I switch to cluster admin pseudo user
-    When I run the :delete client command with:
-      | object_type       | clusterservicebroker |
-      | object_name_or_id | ups-broker           |
-    Then the step should succeed
-    And I wait for the resource "clusterservicebrokers" named "ups-broker" to disappear within 60 seconds
-    When I run the :get client command with:
-      | resource | clusterserviceclass                                                       |
-      | o        | custom-columns=CLASSNAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName |
-    Then the output should not contain "user-provided"

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -13,13 +13,13 @@ Feature: Service Catalog related scenarios
     Given the status of condition "Degraded" for "service-catalog-apiserver" operator is: False
     Given the status of condition "Progressing" for "service-catalog-apiserver" operator is: False
     Given the status of condition "Available" for "service-catalog-apiserver" operator is: True
-    Given the status of condition "Upgradeable" for "service-catalog-apiserver" operator is: True
+    Given the status of condition "Upgradeable" for "service-catalog-apiserver" operator is: Unknown
     # Check cluster operator svcat-controller status
     Given the "service-catalog-controller-manager" operator version matchs the current cluster version
     Given the status of condition "Degraded" for "service-catalog-controller-manager" operator is: False
     Given the status of condition "Progressing" for "service-catalog-controller-manager" operator is: False
     Given the status of condition "Available" for "service-catalog-controller-manager" operator is: True
-    Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
+    Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: Unknown
     #enable the svcat
     When I run the :patch client command with:
       | resource      | ServiceCatalogAPIServer                 |
@@ -43,13 +43,13 @@ Feature: Service Catalog related scenarios
     Given the status of condition "Degraded" for "service-catalog-apiserver" operator is: False
     Given the status of condition "Progressing" for "service-catalog-apiserver" operator is: False
     Given the status of condition "Available" for "service-catalog-apiserver" operator is: True
-    Given the status of condition "Upgradeable" for "service-catalog-apiserver" operator is: Unknown
+    Given the status of condition "Upgradeable" for "service-catalog-apiserver" operator is: True
     # Check cluster operator svcat-controller status
     Given the "service-catalog-controller-manager" operator version matchs the current cluster version
     Given the status of condition "Degraded" for "service-catalog-controller-manager" operator is: False
     Given the status of condition "Progressing" for "service-catalog-controller-manager" operator is: False
     Given the status of condition "Available" for "service-catalog-controller-manager" operator is: True
-    Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: Unknown
+    Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
     
     # Deploy ups broker
     Given admin ensures "ups-broker" clusterservicebroker is deleted after scenario

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -21,6 +21,18 @@ Feature: Service Catalog related scenarios
     Given the status of condition "Available" for "service-catalog-controller-manager" operator is: True
     Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
     #enable the svcat
+    When I run the :patch client command with:
+      | resource      | ServiceCatalogAPIServer          |
+      | resource_name | cluster                          |
+      | p             | spec:\n  managementState:Managed |
+      | type          | merge                            |
+    Then the step should succeed
+    When I run the :patch client command with:
+      | resource      | ServiceCatalogControllerManager  |
+      | resource_name | cluster                          |
+      | p             | spec:\n  managementState:Managed |
+      | type          | merge                            |
+    Then the step should succeed
     
   @admin
   @upgrade-check

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -84,4 +84,3 @@ Feature: Service Catalog related scenarios
       | resource | serviceinstance/ups-instance |
     Then the output should match "Message.*The instance was provisioned successfully"
     """
-    

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -79,7 +79,7 @@ Feature: Service Catalog related scenarios
     Given I switch to the first user
     When I process and create:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-instance-template.yaml |
-      | p | USER_PROJECT=<%= cb.user_project %>                                                                       |
+      | p | USER_PROJECT=<%= project.name %>                                                                          |
     Then the step should succeed
     And I wait up to 30 seconds for the steps to pass:
     """

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -77,7 +77,6 @@ Feature: Service Catalog related scenarios
 
     #Provision a serviceinstance
     Given I switch to the first user
-    And I use the "<%= cb.user_project %>" project
     When I process and create:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-instance-template.yaml |
       | p | USER_PROJECT=<%= cb.user_project %>                                                                       |
@@ -88,10 +87,4 @@ Feature: Service Catalog related scenarios
       | resource | serviceinstance/ups-instance |
     Then the output should match "Message.*The instance was provisioned successfully"
     """
-
-    # Delete serviceinstance
-    When I run the :delete client command with:
-      | object_type       | serviceinstance |
-      | object_name_or_id | ups-instance    |
-    Then the step should succeed
-    Given I wait for the resource "serviceinstance" named "ups-instance" to disappear within 60 seconds
+    Given admin ensures "ups-instance" service_instance is deleted

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -51,7 +51,6 @@ Feature: Service Catalog related scenarios
     Given the status of condition "Available" for "service-catalog-controller-manager" operator is: True
     Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
     
-    # Create a broker
     # Deploy ups broker
     Given admin ensures "ups-broker" clusterservicebroker is deleted after scenario
     Given I have a project
@@ -72,6 +71,7 @@ Feature: Service Catalog related scenarios
       | o        | custom-columns=CLASSNAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName |
     Then the output should contain "user-provided"
     """
+    #Provision a serviceinstance
     Given I switch to the first user
     And I use the "<%= cb.user_project %>" project
     When I process and create:
@@ -84,3 +84,22 @@ Feature: Service Catalog related scenarios
       | resource | serviceinstance/ups-instance |
     Then the output should match "Message.*The instance was provisioned successfully"
     """
+
+    # Delete serviceinstance
+    When I run the :delete client command with:
+      | object_type       | serviceinstance |
+      | object_name_or_id | ups-instance    |
+    Then the step should succeed
+    Given I wait for the resource "serviceinstance" named "ups-instance" to disappear within 60 seconds
+
+    # Delete ups broker
+    When I switch to cluster admin pseudo user
+    When I run the :delete client command with:
+      | object_type       | clusterservicebroker |
+      | object_name_or_id | ups-broker           |
+    Then the step should succeed
+    And I wait for the resource "clusterservicebrokers" named "ups-broker" to disappear within 60 seconds
+    When I run the :get client command with:
+      | resource | clusterserviceclass                                                       |
+      | o        | custom-columns=CLASSNAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName |
+    Then the output should not contain "user-provided"

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -19,7 +19,7 @@ Feature: Service Catalog related scenarios
     Given the status of condition "Degraded" for "service-catalog-controller-manager" operator is: False
     Given the status of condition "Progressing" for "service-catalog-controller-manager" operator is: False
     Given the status of condition "Available" for "service-catalog-controller-manager" operator is: True
-    Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: Unknown
+    Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
     #enable the svcat
     When I run the :patch client command with:
       | resource      | ServiceCatalogAPIServer                 |

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -53,7 +53,9 @@ Feature: Service Catalog related scenarios
     Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
     
     # Deploy ups broker
-    Given admin ensures "ups-broker" clusterservicebroker is deleted after scenario
+    When I run the :get admin command with:
+      | resource | clusterservicebroker |
+    Then the step should succeed  
     Given I have a project
     When I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -55,7 +55,8 @@ Feature: Service Catalog related scenarios
     # Deploy ups broker
     When I run the :get admin command with:
       | resource | clusterservicebroker |
-    Then the step should succeed  
+    Then the step should succeed
+    Given admin ensures "ups-broker" clusterservicebroker is deleted after scenario  
     Given I have a project
     When I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -43,13 +43,13 @@ Feature: Service Catalog related scenarios
     Given the status of condition "Degraded" for "service-catalog-apiserver" operator is: False
     Given the status of condition "Progressing" for "service-catalog-apiserver" operator is: False
     Given the status of condition "Available" for "service-catalog-apiserver" operator is: True
-    Given the status of condition "Upgradeable" for "service-catalog-apiserver" operator is: True
+    Given the status of condition "Upgradeable" for "service-catalog-apiserver" operator is: Unknown
     # Check cluster operator svcat-controller status
     Given the "service-catalog-controller-manager" operator version matchs the current cluster version
     Given the status of condition "Degraded" for "service-catalog-controller-manager" operator is: False
     Given the status of condition "Progressing" for "service-catalog-controller-manager" operator is: False
     Given the status of condition "Available" for "service-catalog-controller-manager" operator is: True
-    Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
+    Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: Unknown
     
     # Deploy ups broker
     Given admin ensures "ups-broker" clusterservicebroker is deleted after scenario

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -48,7 +48,7 @@ Feature: Service Catalog related scenarios
     Given the "service-catalog-controller-manager" operator version matchs the current cluster version
     Given the status of condition "Degraded" for "service-catalog-controller-manager" operator is: False
     Given the status of condition "Progressing" for "service-catalog-controller-manager" operator is: False
-    Given the status of condition "Available" for "operator-lifecycle-manager" operator is: True
+    Given the status of condition "Available" for "service-catalog-controller-manager" operator is: True
     Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
     
     # Create a broker

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -1,0 +1,75 @@
+@svcat
+Feature: Service Catalog related scenarios
+    
+  # @author jfan@redhat.com
+  # @case_id OCP-22621
+  @admin
+  @upgrade-prepare
+  @users=upuser1,upuser2
+  Scenario: upgrade svcat - prepare
+    # Check SVCAT version
+    Given the "service-catalog-apiserver" operator version matchs the current cluster version
+    # Check cluster operator svcat-apiserver status
+    Given the status of condition "Degraded" for "service-catalog-apiserver" operator is: False
+    Given the status of condition "Progressing" for "service-catalog-apiserver" operator is: False
+    Given the status of condition "Available" for "service-catalog-apiserver" operator is: True
+    Given the status of condition "Upgradeable" for "service-catalog-apiserver" operator is: True
+    # Check cluster operator svcat-controller status
+    Given the "service-catalog-controller-manager" operator version matchs the current cluster version
+    Given the status of condition "Degraded" for "service-catalog-controller-manager" operator is: False
+    Given the status of condition "Progressing" for "service-catalog-controller-manager" operator is: False
+    Given the status of condition "Available" for "service-catalog-controller-manager" operator is: True
+    Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
+    #enable the svcat
+    
+  @admin
+  @upgrade-check
+  @users=upuser1,upuser2
+  Scenario: upgrade svcat
+    # Check cluster operator svcat-apiserver status
+    Given the "service-catalog-apiserver" operator version matchs the current cluster version
+    Given the status of condition "Degraded" for "service-catalog-apiserver" operator is: False
+    Given the status of condition "Progressing" for "service-catalog-apiserver" operator is: False
+    Given the status of condition "Available" for "service-catalog-apiserver" operator is: True
+    Given the status of condition "Upgradeable" for "service-catalog-apiserver" operator is: True
+    # Check cluster operator svcat-controller status
+    Given the "service-catalog-controller-manager" operator version matchs the current cluster version
+    Given the status of condition "Degraded" for "service-catalog-controller-manager" operator is: False
+    Given the status of condition "Progressing" for "service-catalog-controller-manager" operator is: False
+    Given the status of condition "Available" for "operator-lifecycle-manager" operator is: True
+    Given the status of condition "Upgradeable" for "service-catalog-controller-manager" operator is: True
+    
+    # Create a broker
+    # Deploy ups broker
+    Given admin ensures "ups-broker" clusterservicebroker is deleted after scenario
+    Given I have a project
+    When I switch to cluster admin pseudo user
+    And I use the "<%= project.name %>" project
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-broker-template.yaml |
+      | p | UPS_BROKER_PROJECT=<%= project.name %>                                                                  |
+    Then the step should succeed
+    And I wait up to 300 seconds for the steps to pass:
+    """
+    When I run the :describe client command with:
+      | resource | clusterservicebroker/ups-broker |
+    Then the output should contain "Successfully fetched catalog entries from broker"
+    """
+    When I run the :get client command with:
+      | resource | clusterserviceclass                                                       |
+      | o        | custom-columns=CLASSNAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName |
+    Then the output should contain "user-provided"
+    """
+    Given I switch to the first user
+    And I use the "<%= cb.user_project %>" project
+    When I process and create:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/svc-catalog/ups-instance-template.yaml |
+      | p | USER_PROJECT=<%= cb.user_project %>                                                                       |
+    Then the step should succeed
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    When I run the :describe client command with:
+      | resource | serviceinstance/ups-instance |
+    Then the output should match "Message.*The instance was provisioned successfully"
+    """
+    


### PR DESCRIPTION
Upgrade the svcat OCP-22621 , Please help  review it @jianzhangbjz  @chengzhang1016 . Thank you.
The test log:
  # @author jfan@redhat.com
  # @case_id OCP-22621
  @admin @upgrade-prepare @users=upuser1,upuser2
  Scenario: upgrade svcat - prepare                                                                         # features/upgrade/svcat/upgrade.feature:9
      [12:04:43] INFO> === Before Scenario: upgrade svcat - prepare ===
      [12:04:44] INFO> === End Before Scenario: upgrade svcat - prepare ===
      # Check SVCAT version
    Given the "service-catalog-apiserver" operator version matchs the current cluster version               # features/step_definitions/operators.rb:29
      [12:05:02] INFO> Exit Status: 0
      | resource      | ServiceCatalogControllerManager         |
      | resource_name | cluster                                 |
      | p             | {"spec":{"managementState": "Managed"}} |
      | type          | merge                                   |
    Then the step should succeed                                                                            # features/step_definitions/common.rb:4
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [12:05:02] INFO> === After Scenario: upgrade svcat - prepare ===
      [12:05:02] INFO> Shell Commands: rm -r -f -- /home/jenkins/workspace/Runner-v3/workdir
      
      [12:05:02] INFO> Exit Status: 0
      [12:05:02] INFO> === End After Scenario: upgrade svcat - prepare ===

1 scenario (1 passed)
15 steps (15 passed)


@svcat
Feature: Service Catalog related scenarios

waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
  @admin @upgrade-check @users=upuser1,upuser2
  Scenario: upgrade svcat                                                                                   # features/upgrade/svcat/upgrade.feature:41
      [12:13:31] INFO> === Before Scenario: upgrade svcat ===
      [12:13:32] INFO> === End Before Scenario: upgrade svcat ===
      # Check cluster operator svcat-apiserver status
    Given the "service-catalog-apiserver" operator version matchs the current cluster version               # features/step_definitions/operators.rb:29
      [12:14:47] INFO> Shell Commands: rm -r -f -- /home/jenkins/workspace/Runner-v3/workdir
      
      [12:14:47] INFO> Exit Status: 0
      [12:14:47] INFO> === End After Scenario: upgrade svcat ===

1 scenario (1 passed)
33 steps (33 passed)
1m15.274s
