### PR TITLE
OCP-25294, OCP-25787 and OCP-26373

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -421,3 +421,20 @@ Feature: Pod related networking scenarios
       | bash | -c | conntrack -L \| grep "<%= cb.nodeport %>" |
     Then the output should contain "<%= cb.host_pod2.ip %>"
     And the output should not contain "<%= cb.host_pod1.ip %>"
+
+  # @author anusaxen@redhat.com
+  # @case_id OCP-25294
+  @admin
+  Scenario: Pod should be accesible via node ip and host port
+    Given I select a random node's host
+    And I have a project
+    When I run the :create admin command with:
+      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/pod-for-ping-with-hostport.yml |
+      | n | <%= project.name %>                                                                                          |
+    Then the step should succeed
+    And status becomes :running of exactly 1 pod labeled:
+      | name=hello-pod |
+    When I run commands on all nodes:	    
+      | curl <%= pod.ip %>:9500 |
+    Then the output should contain:
+      | Hello-OpenShift |

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -379,9 +379,8 @@ Feature: SDN related networking scenarios
   Given the env is using "OVNKubernetes" networkType
   And I select a random node's host
   And the vxlan tunnel name of node "<%= node.name %>" is stored in the :tunnel_inf_name clipboard
-  Given I use the "<%= node.name %>" node
   #bridge interfaces needs to be unmanaged
-  And I run commands on the host:
+  Given I run commands on the host:
     | nmcli |
   Then the output should contain:
     | br-int: unmanaged                    |


### PR DESCRIPTION
This test case was created during 4.2 but eluded testing on 4.3 and 4.4 but its working as expected..phewww. We don't know why the future release versions were never updated in Polarion for this case. I have manually fixed it now and get this automated.
Logs: http://pastebin.test.redhat.com/846486
@weliang1 @zhaozhanqi @huiran0826 @rbbratta 

(Thanks @pruan-rht for helping catching an issue here as i was checking pod running status instead should have checked Ready. Learnt that in pod state table, running comes earlier than Ready :) . So if you check a pod ip on running status it may may not get assigned but definitely get assigned in Ready state)