### PR TITLE
Adding support for oc create_deployment in 4.4+

### DIFF
--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -172,6 +172,17 @@
     :from_file: --from-file=<value>
     :from_literal: --from-literal=<value>
     :name: <value>
+:create_deployment:
+  :cmd: oc create deployment <name>
+  :options:
+    :allow_missing_template_keys: --allow-missing-template-keys=<value>
+    :dry_run: --dry-run=<value>
+    :generator: --generator=<value>
+    :image: --image=<value>
+    :output: --output <value>
+    :save_config: --save-config=<value>
+    :template: --template=<value>
+    :validate: --validate=<value>
 :create_namespace:
   :cmd: oc create namespace <name>
 :create_quota:


### PR DESCRIPTION
https://github.com/openshift/verification-tests/pull/763 adds `oc create_deployment` in 4.1/4.2/4.3. We also need it in 4.4+