### PR TITLE
Remove adm_ca from 4.x as it is an 3.x command

### DIFF
--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -1084,32 +1084,6 @@
     :invalid_option: <value>   # for negative testing
     :o: -o <value>
     :trigger_only: --trigger-only=<value>
-:oadm_ca_create_key_pair:
-  :cmd: oc adm ca create-key-pair
-  :options:
-    :overwrite: --overwrite=<value>
-    :private_key: --private-key=<value>
-    :public_key: --public-key=<value>
-:oadm_ca_create_master_cert:
-  :cmd: oc adm ca create-master-certs
-  :options:
-    :certificate-authority: --certificate-authority=<value>
-    :cert-dir: --cert-dir=<value>
-    :expire-days: --expire-days=<value>
-    :hostnames: --hostnames=<value>
-    :master: --master=<value>
-    :overwrite: --overwrite=<value>
-    :public-master: --public-master=<value>
-    :signer-expire-days: --signer-expire-days=<value>
-    :signer-name: --signer-name=<value>
-:oadm_ca_create_signer_cert:
-  :cmd: oc adm ca create-signer-cert
-  :options:
-    :cert: --cert=<value>
-    :key: --key=<value>
-    :name: --name=<value>
-    :overwrite: --overwrite=<value>
-    :serial: --serial=<value>
 :oadm_config_view:
   :cmd: oc adm config view
   :options:

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -1084,32 +1084,6 @@
     :invalid_option: <value>   # for negative testing
     :o: -o <value>
     :trigger_only: --trigger-only=<value>
-:oadm_ca_create_key_pair:
-  :cmd: oc adm ca create-key-pair
-  :options:
-    :overwrite: --overwrite=<value>
-    :private_key: --private-key=<value>
-    :public_key: --public-key=<value>
-:oadm_ca_create_master_cert:
-  :cmd: oc adm ca create-master-certs
-  :options:
-    :certificate-authority: --certificate-authority=<value>
-    :cert-dir: --cert-dir=<value>
-    :expire-days: --expire-days=<value>
-    :hostnames: --hostnames=<value>
-    :master: --master=<value>
-    :overwrite: --overwrite=<value>
-    :public-master: --public-master=<value>
-    :signer-expire-days: --signer-expire-days=<value>
-    :signer-name: --signer-name=<value>
-:oadm_ca_create_signer_cert:
-  :cmd: oc adm ca create-signer-cert
-  :options:
-    :cert: --cert=<value>
-    :key: --key=<value>
-    :name: --name=<value>
-    :overwrite: --overwrite=<value>
-    :serial: --serial=<value>
 :oadm_config_view:
   :cmd: oc adm config view
   :options:


### PR DESCRIPTION
In 4.x, Certificates are managed by Operators internally.
```
$ oc/oc-4.1.35-202002140309.git.0.7bfae40.el7 adm --help
Administrative Commands

 Actions for administering an OpenShift cluster are exposed here.

Usage:
  oc adm [flags]

Cluster Management:
  upgrade                            Upgrade a cluster
  top                                Show usage statistics of resources on the server
  must-gather                        Launch a new instance of a pod for gathering debug information

Node Management:
  drain                              Drain node in preparation for maintenance
  cordon                             Mark node as unschedulable
  uncordon                           Mark node as schedulable
  taint                              Update the taints on one or more nodes
  node-logs                          Display and filter node logs

Security and Policy:
  new-project                        Create a new project
  policy                             Manage cluster authorization and security policy
  groups                             Manage groups
  certificate                        Approve or reject certificate requests
  pod-network                        Manage pod network

Maintenance:
  prune                              Remove older versions of resources from the server
  migrate                            Migrate data in the cluster

Configuration:
  create-kubeconfig                  Create a basic .kubeconfig file from client certs
  create-api-client-config           Create a config file for connecting to the server as a user
  create-bootstrap-project-template  Create a bootstrap project template
  create-bootstrap-policy-file       Create the default bootstrap policy
  create-login-template              Create a login template
  create-provider-selection-template Create a provider selection template
  create-error-template              Create an error page template

Other Commands:
  build-chain                        Output the inputs and dependencies of your builds
  completion                         Output shell completion code for the specified shell (bash or zsh)
  config                             Change configuration files for the client
  release                            Tools for managing the OpenShift release process
  verify-image-signature             Verify the image identity contained in the image signature

Use "oc adm <command> --help" for more information about a given command.
Use "oc adm options" for a list of global command-line options (applies to all commands).
```