### PR TITLE
OCP-24488: debug VLAN errors by dumping info before

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -13,7 +13,7 @@ Feature: Multus-CNI related scenarios
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |    
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |
       | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |
     Then the step should succeed
 
@@ -74,8 +74,8 @@ Feature: Multus-CNI related scenarios
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-private.yaml"
     When I run oc create as admin over "macvlan-private.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %> |
-      | ["spec"]["config"]| '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "private", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |    
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                     |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "private", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |
     Then the step should succeed
 
     # Create the first pod which consumes the macvlan custom resource
@@ -104,9 +104,9 @@ Feature: Multus-CNI related scenarios
     # Create the second pod which consumes the macvlan cr
     Given I obtain test data file "networking/multus-cni/Pods/1interface-macvlan-private.yaml"
     When I run oc create over "1interface-macvlan-private.yaml" replacing paths:
-       | ["metadata"]["name"]              | macvlan-private-secondpod   |      
-       | ["spec"]["nodeName"]              | "<%= cb.target_node %>"     |
-       | ["spec"]["containers"][0]["name"] | macvlan-private-secondpod   |
+      | ["metadata"]["name"]              | macvlan-private-secondpod |
+      | ["spec"]["nodeName"]              | "<%= cb.target_node %>"   |
+      | ["spec"]["containers"][0]["name"] | macvlan-private-secondpod |
     Then the step should succeed
     And the pod named "macvlan-private-secondpod" becomes ready
 
@@ -133,8 +133,8 @@ Feature: Multus-CNI related scenarios
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-vepa.yaml"
     When I run oc create as admin over "macvlan-vepa.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %> |
-      | ["spec"]["config"]| '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "vepa", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |      
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                  |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "vepa", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |
     Then the step should succeed
 
     # Create the first pod which consumes the macvlan custom resource
@@ -188,13 +188,13 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
     And the multus is enabled on the cluster
-    Given the default interface on nodes is stored in the :default_interface clipboard    
+    Given the default interface on nodes is stored in the :default_interface clipboard
     And evaluation of `node.name` is stored in the :target_node clipboard
     And an 4 character random string of type :hex is stored into the :nic_name clipboard
 
     # Prepare the net link on the node which will be attached to the pod
     When I run command on the "<%= cb.target_node %>" node's sdn pod:
-	    | sh | -c | ip link add <%= cb.nic_name %> link <%= cb.default_interface %> type macvlan mode bridge |
+      | sh | -c | ip link add <%= cb.nic_name %> link <%= cb.default_interface %> type macvlan mode bridge |
     Then the step should succeed
     Given I register clean-up steps:
     """
@@ -207,7 +207,7 @@ Feature: Multus-CNI related scenarios
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/host-device.yaml"
     When I run oc create as admin over "host-device.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %> |
+      | ["metadata"]["namespace"] | <%= project.name %>                                                              |
       | ["spec"]["config"]        | '{"cniVersion": "0.3.0", "type": "host-device", "device": "<%= cb.nic_name %>"}' |
     Then the step should succeed
     # Create the first pod which consumes the host-device custom resource
@@ -258,20 +258,20 @@ Feature: Multus-CNI related scenarios
     Given the master version >= "4.1"
     And the multus is enabled on the cluster
     Given the default interface on nodes is stored in the :default_interface clipboard
-    And evaluation of `node.name` is stored in the :target_node clipboard    
+    And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %> |
-      | ["spec"]["config"]| '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |      
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |
     Then the step should succeed
 
     # Create the pod which consumes multiple macvlan custom resources
     Given I obtain test data file "networking/multus-cni/Pods/2interface-macvlan-macvlan.yaml"
     When I run oc create over "2interface-macvlan-macvlan.yaml" replacing paths:
       | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | macvlan-bridge, macvlan-bridge |
-      | ["spec"]["nodeName"] | "<%= cb.target_node %>" |
+      | ["spec"]["nodeName"]                                       | "<%= cb.target_node %>"        |
     Then the step should succeed
     And a pod becomes ready with labels:
       | name=two-macvlan-pod |
@@ -310,18 +310,18 @@ Feature: Multus-CNI related scenarios
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %> |
-      | ["spec"]["config"]| '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |    
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |
     Then the step should succeed
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/host-device.yaml"
     When I run oc create as admin over "host-device.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %> |
+      | ["metadata"]["namespace"] | <%= project.name %>                                                              |
       | ["spec"]["config"]        | '{"cniVersion": "0.3.0", "type": "host-device", "device": "<%= cb.nic_name %>"}' |
     Then the step should succeed
 
     # Prepare the net link on the node which will be attached to the pod
     When I run command on the "<%= cb.target_node %>" node's sdn pod:
-       | sh | -c | ip link add <%= cb.nic_name%> link <%= cb.default_interface %> type macvlan mode private |
+      | sh | -c | ip link add <%= cb.nic_name%> link <%= cb.default_interface %> type macvlan mode private |
     Then the step should succeed
     Given I register clean-up steps:
     """
@@ -376,23 +376,23 @@ Feature: Multus-CNI related scenarios
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/host-device.yaml"
     When I run oc create as admin over "host-device.yaml" replacing paths:
-      | ["metadata"]["name"]      | host-device       |
+      | ["metadata"]["name"]      | host-device                                                                      |
       | ["spec"]["config"]        | '{"cniVersion": "0.3.0", "type": "host-device", "device": "<%= cb.nic_name1%>"}' |
