### PR TITLE
update the error message

### DIFF
--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -265,7 +265,7 @@ Feature: Operator related networking scenarios
     | since         | 10s                            |
   Then the step should succeed
   And the output should contain:
-    | cannot change openshift-sdn mode |
+    | cannot change openshift-sdn |
     
   # @author anusaxen@redhat.com
   # @case_id OCP-25856


### PR DESCRIPTION
in 4.1. the error message is 
```
       message: 'Not applying unsafe configuration change: invalid configuration: [cannot
          change openshift-sdn configuration]. Use ''oc edit network.operator.openshift.io
          cluster'' to undo the change.'
```
update this for it can be compatible.
@anuragthehatter @huiran0826 @weliang1 @rbbratta 