### PR TITLE
fix machine annotations don't match the output

### DIFF
--- a/features/machine/autoscaler.feature
+++ b/features/machine/autoscaler.feature
@@ -103,7 +103,7 @@ Feature: Cluster Autoscaler Tests
       | resource | machineset              |
       | name     | <%= machine_set.name %> |
     Then the step should succeed
-    And the output should match "Annotations:\s+<none>"
+    And the output should not match "autoscaling.openshift.io/machineautoscaler"
 
   # @author zhsun@redhat.com
   # @case_id OCP-22102
@@ -142,7 +142,7 @@ Feature: Cluster Autoscaler Tests
       | resource | machineset                       |
       | name     | <%= cb.machineset_clone_22102 %> |
     Then the step should succeed
-    And the output should match "Annotations:\s+<none>"
+    And the output should not match "autoscaling.openshift.io/machineautoscaler"
     When I run the :describe admin command with:
       | resource | machineset                         |
       | name     | <%= cb.machineset_clone_22102_2 %> |
@@ -174,7 +174,7 @@ Feature: Cluster Autoscaler Tests
       | resource | machineset                         |
       | name     | <%= cb.machineset_clone_22102_2 %> |
     Then the step should succeed
-    And the output should match "Annotations:\s+<none>"
+    And the output should not match "autoscaling.openshift.io/machineautoscaler"
 
   # @author zhsun@redhat.com
   # @case_id OCP-23745


### PR DESCRIPTION
This pr will fix the failer `pattern not found: (?-mix:Annotations:\s+<none>) (RuntimeError)` in 4.5 env,  this failed beacause in 4.5  machines have annotations by default  in order to support autoscaler scale from zero. @jhou @miyadav Please help to take a look? Tested on 4.4 and 4.5 env.
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/84393/console
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/84392/console