### PR TITLE
auto sriov stage case

### DIFF
--- a/features/networking/sriov.feature
+++ b/features/networking/sriov.feature
@@ -1,0 +1,16 @@
+Feature: Sriov related scenarios
+
+  # @author zzhao@redhat.com
+  # @case_id OCP-29944
+  @admin
+  Scenario: sriov operator can be setup and running well
+    Given I switch to cluster admin pseudo user
+    And I use the "openshift-sriov-network-operator" project
+    And all existing pods are ready with labels:
+      | app=network-resources-injector  |
+    And all existing pods are ready with labels:
+      | app=operator-webhook            |
+    And all existing pods are ready with labels:
+      | app=sriov-network-config-daemon |
+    And status becomes :running of exactly 1 pods labeled:
+      | name=sriov-network-operator     |


### PR DESCRIPTION
add sriov stage testing cases:
`
      And all existing pods are ready with labels:
        | app=network-resources-injector  |
      And all existing pods are ready with labels:
        | app=operator-webhook            |
      And all existing pods are ready with labels:
        | app=sriov-network-config-daemon |
      And status becomes :running of exactly 1 pods labeled:
        | name=sriov-network-operator     |
      """
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [09:25:13] INFO> === After Scenario: sriov operator can be setup and running well ===
      [09:25:13] INFO> Shell Commands: rm -r -f -- /home/zzhao/workdir/dhcp-140-240-zzhao
      
      [09:25:13] INFO> Exit Status: 0
      [09:25:13] INFO> === End After Scenario: sriov operator can be setup and running well ===

1 scenario (1 passed)
3 steps (3 passed)
`
