### PR TITLE
Moving Cleanup steps to the appropriate locations

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -615,11 +615,6 @@ Feature: Multus-CNI related scenarios
       | n | <%= project.name %>                                                                                                                               |
     Then the step should succeed
     
-    #Clean-up required to erase bridge interfaces created due to above net-attach-def
-    Given I register clean-up steps:
-    """
-    the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[0].name %>" node
-    """  
     #Creating first pod in vlan 100
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
       | ["metadata"]["name"]                                      | pod1-vlan100            |
@@ -636,6 +631,7 @@ Feature: Multus-CNI related scenarios
     #Clean-up required to erase bridge interfaces created due to above pod on same node
     Given I register clean-up steps:
     """
+    the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[0].name %>" node
     the bridge interface named "mybridge.100" is deleted from the "<%= cb.nodes[0].name %>" node
     """  
     #Creating 2nd pod on same node as first in vlan 100
@@ -698,11 +694,6 @@ Feature: Multus-CNI related scenarios
       | n | <%= project.name %>                                                                                                                               |
     Then the step should succeed 
     
-    #Clean-up required to erase bridge interfcaes created on sam node above due to vlan pods
-    Given I register clean-up steps:
-    """
-    the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[0].name %>" node
-    """  
     # Create the net-attach-def with vlan 200 via cluster admin
     When I run the :create admin command with:
       | f | <%= BushSlicer::HOME %>/testdata/networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-vlan-200.yaml |
@@ -711,9 +702,9 @@ Feature: Multus-CNI related scenarios
     
     #Creating first pod in vlan 100
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"] | pod1-vlan100 |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"]| bridgevlan100 |
-      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %> |
+      | ["metadata"]["name"] 					  | pod1-vlan100            |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"]| bridgevlan100           |
+      | ["spec"]["nodeName"]                                      | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "pod1-vlan100" becomes ready
     And evaluation of `pod.name` is stored in the :pod1 clipboard
@@ -725,6 +716,7 @@ Feature: Multus-CNI related scenarios
     #Clean-up required to erase bridge interfcaes created on sam node above due to vlan pods
     Given I register clean-up steps:
     """
+    the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[0].name %>" node
     the bridge interface named "mybridge.100" is deleted from the "<%= cb.nodes[0].name %>" node
     """  
     #Creating 2nd pod on same node as first in vlan 100

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -702,9 +702,9 @@ Feature: Multus-CNI related scenarios
     
     #Creating first pod in vlan 100
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"] 					  | pod1-vlan100            |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"]| bridgevlan100           |
-      | ["spec"]["nodeName"]                                      | <%= cb.nodes[0].name %> |
+      | ["metadata"]["name"]                                       | pod1-vlan100            |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | bridgevlan100           |
+      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "pod1-vlan100" becomes ready
     And evaluation of `pod.name` is stored in the :pod1 clipboard

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -622,18 +622,18 @@ Feature: Multus-CNI related scenarios
       | ["spec"]["nodeName"]                                      | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "pod1-vlan100" becomes ready
-    And evaluation of `pod.name` is stored in the :pod1 clipboard
-    And I execute on the pod:
-      | ifconfig | net1 |
-    Then the step should succeed
-    And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod1_net1_ip clipboard
-    
     #Clean-up required to erase bridge interfaces created due to above pod on same node
     Given I register clean-up steps:
     """
     the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[0].name %>" node
     the bridge interface named "mybridge.100" is deleted from the "<%= cb.nodes[0].name %>" node
     """  
+    And evaluation of `pod.name` is stored in the :pod1 clipboard
+    And I execute on the pod:
+      | ifconfig | net1 |
+    Then the step should succeed
+    And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod1_net1_ip clipboard
+    
     #Creating 2nd pod on same node as first in vlan 100
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
       | ["metadata"]["name"]                                      | pod2-vlan100            |
@@ -654,18 +654,18 @@ Feature: Multus-CNI related scenarios
       | ["spec"]["nodeName"]                                      | <%= cb.nodes[1].name %> |
     Then the step should succeed
     And the pod named "pod3-vlan100" becomes ready
