### PR TITLE
Updtae: Fix OCP-11906

### DIFF
--- a/features/cli/oc_volume.feature
+++ b/features/cli/oc_volume.feature
@@ -54,10 +54,10 @@ Feature: oc_volume.feature
       | name   | mydc                 |
       | image  | <%= project_docker_repo %>openshift/hello-openshift |
     Then the step should succeed
-    When I run the :secrets client command with:
-      | action | new             |
-      | name   | my-secret       |
-      | source | /etc/hosts      |
+    When I run the :create_secret client command with:
+      | secret_type | generic    |
+      | name        | my-secret  |
+      | from_file   | /etc/hosts |
     Then the step should succeed
 
     Given I wait until replicationController "mydc-1" is ready


### PR DESCRIPTION
Fix the failed case with deprecated OC command.

> Command "new" is deprecated, use oc create secret


[Pass log](https://privatebin-it-iso.int.open.paas.redhat.com/?9c2dba6b7dc31c52#i7IPi4WivzM7Ek4fEUkNByV2OZYzhRuU4/3sS+cviLs=)