### PR TITLE
Node proxy config verification

### DIFF
--- a/features/node/proxy.feature
+++ b/features/node/proxy.feature
@@ -1,0 +1,31 @@
+Feature: Node proxy configuration tests
+
+  # @author jhou@redhat.com
+  @admin
+  Scenario Outline: Proxy config should be applied to kubelet and crio
+    Given I switch to cluster admin pseudo user
+    When I run the :get client command with:
+      | resource      | proxy   |
+      | resource_name | cluster |
+      | o             | yaml    |
+    Then the step should succeed
+    And evaluation of `YAML.load @result[:response]` is stored in the :proxy clipboard
+
+    Given I store the ready and schedulable workers in the :workers clipboard
+    When I run the :debug client command with:
+      | resource     | node/<%= cb.workers.first.name %> |
+      | oc_opts_end  |                                   |
+      | exec_command | cat                               |
+      | exec_command | /host/<file>                      |
+    Then the step should succeed
+    And the output should match:
+      | Environment=HTTP_PROXY=<%= cb.proxy["spec"]["httpProxy"] %>  |
+      | Environment=HTTPS_PROXY=<%= cb.proxy["spec"]["httpProxy"] %> |
+      | Environment=NO_PROXY=.*<%= cb.proxy["spec"]["noProxy"] %>    |
+
+    Examples:
+      | file                                                      |
+      | /etc/systemd/system/kubelet.service.d/10-default-env.conf | # @case_id OCP-24429
+      | /etc/systemd/system/crio.service.d/10-default-env.conf    | # @case_id OCP-24428
+
+


### PR DESCRIPTION
This covers the proxy config validation for node, verified it works. @sunilcio @weinliu @lyman9966 PTAL.

```
    [09:10:07] INFO> Exit Status: 0
    [09:10:07] INFO> === End After Scenario: Proxy config should be applied to kubelet and crio, Examples (#2) ===

2 scenarios (2 passed)
16 steps (16 passed)
0m43.251s
```