-    And evaluation of `pod.name` is stored in the :pod3 clipboard
-    And I execute on the pod:
-      | ifconfig | net1 |
-    Then the step should succeed
-    And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod3_net1_ip clipboard
-    
     #Clean-up required to erase bridge interfcaes created on node
     Given I register clean-up steps:
     """
     the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[1].name %>" node
     the bridge interface named "mybridge.100" is deleted from the "<%= cb.nodes[1].name %>" node
     """  
+    And evaluation of `pod.name` is stored in the :pod3 clipboard
+    And I execute on the pod:
+      | ifconfig | net1 |
+    Then the step should succeed
+    And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod3_net1_ip clipboard
+    
     #making sure the pods on same node can ping while pods on diff nodes can't
     When I execute on the "<%= cb.pod1 %>" pod:
       | arping | -I | net1 |-c1 | -w2 | <%= cb.pod2_net1_ip %> |
@@ -707,18 +707,18 @@ Feature: Multus-CNI related scenarios
       | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "pod1-vlan100" becomes ready
+    #Clean-up required to erase bridge interfcaes created on same node above due to vlan pods
+    Given I register clean-up steps:
+    """
+    the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[0].name %>" node
+    the bridge interface named "mybridge.100" is deleted from the "<%= cb.nodes[0].name %>" node
+    """  
     And evaluation of `pod.name` is stored in the :pod1 clipboard
     And I execute on the pod:
       | ifconfig | net1 |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod1_net1_ip clipboard
     
-    #Clean-up required to erase bridge interfcaes created on sam node above due to vlan pods
-    Given I register clean-up steps:
-    """
-    the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[0].name %>" node
-    the bridge interface named "mybridge.100" is deleted from the "<%= cb.nodes[0].name %>" node
-    """  
     #Creating 2nd pod on same node as first in vlan 100
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
       | ["metadata"]["name"]                                      | pod2-vlan100            |
@@ -739,17 +739,16 @@ Feature: Multus-CNI related scenarios
       | ["spec"]["nodeName"]                                      | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "pod3-vlan200" becomes ready
+    #Clean-up required to erase bridge interfcaes created on same node above due to vlan pods
+    Given I register clean-up steps:
+    """
+    the bridge interface named "mybridge.200" is deleted from the "<%= cb.nodes[0].name %>" node
+    """  
     And evaluation of `pod.name` is stored in the :pod3 clipboard
     And I execute on the pod:
       | ifconfig | net1 |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod3_net1_ip clipboard
-    
-    #Clean-up required to erase bridge interfcaes created on sam node above due to vlan pods
-    Given I register clean-up steps:
-    """
-    the bridge interface named "mybridge.200" is deleted from the "<%= cb.nodes[0].name %>" node
-    """  
     
     #making sure the pods in same vlan can communicate but in different vlans cannot
     When I execute on the "<%= cb.pod1 %>" pod:


### PR DESCRIPTION
Fixing few code smells here which are causing "Test execution finished prematurely" errors in nightly runs. Small change and can be merged asap to avoid futrther issues @pruan-rht 
cc @weliang1 @rbbratta @zhaozhanqi @huiran0826 

When we create a bridge type net-attach-def, a bridge interface is created on the node only when a pod using that def gets created. The bridge interface doesn't gets created immediately post net-attach-def creation. So the bridge cleanup should definitely be after pod creation step.

Right now ,such tests are throwing premature failure errors due to the fact that say, a net-attach def is successfully created but test fails at pod creation step. However the cleanup is defined post  net-attach-def. So, as we never reached to a pod creation step and hence there is no bridge interface created, automation will throw error saying can't delete bridge interface as no such device found.

e.g. http://ci-qe-openshift.usersys.redhat.com/userContent/cucushift/v3/2020/04/28/21:05:49/Pods_can_communicate_each_other_with_same_vlan_tag/console.html

Re-ran logs: http://pastebin.test.redhat.com/860870