### PR TITLE
Remove adm_registry from 4.x as it is an 3.x command

### DIFF
--- a/features/test/registry.feature
+++ b/features/test/registry.feature
@@ -75,39 +75,3 @@ Feature: registry related test scenario
     Given I have a project
     Given I obtain default registry IP HOSTNAME by a dummy build in the project
     Then the expression should be true> cb.int_reg_ip.to_s =~ /\d+\.\d+\.\d+\.\d+/
-  
-  @admin
-  @destructive
-  Scenario: Secure newly created default docker registry
-    Given I switch to cluster admin pseudo user
-    Then default registry is verified using a pod in a project after scenario
-    And the master service is restarted on all master nodes after scenario
-    And default docker-registry dc is deleted
-    And default docker-registry service is deleted
-    When I run the :oadm_registry admin command with:
-      | namespace | default |
-    And a pod becomes ready with labels:
-      | deploymentconfig=docker-registry |
-    Then the step should succeed
-    When I secure the default docker registry
-    Then the master service is restarted on all master nodes
-    And default registry is verified using a pod in a project
-
-  @admin
-  @destructive
-  Scenario: Secure newly created default docker registry deployed via daemon set
-    Given I switch to cluster admin pseudo user
-    Then default registry is verified using a pod in a project after scenario
-    And the master service is restarted on all master nodes after scenario
-    And default docker-registry dc is deleted
-    And default docker-registry service is deleted
-    And admin ensures "docker-registry" daemonset is deleted from the "default" project after scenario
-    When I run the :oadm_registry admin command with:
-      | namespace | default |
-      | daemonset | true    |
-    And <%= daemon_set("docker-registry").desired_number_scheduled(user: admin) %> pods become ready with labels:
-      | docker-registry=default |
-    Then the step should succeed
-    When I secure the default docker daemon set registry
-    Then the master service is restarted on all master nodes
-    And default registry is verified using a pod in a project

--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -1275,14 +1275,6 @@
     :prune_over_size_limit: --prune-over-size-limit=<value>
     :prune_registry: --prune-registry=<value>
     :registry_url: --registry-url=<value>
-:oadm_registry:
-  :cmd: oc adm registry
-  :options:
-    :daemonset: --daemonset=<value>
-    :images: --images=<value>
-    :mount_host: --mount-host=<value>
-    :ports: --ports=<value>
-    :serviceaccount: --service-account=<value>
 :oadm_router:
   :cmd: oc adm router <name>
   :options:

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -1275,14 +1275,6 @@
     :prune_over_size_limit: --prune-over-size-limit=<value>
     :prune_registry: --prune-registry=<value>
     :registry_url: --registry-url=<value>
-:oadm_registry:
-  :cmd: oc adm registry
-  :options:
-    :daemonset: --daemonset=<value>
-    :images: --images=<value>
-    :mount_host: --mount-host=<value>
-    :ports: --ports=<value>
-    :serviceaccount: --service-account=<value>
 :oadm_router:
   :cmd: oc adm router <name>
   :options:


### PR DESCRIPTION
`oc adm registry` is replaced by the Image Registry Operator.