### PR TITLE
update steps to match logging 4.5

### DIFF
--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -47,16 +47,10 @@ Feature: cluster-logging-operator related test
   @admin
   @destructive
   Scenario: Scale Elasticsearch nodes by nodeCount 2->3->4 in clusterlogging
-    Given I delete the clusterlogging instance
-    Then the step should succeed
-    And I run the :create client command with:
-      | f | <%= BushSlicer::HOME %>/testdata/logging/clusterlogging/scalebase.yaml |
-    Then the step should succeed
-    Given I register clean-up steps:
-    """
-    Given I delete the clusterlogging instance
-    """
-    # Given admin ensures "instance" cluster_logging is deleted from the "openshift-logging" project after scenario
+    Given I create clusterlogging instance with:
+      | remove_logging_pods | true                                                                   |
+      | crd_yaml            | <%= BushSlicer::HOME %>/testdata/logging/clusterlogging/scalebase.yaml |
+      | check_status        | false                                                                  |
     And I wait for the "elasticsearch" elasticsearches to appear
     And the expression should be true> cluster_logging('instance').logstore_node_count == 2
     And the expression should be true> elasticsearch('elasticsearch').nodes[0]['nodeCount'] == 2
@@ -100,9 +94,8 @@ Feature: cluster-logging-operator related test
   Scenario: Fluentd alert rule: FluentdNodeDown
     Given the master version >= "4.2"
     Given I create clusterlogging instance with:
-      | remove_logging_pods | true                                                                                                   |
+      | remove_logging_pods | true                                                                 |
       | crd_yaml            | <%= BushSlicer::HOME %>/testdata/logging/clusterlogging/example.yaml |
-      | log_collector       | fluentd                                                                                                |
     Then the step should succeed
     Given I wait for the "fluentd" prometheus_rule to appear
     And I wait for the "fluentd" service_monitor to appear

--- a/features/logging/collector.feature
+++ b/features/logging/collector.feature
@@ -88,7 +88,8 @@ Feature: collector related tests
 
   # @author qitang@redhat.com
   # @case_id OCP-25365
-  @admin @destructive
+  @admin
+  @destructive
   @commonlogging
   Scenario: The System Journald log can be collected
     Given evaluation of `cluster_logging('instance').collection_type` is stored in the :collection_type clipboard
@@ -103,7 +104,8 @@ Feature: collector related tests
 
   # @author qitang@redhat.com
   # @case_id OCP-18147
-  @admin @destructive
+  @admin
+  @destructive
   @commonlogging
   Scenario: The Container logs metadata check
     Given the master version == "4.1"
@@ -137,7 +139,8 @@ Feature: collector related tests
 
   # @author qitang@redhat.com
   # @case_id OCP-25768
-  @admin @destructive
+  @admin
+  @destructive
   @commonlogging
   Scenario: The container logs metadata check
     Given the master version >= "4.2"

--- a/features/logging/elasticsearch.feature
+++ b/features/logging/elasticsearch.feature
@@ -12,8 +12,8 @@ Feature: Elasticsearch related tests
       | op           | GET                 |
     Then the step should succeed
     And the output should contain:
-      | es_cluster_nodes_number            |
-      | es_cluster_shards_active_percent   |
+      | es_cluster_nodes_number          |
+      | es_cluster_shards_active_percent |
 
   # @author qitang@redhat.com
   # @case_id OCP-22050

--- a/features/logging/elasticsearch.feature
+++ b/features/logging/elasticsearch.feature
@@ -12,8 +12,8 @@ Feature: Elasticsearch related tests
       | op           | GET                 |
     Then the step should succeed
     And the output should contain:
-      | es_cluster_nodes_number                   |
-      | es_cluster_shards_active_percent          |
+      | es_cluster_nodes_number            |
+      | es_cluster_shards_active_percent   |
 
   # @author qitang@redhat.com
   # @case_id OCP-22050
