### PR TITLE
Automate test case OCP-26311

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -8,7 +8,7 @@ Feature: MachineHealthCheck Test Scenarios
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
 
-    Given I pick a random machineset to scale
+    Given I clone a machineset named "machineset-25897"
     # Create MHC
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cloud/mhc/mhc1.yaml" replacing paths:
       | n                                                                                  | openshift-machine-api       |
@@ -20,4 +20,28 @@ Feature: MachineHealthCheck Test Scenarios
 
     # Create unhealthyCondition to trigger machine remediation
     When I create the 'Ready' unhealthyCondition
+    Then the machine should be remediated
+
+  # @author jhou@redhat.com
+  # @case_id OCP-26311
+  @admin
+  @destructive
+  Scenario: Create a machinehealthcheck when there is already an unhealthy machine
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+
+    Given I clone a machineset named "machineset-26311"
+
+    # Create unhealthyCondition before createing a MHC
+    Given I create the 'Ready' unhealthyCondition
+
+    # Create MHC
+    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cloud/mhc/mhc1.yaml" replacing paths:
+      | n                                                                                  | openshift-machine-api       |
+      | ["metadata"]["name"]                                                               | mhc-<%= machine_set.name %> |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]    | <%= machine_set.cluster %>  |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"] | <%= machine_set.name %>     |
+    Then the step should succeed
+    And I ensure "mhc-<%= machine_set.name %>" machinehealthcheck is deleted after scenario
+
     Then the machine should be remediated


### PR DESCRIPTION
The difference with test OCP-25897 is this scenario create unhealthy machine before creating MHC. This is extends the coverage for MHC.

```
      [05:39:08] INFO> Exit Status: 0
      [05:39:08] INFO> === End After Scenario: Create a machinehealthcheck when there is already an unhealthy machine ===

1 scenario (1 passed)
8 steps (8 passed)
17m43.191s
```

@sunzhaohua2 @miyadav Please review.