### PR TITLE
Automate BZ-1827377

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1291,21 +1291,8 @@ Feature: Multus-CNI related scenarios
     Given I switch to the first user
     And I create a new project
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"] | macvlan-bridge-whereabouts-pod1                                           |
+      | ["metadata"]["name"]                                       | macvlan-bridge-whereabouts-pod1     |
       | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | default/macvlan-bridge-whereabouts  |
-      | ["spec"]["containers"][0]["name"] | macvlan-bridge-whereabouts                                   |
+      | ["spec"]["containers"][0]["name"]                          | macvlan-bridge-whereabouts          |
     Then the step should succeed
     And the pod named "macvlan-bridge-whereabouts-pod1" becomes ready
-
-    # Check created pod will not has namespace isolation logs
-    And I wait up to 30 seconds for the steps to pass:
-    """
-    When I run the :describe client command with:
-      | resource | events                           |
-      | name     | macvlan-bridge-whereabouts-pod1  |
-      | n        | <%= cb.project_name %>           |
-    Then the step should succeed
-    And the output should not contain:
-      | namespace isolation |
-      | violat              |
-    """

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1270,7 +1270,7 @@ Feature: Multus-CNI related scenarios
   Scenario: Multus namespaceIsolation should allow references to CRD in the default namespace
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
-    # Create the net-attach-def via cluster admin
+    # Create the net-attach-def in default namespace via cluster admin
     When I run oc create as admin over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml" replacing paths:
       | ["metadata"]["namespace"] | default                                                                                                                         |
       | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/24"} }'|
@@ -1279,9 +1279,8 @@ Feature: Multus-CNI related scenarios
     #Cleanup created net-attach-def from default namespaces
     And admin ensures "macvlan-bridge-whereabouts" network_attachment_definition is deleted from the "default" project after scenario
     
-    # Create a pod absorbing above net-attach-def
-    Given I switch to the first user
-    And I create a new project
+    # Create a pod absorbing above net-attach-def defined in default namespace
+    Given I have a project
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
       | ["metadata"]["name"]                                       | macvlan-bridge-whereabouts-pod1     |
       | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | default/macvlan-bridge-whereabouts  |

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -12,7 +12,7 @@ Feature: Multus-CNI related scenarios
     # Create the net-attach-def via cluster admin
     Given I have a project
     When I run oc create as admin over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %>  |    
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |    
       | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |
     Then the step should succeed
 
@@ -1271,21 +1271,13 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
-    Given I switch to cluster admin pseudo user
-    And I use the "default" project
     When I run oc create as admin over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %>     |
+      | ["metadata"]["namespace"] | default                                                                                                                         |
       | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/24"} }'|
     Then the step should succeed
 
     #Cleanup created net-attach-def from default namespaces
-    Given I register clean-up steps:
-    """
-    I run the :delete admin command with:
-      | object_type       | net-attach-def             |
-      | object_name_or_id | macvlan-bridge-whereabouts |
-    the step should succeed
-    """
+    And admin ensures "macvlan-bridge-whereabouts" network_attachment_definition is deleted from the "default" project after scenario
     
     # Create a pod absorbing above net-attach-def
     Given I switch to the first user

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -12,8 +12,8 @@ Feature: Multus-CNI related scenarios
     # Create the net-attach-def via cluster admin
     Given I have a project
     When I run oc create as admin over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %> |    
-      | ["spec"]["config"]| '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |
+      | ["metadata"]["namespace"] | <%= project.name %>  |    
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "host-local", "subnet": "10.1.1.0/24", "rangeStart": "10.1.1.100", "rangeEnd": "10.1.1.200", "routes": [ { "dst": "0.0.0.0/0" } ], "gateway": "10.1.1.1" } }' |
     Then the step should succeed
 
     # Create the first pod which consumes the macvlan custom resource
@@ -1274,8 +1274,8 @@ Feature: Multus-CNI related scenarios
     Given I switch to cluster admin pseudo user
     And I use the "default" project
     When I run oc create as admin over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %>  |     
-      | ["spec"]["config"]|'{ "cniVersion": "0.3.0", "type": "macvlan", "mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/24"} }'|
+      | ["metadata"]["namespace"] | <%= project.name %>     |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.0", "type": "macvlan", "mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/24"} }'|
     Then the step should succeed
 
     #Cleanup created net-attach-def from default namespaces


### PR DESCRIPTION
Automate: Bug 1827377 - Multus namespaceIsolation should allow references to CRD in the default namespace

Test log: https://privatebin-it-iso.int.open.paas.redhat.com/?b24f41d3c9134d49#d8cj4BjfWcni7BrV1LYS7QTae8vBExEMhC5PM/ri2qY=

@anuragthehatter @rbbratta @zhaozhanqi @huiran0826
Please help to review, thanks!