### PR TITLE
always use multus image as oc debug image

### DIFF
--- a/lib/host.rb
+++ b/lib/host.rb
@@ -857,6 +857,7 @@ module BushSlicer
       exec_opts = {}
 
       # override image, arg order matters, image needs to go before --
+      # needed until https://bugzilla.redhat.com/show_bug.cgi?id=1728135 is fixed
       unless node.env.opts[:host_debug_image]
            mpods = Pod.get_labeled("app=multus", user: node.env.admin, project: Project.new(name: "openshift-multus", env: node.env), quiet: true)
            exec_opts[:image] = mpods.first.container(name: "kube-multus").spec.image

--- a/lib/host.rb
+++ b/lib/host.rb
@@ -854,20 +854,31 @@ module BushSlicer
         commands = ["chroot", "/host/", "bash", "-c", commands_to_string(commands)]
       end
 
+      exec_opts = {}
+
+      # override image, arg order matters, image needs to go before --
+      unless node.env.opts[:host_debug_image]
+           mpods = Pod.get_labeled("app=multus", user: node.env.admin, project: Project.new(name: "openshift-multus", env: node.env), quiet: true)
+           exec_opts[:image] = mpods.first.container(name: "kube-multus").spec.image
+      end
+
+      exec_opts.merge!(
+          {
+              resource: "node/#{node.name}",
+              n: service_project.name,
+              oc_opts_end: "",
+              exec_command_arg: commands,
+              _stdin: opts[:stdin],
+              _stdout: opts[:stdout]
+          }
+      )
+
       @exec_lock.synchronize {
         # note this will block until timeout if command does not exist remotely
         # TODO: check debug pod status in the background to avoid freeze (WRKLDS-99)
         # note2: exit status is always 0 (WRKLDS-98)
         # note3: stdin and stderr come together (WRKLDS-110)
-        node.env.admin.cli_exec(
-          :debug,
-          resource: "node/#{node.name}",
-          n: service_project.name,
-          oc_opts_end: "",
-          exec_command_arg: commands,
-          _stdin: opts[:stdin],
-          _stdout: opts[:stdout]
-        )
+        node.env.admin.cli_exec(:debug, **exec_opts)
       }
     end
 

--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -325,7 +325,7 @@
      :output: --output=<value>
      :template: --template=<value>
 :debug:
-  :cmd: oc debug --image=quay.io/openshifttest/storage@sha256:a05b96d373be86f46e76817487027a7f5b8b5f87c0ac18a246b018df11529b40 <global_options>
+  :cmd: oc debug <global_options>
   :options:
      :c: -c <value>
      :dry_run: --dry-run
@@ -1337,7 +1337,7 @@
   :cmd: oc adm release info
   :options:
     :image_for: --image-for=<value>
-    :image_name: <value>    
+    :image_name: <value>
     :registry_config: --registry-config=<value>
 :oadm_router:
   :cmd: oc adm router <name>

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -325,7 +325,7 @@
      :output: --output=<value>
      :template: --template=<value>
 :debug:
-  :cmd: oc debug --image quay.io/openshifttest/storage@sha256:a05b96d373be86f46e76817487027a7f5b8b5f87c0ac18a246b018df11529b40 <global_options>
+  :cmd: oc debug <global_options>
   :options:
      :c: -c <value>
      :dry_run: --dry-run
@@ -1338,7 +1338,7 @@
   :cmd: oc adm release info
   :options:
     :image_for: --image-for=<value>
-    :image_name: <value>    
+    :image_name: <value>
     :registry_config: --registry-config=<value>
 :oadm_router:
   :cmd: oc adm router <name>


### PR DESCRIPTION
sometime disconnected cluster don't have the
registry.redhat.io/rhel7/support-tools image installed
so we can't run oc debug normally.

The oc debug command allows the user to override the image
so we can use can existing image, e.g. multus image or any other
existing image to run debug commands, give that we always chroot

Add the `OPENSHIFT_ENV_OCP_HOST_DEBUG_IMAGE` option to disable
using the multus image by default