### PR TITLE
Fix new-build with binary option

### DIFF
--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -538,7 +538,7 @@
   :options:
     :allow_missing_imagestream_tags: --allow-missing-imagestream-tags=<value>
     :app_repo: <value>
-    :binary: --binary <value>
+    :binary: --binary=<value>
     :build_arg: --build-arg=<value>
     :build_config_map: --build-config-map=<value>
     :build_env: --build-env=<value>

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -538,7 +538,7 @@
   :options:
     :allow_missing_imagestream_tags: --allow-missing-imagestream-tags=<value>
     :app_repo: <value>
-    :binary: --binary <value>
+    :binary: --binary=<value>
     :build_arg: --build-arg=<value>
     :build_config_map: --build-config-map=<value>
     :build_env: --build-env=<value>


### PR DESCRIPTION
 Fix the error as follow:
$oc new-build --binary true --name=multistage-test 
      STDERR:
      error:  local file access failed with: stat true: no such file or directory
      error: unable to locate any images in image streams, templates loaded in accessible projects, template files, local docker images with name "true"
@openshift/devexp-qe  please check it, thanks