### PR TITLE
Update the way to cleanup the ups-broker

### DIFF
--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -11,13 +11,8 @@ Feature: Service-catalog related scenarios
     And evaluation of `project.name` is stored in the :user_project clipboard
 
     # Deploy ups broker
-    Given I register clean-up steps:
-    """
-    I run the :delete admin command with:
-      | object_type       | clusterservicebroker |
-      | object_name_or_id | ups-broker           |
-    the step should fail
-    """
+
+    Given admin ensures "ups-broker" clusterservicebroker is deleted after scenario
     When I switch to cluster admin pseudo user
     And I use the "<%= cb.ups_broker_project %>" project
     When I process and create:


### PR DESCRIPTION
Update the way about how to clean up the ups-broker.
test result:
  # @case_id OCP-15600
  @admin @destructive
  Scenario: service-catalog walkthrough example                                                           # features/svc-catalog_asb/svc-catalog.feature:7
      [03:18:20] INFO> === Before Scenario: service-catalog walkthrough example ===
      [03:18:20] INFO> === End Before Scenario: service-catalog walkthrough example ===
    Given I have a project                                                                                # features/step_definitions/project.rb:7
      [03:18:20] INFO> HTTP GET https://api.qe431316.qe.devcluster.openshift.com:6443/.well-known/oauth-authorization-server
      [03:18:20] INFO> HTTP GET took 0.429 sec: 200 OK | application/json 648 bytes
      
      [03:18:20] INFO> HTTP GET testuser-26@https://oauth-openshift.apps.qe431316.qe.devcluster.openshift.com/oauth/authorize
      [03:18:21] INFO> HTTP GET took 0.481 sec: 302 Found
      [03:18:21] INFO> REST get_user for user 'BushSlicer::APIAccessor:@ose', base_opts: {:options=>{:api_version=>"v1", :accept=>"application/json", :content_type=>"application/json", :oauth_token=>"zOkds1r5bJL4bT7YW_0rsTtVVfXoh38l-ZIY_FFpecA"}, :base_url=>"https://api.qe431316.qe.devcluster.openshift.com:6443", :headers=>{"Accept"=>"<accept>", "Content-Type"=>"<content_type>", "Authorization"=>"Bearer <oauth_token>"}}, opts: {:username=>"~"}
      [03:18:21] INFO> HTTP GET https://api.qe431316.qe.devcluster.openshift.com:6443/apis/user.openshift.io/v1/users/~
      [03:18:21] INFO> HTTP GET took 0.484 sec: 200 OK | application/json 375 bytes
...
      [03:19:32] INFO> Exit Status: 1
      [03:19:33] INFO> oc get clusterservicebrokers ups-broker --output=yaml --config=/home/jenkins/workspace/Runner-v3/workdir/ose_admin.kubeconfig
      [03:19:33] INFO> After 1 iterations and 0 seconds:
      
      STDERR:
      Error from server (NotFound): clusterservicebrokers.servicecatalog.k8s.io "ups-broker" not found
      
      [03:19:33] INFO> cleaning-up user testuser-26 projects
      [03:19:33] INFO> Shell Commands: oc delete projects --all --config=/home/jenkins/workspace/Runner-v3/workdir/ose_testuser-26.kubeconfig
      project.project.openshift.io "ddt2a" deleted
      project.project.openshift.io "t3045" deleted
      
      [03:19:35] INFO> Exit Status: 0
      [03:19:35] INFO> waiting up to 30 seconds for user clean-up to take place
      [03:19:41] INFO> REST delete_oauthaccesstoken for user 'BushSlicer::APIAccessor:testuser-26@ose', base_opts: {:options=>{:api_version=>"v1", :accept=>"application/json", :content_type=>"application/json", :oauth_token=>"zOkds1r5bJL4bT7YW_0rsTtVVfXoh38l-ZIY_FFpecA"}, :base_url=>"https://api.qe431316.qe.devcluster.openshift.com:6443", :headers=>{"Accept"=>"<accept>", "Content-Type"=>"<content_type>", "Authorization"=>"Bearer <oauth_token>"}}, opts: {:token_to_delete=>"zOkds1r5bJL4bT7YW_0rsTtVVfXoh38l-ZIY_FFpecA"}
      [03:19:41] INFO> HTTP DELETE https://api.qe431316.qe.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthaccesstokens/zOkds1r5bJL4bT7YW_0rsTtVVfXoh38l-ZIY_FFpecA
      [03:19:42] INFO> HTTP DELETE took 0.415 sec: 200 OK | application/json 235 bytes
      
      [03:19:42] INFO> Shell Commands: rm -r -f -- /home/jenkins/workspace/Runner-v3/workdir
      
      [03:19:42] INFO> Exit Status: 0
      [03:19:42] INFO> === End After Scenario: service-catalog walkthrough example ===

1 scenario (1 passed)
32 steps (32 passed)
1m24.691s
