### PR TITLE
Clean-up OCP-9570 (3.x scenarios, not suitable for 4.x)

### DIFF
--- a/features/quickstarts/quickstarts.feature
+++ b/features/quickstarts/quickstarts.feature
@@ -13,14 +13,13 @@ Feature: quickstarts.feature
     Then the output should contain "<output>"
 
     Examples: OS Type
-      | template                  | buildcfg                 | output  | podno |
-      | django-psql-example       | django-psql-example      | Django  | 2     | # @case_id OCP-12609
-      | dancer-mysql-example      | dancer-mysql-example     | Dancer  | 2     | # @case_id OCP-12606
-      | cakephp-mysql-example     | cakephp-mysql-example    | CakePHP | 2     | # @case_id OCP-12541
-      | nodejs-mongodb-example    | nodejs-mongodb-example   | Node.js | 2     | # @case_id OCP-9570
-      | rails-postgresql-example  | rails-postgresql-example | Rails   | 2     | # @case_id OCP-12296
-      | dotnet-example            | dotnet-example           | ASP.NET | 1     | # @case_id OCP-13749
-      | openjdk18-web-basic-s2i   | openjdk-app          | Hello World | 1     | # @case_id OCP-17826
+      | template                 | buildcfg                 | output      | podno |
+      | django-psql-example      | django-psql-example      | Django      | 2     | # @case_id OCP-12609
+      | dancer-mysql-example     | dancer-mysql-example     | Dancer      | 2     | # @case_id OCP-12606
+      | cakephp-mysql-example    | cakephp-mysql-example    | CakePHP     | 2     | # @case_id OCP-12541
+      | rails-postgresql-example | rails-postgresql-example | Rails       | 2     | # @case_id OCP-12296
+      | dotnet-example           | dotnet-example           | ASP.NET     | 1     | # @case_id OCP-13749
+      | openjdk18-web-basic-s2i  | openjdk-app              | Hello World | 1     | # @case_id OCP-17826
 
   # @author xiuwang@redhat.com
   @smoke


### PR DESCRIPTION
OCP-9570 only applies to OCP 3.2~3.4, and it's in Inactive status now.

Should be safe to remove from master branch (for 4.x), as we still have it in v3 branch (for 3.x)

/cc @dongboyan77  @wzheng1  @pruan-rht @akostadinov