### PR TITLE
DRAFT: allow global override of oc debug image

### DIFF
--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -292,6 +292,7 @@
      :exec_command: <value>
      :exec_command_arg: <value>
      :f: -f <value>
+     :image: --image <value>
      :keep_annotations: --keep-annotations
      :keep_init_containers: --keep-init-containers=<value>
      :keep_liveness: --keep-liveness

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -279,6 +279,7 @@
      :exec_command: <value>
      :exec_command_arg: <value>
      :f: -f <value>
+     :image: --image <value>
      :keep_annotations: --keep-annotations
      :keep_init_containers: --keep-init-containers=<value>
      :keep_liveness: --keep-liveness


### PR DESCRIPTION
sometime disconnected cluster don't have the
registry.redhat.io/rhel7/support-tools image installed
so we can't run oc debug normally.

The oc debug command allows the user to override the image
so we can use can existing image, e.g. ovs image or any other
existing image to run debug commands, give that we always chroot

Add the `OPENSHIFT_ENV_OCP_HOST_DEBUG_IMAGE` option change
the global oc debug image

quick hack to enable using the multus image