### PR TITLE
SSH session closed while IO thread listening

### DIFF
--- a/lib/test_case_manager.rb
+++ b/lib/test_case_manager.rb
@@ -88,7 +88,6 @@ module BushSlicer
         @attach_queue << false
         wait_for_attacher
         @artifacts_filer.clean_up if @artifacts_filer
-        # TODO: check `zlib(finalizer): the stream was freed prematurely.`
       end
     end
 


### PR DESCRIPTION
Even though we waited for SCP channel to close when uploading,
seems like closing session too early after channel shows inactive causes
the thread doing `session.process` to fail.

I don't know why timing makes a difference but either way it makes
sense to wait for all channels to become inactive, disable error reporting
of thread and kill it before closing the session.

tested with Runner-v3/83430 and last scenario indeed gets log uploaded