### PR TITLE
Bump up ruby24 to ruby26

### DIFF
--- a/tools/openshift-ci/Dockerfile.centos
+++ b/tools/openshift-ci/Dockerfile.centos
@@ -9,7 +9,7 @@ ADD . /verification-tests/
 
 RUN set -x && \
     SCL_BASE_PKGS="centos-release-scl scl-utils-build" && \
-    INSTALL_PKGS="rh-ruby24 rh-ror50-rubygem-nokogiri rh-ruby24-ruby-devel rh-git29 bsdtar" && \
+    INSTALL_PKGS="rh-ruby26 rh-ruby26-ruby-devel rh-git218 bsdtar" && \
     yum -y update && \
     yum install -y --enablerepo=centosplus $SCL_BASE_PKGS && \
     yum install -y --enablerepo=centosplus $INSTALL_PKGS && \
@@ -20,7 +20,7 @@ RUN set -x && \
     curl -sSL https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -o /tmp/epel-release-latest-7.noarch.rpm && \
     yum install -y /tmp/epel-release-latest-7.noarch.rpm
 
-RUN scl enable rh-ror50 /verification-tests/tools/install_os_deps.sh
-RUN scl enable rh-ror50 /verification-tests/tools/hack_bundle.rb
+RUN scl enable rh-ruby26 /verification-tests/tools/install_os_deps.sh
+RUN scl enable rh-ruby26 /verification-tests/tools/hack_bundle.rb
 
 RUN yum clean all -y && rm -rf /verification-tests /var/cache/yum /tmp/*


### PR DESCRIPTION
From https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_verification-tests/784/pull-ci-openshift-verification-tests-master-images/2689
 --> RUN scl enable rh-ror50 /verification-tests/tools/hack_bundle.rb
$ bundle install --gemfile=/verification-tests/tools/hack_gemfiles/Gemfile_nokogiri
Don't run Bundler as root. Bundler can ask for sudo if it is needed, and
installing your bundle as root will break this application for all non-root
users on this machine.
Resolving dependencies...
Using bundler 2.1.4
Using nokogiri 1.7.0.1
Bundle complete! 1 Gemfile dependency, 2 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
$ bundle install --gemfile=/verification-tests/tools/Gemfile
Don't run Bundler as root. Bundler can ask for sudo if it is needed, and
installing your bundle as root will break this application for all non-root
users on this machine.
Fetching gem metadata from https://rubygems.org/.......
Fetching gem metadata from https://rubygems.org/..
Resolving dependencies....
...
Fetching zeitwerk 2.3.0
Installing zeitwerk 2.3.0
Fetching activesupport 6.0.2.2
Installing activesupport 6.0.2.2
Gem::InstallError: activesupport requires Ruby version >= 2.5.0.
An error occurred while installing activesupport (6.0.2.2), and Bundler cannot
continue.
Make sure that `gem install activesupport -v '6.0.2.2' --source
'https://rubygems.org/'` succeeds before bundling.
In Gemfile:
  jira-ruby was resolved to 2.0.0, which depends on
    activesupport
error: build error: running 'scl enable rh-ror50 /verification-tests/tools/hack_bundle.rb' failed with exit code 1 