### PR TITLE
Hongyli alert browser 4.5

### DIFF
--- a/lib/rules/web/admin_console/4.1/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.1/monitoring_alerts.xyaml
@@ -30,9 +30,7 @@ perform_action_item:
   action: click_actions_button
   action: click_button_text
 perform_silence:
-  params:
-    button_text: Save
-  action: click_button_text
+  action: submit_changes
 silence_alert_from_action:
   params:
     item_text: Silence Alert

--- a/lib/rules/web/admin_console/4.1/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.1/monitoring_alerts.xyaml
@@ -29,6 +29,10 @@ perform_action_item:
     button_text: <item_text>
   action: click_actions_button
   action: click_button_text
+perform_silence:
+  params:
+    button_text: Save
+  action: click_button_text
 silence_alert_from_action:
   params:
     item_text: Silence Alert

--- a/lib/rules/web/admin_console/4.2/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.2/monitoring_alerts.xyaml
@@ -30,9 +30,7 @@ perform_action_item:
   action: click_actions_button
   action: click_button_text
 perform_silence:
-  params:
-    button_text: Save
-  action: click_button_text
+  action: submit_changes
 silence_alert_from_action:
   params:
     item_text: Silence Alert

--- a/lib/rules/web/admin_console/4.2/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.2/monitoring_alerts.xyaml
@@ -29,6 +29,10 @@ perform_action_item:
     button_text: <item_text>
   action: click_actions_button
   action: click_button_text
+perform_silence:
+  params:
+    button_text: Save
+  action: click_button_text
 silence_alert_from_action:
   params:
     item_text: Silence Alert

--- a/lib/rules/web/admin_console/4.2/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.2/monitoring_alerts.xyaml
@@ -38,8 +38,13 @@ silence_alert_from_action:
     item_text: Silence Alert
   action: perform_action_item
   action: click_create_button
+check_silence_detail:
+  element:
+    selector:
+      xpath: //span[text()='Silence Details']
 silence_alert_from_detail:
-  action: silence_alert_from_action
+  action: silence_alert_from_action 
+  action: check_silence_detail
 click_alert_link_with_text:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.2/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.2/monitoring_alerts.xyaml
@@ -38,6 +38,8 @@ silence_alert_from_action:
     item_text: Silence Alert
   action: perform_action_item
   action: click_create_button
+silence_alert_from_detail:
+  action: silence_alert_from_action
 click_alert_link_with_text:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.2/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.2/monitoring_metrics.xyaml
@@ -23,6 +23,7 @@ click_project_link_developer_mode:
     selector:
       xpath: //a[text()='<project_name>']
     op: click
+    timeout: 20
 choose_project_developer_mode:
   action: click_projects_dropdown_developer_mode
   action: input_select_project_developer_mode

--- a/lib/rules/web/admin_console/4.3/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.3/monitoring_alerts.xyaml
@@ -30,9 +30,7 @@ perform_action_item:
   action: click_actions_button
   action: click_button_text
 perform_silence:
-  params:
-    button_text: Save
-  action: click_button_text
+  action: submit_changes
 silence_alert_from_action:
   params:
     item_text: Silence Alert

--- a/lib/rules/web/admin_console/4.3/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.3/monitoring_alerts.xyaml
@@ -29,6 +29,10 @@ perform_action_item:
     button_text: <item_text>
   action: click_actions_button
   action: click_button_text
+perform_silence:
+  params:
+    button_text: Save
+  action: click_button_text
 silence_alert_from_action:
   params:
     item_text: Silence Alert

--- a/lib/rules/web/admin_console/4.3/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.3/monitoring_alerts.xyaml
@@ -38,8 +38,13 @@ silence_alert_from_action:
     item_text: Silence Alert
   action: perform_action_item
   action: click_create_button
+check_silence_detail:
+  element:
+    selector:
+      xpath: //span[text()='Silence Details']
 silence_alert_from_detail:
-  action: silence_alert_from_action
+  action: silence_alert_from_action 
+  action: check_silence_detail
 click_alert_link_with_text:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.3/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.3/monitoring_alerts.xyaml
@@ -38,6 +38,8 @@ silence_alert_from_action:
     item_text: Silence Alert
   action: perform_action_item
   action: click_create_button
+silence_alert_from_detail:
+  action: silence_alert_from_action
 click_alert_link_with_text:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.3/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.3/monitoring_metrics.xyaml
@@ -23,6 +23,7 @@ click_project_link_developer_mode:
     selector:
       xpath: //a[text()='<project_name>']
     op: click
+    timeout: 20
 choose_project_developer_mode:
   action: click_projects_dropdown_developer_mode
   action: input_select_project_developer_mode

--- a/lib/rules/web/admin_console/4.4/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.4/monitoring_alerts.xyaml
@@ -30,9 +30,7 @@ perform_action_item:
   action: click_actions_button
   action: click_button_text
 perform_silence:
-  params:
-    button_text: Save
-  action: click_button_text
+  action: submit_changes
 silence_alert_from_action:
   params:
     item_text: Silence Alert

--- a/lib/rules/web/admin_console/4.4/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.4/monitoring_alerts.xyaml
@@ -29,6 +29,10 @@ perform_action_item:
     button_text: <item_text>
   action: click_actions_button
   action: click_button_text
+perform_silence:
+  params:
+    button_text: Save
+  action: click_button_text
 silence_alert_from_action:
   params:
     item_text: Silence Alert

--- a/lib/rules/web/admin_console/4.4/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.4/monitoring_alerts.xyaml
@@ -38,8 +38,13 @@ silence_alert_from_action:
     item_text: Silence Alert
   action: perform_action_item
   action: click_create_button
