### PR TITLE
Ensure admin tag for NFS server as it needs SCC

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -1,8 +1,7 @@
 # store here steps that create test services within OpenShift test env
 
 Given /^I have a NFS service in the(?: "([^ ]+?)")? project$/ do |project_name|
-  # at the moment I believe only one such PV we can have without interference
-  #ensure_destructive_tagged
+  ensure_admin_tagged
 
   project(project_name)
   unless project.exists?(user: user)


### PR DESCRIPTION
The NFS server need privileged SCC, so ensure admin tagged.