### PR TITLE
Shorten the parameters

### DIFF
--- a/features/build/buildconfig.feature
+++ b/features/build/buildconfig.feature
@@ -73,15 +73,15 @@ Feature: buildconfig.feature
      | type        | kubernetes.io/dockercfg                                                         |
     Then the step should succeed
     When I run the :create client command with:
-      | f | <template> |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/<template> |
     Then the step should succeed
     And the "ruby-sample-build-1" build was created
     Then the "ruby-sample-build-1" build completes
 
     Examples:
-      | template                                                                                                       |
-      | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/tc479540/test-buildconfig-docker.json | # @case_id OCP-11110
-      | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/tc479541/test-buildconfig-s2i.json    | # @case_id OCP-11474
+      | template                              |
+      | tc479540/test-buildconfig-docker.json | # @case_id OCP-11110
+      | tc479541/test-buildconfig-s2i.json    | # @case_id OCP-11474
 
   # @author xiuwang@redhat.com
   # @case_id OCP-12057

--- a/features/build/buildlogic.feature
+++ b/features/build/buildlogic.feature
@@ -94,7 +94,7 @@ Feature: buildlogic.feature
   Scenario Outline: ForcePull image for build
     Given I have a project
     When I run the :create client command with:
-      | f | <template> |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/forcePull/<template> |
     Then the step should succeed
     Given the "ruby-sample-build-1" build was created
     And the "ruby-sample-build-1" build becomes :running
@@ -106,11 +106,11 @@ Feature: buildlogic.feature
       | Force Pull:\s+(true\|yes)|
 
     Examples:
-      | template                                                                                                                    |
-      | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/forcePull/buildconfig-docker-ImageStream.json      | # @case_id OCP-10651
-      | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/forcePull/buildconfig-s2i-ImageStream.json         | # @case_id OCP-11148
-      | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/forcePull/buildconfig-docker-dockerimage.json      | # @case_id OCP-10652
-      | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/forcePull/buildconfig-s2i-dockerimage.json         | # @case_id OCP-11149
+      | template                            |
+      | buildconfig-docker-ImageStream.json | # @case_id OCP-10651
+      | buildconfig-s2i-ImageStream.json    | # @case_id OCP-11148
+      | buildconfig-docker-dockerimage.json | # @case_id OCP-10652
+      | buildconfig-s2i-dockerimage.json    | # @case_id OCP-11149
 
   # @author yantan@redhat.com
   # @case_id OCP-10745

--- a/features/build/stibuild.feature
+++ b/features/build/stibuild.feature
@@ -20,7 +20,7 @@ Feature: stibuild.feature
   Scenario Outline: Trigger s2i/docker/custom build using additional imagestream
     Given I have a project
     And I run the :new_app client command with:
-      | file | <template> |
+      | file | <%= ENV['BUSHSLICER_HOME'] %>/testdata/templates/<template> |
     Then the step should succeed
     And the "sample-build-1" build was created
     When I run the :cancel_build client command with:
@@ -49,10 +49,10 @@ Feature: stibuild.feature
     And the output should not contain "sample-build-4"
 
     Examples:
-      |template|
-      |<%= ENV['BUSHSLICER_HOME'] %>/testdata/templates/tc498848/tc498848-s2i.json   | # @case_id OCP-12041
-      |<%= ENV['BUSHSLICER_HOME'] %>/testdata/templates/tc498847/tc498847-docker.json| # @case_id OCP-11911
-      |<%= ENV['BUSHSLICER_HOME'] %>/testdata/templates/tc498846/tc498846-custom.json| # @case_id OCP-11739
+      | template                      |
+      | tc498848/tc498848-s2i.json    | # @case_id OCP-12041
+      | tc498847/tc498847-docker.json | # @case_id OCP-11911
+      | tc498846/tc498846-custom.json | # @case_id OCP-11739
 
   # @author wewang@redhat.com
   # @case_id OCP-15464

--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -344,7 +344,7 @@ Feature: build 'apps' with CLI
       | object_name_or_id |  <bc_name> |
     Then the step should succeed
     When I run the :create client command with:
-      | f | <file_name> |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/<file_name> |
     When I get project build_config named "<bc_name>"
     Then the step should succeed
     When I run the :start_build client command with:
@@ -353,9 +353,9 @@ Feature: build 'apps' with CLI
     Given the "<build_name>" build becomes :complete
 
     Examples:
