### PR TITLE
Making more readable clone machineset step

### DIFF
--- a/features/machine/autoscaler.feature
+++ b/features/machine/autoscaler.feature
@@ -11,7 +11,7 @@ Feature: Cluster Autoscaler Tests
     Given I store the number of machines in the :num_to_restore clipboard
     And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
 
-    Given I clone a machineset named "machineset-clone-28108"
+    Given I clone a machineset and name it "machineset-clone-28108"
 
     # Create clusterautoscaler
     Given I use the "openshift-machine-api" project
@@ -80,7 +80,7 @@ Feature: Cluster Autoscaler Tests
     And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
 
     Given I use the "openshift-machine-api" project
-    Given I clone a machineset named "machineset-clone-21517"
+    Given I clone a machineset and name it "machineset-clone-21517"
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/cloud/machine-autoscaler.yml" replacing paths:
       | ["metadata"]["name"]               | maotest                 |
       | ["spec"]["minReplicas"]            | 1                       |
@@ -117,9 +117,9 @@ Feature: Cluster Autoscaler Tests
     And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
 
     Given I use the "openshift-machine-api" project
-    Given I clone a machineset named "machineset-clone-22102"
+    Given I clone a machineset and name it "machineset-clone-22102"
     And evaluation of `machine_set.name` is stored in the :machineset_clone_22102 clipboard
-    Given I clone a machineset named "machineset-clone-22102-2"
+    Given I clone a machineset and name it "machineset-clone-22102-2"
     And evaluation of `machine_set.name` is stored in the :machineset_clone_22102_2 clipboard
 
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/cloud/machine-autoscaler.yml" replacing paths:

--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -34,7 +34,7 @@ Feature: Machine features testing
     Given I store the number of machines in the :num_to_restore clipboard
     And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
 
-    Given I clone a machineset named "machineset-clone-25436"
+    Given I clone a machineset and name it "machineset-clone-25436"
 
     Given I scale the machineset to +2
     Then the step should succeed
@@ -125,7 +125,7 @@ Feature: Machine features testing
     Given I store the number of machines in the :num_to_restore clipboard
     And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
 
-    And I clone a machineset named "machineset-clone-27609"
+    And I clone a machineset and name it "machineset-clone-27609"
 
     Then I run the :get admin command with:
      | resource      | machineset             |
@@ -154,7 +154,7 @@ Feature: Machine features testing
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     
-    Given I clone a machineset named "machineset-24363"
+    Given I clone a machineset and name it "machineset-24363"
     And evaluation of `machine_set.machines.first.node_name` is stored in the :noderef_name clipboard
     And evaluation of `machine_set.machines.first.name` is stored in the :machine_name clipboard
 

--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -8,7 +8,7 @@ Feature: MachineHealthCheck Test Scenarios
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     Given I use the "openshift-machine-api" project
-    And I clone a machineset named "machineset-25897"
+    And I clone a machineset and name it "machineset-25897"
 
     # Create MHC
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/cloud/mhc/mhc1.yaml" replacing paths:
@@ -40,7 +40,7 @@ Feature: MachineHealthCheck Test Scenarios
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
 
-    Given I clone a machineset named "machineset-26311"
+    Given I clone a machineset and name it "machineset-26311"
 
     # Create unhealthyCondition before createing a MHC
     Given I create the 'Ready' unhealthyCondition
@@ -64,7 +64,7 @@ Feature: MachineHealthCheck Test Scenarios
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
 
-    Given I clone a machineset named "machineset-25734"
+    Given I clone a machineset and name it "machineset-25734"
 
     # Create MHCs
     Given I run the steps 2 times:
@@ -92,7 +92,7 @@ Feature: MachineHealthCheck Test Scenarios
     Given I store the number of machines in the :num_to_restore clipboard
     And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
     Given I use the "openshift-machine-api" project
-    And I clone a machineset named "machineset-25691"
+    And I clone a machineset and name it "machineset-25691"
 
     # Create MHC
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/cloud/mhc/mhc1.yaml" replacing paths:

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -57,7 +57,7 @@ Then(/^the machineset should have expected number of running machines$/) do
   end
 end
 
-Given(/^I clone a machineset named "([^"]*)"$/) do | ms_name |
+Given(/^I clone a machineset and name it "([^"]*)"$/) do | ms_name |
   step %Q{I pick a random machineset to scale}
 
   ms_yaml = machine_set.raw_resource.to_yaml

--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -63,7 +63,7 @@ Feature: Machine-api components upgrade tests
     Given I store the number of machines in the :num_to_restore clipboard
     And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
 
-    Given I clone a machineset named "machineset-clone-22612"
+    Given I clone a machineset and name it "machineset-clone-22612"
 
     Given I scale the machineset to +2
     Then the step should succeed


### PR DESCRIPTION
made the change using - find /home/miyadav/verification/verification-tests -type f -exec sed -i 's/machineset named/machineset and name it/g' {} \;

Ran one of the cases involving changes , it works fine 
            instanceId: i-03e5945954debaed4
            instanceState: running
      kind: List
      metadata:
        resourceVersion: ""
        selfLink: ""
      
      [06:14:26] INFO> Exit Status: 0
    Then the expression should be true> cb.machines.select{|m|m.instance_state == m.annotation_instance_state}.count == cb.machines.count     # features/step_definitions/common.rb:133
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [06:14:26] INFO> === After Scenario: Verify all machine instance-state should be consistent with their providerStats.instanceState ===
      [06:14:26] INFO> Shell Commands: rm -r -f -- /root/workdir/9d63297830b3-
      
      [06:14:26] INFO> Exit Status: 0
      [06:14:26] INFO> === End After Scenario: Verify all machine instance-state should be consistent with their providerStats.instanceState ===

1 scenario (1 passed)
3 steps (3 passed)
0m11.560s
[06:14:26] INFO> === At Exit ===
