### PR TITLE
remove the etcd-operator part from OLM

### DIFF
--- a/features/upgrade/olm/upgrade.feature
+++ b/features/upgrade/olm/upgrade.feature
@@ -14,13 +14,13 @@ Feature: OLM related scenarios
     Given the status of condition "Progressing" for "operator-lifecycle-manager" operator is: False
     Given the status of condition "Available" for "operator-lifecycle-manager" operator is: True
     Given the status of condition "Upgradeable" for "operator-lifecycle-manager" operator is: True
-    # Create a namespace and an operator in it
-    Given I switch to cluster admin pseudo user
-    When I run the :new_project client command with:
-      | project_name | olm-upgrade |
-    Given etcd operator "etcd-test" is installed successfully in "olm-upgrade" project
-    # Create customer resource in it
-    Given etcdCluster "sample-cluster" is installed successfully in "olm-upgrade" project
+    # # Create a namespace and an operator in it
+    # Given I switch to cluster admin pseudo user
+    # When I run the :new_project client command with:
+    #   | project_name | olm-upgrade |
+    # Given etcd operator "etcd-test" is installed successfully in "olm-upgrade" project
+    # # Create customer resource in it
+    # Given etcdCluster "sample-cluster" is installed successfully in "olm-upgrade" project
     
   @admin
   @upgrade-check
@@ -33,19 +33,19 @@ Feature: OLM related scenarios
     Given the status of condition "Progressing" for "operator-lifecycle-manager" operator is: False
     Given the status of condition "Available" for "operator-lifecycle-manager" operator is: True
     Given the status of condition "Upgradeable" for "operator-lifecycle-manager" operator is: True
-    # Check if this operator works well by changing its customer resource
-    Given I switch to cluster admin pseudo user
-    And I use the "olm-upgrade" project 
-    When I run the :patch client command with:
-      | resource      | etcdcluster            |
-      | resource_name | sample-cluster         |
-      | p             | {"spec": {"size": 4 }} |
-      | type          | merge                  |
-    Then the step should succeed
-    Given status becomes :succeeded of exactly 4 pods labeled:
-      | etcd_cluster=sample-cluster |
-    Then the step should succeed
-    Given etcdCluster "sample-cluster" is removed successfully from "olm-upgrade" project
-    Given etcd operator "etcd-test" is removed successfully from "olm-upgrade" project
-    # This operator can be re-installed succefully
-    Given etcd operator "etcd-test" is installed successfully in "olm-upgrade" project
+    # # Check if this operator works well by changing its customer resource
+    # Given I switch to cluster admin pseudo user
+    # And I use the "olm-upgrade" project 
+    # When I run the :patch client command with:
+    #   | resource      | etcdcluster            |
+    #   | resource_name | sample-cluster         |
+    #   | p             | {"spec": {"size": 4 }} |
+    #   | type          | merge                  |
+    # Then the step should succeed
+    # Given status becomes :succeeded of exactly 4 pods labeled:
+    #   | etcd_cluster=sample-cluster |
+    # Then the step should succeed
+    # Given etcdCluster "sample-cluster" is removed successfully from "olm-upgrade" project
+    # Given etcd operator "etcd-test" is removed successfully from "olm-upgrade" project
+    # # This operator can be re-installed succefully
+    # Given etcd operator "etcd-test" is installed successfully in "olm-upgrade" project


### PR DESCRIPTION
Now, it uses the cluster-scope etcd-operator in https://github.com/openshift/verification-tests/blob/master/features/upgrade/etcd/upgrade.feature#L6.
After the above test finished the `prepare` scenario, the following subscription of etcd-operator will be blocked even if you use namespace-scoped one. See logs: http://virt-openshift-05.lab.eng.nay.redhat.com/buildcorp/Runner-v3/74178/console
```cucumber
  ...
      STDERR:
      Error from server (NotFound): deployments.extensions "etcd-operator" not found
      
      deployment "etcd-operator" did not appear within timeout (RuntimeError)
      /home/jenkins/workspace/Runner-v3/features/step_definitions/resources.rb:151:in `/^(I|admin) waits? for the "(.+?)" (\w+) to appear(?: in the(?: "(.+?)")? project)?(?: up to (\d+) seconds)?$/'
      /opt/rh/rh-ruby26/root/usr/share/ruby/forwardable.rb:230:in `invoke_dynamic_step'
      /home/jenkins/workspace/Runner-v3/features/step_definitions/upgrade/etcd.rb:47:in `/^etcd operator "([^"]*)" is installed successfully in "([^"]*)" project$/'
      features/upgrade/olm/upgrade.feature:21:in `Given etcd operator "etcd-test" is installed successfully in "olm-upgrade" project'
      # Create customer resource in it
    Given etcdCluster "sample-cluster" is installed successfully in "olm-upgrade" project           # features/step_definitions/upgrade/etcd.rb:61
waiting for operation up to 3600 seconds..
```
In this fix, I remove the etcd-operator part. Because the test scenarios are covered by the [etcd upgrade test](https://github.com/openshift/verification-tests/blob/master/features/upgrade/etcd/upgrade.feature)