### PR TITLE
fix service_project.exists? race condition

### DIFF
--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -415,11 +415,14 @@ module BushSlicer
     def service_project
       unless @service_project
         project = Project.new(name: "tests-" + EXECUTOR_NAME.downcase, env: self)
-        unless project.exists?
+        unless project.active?
+          project.wait_to_disappear(admin)
           res = project.create(by: admin, clean_up_registered: true)
           unless res[:success]
             raise "failed to create service project #{project.name}, see log"
           end
+          # we must update the cache, since we just waited for the previously active project to disappear
+          project.reload
         end
         @service_project = project
       end


### PR DESCRIPTION
Problem:
We re-use the service project each time we do step
"run commands on the host"
the clean_up method deletes the project.

When running lots of commands on the host
the after cleanup and before the next access
the service_project can be in the `Terminating` phase

```
  [15:43:58] INFO> Shell Commands: oc get projects tests-cucushift-oc44-standard-slave-gtknl-0 --output=yaml --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig
  apiVersion: project.openshift.io/v1
  kind: Project
....
  status:
    phase: Terminating

  [15:43:59] INFO> Exit Status: 0
  [15:43:59] INFO> Shell Commands: oc debug  --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig -n tests-cucushift-oc44-standard-slave-gtknl-0 node/qeci-3419-8s8xx-control-plane-0 -- chroot /host/ bash -c mkdir\ -v\ -p\ \'/tmp/workdir/cucushift-oc44-standard-slave-gtknl-0\'

  STDERR:
  Error from server (Forbidden): pods "qeci-3419-8s8xx-control-plane-0-debug" is forbidden: unable to create new content in namespace tests-cucushift-oc44-standard-slave-gtknl-0 because it is being terminated

  [15:43:59] INFO> Exit Status: 1
```

The `project.exists?` check doesn't check the phase, so it thinks
a `Terminating` project exists when it doesn't.

Check `project.active?(cached: true)` and if not active wait for it to
terminate.

Also change the cleanup to use `ensure_deleted` so we wait for it to
delete properly
