### PR TITLE
Automate OCP-28968

### DIFF
--- a/features/networking/multus-ipv6.feature
+++ b/features/networking/multus-ipv6.feature
@@ -12,8 +12,8 @@ Feature: Multus-CNI ipv6 related scenarios
     # Create the net-attach-def via cluster admin
     Given I have a project
     When I run oc create as admin over "<%= ENV['BUSHSLICER_HOME'] %>/testdata/networking/multus-cni/NetworkAttachmentDefinitions/IPv6/macvlan-bridge-v6.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                             |    
-      | ["spec"]["config"]| '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "fd00::192:168:22:0/112", "rangeStart": "fd00::192:168:22:100", "rangeEnd": "fd00::192:168:22:200"} }' |
+      | ["metadata"]["namespace"] | <%= project.name %>            |    
+      | ["spec"]["config"]| '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "fd00:dead:beef::/64"} }' |
     Then the step should succeed
 
     # Create the first pod which consumes the macvlan custom resource
@@ -30,7 +30,7 @@ Feature: Multus-CNI ipv6 related scenarios
     Then the output should contain "net1"
     And the output should contain "macvlan mode bridge"
     When I execute on the pod:
-      | bash | -c | /usr/sbin/ip addr show net1 \| grep -Po 'fd00::192:168:22:[0-9a-fA-F]{1,4}' |
+      | bash | -c | /usr/sbin/ip addr show net1 \| grep -Po 'fd00:dead:beef::[0-9a-fA-F]{1,4}' | 
     Then the step should succeed
     And evaluation of `@result[:response].chomp` is stored in the :pod1_multus_ipv6 clipboard
   

--- a/features/networking/multus-ipv6.feature
+++ b/features/networking/multus-ipv6.feature
@@ -1,0 +1,55 @@
+Feature: Multus-CNI ipv6 related scenarios  
+  
+  # @author weliang@redhat.com
+  # @case_id OCP-28968
+  @admin
+  Scenario: IPv6 testing for OCP-21151: Create pods with multus-cni - macvlan bridge mode
+    # Make sure that the multus is enabled
+    Given the master version >= "4.1"
+    And the multus is enabled on the cluster
+    Given the default interface on nodes is stored in the :default_interface clipboard
+    And evaluation of `node.name` is stored in the :target_node clipboard
+    # Create the net-attach-def via cluster admin
+    Given I have a project
+    When I run oc create as admin over "https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/Features/multus/IPv6/macvlan-bridge-v6.yaml" replacing paths:
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                             |    
+      | ["spec"]["config"]| '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "fd00::192:168:22:0/112", "rangeStart": "fd00::192:168:22:100", "rangeEnd": "fd00::192:168:22:200"} }' |
+    Then the step should succeed
+
+    # Create the first pod which consumes the macvlan custom resource
+    When I run oc create over "https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/Features/multus/IPv6/1interface-macvlan-bridge-v6.yaml" replacing paths:
+      | ["spec"]["nodeName"] | "<%= cb.target_node %>" |
+    Then the step should succeed
+    And a pod becomes ready with labels:
+      | name=macvlan-bridge-pod-v6 |
+    And evaluation of `pod.node_name` is stored in the :pod_node clipboard
+
+    # Check that the macvlan with mode bridge is added to the pod
+    When I execute on the pod:
+      | /usr/sbin/ip | -d | link |
+    Then the output should contain "net1"
+    And the output should contain "macvlan mode bridge"
+    When I execute on the pod:
+      | bash | -c | /usr/sbin/ip addr |
+    Then the step should succeed
+    When I execute on the pod:
+      | bash | -c | /usr/sbin/ip addr show net1 \| grep -Po 'fd00::192:168:22:[0-9a-fA-F]{1,4}' |
+    Then the step should succeed
+    And evaluation of `@result[:response].chomp` is stored in the :pod1_multus_ipv6 clipboard
+  
+    # Create the second pod which consumes the macvlan cr
+    When I run oc create over "https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/Features/multus/IPv6/1interface-macvlan-bridge-v6.yaml" replacing paths:
+      | ["spec"]["nodeName"] | "<%= cb.target_node %>" |
+    Then the step should succeed
+    And 2 pods become ready with labels:
+      | name=macvlan-bridge-pod-v6 |
+    And evaluation of `pod(-1).name` is stored in the :pod2 clipboard
+    When I execute on the "<%= cb.pod2 %>" pod:
+      | bash | -c | /usr/sbin/ip addr |
+    Then the step should succeed
+
+    # Try to access macvlan ip on pod1 from pod2
+    When I execute on the "<%= cb.pod2 %>" pod:
+      | curl | -g | -6 | --connect-timeout | 5 | [<%= cb.pod1_multus_ipv6 %>]:8080 |
+    Then the step should succeed
+    And the output should contain "Hello OpenShift"

