### PR TITLE
Add arp command to help debug

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -812,7 +812,7 @@ Given /^a DHCP service is configured for interface "([^"]*)" on "([^"]*)" node w
     if host.exec_admin("systemctl status dnsmasq")[:response].include? "running"
       logger.info("dnsmasq service is running fine")
     else
-      host.exec_admin("cp /etc/dnsmasq.conf.bak /etc/dnsmasq.conf && systemctl restart dnsmasq --now")
+      host.exec_admin("arp -a;cp /etc/dnsmasq.conf.bak /etc/dnsmasq.conf && systemctl restart dnsmasq --now")
       raise "Failed to start dnsmasq service. Check you cluster health manually"
     end
   }


### PR DESCRIPTION
@pruan-rht Can you help merging this?
This step sometimes fails on misc clusters complaining say 192.168.1.1 is already in use. arp -a output will always help us regardless of fail or pass. Its not reproducible on personal setups.Thanks!