### PR TITLE
Fix rule check_binary_data_contains for 4.4

### DIFF
--- a/lib/rules/web/admin_console/4.4/configmap.xyaml
+++ b/lib/rules/web/admin_console/4.4/configmap.xyaml
@@ -1,7 +1,7 @@
 check_binary_data_contains:
   elements:
   - selector:
-      xpath: //h2[@class='co-section-heading' and text()='Binary Data']/following::dt[text()='<binary_key>']
+      xpath: //h2[@data-test-section-heading='Binary Data']/following::dt[text()='<binary_key>']
   - selector:
       text: Save File
     type: button


### PR DESCRIPTION
Affect case OCP-24342
Now the xpath has been updated. 
@yapei Please help to review. Thanks!
PASS on 4.4: https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3/75851/console