@@ -36,8 +36,8 @@ Feature: Elasticsearch related tests
     """
     When I process and create:
       | f | <%= BushSlicer::HOME %>/testdata/logging/clusterlogging/clusterlogging-storage-template.yaml |
-      | p | STORAGE_CLASS=<%= cb.default_sc.name %>                                                            |
-      | p | PVC_SIZE=10Gi                                                                                      |
+      | p | STORAGE_CLASS=<%= cb.default_sc.name %>                                                      |
+      | p | PVC_SIZE=10Gi                                                                                |
     Then the step should succeed
     Given I wait for the "instance" clusterloggings to appear
     And the expression should be true> cluster_logging('instance').logstore_storage_class_name == cb.default_sc.name

--- a/features/logging/elasticsearch_operator.feature
+++ b/features/logging/elasticsearch_operator.feature
@@ -25,9 +25,8 @@ Feature: elasticsearch-operator related tests
   @destructive
   Scenario: elasticsearch alerting rules test: ElasticsearchClusterNotHealthy
     Given I create clusterlogging instance with:
-      | remove_logging_pods | true                                                                                                   |
+      | remove_logging_pods | true                                                                 |
       | crd_yaml            | <%= BushSlicer::HOME %>/testdata/logging/clusterlogging/example.yaml |
-      | log_collector       | fluentd                                                                                                |
     Then the step should succeed
     Given I wait for the "elasticsearch-prometheus-rules" prometheus_rule to appear
     And I wait for the "monitor-elasticsearch-cluster" service_monitor to appear

--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -5,12 +5,14 @@
 Given /^logging service has been installed successfully$/ do
   ensure_destructive_tagged
   ensure_admin_tagged
-  crd_yaml = "#{ENV['BUSHSLICER_HOME']}/testdata/logging/clusterlogging/example.yaml"
-  step %Q/logging operators are installed successfully/
+  if env.version_cmp('4.5', user: user) < 0
+    example_cr = "<%= BushSlicer::HOME %>/testdata/logging/clusterlogging/example.yaml"
+  else
+    example_cr = "<%= BushSlicer::HOME %>/testdata/logging/clusterlogging/example_indexmanagement.yaml"
+  end
   step %Q/I create clusterlogging instance with:/, table(%{
-    | remove_logging_pods | true        |
-    | crd_yaml            | #{crd_yaml} |
-    | log_collector       | fluentd     |
+    | remove_logging_pods | false         |
+    | crd_yaml            | #{example_cr} |
   })
 end
 
@@ -79,6 +81,7 @@ Given /^logging operators are installed successfully$/ do
       end
     end
   end
+  step %Q/elasticsearch operator is ready/
 
   # Create namespace
   unless project('openshift-logging').exists?
@@ -121,8 +124,6 @@ Given /^logging operators are installed successfully$/ do
       end
     end
   end
-
-  step %Q/elasticsearch operator is ready/
   step %Q/cluster logging operator is ready/
 end
 
@@ -169,9 +170,15 @@ Given /^I wait for clusterlogging(?: named "(.+)")? with #{QUOTED} log collector
     | component=kibana |
   })
   cl.wait_until_kibana_is_ready
-  # lastly check the curator cronjob.
-  # XXX: the curator pod will not appear immediately after the installation, should we wait for it??
-  raise "Failed to find cronjob for curator" if cron_job('curator').schedule.nil?
+  # lastly check the cronjob. 
+  if env.version_cmp('4.5', user: user) < 0
+    raise "Failed to find cronjob for curator" if cron_job('curator').schedule.nil?
+  else
+    cj_names = ["elasticsearch-delete-app", "elasticsearch-delete-infra", "elasticsearch-rollover-app", "elasticsearch-rollover-infra"]
+    for cj_name in cj_names do
+      raise "Failed to find cronjob for #{cj_name}" if cron_job(cj_name).schedule.nil?
+    end
+  end
 end
 
 # to cleanup OLM installed clusterlogging
@@ -206,31 +213,22 @@ Given /^logging service is removed successfully$/ do
   end
 end
 
-# For 4.x we just check the clusterlogging status for ES components,
-# We have to assume clusterlogging is saved in the cb.cluster_logging
-#
-Given /^I wait(?: for (\d+) seconds)? until fluentd is ready$/ do |seconds|
-  seconds = Integer(seconds) unless seconds.nil?
-  seconds ||= 5 * 60
-  cb.cluster_logging ||= cluster_logging('instance')
-  cl = cb.cluster_logging
-  cl.wait_until_fluentd_is_ready(timeout: seconds)
+Given /^I wait until #{QUOTED} log collector is ready$/ do | log_collector |  
+  step %Q/#{daemon_set(log_collector).replica_counters[:desired]} pods become ready with labels:/, table(%{
+    | logging-infra=#{log_collector} |
+  }) 
 end
 
-Given /^I wait(?: for (\d+) seconds)? until rsyslog is ready$/ do |seconds|
-  seconds = Integer(seconds) unless seconds.nil?
-  seconds ||= 5 * 60
-  cb.cluster_logging ||= cluster_logging('instance')
-  cl = cb.cluster_logging
-  cl.wait_until_rsyslog_is_ready(timeout: seconds)
+Given /^I wait until ES cluster is ready$/ do
+  step %Q/#{cluster_logging('instance').logstore_node_count.to_i} pods become ready with labels:/, table(%{
+    | cluster-name=elasticsearch,component=elasticsearch |
+  }) 
 end
 
-Given /^I wait(?: for (\d+) seconds)? until the ES cluster is healthy$/ do |seconds|
-  seconds = Integer(seconds) unless seconds.nil?
-  seconds ||= 9 * 60
-  cb.cluster_logging ||= cluster_logging('instance')
-  cl = cb.cluster_logging
-  cl.wait_until_es_is_ready(timeout: seconds)
+Given /^I wait until kibana is ready$/ do 
+  step %Q/#{deployment('kibana').replica_counters[:desired]} pods become ready with labels:/, table(%{
+    | component=kibana |
+  }) 
 end
 
 Given /^cluster logging operator is ready$/ do
@@ -261,6 +259,11 @@ Given /^I create clusterlogging instance with:$/ do | table |
   step %Q/I use the "openshift-logging" project/
   logging_ns = "openshift-logging"
   crd_yaml = opts[:crd_yaml]
+  if opts[:check_status].nil?
+    check_status = 'true'
+  else
+    check_status = opts[:check_status]
+  end
 
   if cluster_logging("instance").exists?
     step %Q/I delete the clusterlogging instance/
@@ -273,14 +276,19 @@ Given /^I create clusterlogging instance with:$/ do | table |
       step %Q/I delete the clusterlogging instance/
     }
   end
-  log_collector = opts[:log_collector]
   step %Q/I wait for the "instance" clusterloggings to appear up to 300 seconds/
-  step %Q/I wait for the "elasticsearch" elasticsearches to appear up to 300 seconds/
-  step %Q/I wait for the "kibana" deployment to appear up to 300 seconds/
-  step %Q/I wait for the "#{log_collector}" daemonset to appear up to 300 seconds/
-  # to wait for the status informations to show up in the clusterlogging instance
-  sleep 10
-  step %Q/I wait for clusterlogging with "#{log_collector}" log collector to be functional in the project/
+  if check_status == 'true'
+    step %Q/I wait for the "elasticsearch" elasticsearches to appear up to 300 seconds/
+    step %Q/I wait for the "kibana" deployment to appear up to 300 seconds/
+    log_collector = cluster_logging('instance').collection_type
+    step %Q/I wait for the "#{log_collector}" daemonset to appear up to 300 seconds/
+    # to wait for the status informations to show up in the clusterlogging instance
+    #sleep 10
+    #step %Q/I wait for clusterlogging with "#{log_collector}" log collector to be functional in the project/
+    step %Q/I wait until "#{log_collector}" log collector is ready/
+    step %Q/I wait until ES cluster is ready/
+    step %Q/I wait until kibana is ready/
+  end
 end
 
 Given /^I delete the clusterlogging instance$/ do
@@ -298,6 +306,12 @@ Given /^I delete the clusterlogging instance$/ do
   step %Q/I wait for the resource "cronjob" named "curator" to disappear/
   step %Q/I wait for the resource "daemonset" named "rsyslog" to disappear/
   step %Q/I wait for the resource "daemonset" named "fluentd" to disappear/
+  step %Q/all existing pods die with labels:/, table(%{
+    | component=elasticsearch |
+  })
+  step %Q/all existing pods die with labels:/, table(%{
+    | component=kibana |
+  })
 end
 
 Given /^logging channel name is stored in the#{OPT_SYM} clipboard$/ do | cb_name |
@@ -399,12 +413,12 @@ Given /^I create the resources for the receiver with:$/ do | table |
   step %Q/I ensures "#{receiver_name}" service is deleted from the "#{namespace}" project after scenario/
   files = [configmap_file, deployment_file]
   for file in files do
-    @result = user.cli_exec(:create, f: file)
+    @result = user.cli_exec(:create, f: file, n: namespace)
     raise "Unable to create resoure with #{file}" unless @result[:success]
   end
   if receiver_name == "rsyslogserver"
     svc_file = "#{ENV['BUSHSLICER_HOME']}/testdata/logging/logforwarding/rsyslog/rsyslogserver_svc.yaml"
-    @result = user.cli_exec(:create, f: svc_file)
+    @result = user.cli_exec(:create, f: svc_file, n: namespace)
     raise "Unable to expose the service for rsyslog server" unless @result[:success]
   else
     @result = user.cli_exec(:expose, name: receiver_name, resource: 'deployment', resource_name: receiver_name, namespace: namespace)
@@ -418,7 +432,6 @@ end
 
 Given /^(fluentd|elasticsearch|rsyslog) receiver is deployed as (secure|insecure)(?: in the#{OPT_QUOTED} project)?$/ do | server, security, project_name |
   project_name ||= "openshift-logging"
-  org_user = user
   project(project_name)
   case server
   when "fluentd"
@@ -435,6 +448,7 @@ Given /^(fluentd|elasticsearch|rsyslog) receiver is deployed as (secure|insecure
         | from_file    | ca-bundle.crt=ca.crt     |
         | from_file    | ca.key=ca.key            |
         | from_literal | shared_key=fluentdserver |
+        | n            | #{project_name}          |
       })
       step %Q/the step should succeed/
       if project_name != "openshift-logging"
@@ -461,6 +475,7 @@ Given /^(fluentd|elasticsearch|rsyslog) receiver is deployed as (secure|insecure
         | from_file   | elasticsearch.key=elasticsearch.key |
         | from_file   | elasticsearch.crt=elasticsearch.crt |
         | from_file   | admin-ca=ca.crt                     |
+        | n           | #{project_name}                     |
       })
       step %Q/the step should succeed/
       step %Q/I create pipelinesecret named "piplinesecret"/

--- a/features/support/clusterlogging_env.rb
+++ b/features/support/clusterlogging_env.rb
@@ -10,10 +10,14 @@ Before('@commonlogging') do
   step %Q/I switch to cluster admin pseudo user/
   step %Q/I use the "openshift-logging" project/
   unless cluster_logging("instance").exists?
+    if env.version_cmp('4.5', user: user) < 0
+      example_cr = "<%= BushSlicer::HOME %>/testdata/logging/clusterlogging/example.yaml"
+    else
+      example_cr = "<%= BushSlicer::HOME %>/testdata/logging/clusterlogging/example_indexmanagement.yaml"
+    end
     step %Q/I create clusterlogging instance with:/, table(%{
-      | remove_logging_pods | false                                                                      |
-      | crd_yaml            | <%= BushSlicer::HOME %>/testdata/logging/clusterlogging/example.yaml |
-      | log_collector       | fluentd                                                                    |
+      | remove_logging_pods | false         |
+      | crd_yaml            | #{example_cr} |
     })
   end
 end

--- a/features/test/logging_metrics.feature
+++ b/features/test/logging_metrics.feature
@@ -179,7 +179,6 @@ Feature: test logging and metrics related steps
     Given logging operators are installed successfully
     Given I create clusterlogging instance with:
       | crd_yaml            | <%= BushSlicer::HOME %>/testdata/logging/clusterlogging/example.yaml |
-      | remove_logging_pods | true                                                                                                   |
-      | log_collector       | fluentd                                                                                                |
+      | remove_logging_pods | true                                                                 |
 
 

--- a/lib/openshift/cluster_logging.rb
+++ b/lib/openshift/cluster_logging.rb
@@ -175,7 +175,7 @@ module BushSlicer
       raw_resource(user: user, cached: cached, quiet: quiet).dig('spec', 'visualization')
     end
 
-    def collection_type(user: nil, quiet: false, cached: false)
+    def collection_type(user: nil, quiet: false, cached: true)
       return collection_spec(user: user, cached: cached, quiet: quiet).dig('logs', 'type')
     end
 

--- a/testdata/logging/clusterlogging/example_indexmanagement.yaml
+++ b/testdata/logging/clusterlogging/example_indexmanagement.yaml
@@ -1,0 +1,31 @@
+apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  name: "instance"
+  namespace: "openshift-logging"
+spec:
+  managementState: "Managed"
+  logStore:
+    type: "elasticsearch"
+    retentionPolicy: 
+      application:
+        maxAge: 1d
+      infra:
+        maxAge: 7d
+      audit:
+        maxAge: 1w
+    elasticsearch:
+      nodeCount: 1
+      redundancyPolicy: "ZeroRedundancy"
+      resources:
+        requests:
+          memory: "1Gi"
+      storage: {}
+  visualization:
+    type: "kibana"
+    kibana:
+      replicas: 1
+  collection:
+    logs:
+      type: "fluentd"
+      fluentd: {}


### PR DESCRIPTION
There have some differences between logging 4.5 and logging 4.1~4.4, I update some steps to make them could match logging 4.5. @anpingli PTAL, thanks.

I have executed all the existing cases with these changes in logging 4.4, the logs are in the below:
Logs: https://url.corp.redhat.com/496eeb6 (2 cases failed, but weren't caused by these changes)