### PR TITLE
Update to handle instanceState node changed to vmState in Azure clusters

### DIFF
--- a/lib/openshift/machine.rb
+++ b/lib/openshift/machine.rb
@@ -27,8 +27,9 @@ module BushSlicer
     end
 
     def instance_state(user: nil, cached: true, quiet: false)
-      raw_resource(user: user, cached: cached, quiet: quiet).
-          dig('status', 'providerStatus', 'instanceState')
+      rr = raw_resource(user: user, cached: cached, quiet: quiet)
+      rr.dig('status', 'providerStatus', 'instanceState') ||
+      rr.dig('status', 'providerStatus', 'vmState')
     end
 
     def annotation_instance_state(user: nil, cached: true, quiet: false)


### PR DESCRIPTION
Validated the update to code 
      [05:53:45] INFO> Exit Status: 0
    Then the expression should be true> cb.machines.select{|m|m.instance_state == m.annotation_instance_state}.count == cb.machines.count     # features/step_definitions/common.rb:133
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [05:53:45] INFO> === After Scenario: Verify all machine instance-state should be consistent with their providerStats.instanceState ===
      [05:53:45] INFO> Shell Commands: rm -r -f -- /root/workdir/c92ee1977c9c-
      
      [05:53:45] INFO> Exit Status: 0
      [05:53:45] INFO> === End After Scenario: Verify all machine instance-state should be consistent with their providerStats.instanceState ===

1 scenario (1 passed)
3 steps (3 passed)
0m7.197s
[05:53:45] INFO> === At Exit ===
