### PR TITLE
Fix browser exit for invalid session id

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -139,7 +139,7 @@ require_relative 'chrome_extension'
           chrome_caps[:element_scroll_behavior] = @scroll_strategy
         end
         if self.class.container?
-          chrome_switches.concat %w[--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-infobars]
+          chrome_switches.concat %w[--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-infobars --disable-dev-shm-usage]
         end
         # options = Selenium::WebDriver::Chrome::Options.new
         # options.add_extension proxy_chrome_ext_file if proxy_chrome_ext_file


### PR DESCRIPTION
To resolve issue:
unknown error: session deleted because of page crash from unknown error: cannot determine loading status from tab crashed (Session info: chrome=80.0.3987.116)
Selenium::WebDriver::Error::UnknownError
……
 [07:25:14] ERROR> Test Execution will finish prematurely.
      invalid session id (Selenium::WebDriver::Error::InvalidSessionIdError)
      #0 0x559cd1a6bd29 <unknown>

The fix is for chrome to provide more disk. Run batch of jobs against chrome, no this kind of error now: http://pastebin.test.redhat.com/849034
@liangxia @akostadinov @pruan-rht pls help to review, thanks!