-      | ["metadata"]["namespace"] | <%= project.name %> |
+      | ["metadata"]["namespace"] | <%= project.name %>                                                              |
     Then the step should succeed
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/host-device.yaml"
     When I run oc create as admin over "host-device.yaml" replacing paths:
-      | ["metadata"]["name"]      | host-device-2       |
+      | ["metadata"]["name"]      | host-device-2                                                                    |
       | ["spec"]["config"]        | '{"cniVersion": "0.3.0", "type": "host-device", "device": "<%= cb.nic_name2%>"}' |
-      | ["metadata"]["namespace"] | <%= project.name %> |
+      | ["metadata"]["namespace"] | <%= project.name %>                                                              |
     Then the step should succeed
 
     # Prepare the net link on the node which will be attached to the pod
     When I run command on the "<%= cb.target_node %>" node's sdn pod:
-       | sh | -c | ip link add <%= cb.nic_name1%> link <%= cb.default_interface %> type macvlan mode bridge |
+      | sh | -c | ip link add <%= cb.nic_name1%> link <%= cb.default_interface %> type macvlan mode bridge |
     Then the step should succeed
     When I run command on the "<%= cb.target_node %>" node's sdn pod:
-       | sh | -c | ip link add <%= cb.nic_name2%> link <%= cb.default_interface %> type macvlan mode bridge |
+      | sh | -c | ip link add <%= cb.nic_name2%> link <%= cb.default_interface %> type macvlan mode bridge |
     Then the step should succeed
     Given I register clean-up steps:
     """
@@ -407,7 +407,7 @@ Feature: Multus-CNI related scenarios
     # Create the pod which consumes two hostdev custom resources
     Given I obtain test data file "networking/multus-cni/Pods/2interface-hostdevice-hostdevice.yaml"
     When I run oc create over "2interface-hostdevice-hostdevice.yaml" replacing paths:
-      | ["spec"]["nodeName"] | "<%= cb.target_node %>" |
+      | ["spec"]["nodeName"]                                       | "<%= cb.target_node %>"    |
       | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | host-device, host-device-2 |
     Then the step should succeed
     Given I register clean-up steps:
@@ -428,7 +428,7 @@ Feature: Multus-CNI related scenarios
     Then the output should contain "net1"
     And the output should contain "net2"
     And the output should contain 2 times:
-	    | macvlan mode bridge |
+      | macvlan mode bridge |
 
   # @author anusaxen@redhat.com
   # @case_id OCP-24488
@@ -441,18 +441,23 @@ Feature: Multus-CNI related scenarios
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-novlan.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-novlan.yaml |
-      | n | <%= project.name %>                                                                                                                              |
+      | n | <%= project.name %>           |
     Then the step should succeed
     #Creating no-vlan pod absorbing above net-attach-def
+    Given I store the ready and schedulable workers in the :nodes clipboard
+    And CNI vlan info is obtained on the "<%= cb.nodes[0].name %>" node
+    And evaluation of `@result[:parsed]` is stored in the :vlans_before clipboard
+    # force pod onto the node we already got CNI vlan information for
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"] | pod-novlan |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | bridge3    |
-      | ["spec"]["containers"][0]["name"] | pod-novlan |
+      | ["metadata"]["name"]                                       | pod-novlan              |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | bridge3                 |
+      | ["spec"]["containers"][0]["name"]                          | pod-novlan              |
+      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "pod-novlan" becomes ready
     And evaluation of `pod` is stored in the :pod clipboard
-    
+
     #Clean-up required to erase bridge interfcaes created on node after this step
     Given I register clean-up steps:
     """
@@ -464,9 +469,13 @@ Feature: Multus-CNI related scenarios
     #Entering into corresponding no eot make sure No VLAN ID information shown for secondary interface
     Given CNI vlan info is obtained on the "<%= cb.pod.node_name %>" node
     Then the step should succeed
-    And the output should contain 2 times:
-      | 1 PVID   |
-      | ntagged |
+    And evaluation of `@result[:parsed]` is stored in the :vlans_after clipboard
+    # check "ntagged" substring due to iproute2 changes,
+    # iproute2 before v4.19.0 should output "untagged"
+    # https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/bridge/vlan.c?h=v5.3.0&id=0f36267485e30099a4f735c3aadfa58b5efa1918
+    # after v4.19.0 it should output "Egress Untagged"
+    Given the number of bridge PVID 1 VLANs matching "ntagged" added between the :vlans_before and :vlans_after clipboards is 2
+
 
   # @author anusaxen@redhat.com
   # @case_id OCP-24489
@@ -480,7 +489,7 @@ Feature: Multus-CNI related scenarios
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-vlan-200.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-vlan-200.yaml |
-      | n | <%= project.name %>                                                                                                 |
+      | n | <%= project.name %>             |
     Then the step should succeed
     #Creating vlan pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
@@ -491,7 +500,7 @@ Feature: Multus-CNI related scenarios
     Then the step should succeed
     And the pod named "pod1-vlan200" becomes ready
     And evaluation of `pod` is stored in the :pod clipboard
-    
+
     #Clean-up required to erase bridge interfcaes created on node after this step
     Given I register clean-up steps:
     """
@@ -500,14 +509,14 @@ Feature: Multus-CNI related scenarios
     """
     When I execute on the pod:
       | /usr/sbin/ip | -d | link |
-    Then the output should contain: 
+    Then the output should contain:
       | net1 |
     #Entering into corresponding node to make sure VLAN ID information shown for interfaces
     Given CNI vlan info is obtained on the "<%= cb.pod.node_name %>" node
     Then the step should succeed
     And the output should contain:
       | 200 |
