### PR TITLE
fix rule for a Chinese colon character

### DIFF
--- a/lib/rules/web/admin_console/4.3/projects.xyaml
+++ b/lib/rules/web/admin_console/4.3/projects.xyaml
@@ -14,7 +14,7 @@ create_project_from_dropdown:
     dropdown_name: namespace-bar
   action: click_dropdown
   action: create_project
-click_create_project_button：
+click_create_project_button:
   params:
     button_text: Create Project
   action: click_button_text


### PR DESCRIPTION
Rule needs fix, there is a Chinese colon character.
Failed log which terminated run by OCP-26910:
```
/home/jenkins/workspace/Runner-v3/lib/rules/web/admin_console/4.3/projects.xyaml
http://ci-qe-openshift.usersys.redhat.com/userContent/cucushift/v3/2020/04/05/23:38:57/Check_resource_events/console.html

(/home/jenkins/workspace/Runner-v3/lib/rules/web/admin_console/4.3/projects.xyaml): could not find expected ':' while scanning a simple key at line 17 column 1
Psych::SyntaxError
```

@liangxia Please review. Thx