### PR TITLE
Wait default-route appearing for image-registry svc

### DIFF
--- a/features/step_definitions/registry.rb
+++ b/features/step_definitions/registry.rb
@@ -375,7 +375,8 @@ end
 # Generate default route
 Given /^I enable image-registry default route$/ do
   ensure_admin_tagged
-#  ensure_destructive_tagged
+  org_proj_name = project(generate: false).name rescue nil
+
   step 'I run the :patch admin command with:', table(%{
       | resource      | configs.imageregistry.operator.openshift.io |
       | resource_name | cluster                                     |
@@ -383,13 +384,15 @@ Given /^I enable image-registry default route$/ do
       | type          | merge                                       |
   })
   step %Q/the step should succeed/
+  step %Q/admin waits for the "default-route" route to appear in the "openshift-image-registry" project up to 120 seconds/
+  project(org_proj_name) if org_proj_name
 end
 
 Given /^default image registry route is stored in the#{OPT_SYM} clipboard$/ do |cb_name| 
   ensure_admin_tagged
   org_proj_name = project(generate: false).name rescue nil
   cb_name ||= :registry_route
-  cb[cb_name] = route('default-route', service('default-route',project('openshift-image-registry'))).dns(by: admin)
+  cb[cb_name] = route('default-route', service('image-registry',project('openshift-image-registry'))).dns(by: admin)
   project(org_proj_name) if org_proj_name
 end
 


### PR DESCRIPTION
After patch to enable default route, the-route need times to show up depend on the cluster performance.
@openshift/devexp-qe please help review, thanks