### PR TITLE
[OSP][IaaS scope] add proxy support for private OSP

### DIFF
--- a/lib/launchers/openstack.rb
+++ b/lib/launchers/openstack.rb
@@ -28,10 +28,16 @@ module BushSlicer
                      'openstack_qeos10'
       opts = default_opts(service_name).merge options
 
+      http_additional_opts={}
+
+      if opts[:proxy]
+        http_additional_opts.merge!({:proxy => opts[:proxy]})
+      end
+
       ## poor's man OSP version detection
       url = opts[:url].match(%r{(^https?://[-:.a-zA-Z0-9]+)(/.*)?$})&.to_a&.fetch(1)
       raise "cannot parse auth URL #{opts[:url].inspect}" unless url
-      res = Http.get(url: url)
+      res = Http.get(url: url, **http_additional_opts)
       if res[:exitstatus] == 300
         versions = JSON.parse(res[:response]).dig("versions","values")
         if !versions ||

--- a/lib/launchers/openstack10.rb
+++ b/lib/launchers/openstack10.rb
@@ -34,6 +34,8 @@ module BushSlicer
                      'openstack_upshift'
       @opts = default_opts(service_name).merge options
 
+      @proxy = opts[:proxy] || ENV["http_proxy"]
+
       @os_user = ENV['OPENSTACK_USER'] || opts[:user]
       unless @os_user
         Timeout::timeout(120) do
@@ -78,6 +80,11 @@ module BushSlicer
       self.get_token()
     end
 
+
+    def proxy_set?()
+      return @proxy ? true : false
+    end
+
     # @return [ResultHash]
     # @yield [req_result] if block is given, it is yielded with the result as
     #   param
@@ -93,6 +100,10 @@ module BushSlicer
         :read_timeout => read_timeout,
         :open_timeout => open_timeout
       }
+
+      if proxy_set?()
+        req_opts.merge!({:proxy => @proxy})
+      end
 
       case method
       when "GET", "DELETE"

--- a/lib/launchers/openstack10.rb
+++ b/lib/launchers/openstack10.rb
@@ -101,7 +101,7 @@ module BushSlicer
         :open_timeout => open_timeout
       }
 
-      if proxy_set?()
+      if proxy_set?
         req_opts.merge!({:proxy => @proxy})
       end
 

--- a/lib/launchers/openstack4.rb
+++ b/lib/launchers/openstack4.rb
@@ -94,7 +94,7 @@ module BushSlicer
         :open_timeout => open_timeout
       }
 
-      if proxy_set?()
+      if proxy_set?
         req_opts.merge!({ :proxy => @proxy })
       end
 


### PR DESCRIPTION
follow-up https://github.com/openshift/verification-tests/pull/851 

```
[5] pry(#<BushSlicer::DefaultWorld>)> iaas = iaas_by_service("openstack_osp16_titan25")
[6] pry(#<BushSlicer::DefaultWorld>)> iaas.proxy_set?
=> true
[7] pry(#<BushSlicer::DefaultWorld>)> iaas.get_networks.length
=> 2
[8] pry(#<BushSlicer::DefaultWorld>)> iaas = iaas_by_service("openstack_osp16_aosqe_rdu2")
[9] pry(#<BushSlicer::DefaultWorld>)> iaas.proxy_set?
=> false
[10] pry(#<BushSlicer::DefaultWorld>)> iaas.get_networks.length
=> 5

```