### PR TITLE
Enhance machine healthcheck test for 4.3

### DIFF
--- a/features/step_definitions/machine_healthcheck.rb
+++ b/features/step_definitions/machine_healthcheck.rb
@@ -8,6 +8,8 @@ When(/^I create the 'Ready' unhealthyCondition$/) do
 
   # somtimes PDB may prevent a successful node-drain thus blocks the test
   # annnotate the machine to exclude node-drain so that test does not flake
+  killer_pod_tmpl = "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cloud/mhc/kubelet-killer-pod.yml"
+
   # this is no longer needed after 4.4
   if env.version_le("4.3", user: user)
     step %Q{I run the :annotate client command with:}, table(%{
@@ -17,10 +19,11 @@ When(/^I create the 'Ready' unhealthyCondition$/) do
       | overwrite    | true                                        |
       | keyval       | machine.openshift.io/exclude-node-draining= |
     })
+    killer_pod_tmpl = "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cloud/mhc/kubelet-killer-pod-43.yml"
   end
 
   # create a priviledged pod that kills kubelet on its node
-  step %Q{I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cloud/mhc/kubelet-killer-pod.yml" replacing paths:}, table(%{
+  step %Q{I run oc create over "#{killer_pod_tmpl}" replacing paths:}, table(%{
     | n                    | openshift-machine-api |
     | ["spec"]["nodeName"] | #{machine.node_name}  |
   })
@@ -29,8 +32,8 @@ end
 
 Then(/^the machine should be remediated$/) do
   # unhealthy machine and should be deleted
-  step %Q{I wait for the resource "node" named "<%= machine.node_name %>" to disappear within 600 seconds}
-  step %Q{I wait for the resource "machine" named "<%= machine.name %>" to disappear within 600 seconds}
+  step %Q{I wait for the resource "node" named "<%= machine.node_name %>" to disappear within 900 seconds}
+  step %Q{I wait for the resource "machine" named "<%= machine.name %>" to disappear within 900 seconds}
 
   # new machine and node should provisioned
   step %Q{the machineset should have expected number of running machines}


### PR DESCRIPTION
In 4.3, to make a node NotReady, kill the `hyperkube` process; in >= 4.4, kill the `kubelet` process. Add a condition so that the case runs well for 4.3.

At the same time, increase the timeout because on Azure and OSP, the instance creation/deletion is slower. 

@sunzhaohua2 @miyadav @liangxia PTAL