### PR TITLE
Fix OCP-19675 rules on 4.5 changed

### DIFF
--- a/lib/rules/web/admin_console/4.3/filters.xyaml
+++ b/lib/rules/web/admin_console/4.3/filters.xyaml
@@ -98,3 +98,6 @@ check_item_in_table:
   elements:
   - selector:
       xpath: //tr[@data-test-rows='resource-row']//*[text()='<item>']
+
+# Below is PF4 filter bar related rules (since OCP4.5)
+open_filter_dropdown_list: {}

--- a/lib/rules/web/admin_console/4.4/filters.xyaml
+++ b/lib/rules/web/admin_console/4.4/filters.xyaml
@@ -97,3 +97,6 @@ clear_all_filters:
   - selector:
       xpath: //div/button[starts-with(text(),'Clear')]
     op: click
+
+# Below is PF4 filter bar related rules (since OCP4.5)
+open_filter_dropdown_list: {}

--- a/lib/rules/web/admin_console/4.5/filters.xyaml
+++ b/lib/rules/web/admin_console/4.5/filters.xyaml
@@ -107,3 +107,10 @@ clear_all_filters:
   - selector:
       xpath: //div/button[starts-with(text(),'Clear')]
     op: click
+
+# Below is PF4 filter bar related rules (since OCP4.5)
+open_filter_dropdown_list:
+  elements:
+  - selector:
+      xpath: //button[@class='pf-c-dropdown__toggle' and @data-test-id='filter-dropdown-toggle']
+    op: click


### PR DESCRIPTION
4.5 updated filter bar for each resource list page using PF4, it came from this User Story: https://issues.redhat.com/browse/CONSOLE-2134
Now the step needs an extra Click action to check the filter categories text.
PASSed on latest 4.5 with version 4.5.0-0.nightly-2020-04-25-170442
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/87060/console 
@yanpzhan Please help review. Thanks 