### PR TITLE
Fix step definition because #ready? returns a hash not a boolean

### DIFF
--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -8,7 +8,7 @@ Given(/^I have an IPI deployment$/) do
   end
 
   machine_sets.each do | machine_set |
-    unless machine_set.ready?
+    unless machine_set.ready?[:success]
       raise "Not an IPI deployment or machineSet #{machine_set.name} not fully scaled, abort test."
     end
   end


### PR DESCRIPTION
Thanks to @miyadav reporting, fix the step definition so that test will fail on UPI because the way UPI is installed, it has no valid machinesets.