-    
+
   # @author anusaxen@redhat.com
   # @case_id OCP-24467
   @admin
@@ -515,18 +524,18 @@ Feature: Multus-CNI related scenarios
   Scenario: CNO manager mavlan configured manually with static
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
-    Given the default interface on nodes is stored in the :default_interface clipboard 
+    Given the default interface on nodes is stored in the :default_interface clipboard
     #Patching simplemacvlan config in network operator config CRD
     Given I have a project
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
-	    | {"spec":{"additionalNetworks":[{"name":"test-macvlan-case3","namespace":"<%= project.name %>","simpleMacvlanConfig":{"ipamConfig":{"staticIPAMConfig":{"addresses": [{"address":"10.128.2.100/23","gateway":"10.128.2.1"}]},"type":"static"},"master":"<%= cb.default_interface %>","mode":"bridge"},"type":"SimpleMacvlan"}]}} |
+      | {"spec":{"additionalNetworks":[{"name":"test-macvlan-case3","namespace":"<%= project.name %>","simpleMacvlanConfig":{"ipamConfig":{"staticIPAMConfig":{"addresses": [{"address":"10.128.2.100/23","gateway":"10.128.2.1"}]},"type":"static"},"master":"<%= cb.default_interface %>","mode":"bridge"},"type":"SimpleMacvlan"}]}} |
     #Cleanup for bringing CRD to original
     Given I register clean-up steps:
     """
-    Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with: 
-    | {"spec":{"additionalNetworks": null}} |
+    Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
+      | {"spec":{"additionalNetworks": null}} |
     """
- 
+
     And I wait up to 30 seconds for the steps to pass:
     """
     When I run the :get admin command with:
@@ -549,7 +558,7 @@ Feature: Multus-CNI related scenarios
     When I execute on the pod:
       | /usr/sbin/ip | -d | link |
     Then the output should contain "net1"
-    
+
   # @author anusaxen@redhat.com
   # @case_id OCP-21946
   @admin
@@ -564,16 +573,16 @@ Feature: Multus-CNI related scenarios
       | ["spec"]["config"]   | 'asdf'               |
     Then the step should fail
     And the output should contain:
-      | admission webhook "multus-validating-config.k8s.io" denied the request|
+      | admission webhook "multus-validating-config.k8s.io" denied the request |
     And admin ensures "macvlan-bridge-21756" network_attachment_definition is deleted from the "default" project after scenario
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
       | ["metadata"]["name"] | macvlan-bridge@$ |
     Then the step should fail
     And the output should contain:
-      |subdomain must consist of lower case alphanumeric characters|
+      | subdomain must consist of lower case alphanumeric characters |
     And admin ensures "macvlan-bridge@$" network_attachment_definition is deleted from the "default" project after scenario
-    
+
   # @author anusaxen@redhat.com
   # @case_id OCP-21949
   @admin
@@ -585,7 +594,7 @@ Feature: Multus-CNI related scenarios
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml"" replacing paths:
       | ["metadata"]["name"] | macvlan-bridge-21456 |
-    Then the step should succeed 
+    Then the step should succeed
     And admin ensures "macvlan-bridge-21456" network_attachment_definition is deleted from the "default" project after scenario
     # Create a pod consuming net-attach-def simulating wrong syntax in name
     Given I obtain test data file "networking/multus-cni/Pods/1interface-macvlan-bridge.yaml"
@@ -594,11 +603,11 @@ Feature: Multus-CNI related scenarios
     Then the step should fail
     And the output should contain:
       | subdomain must consist of lower case alphanumeric characters |
-    
+
   # @author anusaxen@redhat.com
   # @case_id OCP-21793
   @admin
-  Scenario: User cannot consume the net-attach-def created in other project which is namespace isolated	
+  Scenario: User cannot consume the net-attach-def created in other project which is namespace isolated
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     Given I have a project
@@ -608,8 +617,8 @@ Feature: Multus-CNI related scenarios
       | ["metadata"]["name"]      | macvlan-bridge-21793 |
       | ["metadata"]["namespace"] | <%= project.name %>  |
     Then the step should succeed
-    
-    # Creating pod in the another namespace which consumes the net-attach-def created in project1 namespace 
+
+    # Creating pod in the another namespace which consumes the net-attach-def created in project1 namespace
     Given I create a new project
     Given I obtain test data file "networking/multus-cni/Pods/1interface-macvlan-bridge.yaml"
     When I run oc create over "1interface-macvlan-bridge.yaml" replacing paths:
@@ -631,7 +640,7 @@ Feature: Multus-CNI related scenarios
   # @author anusaxen@redhat.com
   # @case_id OCP-24490
   @admin
-  @destructive	
+  @destructive
   Scenario: Pods can communicate each other with same vlan tag
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -640,15 +649,15 @@ Feature: Multus-CNI related scenarios
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-vlan.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-vlan.yaml |
-      | n | <%= project.name %>                                                                                                                               |
+      | n | <%= project.name %>         |
     Then the step should succeed
-    
+
     #Creating first pod in vlan 100
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                      | pod1-vlan100            |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"]| bridgevlan100           |
-      | ["spec"]["nodeName"]                                      | <%= cb.nodes[0].name %> |
+      | ["metadata"]["name"]                                       | pod1-vlan100            |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | bridgevlan100           |
+      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "pod1-vlan100" becomes ready
     #Clean-up required to erase bridge interfaces created due to above pod on same node
@@ -656,19 +665,19 @@ Feature: Multus-CNI related scenarios
     """
     the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[0].name %>" node
     the bridge interface named "mybridge.100" is deleted from the "<%= cb.nodes[0].name %>" node
