### PR TITLE
Print out all of the actual tried paths

### DIFF
--- a/features/step_definitions/file.rb
+++ b/features/step_definitions/file.rb
@@ -3,15 +3,16 @@ Given /^I obtain test data file #{QUOTED}$/ do |path|
     "#{BushSlicer::HOME}/testdata",
     "#{BushSlicer::HOME}/features/tierN/testdata",
   ]
-
+  tried_paths = []
   found = accepted_roots.any? do |root|
     test_file = "#{root}/#{path}"
+    tried_paths << test_file
     if File.exist? test_file
       FileUtils.cp(test_file, File.basename(path))
       cb.test_file = File.absolute_path(File.basename(path))
     end
   end
-  raise "could not find test file '#{path}'" unless found
+  raise "could not find test file in '#{tried_paths}'" unless found
 end
 
 Given /^I save the (output|response) to file>(.+)$/ do |part, filepath|


### PR DESCRIPTION
if the user input the correct path like `<%= BushSlicer::HOME %>/features/tierN/testdata/daemon/daemonset.yaml` into the method, the error message currently prints the correct path which is misleading.  We should print the actual paths that were tried instead.   

>     Given I obtain test data file "<%= BushSlicer::HOME %>/features/tierN/testdata/templates/OCP-12856/push-generic-build-args.json" # features/step_definitions/file.rb:1
>       could not find test file in '["/Users/pruan/workspace/BushSlicer/testdata//Users/pruan/workspace/BushSlicer/features/tierN/testdata/templates/OCP-12856/push-generic-build-args.json", "/Users/pruan/workspace/BushSlicer/features/tierN/testdata//Users/pruan/workspace/BushSlicer/features/tierN/testdata/templates/OCP-12856/push-generic-build-args.json"]' (RuntimeError)