### PR TITLE
modify the status of upgradeable

### DIFF
--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -13,7 +13,6 @@ Feature: Service Catalog related scenarios
     Given the status of condition "Degraded" for "service-catalog-apiserver" operator is: False
     Given the status of condition "Progressing" for "service-catalog-apiserver" operator is: False
     Given the status of condition "Available" for "service-catalog-apiserver" operator is: True
-    Given the status of condition "Upgradeable" for "service-catalog-apiserver" operator is: Unknown
     # Check cluster operator svcat-controller status
     Given the "service-catalog-controller-manager" operator version matchs the current cluster version
     Given the status of condition "Degraded" for "service-catalog-controller-manager" operator is: False


### PR DESCRIPTION
Remove the Upgradeable status check before upgrade the cluster since it is not the same in OCP 4.3 4.2 4.1.