+check_silence_detail:
+  element:
+    selector:
+      xpath: //span[text()='Silence Details']
 silence_alert_from_detail:
   action: silence_alert_from_action 
+  action: check_silence_detail
 click_alert_link_with_text:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.4/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.4/monitoring_alerts.xyaml
@@ -38,6 +38,8 @@ silence_alert_from_action:
     item_text: Silence Alert
   action: perform_action_item
   action: click_create_button
+silence_alert_from_detail:
+  action: silence_alert_from_action 
 click_alert_link_with_text:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.4/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.4/monitoring_metrics.xyaml
@@ -23,6 +23,7 @@ click_project_link_developer_mode:
     selector:
       xpath: //a[text()='<project_name>']
     op: click
+    timeout: 20
 choose_project_developer_mode:
   action: click_projects_dropdown_developer_mode
   action: input_select_project_developer_mode

--- a/lib/rules/web/admin_console/4.5/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.5/common_ui_elements.xyaml
@@ -160,6 +160,16 @@ set_label_input_simple:
       <<: *label_input_value
     op: send_keys <input_value>
     type: input
+set_label_textarea:
+  elements:
+  - selector: &label_textarea
+      xpath: //label[text()='<label_text>']/..//textarea
+    op: clear
+    type: textarea
+  - selector:
+      <<: *label_textarea
+    op: send_keys <input_value>
+    type: textarea
 check_editor_is_monaco_editor:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.5/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.5/monitoring_alerts.xyaml
@@ -39,9 +39,7 @@ input_silence_comments:
     input_value: <comment_text>
   action: set_label_textarea
 perform_silence:
-  params:
-    button_text: Silence
-  action: click_button_text
+  action: submit_changes
 check_silence_detail:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.5/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.5/monitoring_alerts.xyaml
@@ -42,7 +42,7 @@ perform_silence:
   params:
     button_text: Silence
   action: click_button_text
-check_silence_by:
+check_silence_detail:
   element:
     selector:
       xpath: //span[text()='Silence Details']
@@ -52,7 +52,7 @@ silence_alert_from_detail:
   action: click_silence_alert
   action: input_silence_comments
   action: perform_silence
-  action: check_silence_by
+  action: check_silence_detail
 click_alert_link_with_text:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.5/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.5/monitoring_alerts.xyaml
@@ -107,11 +107,28 @@ input_matcher_name_silence:
 expire_alert_from_actions:
   action: click_actions_button
   action: click_expire_alert_button
-
+click_duration_dropdown_button:
+  element:
+    selector:
+      xpath: //button[@class='pf-c-dropdown__toggle']
+    op: click
+set_silence_duration:
+  action: click_duration_dropdown_button
+  element:
+    selector:
+      xpath: //ul[@class='pf-c-dropdown__menu']//button[text()='<duration>']
+    op: click
+set_silence_duration_null:
+  action: click_duration_dropdown_button
+  element:
+    selector:
+      xpath: //ul[@class='pf-c-dropdown__menu']//button[text()='-']
+    op: click  
 set_invalid_end_time_silence:
   params:
     label_text: Until...
     input_value: 2020/03/05 20:11:44
+  action: set_silence_duration_null
   action: set_label_input_simple
   
 status_specific_alert:

--- a/lib/rules/web/admin_console/4.5/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.5/monitoring_alerts.xyaml
@@ -29,11 +29,30 @@ perform_action_item:
     button_text: <item_text>
   action: click_actions_button
   action: click_button_text
-silence_alert_from_action:
+click_silence_alert:
   params:
-    item_text: Silence Alert
-  action: perform_action_item
-  action: click_create_button
+    button_text: Silence Alert
+  action: click_button_text
+input_silence_comments:
+  params:
+    label_text: Comment
+    input_value: <comment_text>
+  action: set_label_textarea
+perform_silence:
+  params:
+    button_text: Silence
+  action: click_button_text
+check_silence_by:
+  element:
+    selector:
+      xpath: //span[text()='Silence Details']
+silence_alert_from_detail:
+  params:
+    comment_text: silence comments is a must from ocp 4.50
+  action: click_silence_alert
+  action: input_silence_comments
+  action: perform_silence
+  action: check_silence_by
 click_alert_link_with_text:
   element:
     selector:
@@ -93,7 +112,7 @@ expire_alert_from_actions:
 
 set_invalid_end_time_silence:
   params:
-    label_text: End
+    label_text: Until...
     input_value: 2020/03/05 20:11:44
   action: set_label_input_simple
   

--- a/lib/rules/web/admin_console/4.5/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.5/monitoring_metrics.xyaml
@@ -72,7 +72,7 @@ check_query_input_text_area:
 click_promql_button:
   element:
     selector: &promql_button
-      xpath: //button[text()='<text>']
+      xpath: //span[text()='<text>']/parent::button
     op: click
 click_hide_promql_button:
   params:

--- a/lib/rules/web/admin_console/4.5/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.5/monitoring_metrics.xyaml
@@ -23,6 +23,7 @@ click_project_link_developer_mode:
     selector:
       xpath: //a[text()='<project_name>']
     op: click
+    timeout: 20
 choose_project_developer_mode:
   action: click_projects_dropdown_developer_mode
   action: input_select_project_developer_mode


### PR DESCRIPTION
Change code to make monitoring UI cases can work on 4.5 and previous releases
Depend on PR:
https://github.com/openshift/cucushift/pull/7665
The PR also fixed intermittent test failure when integration run
https://issues.redhat.com/browse/OCPQE-231
https://issues.redhat.com/browse/OCPQE-232
V3 job on 4.4: all UI cases pass
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/87917/
V3 job on 4.5: all UI cases pass
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/88145/console