### PR TITLE
support for 4.5

### DIFF
--- a/features/step_definitions/operators.rb
+++ b/features/step_definitions/operators.rb
@@ -26,6 +26,35 @@ Given /^the status of condition "([^"]*)" for "([^"]*)" operator is: (.+)$/ do |
   end
 end
 
+Given /^the marketplace works well$/ do
+  ensure_admin_tagged
+  if env.version_lt("4.5", user: user)
+    step %Q/I run the :get admin command with:/, table(%{
+      | resource       | packagemanifest |
+      | all_namespaces | true            |
+    })
+    step %Q/the output should contain:/, table(%{
+      | Community Operators  |
+      | Red Hat Operators    |
+      | Certified Operators  |
+      | Test Operators       |
+      | CSC Operators        |
+    })
+  else
+    step %Q/I run the :get client command with:/, table(%{
+      | resource       | packagemanifest |
+      | all_namespaces | true            |
+    })
+    step %Q/the output should contain:/, table(%{
+      | Community Operators  |
+      | Red Hat Operators    |
+      | Certified Operators  |
+      | Test Operators       |
+    })
+  end
+
+end
+
 Given /^the status of condition Upgradeable for marketplace operator as expected$/ do
   ensure_admin_tagged
   cluster_version = cluster_version('version').channel.split('-')[1]
@@ -35,7 +64,7 @@ Given /^the status of condition Upgradeable for marketplace operator as expected
     actual_status = cluster_operator('marketplace').condition(type: 'Upgradeable', cached: false)['status']
   end
   status = 'True'
-  if cluster_version == "4.4"
+  if cluster_version.to_f >= "4.4".to_f
     csc_items = Array.new
     os_items = Array.new
     if custom_resource_definition('catalogsourceconfigs.operators.coreos.com').exists?

--- a/features/upgrade/marketplace/upgrade.feature
+++ b/features/upgrade/marketplace/upgrade.feature
@@ -13,35 +13,27 @@ Feature: Marketplace related scenarios
     Given the status of condition "Degraded" for "marketplace" operator is: False
     Given the status of condition "Progressing" for "marketplace" operator is: False
     Given the status of condition "Available" for "marketplace" operator is: True
-    # In 4.4, if exists csc or cutomize operatorsource objects, the status should be `False`
+    # In 4.4+, if exists csc or cutomize operatorsource objects, the status should be `False`
     Given the status of condition Upgradeable for marketplace operator as expected
     Given I switch to cluster admin pseudo user
     # Create a new OperatorSource
     When I process and create:
       | f | <%= BushSlicer::HOME %>/testdata/olm/operatorsource-template.yaml |
-      | p | NAME=test-operators                                                     |
-      | p | SECRET=                                                                 |
-      | p | DISPLAYNAME=Test Operators                                              |
-      | p | REGISTRY=jiazha                                                         |
+      | p | NAME=test-operators                                               |
+      | p | SECRET=                                                           |
+      | p | DISPLAYNAME=Test Operators                                        |
+      | p | REGISTRY=jiazha                                                   |
     Then the step should succeed
     # Create a new CatalogSourceConfig
     When I process and create:
       | f | <%= BushSlicer::HOME %>/testdata/olm/csc-template.yaml            |
-      | p | PACKAGES=codeready-toolchain-operator                                   |
-      | p | DISPLAYNAME=CSC Operators                                               |
+      | p | PACKAGES=codeready-toolchain-operator                             |
+      | p | DISPLAYNAME=CSC Operators                                         |
     Then the step should succeed
     # Check if the marketplace works well
-    And I wait up to 240 seconds for the steps to pass:
+    And I wait up to 360 seconds for the steps to pass:
     """
-    When I run the :get client command with:
-      | resource       | packagemanifest |
-      | all_namespaces | true            |
-    Then the output should contain:
-      | Community Operators  |
-      | Red Hat Operators    |
-      | Certified Operators  |
-      | Test Operators       |
-      | CSC Operators        |
+    Given the marketplace works well
     """
 
   @admin
@@ -54,19 +46,11 @@ Feature: Marketplace related scenarios
     Given the status of condition "Degraded" for "marketplace" operator is: False
     Given the status of condition "Progressing" for "marketplace" operator is: False
     Given the status of condition "Available" for "marketplace" operator is: True
-    # In 4.4, if exists csc or cutomize operatorsource objects, the status should be `False`
+    # In 4.4+, if exists csc or cutomize operatorsource objects, the status should be `False`
     Given the status of condition Upgradeable for marketplace operator as expected
     Given I switch to cluster admin pseudo user
     # Check if the marketplace works well
-    And I wait up to 240 seconds for the steps to pass:
+    And I wait up to 360 seconds for the steps to pass:
     """
-    When I run the :get client command with:
-      | resource       | packagemanifest |
-      | all_namespaces | true            |
-    Then the output should contain:
-      | Community Operators  |
-      | Red Hat Operators    |
-      | Certified Operators  |
-      | Test Operators       |
-      | CSC Operators        |
+    Given the marketplace works well
     """


### PR DESCRIPTION
Fix issue: https://issues.redhat.com/browse/OCPQE-364, the CSC resource is deprecated in 4.5.

Before the upgrade, logs: http://pastebin.test.redhat.com/864064
After the upgrade, logs: http://pastebin.test.redhat.com/864092