--- a/features/networking/multus-ipv6.feature
+++ b/features/networking/multus-ipv6.feature
@@ -11,13 +11,13 @@ Feature: Multus-CNI ipv6 related scenarios
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
-    When I run oc create as admin over "https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/Features/multus/IPv6/macvlan-bridge-v6.yaml" replacing paths:
+    When I run oc create as admin over "<%= ENV['BUSHSLICER_HOME'] %>/testdata/networking/multus-cni/NetworkAttachmentDefinitions/IPv6/macvlan-bridge-v6.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                             |    
       | ["spec"]["config"]| '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "fd00::192:168:22:0/112", "rangeStart": "fd00::192:168:22:100", "rangeEnd": "fd00::192:168:22:200"} }' |
     Then the step should succeed
 
     # Create the first pod which consumes the macvlan custom resource
-    When I run oc create over "https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/Features/multus/IPv6/1interface-macvlan-bridge-v6.yaml" replacing paths:
+    When I run oc create over "<%= ENV['BUSHSLICER_HOME'] %>/testdata/networking/multus-cni//Pods/IPv6/1interface-macvlan-bridge-v6.yaml" replacing paths:
       | ["spec"]["nodeName"] | "<%= cb.target_node %>" |
     Then the step should succeed
     And a pod becomes ready with labels:
@@ -38,7 +38,7 @@ Feature: Multus-CNI ipv6 related scenarios
     And evaluation of `@result[:response].chomp` is stored in the :pod1_multus_ipv6 clipboard
   
     # Create the second pod which consumes the macvlan cr
-    When I run oc create over "https://raw.githubusercontent.com/weliang1/Openshift_Networking/master/Features/multus/IPv6/1interface-macvlan-bridge-v6.yaml" replacing paths:
+    When I run oc create over "<%= ENV['BUSHSLICER_HOME'] %>/testdata/networking/multus-cni//Pods/IPv6/1interface-macvlan-bridge-v6.yaml" replacing paths:
       | ["spec"]["nodeName"] | "<%= cb.target_node %>" |
     Then the step should succeed
     And 2 pods become ready with labels:

--- a/features/networking/multus-ipv6.feature
+++ b/features/networking/multus-ipv6.feature
@@ -30,7 +30,7 @@ Feature: Multus-CNI ipv6 related scenarios
     Then the output should contain "net1"
     And the output should contain "macvlan mode bridge"
     When I execute on the pod:
-      | bash | -c | /usr/sbin/ip addr show net1 \| grep -Po 'fd00:dead:beef::[0-9a-fA-F]{1,4}' | 
+      | bash | -c | /usr/sbin/ip addr show net1 \| grep -Po 'fd00:dead:beef::[[:xdigit:]]{1,4}' |
     Then the step should succeed
     And evaluation of `@result[:response].chomp` is stored in the :pod1_multus_ipv6 clipboard
   

--- a/features/networking/multus-ipv6.feature
+++ b/features/networking/multus-ipv6.feature
@@ -30,9 +30,6 @@ Feature: Multus-CNI ipv6 related scenarios
     Then the output should contain "net1"
     And the output should contain "macvlan mode bridge"
     When I execute on the pod:
