### PR TITLE
Fix case ID

### DIFF
--- a/features/networking/egress-ip.feature
+++ b/features/networking/egress-ip.feature
@@ -113,7 +113,7 @@ Feature: Egress IP related features
     """
 
   # @author huirwang@redhat.com
-  # @case_id OCP-21812 OCP-15473
+  # @case_id OCP-21812
   # @bug_id  1609112
   @admin
   @destructive


### PR DESCRIPTION
OCP-21812 - [bz1609112][egressIP] Should remove the egressIP from the array if it was not being used
OCP-15473 - [egressIP] The related iptables/openflow rules will be removed once the egressIP gets removed from netnamespace

Multiple test cases pointing to the same scenario (not scenario outline) does not look correct to me.

I'm removing the "wrong" ID OCP-15473 here based on the test case title, and moved OCP-15473 to not automated in Polarion.
@huiran0826  Please take follow up action for the test cases in Polarion.
/cc @akostadinov @pruan-rht 