### PR TITLE
Modify operators.rb to judge whether it's OCP4.1 since no Upgradeable

### DIFF
--- a/features/step_definitions/operators.rb
+++ b/features/step_definitions/operators.rb
@@ -28,9 +28,13 @@ end
 
 Given /^the status of condition Upgradeable for marketplace operator as expected$/ do
   ensure_admin_tagged
-  actual_status = cluster_operator('marketplace').condition(type: 'Upgradeable', cached: false)['status']
-  status = 'True'
   cluster_version = cluster_version('version').channel.split('-')[1]
+  if cluster_version == "4.1"
+    actual_status = 'True'
+  else
+    actual_status = cluster_operator('marketplace').condition(type: 'Upgradeable', cached: false)['status']
+  end
+  status = 'True'
   if cluster_version == "4.4"
     csc_items = Array.new
     os_items = Array.new


### PR DESCRIPTION
Modify operators.rb to judge whether it's OCP-4.1 since no Upgradeable condition in OCP-4.1