### PR TITLE
Automate OCP-25691

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -72,3 +72,47 @@ Feature: MachineHealthCheck Test Scenarios
     When I create the 'Ready' unhealthyCondition
 
     Then the machine should be remediated
+
+  # @author jhou@redhat.com
+  # @case_id OCP-25691
+  @admin
+  @destructive
+  Scenario: Use "maxUnhealthy" to prevent automated remediation
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    Given I store the number of machines in the :num_to_restore clipboard
+    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
+    Given I use the "openshift-machine-api" project
+    And I clone a machineset named "machineset-25691"
+
+    # Create MHC
+    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cloud/mhc/mhc1.yaml" replacing paths:
+      | n                                                                                  | openshift-machine-api         |
+      | ["metadata"]["name"]                                                               | mhc-<%= machine_set.name %>-1 |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]    | <%= machine_set.cluster %>    |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"] | <%= machine_set.name %>       |
+      | ["spec"]["maxUnhealthy"]                                                           | 0                             |
+    Then the step should succeed
+    And I ensure "mhc-<%= machine_set.name %>-1" machinehealthcheck is deleted after scenario
+    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cloud/mhc/mhc1.yaml" replacing paths:
+      | n                                                                                  | openshift-machine-api         |
+      | ["metadata"]["name"]                                                               | mhc-<%= machine_set.name %>-2 |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]    | <%= machine_set.cluster %>    |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"] | <%= machine_set.name %>       |
+      | ["spec"]["maxUnhealthy"]                                                           | 90%                           |
+    Then the step should succeed
+    And I ensure "mhc-<%= machine_set.name %>-2" machinehealthcheck is deleted after scenario
+
+    # Create unhealthyCondition to trigger machine remediation
+    Given I create the 'Ready' unhealthyCondition
+    Given a pod becomes ready with labels:
+      | api=clusterapi, k8s-app=controller |
+    And I wait for the steps to pass:
+    """
+    When I run the :logs admin command with:
+      | resource_name | <%= pod.name %>                |
+      | c             | machine-healthcheck-controller |
+    Then the output should contain:
+      | mhc-<%= machine_set.name %>-1: total targets: 1,  maxUnhealthy: 0, unhealthy: 1. Short-circuiting remediation   |
+      | mhc-<%= machine_set.name %>-2: total targets: 1,  maxUnhealthy: 90%, unhealthy: 1. Short-circuiting remediation |
+    """


### PR DESCRIPTION
Scenario: prevent remediation with `maxUnhealthy`. Also combines the test scenario with OCP-25687 for testing the together in automation is easier.

Tested and passed

```
      [10:06:53] INFO> === End After Scenario: Use "maxUnhealthy" to prevent automated remediation ===

1 scenario (1 passed)
15 steps (15 passed)
11m49.742s
```

@sunzhaohua2 @miyadav PTAL