### PR TITLE
OCP-24363 - Reconciling machine taints with nodes

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -148,13 +148,10 @@ Feature: Machine features testing
   Scenario: [MAO] Reconciling machine taints with nodes
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
-
-    Given I store the number of machines in the :num_to_restore clipboard
-    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
-
+    
     Given I clone a machineset named "machineset-24363"
-    When I store the last provisioned machine in the :machine clipboard
-    And evaluation of `machine(cb.machine).node_name` is stored in the :noderef_name clipboard
+    And evaluation of `machine_set.machines.first.node_name` is stored in the :noderef_name clipboard
+    And evaluation of `machine_set.machines.first.name` is stored in the :machine_name clipboard
 
     Given I saved following keys to list in :taintsid clipboard:
       | {"spec":{"taints": [{"effect": "NoExecute","key": "role","value": "master"}]}}  | |
@@ -163,7 +160,7 @@ Feature: Machine features testing
     And I use the "openshift-machine-api" project
     Then I repeat the following steps for each :id in cb.taintsid:
     """
-    Given as admin I successfully merge patch resource "machine/<%= cb.machine %>" with:
+    Given as admin I successfully merge patch resource "machine/<%= cb.machine_name %>" with:
       | #{cb.id} |
     Then the step should succeed
     """


### PR DESCRIPTION
hi @akostadinov  , As you suggested to creating a pull request 
 logs : 
.
.
.waiting for operation up to 3600 seconds..
    Then I run the :get admin command with:                                                                                            # features/step_definitions/cli.rb:31
      [02:28:07] INFO> Shell Commands: oc get machine miyadav-2603-gcsjd-worker-us-east-2a-xsngw -o yaml --config=/root/workdir/efd4aeb4bf8d-/ocp4_admin.kubeconfig
      
      STDERR:
      Error from server (NotFound): machines.machine.openshift.io "miyadav-2603-gcsjd-worker-us-east-2a-xsngw" not found
      
      [02:28:07] INFO> Exit Status: 1
      | resource      | machine           |
      | resource_name | <%= cb.machine %> |
      | o             | yaml              |
    And I save the output to file>machines_to_taint.yml                                                                                # features/step_definitions/file.rb:1
    Given I have the machine yaml file machines_to_taint.yml and I add the taints [{\"effect\"=>\"\", \"key\"=>\"\", \"value\"=>\"\"}] # features/step_definitions/yamlmodification.rb:1
      undefined method `[]' for false:FalseClass (NoMethodError)
      /verification-tests/verification-tests/features/step_definitions/yamlmodification.rb:3:in `/^I have the machine yaml file (.+) and I add the taints (.+)$/'
      features/machine/OCP24363.feature:16:in `Given I have the machine yaml file machines_to_taint.yml and I add the taints [{\"effect\"=>\"\", \"key\"=>\"\", \"value\"=>\"\"}]'
    Then the step should succeed                                                                                                       # features/step_definitions/common.rb:4

From: /verification-tests/verification-tests/lib/world.rb:48 BushSlicer::DefaultWorld#debug_in_after_hook:

    45: def debug_in_after_hook
    46:   if debug_in_after_hook?
    47:     require 'pry'
 => 48:     binding.pry
    49:     fix_require_lock # see method in Common::Hacks
    50:   end
    51: end

[1] pry(#<BushSlicer::DefaultWorld>)> exit
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [02:28:07] INFO> === After Scenario: [MAO] Reconciling machine taints with nodes ===
      [02:30:09] INFO> Shell Commands: rm -r -f -- /root/workdir/efd4aeb4bf8d-
      
      [02:30:09] INFO> Exit Status: 0
      [02:30:09] INFO> === End After Scenario: [MAO] Reconciling machine taints with nodes ===

Failing Scenarios:
cucumber -p devel -p _devel features/machine/OCP24363.feature:6 # Scenario: [MAO] Reconciling machine taints with nodes

1 scenario (1 failed)
6 steps (1 failed, 1 skipped, 4 passed)
2m12.396s
[02:30:09] INFO> === At Exit ===
.
.
