### PR TITLE
Match only positive text for version<=4.3

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -30,8 +30,7 @@ Feature: MachineHealthCheck Test Scenarios
       | resource_name | <%= pod.name %>    |
       | c             | machine-controller |
     Then the output should contain:
-      | Node "<%= machine.node_name %>" is unreachable, draining will wait |
-      | drain successful for machine "<%= machine.name %>"                 |
+      | drain successful for machine "<%= machine.name %>" |
 
   # @author jhou@redhat.com
   # @case_id OCP-26311


### PR DESCRIPTION
The test fails on 4.3 because we wanted to catch too many texts. Now catch only what is important from the controller log.
