### PR TITLE
Automate OCP-25734

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -45,3 +45,30 @@ Feature: MachineHealthCheck Test Scenarios
     And I ensure "mhc-<%= machine_set.name %>" machinehealthcheck is deleted after scenario
 
     Then the machine should be remediated
+
+  # @author jhou@redhat.com
+  # @case_id OCP-25734
+  @admin
+  @destructive
+  Scenario: Create multiple MHCs to monitor same machineset
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+
+    Given I clone a machineset named "machineset-25734"
+
+    # Create MHCs
+    Given I run the steps 2 times:
+    """
+    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cloud/mhc/mhc1.yaml" replacing paths:
+      | n                                                                                  | openshift-machine-api                 |
+      | ["metadata"]["name"]                                                               | mhc-<%= machine_set.name %>-#{ cb.i } |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]    | <%= machine_set.cluster %>            |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"] | <%= machine_set.name %>               |
+    Then the step should succeed
+    And I ensure "mhc-<%= machine_set.name %>-#{ cb.i }" machinehealthcheck is deleted after scenario
+    """
+
+    # Create unhealthyCondition before createing a MHC
+    When I create the 'Ready' unhealthyCondition
+
+    Then the machine should be remediated


### PR DESCRIPTION
Having multiple MHC for same machineset, the machine can be remediated. @sunzhaohua2 @miyadav PTAL.

```
      [02:41:45] INFO> === End After Scenario: Create multiple MHCs to monitor same machineset ===

1 scenario (1 passed)
11 steps (11 passed)
17m12.245s
```