-    """  
+    """
     And evaluation of `pod.name` is stored in the :pod1 clipboard
     And I execute on the pod:
       | ifconfig | net1 |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod1_net1_ip clipboard
-    
+
     #Creating 2nd pod on same node as first in vlan 100
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                      | pod2-vlan100            |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"]| bridgevlan100           |
-      | ["spec"]["nodeName"]                                      | <%= cb.nodes[0].name %> |
+      | ["metadata"]["name"]                                       | pod2-vlan100            |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | bridgevlan100           |
+      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "pod2-vlan100" becomes ready
     And evaluation of `pod.name` is stored in the :pod2 clipboard
@@ -676,13 +685,13 @@ Feature: Multus-CNI related scenarios
       | ifconfig | net1 |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod2_net1_ip clipboard
-    
+
     #Creating 3rd pod on different node in vlan 100
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                      | pod3-vlan100            |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"]| bridgevlan100           |
-      | ["spec"]["nodeName"]                                      | <%= cb.nodes[1].name %> |
+      | ["metadata"]["name"]                                       | pod3-vlan100            |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | bridgevlan100           |
+      | ["spec"]["nodeName"]                                       | <%= cb.nodes[1].name %> |
     Then the step should succeed
     And the pod named "pod3-vlan100" becomes ready
     #Clean-up required to erase bridge interfcaes created on node
@@ -690,26 +699,26 @@ Feature: Multus-CNI related scenarios
     """
     the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[1].name %>" node
     the bridge interface named "mybridge.100" is deleted from the "<%= cb.nodes[1].name %>" node
-    """  
+    """
     And evaluation of `pod.name` is stored in the :pod3 clipboard
     And I execute on the pod:
       | ifconfig | net1 |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod3_net1_ip clipboard
-    
+
     #making sure the pods on same node can ping while pods on diff nodes can't
     When I execute on the "<%= cb.pod1 %>" pod:
-      | arping | -I | net1 |-c1 | -w2 | <%= cb.pod2_net1_ip %> |
+      | arping | -I | net1 | -c1 | -w2 | <%= cb.pod2_net1_ip %> |
     Then the step should succeed
 
     When I execute on the "<%= cb.pod3 %>" pod:
-      | arping | -I | net1 |-c1 | -w2 | <%= cb.pod1_net1_ip %> |
+      | arping | -I | net1 | -c1 | -w2 | <%= cb.pod1_net1_ip %> |
     Then the step should fail
-    
+
     When I execute on the "<%= cb.pod3 %>" pod:
-      | arping | -I | net1 |-c1 | -w2 | <%= cb.pod2_net1_ip %> |
+      | arping | -I | net1 | -c1 | -w2 | <%= cb.pod2_net1_ip %> |
     Then the step should fail
-    
+
   # @author anusaxen@redhat.com
   # @case_id OCP-24491
   @admin
@@ -723,16 +732,16 @@ Feature: Multus-CNI related scenarios
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-vlan.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-vlan.yaml |
-      | n | <%= project.name %>                                                                                                                               |
-    Then the step should succeed 
-    
+      | n | <%= project.name %>         |
+    Then the step should succeed
+
     # Create the net-attach-def with vlan 200 via cluster admin
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-vlan-200.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-vlan-200.yaml |
-      | n | <%= project.name %>                                                                                                                                   |
-    Then the step should succeed 
-    
+      | n | <%= project.name %>             |
+    Then the step should succeed
+
     #Creating first pod in vlan 100
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
@@ -746,19 +755,19 @@ Feature: Multus-CNI related scenarios
     """
     the bridge interface named "mybridge" is deleted from the "<%= cb.nodes[0].name %>" node
     the bridge interface named "mybridge.100" is deleted from the "<%= cb.nodes[0].name %>" node
-    """  
+    """
     And evaluation of `pod.name` is stored in the :pod1 clipboard
     And I execute on the pod:
       | ifconfig | net1 |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod1_net1_ip clipboard
-    
+
     #Creating 2nd pod on same node as first in vlan 100
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                      | pod2-vlan100            |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"]| bridgevlan100           |
-      | ["spec"]["nodeName"]                                      | <%= cb.nodes[0].name %> |
+      | ["metadata"]["name"]                                       | pod2-vlan100            |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | bridgevlan100           |
+      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "pod2-vlan100" becomes ready
     And evaluation of `pod.name` is stored in the :pod2 clipboard
@@ -766,26 +775,26 @@ Feature: Multus-CNI related scenarios
       | ifconfig | net1 |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod2_net1_ip clipboard
