### PR TITLE
Add option for remote selenium URL

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -45,6 +45,10 @@ global:
   # browser: chrome
   # browser: firefox_marionette
 
+  # Optional: remote selenium URL to connect to.
+  # Leave unset for default of launching local browser via geckodriver etc.
+  # selenium_url: http://example.com:4444/wd/hub
+
 environments:
   online_starter:
     hosts: api.starter-us-east-1.openshift.com:etcd:master:node

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -51,16 +51,23 @@ Also we have `services` to define some third party services options. Access to t
 
 == Web Driver
 
-For tests which require a web driver please install the driver for the browser you would prefer to use.
+For tests which require a web browser:
+
+The typical configuration requires a local "driver" binary to configure and launch a subprocess. Please install the driver for the browser you would prefer to use:
 
 Firefox:
  Please download the server from https://github.com/mozilla/geckodriver/releases and place it somewhere on your PATH.
- See https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver for more information
+ See https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver for more information. The config defaults to firefox, so you're all set!
 
 Chrome:
- Please download the driver from http://chromedriver.storage.googleapis.com/index.html that matches the version of Chrome you are using, place it somewhere on your PATH and set the following environment variable. 
+ Please download the driver from http://chromedriver.storage.googleapis.com/index.html that matches the version of Chrome you are using, place it somewhere on your PATH and set the following environment variable.
 
 * `export BUSHSLICER_CONFIG='{"global": {"browser": "chrome"}}'`
+
+You may instead specify a remote Selenium URL to connect to, e.g.:
+
+* `export BUSHSLICER_CONFIG='{"global": {"browser": "chrome", "selenium_url": "http://localhost:4444/wd/hub"}}'`
+
 
 == accessing configuration
 

--- a/features/step_definitions/web.rb
+++ b/features/step_definitions/web.rb
@@ -77,6 +77,9 @@ Given /^I have a browser with:$/ do |table|
   if conf[:browser]
     init_params[:browser_type] ||= conf[:browser].to_sym
   end
+  if conf[:selenium_url]
+    init_params[:selenium_url] ||= conf[:selenium_url]
+  end
   if env.client_proxy
     init_params[:http_proxy] ||= env.client_proxy
   end

--- a/lib/webauto/webconsole_executor.rb
+++ b/lib/webauto/webconsole_executor.rb
@@ -32,11 +32,11 @@ module BushSlicer
         logger: logger,
         base_url: env.web_console_url,
         browser_type: conf[:browser] ? conf[:browser].to_sym : :firefox,
+        selenium_url: conf[:selenium_url],
         rules: RULES_DIR +  "base/", # will be updated after version is found
         snippets_dir: SNIPPETS_DIR,
         http_proxy: env.client_proxy
       }
-
       logger.debug "initializing web console browser for user #{user.name}"
       e = @executors[user.name] = Web4Cucumber.new(**browser_opts)
 


### PR DESCRIPTION
Motivation: I want to run tests in development with browser in one container but cucumber running outside it / in another container.
Not 100% sure how I'll end using this, but gives flexibility.  Any objections?

- [x] Got it to successfully connect to ["selenium standalone" containers](https://github.com/SeleniumHQ/docker-selenium):
```
$ podman run -d -p 4444:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug
$ export BUSHSLICER_CONFIG='{"global": {"browser": "chrome", "selenium_url": "http://localhost:4444/wd/hub"}}'
```
- Didn't check with separate selenium hub.

- Don't know if openshift's test work in this config as I'm not actually running them :smile: 
  I'm from dev team of cloud.redhat.com/openshift site, and what I actually care about are the "ocm" tests in https://github.com/xueli181114/verification-tests & https://github.com/xueli181114/cucushift forks.

- I'm new to WebDriver / Selenium.  Is "Selenium URL" terminology clear / unambiguous?

(internal jira card: https://issues.redhat.com/browse/SDA-2021)