### PR TITLE
Add create_poddisruptionbudget for 4.4, sync oadm_inspect in 4.1/4.4

### DIFF
--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -1152,8 +1152,9 @@
 :oadm_inspect:
   :cmd: oc adm inspect <resource_type> <resource_name>
   :options:
-    :A: -all-namespaces=<value>
-    :dest-dir: --dest-dir=<value>
+    :A: --all-namespaces=<value>
+    :all_namespaces: --all-namespaces=<value>
+    :dest_dir: --dest-dir=<value>
 :oadm_new_project:
   :cmd: oc adm new-project <project_name>
   #:expected:

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -186,6 +186,19 @@
     :validate: --validate=<value>
 :create_namespace:
   :cmd: oc create namespace <name>
+:create_poddisruptionbudget:
+  :cmd: oc create poddisruptionbudget <name>
+  :options:
+    :allow_missing_template_keys: --allow-missing-template-keys=<value>
+    :dry_run: --dry-run=<value>
+    :generator: --generator=<value>
+    :max_unavailable: --max-unavailable=<value>
+    :min_available: --min-available=<value>
+    :o: -o <value>
+    :save_config: --save-config=<value>
+    :selector: --selector=<value>
+    :template: --template=<value>
+    :validate: --validate=<value>
 :create_quota:
   :cmd: oc create quota <name>
   :options:
@@ -1137,12 +1150,11 @@
     :type: --type=<value>
     :whitelist: --whitelist=<value>
 :oadm_inspect:
-  :cmd: oc adm inspect
+  :cmd: oc adm inspect <resource_type> <resource_name>
   :options:
+    :A: --all-namespaces=<value>
     :all_namespaces: --all-namespaces=<value>
     :dest_dir: --dest-dir=<value>
-    :resource: <value>
-    :resource_name: <value>
 :oadm_new_project:
   :cmd: oc adm new-project <project_name>
   #:expected:


### PR DESCRIPTION
- Add create_poddisruptionbudget for 4.4+ (already have that in 4.1.yaml)
```
$ ~/oc/oc-4.4.0-202003060720.git.0.f2e420d.el7 create poddisruptionbudget --help
Create a pod disruption budget with the specified name, selector, and desired minimum available pods

Aliases:
poddisruptionbudget, pdb

Usage:
  oc create poddisruptionbudget NAME --selector=SELECTOR --min-available=N [--dry-run] [flags]
```


- Sync oadm_inspect in 4.1/4.4 (We have the command in 4.1 and 4.4, but some options with different names)

```
features/registry/registry.feature:    When I run the :oadm_inspect admin command with:
features/registry/registry.feature-      | resource_type | co             |
features/registry/registry.feature-      | resource_name | image-registry |
features/registry/registry.feature-    Then the step should succeed
```