-    
+
     #Creating 3rd pod on same node but in vlan 200
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                      | pod3-vlan200            |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"]| bridgevlan200           |
-      | ["spec"]["nodeName"]                                      | <%= cb.nodes[0].name %> |
+      | ["metadata"]["name"]                                       | pod3-vlan200            |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | bridgevlan200           |
+      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %> |
     Then the step should succeed
     And the pod named "pod3-vlan200" becomes ready
     #Clean-up required to erase bridge interfcaes created on same node above due to vlan pods
     Given I register clean-up steps:
     """
     the bridge interface named "mybridge.200" is deleted from the "<%= cb.nodes[0].name %>" node
-    """  
+    """
     And evaluation of `pod.name` is stored in the :pod3 clipboard
     And I execute on the pod:
       | ifconfig | net1 |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod3_net1_ip clipboard
-    
+
     #making sure the pods in same vlan can communicate but in different vlans cannot
     When I execute on the "<%= cb.pod1 %>" pod:
       | ping | -c1 | -W2 | <%= cb.pod2_net1_ip %> |
@@ -794,7 +803,7 @@ Feature: Multus-CNI related scenarios
     When I execute on the "<%= cb.pod2 %>" pod:
       | ping | -c1 | -W2 | <%= cb.pod1_net1_ip %> |
     Then the step should succeed
-    
+
     When I execute on the "<%= cb.pod1 %>" pod:
       | ping | -c1 | -W2 | <%= cb.pod3_net1_ip %> |
     Then the step should fail
@@ -802,11 +811,11 @@ Feature: Multus-CNI related scenarios
     When I execute on the "<%= cb.pod3 %>" pod:
       | ping | -c1 | -W2 | <%= cb.pod1_net1_ip %> |
     Then the step should fail
-    
+
     When I execute on the "<%= cb.pod3 %>" pod:
       | ping | -c1 | -W2 | <%= cb.pod2_net1_ip %> |
     Then the step should fail
-    
+
     When I execute on the "<%= cb.pod2 %>" pod:
       | ping | -c1 | -W2 | <%= cb.pod3_net1_ip %> |
     Then the step should fail
@@ -814,7 +823,7 @@ Feature: Multus-CNI related scenarios
   # @author anusaxen@redhat.com
   # @case_id OCP-24607
   @admin
-  Scenario: macvlan plugin without master parameter	
+  Scenario: macvlan plugin without master parameter
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def without master pmtr via cluster admin
@@ -822,7 +831,7 @@ Feature: Multus-CNI related scenarios
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-conf-without-master.yaml"
     When I run the :create admin command with:
       | f | macvlan-conf-without-master.yaml |
-      | n | <%= project.name %>                                                                                                                                    |
+      | n | <%= project.name %>              |
     Then the step should succeed
 
     #Creating a pod absorbing above net-attach-def
@@ -847,15 +856,15 @@ Feature: Multus-CNI related scenarios
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-ipandmac.yaml"
     When I run the :create admin command with:
-      | f | runtimeconfig-def-ipandmac.yaml                   |
-      | n | <%= project.name %>   |
+      | f | runtimeconfig-def-ipandmac.yaml |
+      | n | <%= project.name %>             |
     Then the step should succeed
 
     # Create a pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/runtimeconfig-pod-ipandmac.yaml"
     When I run the :create client command with:
       | f | runtimeconfig-pod-ipandmac.yaml |
-      | n | <%= project.name %>                                                                                                           |
+      | n | <%= project.name %>             |
     Then the step should succeed
     And the pod named "runtimeconfig-pod" becomes ready
 
@@ -863,8 +872,8 @@ Feature: Multus-CNI related scenarios
     When I execute on the pod:
       | /usr/sbin/ip | -d | link |
     Then the output should contain:
-      | net1                 |
-      | macvlan mode bridge  |
+      | net1                |
+      | macvlan mode bridge |
     When I execute on the pod:
       | /usr/sbin/ip | a |
     Then the output should contain:
@@ -886,7 +895,7 @@ Feature: Multus-CNI related scenarios
     #Cleanup for bringing CRD to original
     Given I register clean-up steps:
     """
-    as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with: 
+    as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
     | {"spec":{"additionalNetworks": null}} |
     """
     And admin ensures "bridge-ipam-dhcp" network_attachment_definition is deleted from the "openshift-multus" project after scenario
@@ -924,12 +933,12 @@ Feature: Multus-CNI related scenarios
     When I execute on the pod:
       | /usr/sbin/ip | a |
     Then the output should contain "88.8.8"
- 
+
   # @author anusaxen@redhat.com
   # @case_id OCP-24466
   @admin
   @destructive
-  Scenario: CNO manager macvlan configured manually with DHCP	
+  Scenario: CNO manager macvlan configured manually with DHCP
     Given the multus is enabled on the cluster
     And I store the masters in the :master clipboard
     And I store all worker nodes to the :worker clipboard
@@ -970,7 +979,7 @@ Feature: Multus-CNI related scenarios
     And I run commands on the host:
       | ping -c1 -W2 192.18.0.10 |
     Then the step should succeed
-    
+
     #Configuring DHCP service on master node
     Given a DHCP service is configured for interface "mvlanp0" on "<%= cb.master[0].name %>" node with address range and lease time as "192.18.0.100,192.18.0.120,24h"
     #Cleanup for deconfiguring DHCP service on target node
@@ -985,8 +994,8 @@ Feature: Multus-CNI related scenarios
     #Cleanup for bringing CRD to original
     Given I register clean-up steps:
     """
