### PR TITLE
Fix occacional failure of ci job

### DIFF
--- a/tools/openshift-ci/Dockerfile.centos
+++ b/tools/openshift-ci/Dockerfile.centos
@@ -11,12 +11,11 @@ RUN set -x && \
     SCL_BASE_PKGS="centos-release-scl scl-utils-build" && \
     INSTALL_PKGS="rh-ruby26 rh-ruby26-ruby-devel rh-git218 bsdtar" && \
     yum -y update && \
-    yum install -y --enablerepo=centosplus $SCL_BASE_PKGS && \
-    yum install -y --enablerepo=centosplus $INSTALL_PKGS && \
-    GECKODRIVER_DOWNLOAD_URL="$(curl -sSL https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep -E 'browser_download_url.*linux64' | sed -E 's/.*(https[^"]*).*/\1/')" && \
+    yum install -y --enablerepo=centosplus --setopt=skip_missing_names_on_install=False $SCL_BASE_PKGS && \
+    yum install -y --enablerepo=centosplus --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
+    GECKODRIVER_DOWNLOAD_URL="$(curl -sSL https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep -Eo 'http.*linux64.tar.gz' | sed -E 's/.*(https[^"]*).*/\1/')" && \
     curl -sSL "$GECKODRIVER_DOWNLOAD_URL" | bsdtar -xvf - -C /usr/local/bin && \
     chmod +x /usr/local/bin/geckodriver && \
-    rpm -V $INSTALL_PKGS $SCL_BASE_PKGS && \
     curl -sSL https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -o /tmp/epel-release-latest-7.noarch.rpm && \
     yum install -y /tmp/epel-release-latest-7.noarch.rpm
 


### PR DESCRIPTION
++ curl -sSL https://api.github.com/repos/mozilla/geckodriver/releases/latest
++ grep -E 'browser_download_url.*linux64'
++ sed -E 's/.*(https[^"]*).*/\1/'
+ GECKODRIVER_DOWNLOAD_URL=https://github.com/vladikoff
+ curl -sSL https://github.com/vladikoff
+ bsdtar -xvf - -C /usr/local/bin
bsdtar: Error opening archive: Unrecognized archive format
subprocess exited with status 1
subprocess exited with status 1
error: build error: error building at STEP "RUN set -x &&     SCL_BASE_PKGS="centos-release-scl scl-utils-build" &&     INSTALL_PKGS="rh-ruby26 rh-ruby26-ruby-devel rh-git218 bsdtar" &&     yum -y update &&     yum install -y --enablerepo=centosplus $SCL_BASE_PKGS &&     yum install -y --enablerepo=centosplus $INSTALL_PKGS &&     GECKODRIVER_DOWNLOAD_URL="$(curl -sSL https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep -E 'browser_download_url.*linux64' | sed -E 's/.*(https[^"]*).*/\1/')" &&     curl -sSL "$GECKODRIVER_DOWNLOAD_URL" | bsdtar -xvf - -C /usr/local/bin &&     chmod +x /usr/local/bin/geckodriver &&     rpm -V $INSTALL_PKGS $SCL_BASE_PKGS &&     curl -sSL https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -o /tmp/epel-release-latest-7.noarch.rpm &&     yum install -y /tmp/epel-release-latest-7.noarch.rpm": exit status 1
2020/03/31 05:48:03 No custom metadata found and prow metadata already exists. Not updating the metadata.
2020/03/31 05:48:04 Ran for 2m54s
2020/03/31 05:48:04 Submitted failure event to sentry (id=eefc4b86e494496297529e54e03e1633)
error: could not run steps: step centos failed: could not wait for build: the build centos failed after 1m33s with reason DockerBuildFailed: Dockerfile build strategy has failed.