-      | bc_name              | build_name             | file_name                                                                                             |
-      | ruby-sample-build-ns | ruby-sample-build-ns-1 | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/tc525736/Nonesrc-sti.json    | # @case_id OCP-11580
-      | ruby-sample-build-nc | ruby-sample-build-nc-1 | <%= ENV['BUSHSLICER_HOME'] %>/testdata/build/tc525735/Nonesrc-docker.json | # @case_id OCP-11268
+      | bc_name              | build_name             | file_name                    |
+      | ruby-sample-build-ns | ruby-sample-build-ns-1 | tc525736/Nonesrc-sti.json    | # @case_id OCP-11580
+      | ruby-sample-build-nc | ruby-sample-build-nc-1 | tc525735/Nonesrc-docker.json | # @case_id OCP-11268
 
   # @author cryan@redhat.com
   # @case_id OCP-11582

--- a/features/routing/rate-limit.feature
+++ b/features/routing/rate-limit.feature
@@ -18,10 +18,10 @@ Feature: Testing haproxy rate limit related features
     And evaluation of `pod.ip` is stored in the :pod_ip clipboard
 
     When I run the :create client command with:
-      | f | <service> |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/routetimeout/<service> |
     Then the step should succeed
     When I run the :create client command with:
-      | f | <route> |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/<route> |
     Then the step should succeed
     When I run the :annotate client command with:
       | resource     | route        |
@@ -40,8 +40,8 @@ Feature: Testing haproxy rate limit related features
     """
 
     Examples:
-      | route_type | route_name | service | route | resolve_str | url | pass_num | fail_num |
-      | unsecure | route | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/routetimeout/unsecure/service_unsecure.json | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/unsecure/route_unsecure.json | unsecure.example.com:80 | http://unsecure.example.com | 1 | 3 |
-      | edge | secured-edge-route | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/routetimeout/edge/service_unsecure.json | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/edge/route_edge.json | test-edge.example.com:443 | https://test-edge.example.com | 2 | 2 |
-      | reen | route-reencrypt | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/routetimeout/reencrypt/service_secure.json | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/reencrypt/route_reencrypt.json | test-reen.example.com:443 | https://test-reen.example.com | 3 | 1 |
+      | route_type | route_name         | service                        | route                          | resolve_str               | url                           | pass_num |
+      | unsecure   | route              | unsecure/service_unsecure.json | unsecure/route_unsecure.json   | unsecure.example.com:80   | http://unsecure.example.com   | 1        |
+      | edge       | secured-edge-route | edge/service_unsecure.json     | edge/route_edge.json           | test-edge.example.com:443 | https://test-edge.example.com | 2        |
+      | reen       | route-reencrypt    | reencrypt/service_secure.json  | reencrypt/route_reencrypt.json | test-reen.example.com:443 | https://test-reen.example.com | 3        |
 

--- a/features/routing/wildcard-route.feature
+++ b/features/routing/wildcard-route.feature
@@ -15,10 +15,10 @@ Feature: Testing wildcard routes
     Then the step should succeed
     And the pod named "caddy-docker" becomes ready
     When I run the :create client command with:
-      | f | "<service>" |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/<service> |
     Then the step should succeed
     When I run the :create client command with:
-      | f | "<route>" |
+      | f | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/wildcard_route/<route> |
     Then the step should succeed
 
     Given I have a pod-for-ping in the project
@@ -44,8 +44,8 @@ Feature: Testing wildcard routes
     And the output should contain "Hello-OpenShift"
 
     Examples:
-      | route_type | service | route | route-suffix |
-      | edge | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/edge/service_unsecure.json | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/wildcard_route/route_edge.json | edge.example.com | # @case_id OCP-11403
-      | reencrypt | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/reencrypt/service_secure.json | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/wildcard_route/route_reencrypt.json | reen.example.com | # @case_id OCP-11855
-      | passthrough | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/passthrough/service_secure.json | <%= ENV['BUSHSLICER_HOME'] %>/testdata/routing/wildcard_route/route_pass.json | pass.example.com | # @case_id OCP-11671
+      | route_type  | service                         | route                | route-suffix     |
+      | edge        | edge/service_unsecure.json      | route_edge.json      | edge.example.com | # @case_id OCP-11403
+      | reencrypt   | reencrypt/service_secure.json   | route_reencrypt.json | reen.example.com | # @case_id OCP-11855
+      | passthrough | passthrough/service_secure.json | route_pass.json      | pass.example.com | # @case_id OCP-11671
 


### PR DESCRIPTION
Using short parameters can adapt to the URL change, e.g, from v3-testfiles to integrate test files (or any other changes like this in the future), without any change in Polarion in future.
Also, a shorter parameter is more readable.

/cc @xiuwang @zhaozhanqi @lihongan