-    as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with: 
-    | {"spec":{"additionalNetworks": null}} |
+    as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
+      | {"spec":{"additionalNetworks": null}} |
     """
     #Creating pod under test project to absorb above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
@@ -1011,15 +1020,15 @@ Feature: Multus-CNI related scenarios
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-ip.yaml"
     When I run the :create admin command with:
-      | f | runtimeconfig-def-ip.yaml                                                                                                                           |
-      | n | <%= project.name %>                                                                                                     |
+      | f | runtimeconfig-def-ip.yaml |
+      | n | <%= project.name %>       |
     Then the step should succeed
-    
+
     # Create a pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/runtimeconfig-pod-ip.yaml"
     When I run the :create client command with:
       | f | runtimeconfig-pod-ip.yaml |
-      | n | <%= project.name %>                                                                                                     |
+      | n | <%= project.name %>       |
     Then the step should succeed
     And the pod named "runtimeconfig-pod-ip" becomes ready
 
@@ -1027,12 +1036,12 @@ Feature: Multus-CNI related scenarios
     When I execute on the pod:
       | /usr/sbin/ip | -d | link |
     Then the output should contain:
-      | net1                 |
-      | macvlan mode bridge  |
+      | net1                |
+      | macvlan mode bridge |
     When I execute on the pod:
       | /usr/sbin/ip | a |
     Then the output should contain:
-      | 192.168.22.2     |
+      | 192.168.22.2 |
 
   # @author weliang@redhat.com
   # @case_id OCP-25910
@@ -1045,14 +1054,14 @@ Feature: Multus-CNI related scenarios
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-mac.yaml"
     When I run the :create admin command with:
       | f | runtimeconfig-def-mac.yaml |
-      | n | <%= project.name %>                                                                                                                              |
+      | n | <%= project.name %>        |
     Then the step should succeed
-    
+
     # Create a pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/runtimeconfig-pod-mac.yaml"
     When I run the :create client command with:
       | f | runtimeconfig-pod-mac.yaml |
-      | n | <%= project.name %>                                                                                                      |
+      | n | <%= project.name %>        |
     Then the step should succeed
     And the pod named "runtimeconfig-pod-mac" becomes ready
     # Check created pod has correct MAC interface net1
@@ -1062,7 +1071,7 @@ Feature: Multus-CNI related scenarios
       | net1                |
       | macvlan mode bridge |
     When I execute on the pod:
-      | /usr/sbin/ip | a  |
+      | /usr/sbin/ip | a |
     Then the output should contain:
       | c2:b0:57:49:47:f1 |
 
@@ -1076,24 +1085,24 @@ Feature: Multus-CNI related scenarios
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/ipam-static.yaml"
     When I run oc create as admin over "ipam-static.yaml" replacing paths:
-      | ["metadata"]["namespace"]  | <%= project.name %> | 
-      | ["metadata"]["name"]       | bridge-static       |
-      | ["spec"]["config"]| '{ "cniVersion": "0.3.0", "type": "bridge", "ipam": {"type":"static","addresses": [{"address": "22.2.2.22/24","gateway": "22.2.2.1"}]}}' |
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                      |
+      | ["metadata"]["name"]      | bridge-static                                                                                                                            |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "bridge", "ipam": {"type":"static","addresses": [{"address": "22.2.2.22/24","gateway": "22.2.2.1"}]}}' |
     Then the step should succeed
-      
+
     # Create a pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/multus-default-route-pod.yaml"
     When I run the :create client command with:
       | f | multus-default-route-pod.yaml |
-      | n | <%= project.name %>                                                                                                         |
+      | n | <%= project.name %>           |
     Then the step should succeed
     And the pod named "multus-default-route-pod" becomes ready
 
     # Check created pod has correct default route
     When I execute on the pod:
-      | /usr/sbin/ip | route             |
+      | /usr/sbin/ip | route |
     Then the output should contain:
-      | default via 22.2.2.254 dev net1  |
+      | default via 22.2.2.254 dev net1 |
 
   # @author weliang@redhat.com
   # @case_id OCP-25917
@@ -1110,7 +1119,7 @@ Feature: Multus-CNI related scenarios
     When admin executes on the "<%=cb.pod_name%>" pod:
       | /usr/bin/curl | localhost:9091/metrics |
     Then the output should contain:
-      | network_attachment_definition_instances{networks="any"} 0 |  
+      | network_attachment_definition_instances{networks="any"} 0 |
 
     # Create the net-attach-def via cluster admin
     Given I switch to the first user
@@ -1119,15 +1128,15 @@ Feature: Multus-CNI related scenarios
 
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-mac.yaml"
     When I run the :create admin command with:
-      | f | runtimeconfig-def-mac.yaml                      |
-      | n | <%= project.name %> |
+      | f | runtimeconfig-def-mac.yaml |
+      | n | <%= project.name %>        |
     Then the step should succeed
 
     # Create a pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/runtimeconfig-pod-mac.yaml"
     When I run the :create client command with:
       | f | runtimeconfig-pod-mac.yaml |
-      | n | <%= project.name %>                                                                                                      |
+      | n | <%= project.name %>        |
     Then the step should succeed
     And the pod named "runtimeconfig-pod-mac" becomes ready
 
@@ -1136,9 +1145,9 @@ Feature: Multus-CNI related scenarios
     When admin executes on the "<%=cb.pod_name%>" pod:
       | /usr/bin/curl | localhost:9091/metrics |
     Then the output should contain:
-      | network_attachment_definition_instances{networks="any"} 1     | 
+      | network_attachment_definition_instances{networks="any"} 1     |
       | network_attachment_definition_instances{networks="macvlan"} 1 |
-   
+
     # Delete created pod and svc
     Given I switch to the first user
     Given I ensure "runtimeconfig-pod-mac" pod is deleted from the "<%= cb.usr_project%>" project
@@ -1160,7 +1169,7 @@ Feature: Multus-CNI related scenarios
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
       | ["metadata"]["name"]      | macvlan-bridge-25657    |
-      | ["metadata"]["namespace"] | <%= project(-1).name %> |    
+      | ["metadata"]["namespace"] | <%= project(-1).name %> |
     Then the step should succeed
     Given I use the "<%= project(-2).name %>" project
     # Create a pod in new project consuming net-attach-def from 1st project
@@ -1184,7 +1193,7 @@ Feature: Multus-CNI related scenarios
   # @author anusaxen@redhat.com
   # @case_id OCP-24492
   @admin
-  Scenario: Create pod with Multus ipvlan CNI plugin	
+  Scenario: Create pod with Multus ipvlan CNI plugin
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     And the default interface on nodes is stored in the :default_interface clipboard
@@ -1217,7 +1226,7 @@ Feature: Multus-CNI related scenarios
     And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod1_net1_ip clipboard
     And evaluation of `@result[:response].match(/\h+:\h+:\h+:\h+:\h+:\h+/)[0]` is stored in the :pod1_net1_mac clipboard
     And the expression should be true> cb.pod1_net1_mac==cb.default_interface_mac
-    
+
     #Creating pod2 absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
@@ -1245,10 +1254,10 @@ Feature: Multus-CNI related scenarios
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml"
     When I run oc create as admin over "whereabouts-macvlan.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %>          |    
-      | ["spec"]["config"]|'{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/30"} }' |
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                      |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/30"} }' |
     Then the step should succeed
-    
+
     # Create a pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
@@ -1266,9 +1275,9 @@ Feature: Multus-CNI related scenarios
       | macvlan mode bridge |
     # Check created pod has correct ip address on interface net1
     When I execute on the "macvlan-bridge-whereabouts-pod1" pod:
-      | /usr/sbin/ip | a  |
+      | /usr/sbin/ip | a |
     Then the output should contain:
-      | 192.168.22.101    |
+      | 192.168.22.101 |
 
     # Create second pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
@@ -1287,39 +1296,39 @@ Feature: Multus-CNI related scenarios
       | macvlan mode bridge |
     # Check created pod has correct ip address on interface net1
     When I execute on the "macvlan-bridge-whereabouts-pod2" pod:
-      | /usr/sbin/ip | a  |
+      | /usr/sbin/ip | a |
     Then the output should contain:
-      | 192.168.22.102    |
+      | 192.168.22.102 |
 
   # @author weliang@redhat.com
   # @case_id OCP-28518
   @admin
-  Scenario: Multus custom route change with route override	
+  Scenario: Multus custom route change with route override
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/route-override.yaml"
     When I run oc create as admin over "route-override.yaml" replacing paths:
-      | ["metadata"]["namespace"]  | <%= project.name %> | 
-      | ["metadata"]["name"]       | route-override      |
-      | ["spec"]["config"]         | '{ "cniVersion": "0.3.0", "name" : "mymacvlan", "plugins": [ { "type": "macvlan", "mode": "bridge", "ipam": { "type": "static", "addresses": [{"address": "192.168.20.2/24"}] } }, { "type" : "route-override", "addroutes": [ { "dst": "192.168.10.0/24" }] } ] }' |
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                 |
+      | ["metadata"]["name"]      | route-override                                                                                                                                                                                                                                                      |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "name" : "mymacvlan", "plugins": [ { "type": "macvlan", "mode": "bridge", "ipam": { "type": "static", "addresses": [{"address": "192.168.20.2/24"}] } }, { "type" : "route-override", "addroutes": [ { "dst": "192.168.10.0/24" }] } ] }' |
     Then the step should succeed
-      
+
     # Create a pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                       | route-override   |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | route-override   |
-      | ["spec"]["containers"][0]["name"]                          | route-override   |
+      | ["metadata"]["name"]                                       | route-override |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | route-override |
+      | ["spec"]["containers"][0]["name"]                          | route-override |
     Then the step should succeed
     And the pod named "route-override" becomes ready
 
     # Check created pod has correct default route
     When I execute on the "route-override" pod:
-      | /usr/sbin/ip | route         |
+      | /usr/sbin/ip | route |
     Then the output should contain:
-      | 192.168.10.0                 |
+      | 192.168.10.0 |
 
   # @author weliang@redhat.com
   # @case_id OCP-30054
@@ -1330,60 +1339,60 @@ Feature: Multus-CNI related scenarios
     # Create the net-attach-def in default namespace via cluster admin
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml"
     When I run oc create as admin over "whereabouts-macvlan.yaml" replacing paths:
-      | ["metadata"]["namespace"] | default                                                                                                                         |
-      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/24"} }'|
+      | ["metadata"]["namespace"] | default                                                                                                                          |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/24"} }' |
     Then the step should succeed
 
     #Cleanup created net-attach-def from default namespaces
     And admin ensures "macvlan-bridge-whereabouts" network_attachment_definition is deleted from the "default" project after scenario
-    
+
     # Create a pod absorbing above net-attach-def defined in default namespace
     Given I have a project
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                       | macvlan-bridge-whereabouts-pod1     |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | default/macvlan-bridge-whereabouts  |
-      | ["spec"]["containers"][0]["name"]                          | macvlan-bridge-whereabouts          |
+      | ["metadata"]["name"]                                       | macvlan-bridge-whereabouts-pod1    |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | default/macvlan-bridge-whereabouts |
+      | ["spec"]["containers"][0]["name"]                          | macvlan-bridge-whereabouts         |
     Then the step should succeed
     And the pod named "macvlan-bridge-whereabouts-pod1" becomes ready
-    
+
   # @author weliang@redhat.com
   # @case_id OCP-29742
   @admin
-  Scenario: Log pod IP and pod UUID when pod start	
+  Scenario: Log pod IP and pod UUID when pod start
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml"
     When I run oc create as admin over "whereabouts-macvlan.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %>      |    
-      | ["spec"]["config"]        |'{ "cniVersion": "0.3.0", "type": "macvlan","mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/24"} }' |
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                             |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan","mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/24"} }' |
     Then the step should succeed
-    
+
     # Create a pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                       | macvlan-bridge-whereabouts-pod1  |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | macvlan-bridge-whereabouts       |
-      | ["spec"]["containers"][0]["name"]                          | macvlan-bridge-whereabouts       |
-      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %>          |
+      | ["metadata"]["name"]                                       | macvlan-bridge-whereabouts-pod1 |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | macvlan-bridge-whereabouts      |
+      | ["spec"]["containers"][0]["name"]                          | macvlan-bridge-whereabouts      |
+      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %>         |
     Then the step should succeed
     And the pod named "macvlan-bridge-whereabouts-pod1" becomes ready
     And evaluation of `pod.ip` is stored in the :pod_eth0_ip clipboard
 
     When I run the :get admin command with:
-      | resource      | pod                                |
-      | n             | <%= project.name %>                |
-      | o             | jsonpath={.items[*].metadata.uid}  |
+      | resource | pod                               |
+      | n        | <%= project.name %>               |
+      | o        | jsonpath={.items[*].metadata.uid} |
     Then the step should succeed
     And evaluation of `@result[:response]` is stored in the :pod_uid clipboard
-   
+
     And I execute on the "macvlan-bridge-whereabouts-pod1" pod:
       | bash | -c | /usr/sbin/ip addr show net1 |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod_net1_ip clipboard
-    
+
     Given I use the "<%= cb.nodes[0].name %>" node
     And I run commands on the host:
       | journalctl -u crio \| grep verbose.*macvlan-bridge-whereabouts-pod1 |
@@ -1392,11 +1401,11 @@ Feature: Multus-CNI related scenarios
       | <%= project.name %>:macvlan-bridge-whereabouts-pod1:<%= cb.pod_uid %> |
       | <%= cb.pod_eth0_ip %>                                                 |
       | <%= cb.pod_net1_ip %>                                                 |
-      
+
   # @author weliang@redhat.com
   # @case_id OCP-31999
   @admin
-  Scenario: Whereabouts with exclude IP address	
+  Scenario: Whereabouts with exclude IP address
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
@@ -1405,7 +1414,7 @@ Feature: Multus-CNI related scenarios
     When I run oc create as admin over "whereabouts-excludeIP.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %> |
     Then the step should succeed
-    
+
     # Create a pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
@@ -1414,7 +1423,7 @@ Feature: Multus-CNI related scenarios
       | ["spec"]["containers"][0]["name"]                          | whereabouts-excludeip           |
     Then the step should succeed
     And the pod named "macvlan-bridge-whereabouts-pod1" becomes ready
-    # Check the created pod has correct ip 
+    # Check the created pod has correct ip
     When I execute on the "macvlan-bridge-whereabouts-pod1" pod:
       | bash | -c | /usr/sbin/ip -4 -brief a |
     Then the output should contain:
@@ -1428,12 +1437,12 @@ Feature: Multus-CNI related scenarios
       | ["spec"]["containers"][0]["name"]                          | whereabouts-excludeip           |
     Then the step should succeed
     And the pod named "macvlan-bridge-whereabouts-pod2" becomes ready
-    # Check the created pod has correct ip 
+    # Check the created pod has correct ip
     When I execute on the "macvlan-bridge-whereabouts-pod2" pod:
       | bash | -c | /usr/sbin/ip -4 -brief a |
     Then the output should contain:
       | 192.168.10.5 |
-      
+
     # Create third pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
@@ -1463,7 +1472,7 @@ Feature: Multus-CNI related scenarios
       | ["metadata"]["namespace"] | <%= project.name %>    |
       | ["metadata"]["name"]      | whereabouts-shortrange |
     Then the step should succeed
-    
+
     # Create a pod absorbing above net-attach-def
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
@@ -1484,7 +1493,7 @@ Feature: Multus-CNI related scenarios
       | ["metadata"]["name"]      | whereabouts-largerange |
       | ["spec"]["config"]        |'{ "cniVersion": "0.3.0", "type": "macvlan","mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.42.0/24"} }' |
     Then the step should succeed
-    
+
     # Create a pod absorbing above net-attach-def
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
       | ["metadata"]["name"]                                       | whereabouts-largerange-pod1 |
@@ -1511,7 +1520,7 @@ Feature: Multus-CNI related scenarios
       | ["spec"]["containers"][0]["name"]                          | whereabouts-largerange      |
     Then the step should succeed
     And the pod named "whereabouts-largerange-pod2" becomes ready
- 
+
     # Check third pod which has correct ip
     When I execute on the "whereabouts-shortrange-pod2" pod:
       | bash | -c | /usr/sbin/ip -4 -brief a |


### PR DESCRIPTION
We keep getting automation failures because of existing VLANs
before the test.

Dump the VLAN information before we run the test.
To do this we have to pick a node first, then put the pod
on that node.

Failures:

```
/sbin/bridge\ vlan\ show
port	vlan ids
cni0	 1 PVID Egress Untagged

bridge3	 1 PVID Egress Untagged

veth9056d1f1	 1 PVID Egress Untagged
```