### PR TITLE
Clean-up OCP-9640/11726 (3.x scenarios, not suitable for 4.x)

### DIFF
--- a/features/storage/hostpath.feature
+++ b/features/storage/hostpath.feature
@@ -46,5 +46,3 @@ Feature: Storage of Hostpath plugin testing
     Examples:
       | access_mode   | reclaim_policy | pv_status | step_status |
       | ReadWriteOnce | Retain         | released  | succeed     | # @case_id OCP-9639
-      | ReadOnlyMany  | Default        | released  | succeed     | # @case_id OCP-11726
-      | ReadWriteMany | Recycle        | available | fail        | # @case_id OCP-9640


### PR DESCRIPTION
[Those test cases](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitems?query=id%3A(OCP%5C-9640%20OCP%5C-11726)) only apply to OCP 3.x, should be safe to remove from master branch which is for 4.x, as we still have it in v3 branch (for 3.x)

/cc @qinpingli @chao007 @pruan-rht @akostadinov