-      | bash | -c | /usr/sbin/ip addr |
-    Then the step should succeed
-    When I execute on the pod:
       | bash | -c | /usr/sbin/ip addr show net1 \| grep -Po 'fd00::192:168:22:[0-9a-fA-F]{1,4}' |
     Then the step should succeed
     And evaluation of `@result[:response].chomp` is stored in the :pod1_multus_ipv6 clipboard
@@ -44,9 +41,6 @@ Feature: Multus-CNI ipv6 related scenarios
     And 2 pods become ready with labels:
       | name=macvlan-bridge-pod-v6 |
     And evaluation of `pod(-1).name` is stored in the :pod2 clipboard
-    When I execute on the "<%= cb.pod2 %>" pod:
-      | bash | -c | /usr/sbin/ip addr |
-    Then the step should succeed
 
     # Try to access macvlan ip on pod1 from pod2
     When I execute on the "<%= cb.pod2 %>" pod:

--- a/testdata/networking/multus-cni/NetworkAttachmentDefinitions/IPv6/macvlan-bridge-v6.yaml
+++ b/testdata/networking/multus-cni/NetworkAttachmentDefinitions/IPv6/macvlan-bridge-v6.yaml
@@ -10,8 +10,6 @@ spec:
       "mode": "bridge",
       "ipam": {
         "type": "host-local",
-        "subnet": "fd00::192:168:22:0/112",
-        "rangeStart": "fd00::192:168:22:100",
-        "rangeEnd": "fd00::192:168:22:200"
+        "subnet": "fd00:dead:beef::/64"
       }
     }'

--- a/testdata/networking/multus-cni/NetworkAttachmentDefinitions/IPv6/macvlan-bridge-v6.yaml
+++ b/testdata/networking/multus-cni/NetworkAttachmentDefinitions/IPv6/macvlan-bridge-v6.yaml
@@ -1,0 +1,17 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvlan-bridge-v6
+spec:
+  config: '{
+      "cniVersion": "0.3.0",
+      "type": "macvlan",
+      "master": "ens3",
+      "mode": "bridge",
+      "ipam": {
+        "type": "host-local",
+        "subnet": "fd00::192:168:22:0/112",
+        "rangeStart": "fd00::192:168:22:100",
+        "rangeEnd": "fd00::192:168:22:200"
+      }
+    }'

--- a/testdata/networking/multus-cni/Pods/IPv6/1interface-macvlan-bridge-v6.yaml
+++ b/testdata/networking/multus-cni/Pods/IPv6/1interface-macvlan-bridge-v6.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: macvlan-bridge-pod-v6
+  labels:
+    name: macvlan-bridge-pod-v6
+  annotations:
+    k8s.v1.cni.cncf.io/networks: macvlan-bridge-v6
+spec:
+  containers:
+  - name: macvlan-bridge-pod-v6
+    image: docker.io/aosqe/multus-pod:latest
+    imagePullPolicy: IfNotPresent

--- a/testdata/networking/multus-cni/Pods/IPv6/1interface-macvlan-bridge-v6.yaml
+++ b/testdata/networking/multus-cni/Pods/IPv6/1interface-macvlan-bridge-v6.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
   containers:
   - name: macvlan-bridge-pod-v6
-    image: docker.io/aosqe/multus-pod:latest
+    image: docker.io/aosqe/centos-network@sha256:48da37205f9b43424e0983d4c5e7e07f77b7ba1504bbe35e2f264c75dcb4cd15 
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Auto cases OCP-28968: IPv6 testing for OCP-21151: Create pods with multus-cni - macvlan bridge mode	

Test case in polarion:
https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-28968

Automation logs:
https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Runner-v3-smoke/855/console

@zhaozhanqi @huiran0826 @anuragthehatter @rbbratta
Please help to review both test case and automation scripts, thanks!