### PR TITLE
Workaround for download file with relative path

### DIFF
--- a/features/test/download.feature
+++ b/features/test/download.feature
@@ -1,0 +1,14 @@
+Feature: download a file from web or relative path
+  Scenario: download from web
+    Given I have a project
+    And I download a file from "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/quota/pvc-storage-class.json"
+    When I run the :create client command with:
+      | f | pvc-storage-class.json |
+    Then the step should succeed
+
+  Scenario: download from relative path
+    Given I have a project
+    And I download a file from "<%= BushSlicer::HOME %>/testdata/quota/pvc-storage-class.json"
+    When I run the :create client command with:
+      | f | pvc-storage-class.json |
+    Then the step should succeed


### PR DESCRIPTION
We still have lots of scenarios contain the step 'download a file from' with relative path.
Before those scenarios are fixed, we need a workaround to not failing those tests.

The idea is that we only do real download if the url contains '://', or else we copy the file from the relative path.
We can revert the workaround after those scenarios are fixed.

/cc @akostadinov @pruan-rht @xltian 