### PR TITLE
fix OCP-27609

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -120,13 +120,18 @@ Feature: Machine features testing
   @destructive
   Scenario: Scaling a machineset with providerSpec.publicIp set to true
     Given I have an IPI deployment
-    And I clone a machineset named "machineset-clone-publiciptrue"
+    And I switch to cluster admin pseudo user
+
+    Given I store the number of machines in the :num_to_restore clipboard
+    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
+
+    And I clone a machineset named "machineset-clone-27609"
 
     Then I run the :get admin command with:
-     | resource      | machineset                    |
-     | resource_name | machineset-clone-publiciptrue |
-     | namespace     | openshift-machine-api         |
-     | o             | yaml                          |
+     | resource      | machineset             |
+     | resource_name | machineset-clone-27609 |
+     | namespace     | openshift-machine-api  |
+     | o             | yaml                   |
     And I save the output to file> new_machineset.yaml
 
     And I replace lines in "new_machineset.yaml":


### PR DESCRIPTION
According to this test: https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/87184/consoleFull, this step failed "`Failed to restore cluster, expected number of nodes 9, got 6 (RuntimeError)`". It is because the cluster was not restored. @jhou1 @miyadav Please help to take a look.