### PR TITLE
Fixing autoscaler test flakes

### DIFF
--- a/features/machine/autoscaler.feature
+++ b/features/machine/autoscaler.feature
@@ -38,18 +38,18 @@ Feature: Cluster Autoscaler Tests
     And admin ensures "workload" job is deleted from the "openshift-machine-api" project after scenario
 
     # Verify machineset has scaled
-    Given I wait up to 60 seconds for the steps to pass:
+    Given I wait up to 300 seconds for the steps to pass:
     """
-    the expression should be true> machine_set.desired_replicas(cached: false) == 3
+    Then the expression should be true> machine_set.desired_replicas(cached: false) == 3
     """
     Then the machineset should have expected number of running machines
 
     # Delete workload
     Given admin ensures "workload" job is deleted from the "openshift-machine-api" project
     # Check cluster auto scales down
-    And I wait up to 120 seconds for the steps to pass:
+    And I wait up to 300 seconds for the steps to pass:
     """
-    the expression should be true> machine_set.desired_replicas(cached: false) == 1
+    Then the expression should be true> machine_set.desired_replicas(cached: false) == 1
     """
     Then the machineset should have expected number of running machines
 

--- a/lib/openshift/machine_set.rb
+++ b/lib/openshift/machine_set.rb
@@ -15,10 +15,10 @@ module BushSlicer
       rr.dig('status', 'availableReplicas').to_i
     end
 
-    def ready?(user: nil, cached: false, quiet: false)
+    def ready?(user: nil, quiet: false)
       result = {}
-      result[:success] = (desired_replicas(user: user, cached: cached, quiet: quiet) ==
-        available_replicas(user: user, cached: true, quiet: quiet))
+      status = raw_resource(user: user, cached: false, quiet: quiet)['status']
+      result[:success] = ([status['availableReplicas'], status['readyReplicas'], status['fullyLabeledReplicas'], status['replicas']].uniq.length == 1)
       return result
     end
 


### PR DESCRIPTION
This should fix the issue in https://issues.redhat.com/browse/OCPQE-34. It includes fixes to:
-  `the expression should be true` was incorrectly used which always returns true
- Update the `#ready?` to firmly check machineset has consistent `availableReplicas`, `readyReplicas`, `replicas` and `fullyLabeledReplicas`. Description of these fields are in https://github.com/openshift/machine-api-operator/blob/master/install/0000_30_machine-api-operator_03_machineset.crd.yaml#L223

I've tested all autoscaler test on GCP which we fail often, now they are all passing.

@sunzhaohua2 @miyadav PTAL