### PR TITLE
Making test more stable

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -107,7 +107,7 @@ Feature: MachineHealthCheck Test Scenarios
     Given I create the 'Ready' unhealthyCondition
     Given a pod becomes ready with labels:
       | api=clusterapi, k8s-app=controller |
-    And I wait for the steps to pass:
+    And I wait up to 600 seconds for the steps to pass:
     """
     When I run the :logs admin command with:
       | resource_name | <%= pod.name %>                |

--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -63,7 +63,7 @@ Then(/^admin ensures node number is restored to #{QUOTED} after scenario$/) do |
   teardown_add {
     num_actual = 0
 
-    success = wait_for(600, interval: 30) {
+    success = wait_for(900, interval: 20) {
       num_actual = BushSlicer::Node.list(user: admin).length
       num_expected == num_actual.to_s
     }

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -35,8 +35,8 @@ Then(/^the machineset should have expected number of running machines$/) do
   machines.each do | machine |
     next if machine.machine_set_name != machine_set.name
 
-    # if machine phase is 'Deleting' then wait for its node to disappear
-    if machine.phase == 'Deleting'
+    # if machine has delete annotation, then wait for it and its node to disappear
+    unless machine.annotation("machine.openshift.io/cluster-api-delete-machine").nil?
       step %Q{I wait for the resource "node" named "#{machine.node_name}" to disappear within 900 seconds}
       step %Q{I wait for the resource "machine" named "#{machine.name}" to disappear within 900 seconds}
       next

--- a/testdata/cloud/autoscaler-auto-tmpl.yml
+++ b/testdata/cloud/autoscaler-auto-tmpl.yml
@@ -16,5 +16,5 @@ spec:
             cpu: 500m
       restartPolicy: Never
   backoffLimit: 4
-  completions: 50
-  parallelism: 50
+  completions: 100
+  parallelism: 100


### PR DESCRIPTION
Increase wait time to make the tests more stable. Currently scale down takes longer than scale up, and sometimes test exit before nodes are scaled down. @sunzhaohua2 @miyadav PTAL