### PR TITLE
debug Pending status with describe pod

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -326,7 +326,10 @@ Given /^I have a pod-for-ping in the#{OPT_QUOTED} project$/ do |project_name|
 
   cb.ping_pod = pod("hello-pod")
   @result = pod("hello-pod").wait_till_ready(user, 300)
-  raise "pod-for-ping did not become ready in time" unless @result[:success]
+  unless @result[:success]
+    pod.describe(user, quiet: false)
+    raise "pod-for-ping did not become ready in time"
+  end
 end
 
 # headertest is a service that returns all HTTP request headers used by client

--- a/features/step_definitions/pod.rb
+++ b/features/step_definitions/pod.rb
@@ -155,6 +155,7 @@ Given /^#{NUMBER} pods become ready with labels:$/ do |count, table|
     @result = pod.wait_till_status(BushSlicer::Pod::SUCCESS_STATUSES, user, ready_timeout)
 
     unless @result[:success]
+      pod.describe(user, quiet: false)
       raise "pod #{pod.name} did not reach expected status"
     end
   end


### PR DESCRIPTION
We seem to be getting frequent pods stuck in `:pending` status
when using "pods become ready with labels:" step.

This step calls `wait_till_status`, so if we fail
we can run `oc describe pod` to try to debug the pod failure

```
Given 1 pods become ready with labels:                                                                                     # features/step_definitions/pod.rb:136
  [05:56:03] INFO> oc get pods --output=yaml -l name\=test-pods --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_testuser-0.kubeconfig -n sx5hd
  [05:56:03] INFO> 1 iterations for 0 sec, returned 1 pods, 1 matching
  [05:56:04] INFO>
  [06:11:03] INFO> After 531 iterations and 900 seconds:
  matched status for pods test-rc-dgbzv: 'pending' while expecting '[:running, :succeeded, :missing]'
  | name=test-pods |
  pod test-rc-dgbzv did not reach expected status (RuntimeError)

```

Also occurs with `pod-for-ping`

```
      status:
	conditions:
	- lastProbeTime: null
	  lastTransitionTime: "2020-04-21T06:30:48Z"
	  message: '0/4 nodes are available: 1 Insufficient memory, 3 node(s) had taints
	    that the pod didn''t tolerate.'
	  reason: Unschedulable
	  status: "False"
	  type: PodScheduled
	phase: Pending
	qosClass: Burstable

      pod-for-ping did not become ready in time (RuntimeError)
```
