### PR TITLE
fix wrong arguement

### DIFF
--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -1,6 +1,6 @@
 Given(/^I pick a random machineset to scale$/) do
   ensure_admin_tagged
-  machine_sets = BushSlicer::MachineSet.list(user: admin, project: project("openshift-machine-api"))
+  machine_sets = BushSlicer::MachineSet.list(user: admin, project: project("openshift-machine-api")).
     select { |ms| ms.available_replicas >= 1 }
   cache_resources *machine_sets.shuffle
 end


### PR DESCRIPTION
@jhou1 @miyadav Please help to review, this will fix the below error: 
```
      wrong number of arguments (given 0, expected 1..4) (ArgumentError)
      /home/jenkins/workspace/Runner-v3/features/step_definitions/machine_set.rb:4:in `select'
      /home/jenkins/workspace/Runner-v3/features/step_definitions/machine_set.rb:4:in `/^I pick a random machineset to scale$/'
      /opt/rh/rh-ruby26/root/usr/share/ruby/forwardable.rb:230:in `invoke_dynamic_step'
      /home/jenkins/workspace/Runner-v3/features/step_definitions/machine_set.rb:62:in `/^I clone a machineset named "([^"]*)"$/'
      features/machine/machine.feature:128:in `And I clone a machineset named "machineset-clone-27609"'
```
Test: https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/90659/console
