### PR TITLE
DRAFT: allow changing oc debug image

### DIFF
--- a/features/step_definitions/node.rb
+++ b/features/step_definitions/node.rb
@@ -86,11 +86,15 @@ Given /^environment has( at least| at most) (\d+)( schedulable)? nodes?$/ do |cm
 end
 
 # @host from World will be used.
-Given /^I run( background)? commands on the host:$/ do |bg, table|
+Given /^I run( background)? commands on the host(?: using image "(.+?)")?:$/ do |bg, image, table|
   ensure_admin_tagged
 
   raise "You must set a host prior to running this step" unless host
-  @result = host.exec(*table.raw.flatten, background: !!bg)
+  if image
+    @result = host.exec(*table.raw.flatten, background: !!bg, image: image)
+  else
+    @result = host.exec(*table.raw.flatten, background: !!bg)
+  end
 end
 
 Given /^I run commands on the host after scenario:$/ do |table|

--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -292,6 +292,7 @@
      :exec_command: <value>
      :exec_command_arg: <value>
      :f: -f <value>
+     :image: --image <value>
      :keep_annotations: --keep-annotations
      :keep_init_containers: --keep-init-containers=<value>
      :keep_liveness: --keep-liveness

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -279,6 +279,7 @@
      :exec_command: <value>
      :exec_command_arg: <value>
      :f: -f <value>
+     :image: --image <value>
      :keep_annotations: --keep-annotations
      :keep_init_containers: --keep-init-containers=<value>
      :keep_liveness: --keep-liveness


### PR DESCRIPTION
sometime disconnected cluster don't have the
registry.redhat.io/rhel7/support-tools image installed
so we can't run oc debug normally.

The oc debug command allows the user to override the image
so we can use can existing image, e.g. ovs image or any other
existing image to run debug commands, give that we always chroot

Add the `using image ""` option to the step and pass
the :image option all the way down to `exec_raw`

This might not work for all callers of `exec_raw`