### PR TITLE
oc policy can-i is deprecated

### DIFF
--- a/lib/openshift/project.rb
+++ b/lib/openshift/project.rb
@@ -113,7 +113,7 @@ module BushSlicer
       unless cached && @is_admin_hash&.has_key?(user)
         @is_admin_hash ||= {}
         if env.version_ge("3.3", user: user)
-          res = user.cli_exec(:policy_can_i,
+          res = user.cli_exec(:auth_can_i,
                               verb: "delete",
                               resource: "project",
                               n: self.name,

--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -65,6 +65,10 @@
     :stdin: --stdin=<value>
     :t: -t
     :tty: --tty=<value>
+:auth_can_i:
+  :cmd: oc auth can-i <verb> <resource>
+  :options:
+    :q: -q
 :autoscale:
   :cmd: oc autoscale <name>
   :options:
@@ -1184,7 +1188,7 @@
   :cmd: oc adm node-logs <options>
   :options:
     :path: --path=<value>
-    :role: --role=<value>    
+    :role: --role=<value>
 :oadm_pod_network_join_projects:
   :cmd: oc adm pod-network join-projects
   :options:

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -65,6 +65,10 @@
     :stdin: --stdin=<value>
     :t: -t
     :tty: --tty=<value>
+:auth_can_i:
+  :cmd: oc auth can-i <verb> <resource>
+  :options:
+    :q: -q
 :autoscale:
   :cmd: oc autoscale <name>
   :options:
@@ -1184,7 +1188,7 @@
   :cmd: oc adm node-logs <options>
   :options:
     :path: --path=<value>
-    :role: --role=<value>    
+    :role: --role=<value>
 :oadm_pod_network_join_projects:
   :cmd: oc adm pod-network join-projects
   :options:


### PR DESCRIPTION
`Command "can-i" is deprecated, use 'oc auth can-i'`

at least since 4.2, so we might as well fix it

Fixing in 4.4 for now