### PR TITLE
Fix step that download file from relative path

### DIFF
--- a/features/cli/policy.feature
+++ b/features/cli/policy.feature
@@ -410,54 +410,52 @@ Feature: change the policy of user/service account
   @admin
   Scenario: User can know which serviceaccount and SA groups can create the podspec against the current sccs by CLI
     Given I have a project
-    When I download a file from "<%= ENV['BUSHSLICER_HOME'] %>/testdata/authorization/scc/tc538264/PodSecurityPolicyReview.json"
-    Then the step should succeed
     Given I run the :policy_scc_review client command with:
-      | f | PodSecurityPolicyReview.json |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/authorization/scc/tc538264/PodSecurityPolicyReview.json |
     Then the step should succeed
     And the output should not match:
       | .*default.*restricted |
     Given I run the :policy_scc_review client command with:
-      | f | PodSecurityPolicyReview.json |
-      | n | <%= project.name %>          |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/authorization/scc/tc538264/PodSecurityPolicyReview.json |
+      | n | <%= project.name %>                                                                            |
     Then the step should succeed
     And the output should not match:
       | .*default.*restricted |
     Given I run the :policy_scc_review client command with:
-      | serviceaccount | default                      |
-      | f              | PodSecurityPolicyReview.json |
+      | serviceaccount | default                                                                                        |
+      | f              | <%= ENV['BUSHSLICER_HOME'] %>/testdata/authorization/scc/tc538264/PodSecurityPolicyReview.json |
     Then the step should succeed
     And the output should not match:
       | .*default.*restricted |
     Given I run the :policy_scc_review client command with:
-      | serviceaccount | default                      |
-      | f              | PodSecurityPolicyReview.json |
-      | n              | <%= project.name %>          |
+      | serviceaccount | default                                                                                        |
+      | f              | <%= ENV['BUSHSLICER_HOME'] %>/testdata/authorization/scc/tc538264/PodSecurityPolicyReview.json |
+      | n              | <%= project.name %>                                                                            |
     Then the step should succeed
     And the output should not match:
       | .*default.*restricted |
     Given SCC "restricted" is added to the "default" service account
     Given I run the :policy_scc_review client command with:
-      | f | PodSecurityPolicyReview.json |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/authorization/scc/tc538264/PodSecurityPolicyReview.json |
     Then the step should succeed
     And the output should match:
       | .*default.*restricted |
     Given I run the :policy_scc_review client command with:
-      | f | PodSecurityPolicyReview.json |
-      | n | <%= project.name %>          |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/authorization/scc/tc538264/PodSecurityPolicyReview.json |
+      | n | <%= project.name %>                                                                            |
     Then the step should succeed
     And the output should match:
       | .*default.*restricted |
     Given I run the :policy_scc_review client command with:
-      | serviceaccount | default                      |
-      | f              | PodSecurityPolicyReview.json |
+      | serviceaccount | default                                                                                        |
+      | f              | <%= ENV['BUSHSLICER_HOME'] %>/testdata/authorization/scc/tc538264/PodSecurityPolicyReview.json |
     Then the step should succeed
     And the output should match:
       | .*default.*restricted |
     Given I run the :policy_scc_review client command with:
-      | serviceaccount | default                      |
-      | f              | PodSecurityPolicyReview.json |
-      | n              | <%= project.name %>          |
+      | serviceaccount | default                                                                                        |
+      | f              | <%= ENV['BUSHSLICER_HOME'] %>/testdata/authorization/scc/tc538264/PodSecurityPolicyReview.json |
+      | n              | <%= project.name %>                                                                            |
     Then the step should succeed
     And the output should match:
       | .*default.*restricted |

--- a/features/test/http.feature
+++ b/features/test/http.feature
@@ -3,10 +3,6 @@ Feature: Some raw HTTP fetures
   Scenario: test download
     When I open web server via the "<%= ENV['BUSHSLICER_HOME'] %>/testdata/build/shared_compressed_files/char_test.txt" url
     Then the step should succeed
-    When I download a big file from "<%= ENV['BUSHSLICER_HOME'] %>/testdata/build/shared_compressed_files/char_test.tar.gz"
-    Then the step should succeed
-    When I download a big file from "<%= ENV['BUSHSLICER_HOME'] %>/testdata/build/shared_compressed_files/char_test.txt"
-    Then the step should succeed
 
   Scenario: Concurrent Get
     When I perform 100 HTTP GET requests with concurrency 25 to: <%= env.web_console_url %>


### PR DESCRIPTION
As the change from v3-testfiles to integrated test files, some steps that use 'download a file from' is no longer needed.