### PR TITLE
fix IPI abort test

### DIFF
--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -8,8 +8,13 @@ Given(/^I have an IPI deployment$/) do
   end
 
   machine_sets.each do | machine_set |
-    unless machine_set.ready?[:success]
-      raise "Not an IPI deployment or machineSet #{machine_set.name} not fully scaled, abort test."
+    i = 0
+    if machine_set.ready?[:success]
+       break
+    end
+    i = i + 1
+    if machine_sets.length == i
+       raise "Not an IPI deployment or machineSet #{machine_set.name} not fully scaled, abort test."
     end
   end
 end

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -1,6 +1,7 @@
 Given(/^I pick a random machineset to scale$/) do
   ensure_admin_tagged
   machine_sets = BushSlicer::MachineSet.list(user: admin, project: project("openshift-machine-api"))
+    select { |ms| ms.available_replicas >= 1 }
   cache_resources *machine_sets.shuffle
 end
 


### PR DESCRIPTION
In IPI env, if there is one machineset with replicas=0 the test will be aborted. This PR will fix this issue. As long as there is one machineset with replicas > 0, the test will continue.  @jhou @miyadav Please help to take a look. 