### PR TITLE
Modifying interface names on OVN

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -406,7 +406,7 @@ Feature: SDN related networking scenarios
   Then the output should contain:
     | br-int: unmanaged                    |
     | br-local: unmanaged                  |
-    | br-nexthop: unmanaged                |
+    | ovn-k8s-gw0: unmanaged               |
     | genev_sys_6081: unmanaged            |
     | <%= cb.tunnel_inf_name %>: unmanaged |
   # And veths ovs interfaces also needs to be unmanaged

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -852,8 +852,7 @@ Given /^the vxlan tunnel name of node "([^"]*)" is stored in the#{OPT_SYM} clipb
   end
   case networkType
   when "OVNKubernetes"
-    inf_name = host.exec_admin("ifconfig | egrep -o '^k8[^:]+'")
-    cb[cb_name] = inf_name[:response].split("\n")[0]
+    cb[cb_name]="ovn-k8s-mp0"
   when "OpenShiftSDN"
     cb[cb_name]="tun0"
   else
@@ -873,8 +872,8 @@ Given /^the vxlan tunnel address of node "([^"]*)" is stored in the#{OPT_SYM} cl
   end
   case networkType
   when "OVNKubernetes"
-    inf_name = host.exec_admin("ifconfig | egrep -o '^k8[^:]+'")
-    @result = host.exec_admin("ifconfig #{inf_name[:response].split("\n")[0]}")
+    inf_name="ovn-k8s-mp0" 
+    @result = host.exec_admin("ifconfig #{inf_name.split("\n")[0]}")
     cb[cb_address] = @result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]
   when "OpenShiftSDN"
     @result=host.exec_admin("ifconfig tun0")


### PR DESCRIPTION
Just modifying couple of inf names in OVN due to underlying (merged ) dev PRs
https://github.com/ovn-org/ovn-kubernetes/pull/1165
https://github.com/ovn-org/ovn-kubernetes/pull/1181
This is causing CI failures in tests dependent on earlier inf names. Please merge it on urgent basis if possible @pruan-rht 
cc @zhaozhanqi @rbbratta @weliang1 

re-ran couple of tests: http://pastebin.test.redhat.com/859952