### PR TITLE
Remove adm_diagnostics from 4.x as it is an 3.x command

### DIFF
--- a/features/step_definitions/logging_metrics.rb
+++ b/features/step_definitions/logging_metrics.rb
@@ -1054,26 +1054,6 @@ end
 Given /^I verify metrics service is functioning$/ do
   if cb.install_prometheus
     step %Q/I verify Prometheus metrics service is functioning/
-  else
-    # assume the other is Hawkular
-    # XXX: disable this check for now until https://bugzilla.redhat.com/show_bug.cgi?id=1571176  is fixed
-    #step %Q/I verify Hawkular metrics service is functioning/
-  end
-end
-
-# do a quick sanity check using oc adm diagnostics MetricsApiProxy
-# XXX: only seems to be supported by OCP >= 3.3
-# https://docs.openshift.com/container-platform/3.3/install_config/cluster_metrics.html
-# https://docs.openshift.com/container-platform/3.6/install_config/cluster_metrics.html
-
-Given /^I verify Hawkular metrics service is functioning$/ do
-  ensure_admin_tagged
-  @result = admin.cli_exec(:oadm_diagnostics, diagnostics_name: "MetricsApiProxy")
-
-  if @result[:success]
-    raise "Failed diagnostic, output: #{@result[:response]}"  unless @result[:response].include? 'Completed with no errors or warnings seen'
-  else
-    raise "Failed diagnostic, output: #{@result[:response]}"
   end
 end
 

--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -1117,21 +1117,6 @@
     :raw: --raw
 :oadm_cordon_node:
   :cmd: oc adm cordon <node_name>
-:oadm_diagnostics:
-  :cmd: oc adm diagnostics
-  :options:
-    :cluster-context: --cluster-context=<value>
-    :config: --config=<value>
-    :context: --context=<value>
-    :diaglevel: --diaglevel=<value>
-    :diagnostics_name: <value>
-    :host: --host=<value>
-    :images: --images=<value>
-    :latest-images: --latest-images=<value>
-    :loglevel: --loglevel=<value>
-    :master-config: --master-config=<value>
-    :node-config: --node-config=<value>
-    :prevent-modification: --prevent-modification=<value>
 :oadm_drain:
   :cmd: oc adm drain
   :options:

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -1117,21 +1117,6 @@
     :raw: --raw
 :oadm_cordon_node:
   :cmd: oc adm cordon <node_name>
-:oadm_diagnostics:
-  :cmd: oc adm diagnostics
-  :options:
-    :cluster-context: --cluster-context=<value>
-    :config: --kubeconfig=<value>
-    :context: --context=<value>
-    :diaglevel: --diaglevel=<value>
-    :diagnostics_name: <value>
-    :host: --host=<value>
-    :images: --images=<value>
-    :latest-images: --latest-images=<value>
-    :loglevel: --loglevel=<value>
-    :master-config: --master-config=<value>
-    :node-config: --node-config=<value>
-    :prevent-modification: --prevent-modification=<value>
 :oadm_drain:
   :cmd: oc adm drain
   :options:


### PR DESCRIPTION
Hawkular is replaced by cluster monitoring.
`oc adm diagnostics` is replaced by operator-based diagnostics.