### PR TITLE
Improve cloud tests

### DIFF
--- a/features/machine/autoscaler.feature
+++ b/features/machine/autoscaler.feature
@@ -7,14 +7,12 @@ Feature: Cluster Autoscaler Tests
   Scenario: Cluster should automatically scale up and scale down with clusterautoscaler deployed
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
-
-    Given I store the number of machines in the :num_to_restore clipboard
-    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
 
     Given I clone a machineset and name it "machineset-clone-28108"
 
     # Create clusterautoscaler
-    Given I use the "openshift-machine-api" project
     When I run the :create admin command with:
       | f | <%= BushSlicer::HOME %>/testdata/cloud/cluster-autoscaler.yml |
     Then the step should succeed
@@ -60,6 +58,7 @@ Feature: Cluster Autoscaler Tests
   Scenario: Cao listens and deploys cluster-autoscaler based on ClusterAutoscaler resource
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
 
     When I run the :create admin command with:
       | f | <%= BushSlicer::HOME %>/testdata/cloud/cluster-autoscaler.yml |
@@ -75,11 +74,9 @@ Feature: Cluster Autoscaler Tests
   Scenario: CAO listens and annotations machineSets based on MachineAutoscaler resource
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
 
-    Given I store the number of machines in the :num_to_restore clipboard
-    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
-
-    Given I use the "openshift-machine-api" project
     Given I clone a machineset and name it "machineset-clone-21517"
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/cloud/machine-autoscaler.yml" replacing paths:
       | ["metadata"]["name"]               | maotest                 |
@@ -112,11 +109,9 @@ Feature: Cluster Autoscaler Tests
   Scenario: Update machineAutoscaler to reference a different MachineSet
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
 
-    Given I store the number of machines in the :num_to_restore clipboard
-    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
-
-    Given I use the "openshift-machine-api" project
     Given I clone a machineset and name it "machineset-clone-22102"
     And evaluation of `machine_set.name` is stored in the :machineset_clone_22102 clipboard
     Given I clone a machineset and name it "machineset-clone-22102-2"
@@ -183,11 +178,9 @@ Feature: Cluster Autoscaler Tests
   Scenario: Machineautoscaler can be deleted when its referenced machineset does not exist
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
 
-    Given I store the number of machines in the :num_to_restore clipboard
-    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
-
-    Given I use the "openshift-machine-api" project
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/cloud/machine-autoscaler.yml" replacing paths:
       | ["metadata"]["name"]               | maotest |
       | ["spec"]["minReplicas"]            | 1       |
@@ -195,4 +188,3 @@ Feature: Cluster Autoscaler Tests
       | ["spec"]["scaleTargetRef"]["name"] | invalid |
     Then the step should succeed
     And admin ensures "maotest" machineautoscaler is deleted
-

--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -30,9 +30,8 @@ Feature: Machine features testing
   Scenario: Scale up and scale down a machineSet
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
-
-    Given I store the number of machines in the :num_to_restore clipboard
-    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
 
     Given I clone a machineset and name it "machineset-clone-25436"
 
@@ -99,12 +98,15 @@ Feature: Machine features testing
       | type          | merge                                  |
       | n             | openshift-machine-api                  |
     Then the step should succeed
+    And I wait up to 30 seconds for the steps to pass:
+    """
     When I run the :describe admin command with:
       | resource      | machine                                |
       | name          | <%= cb.machine %>                      |
       | n             | openshift-machine-api                  |
     Then the step should succeed
     And the output should match "Provider ID:\s+<%= cb.providerID %>"
+    """
 
   # @author miyadav@redhat.com
   # @case_id OCP-27627
@@ -121,11 +123,10 @@ Feature: Machine features testing
   Scenario: Scaling a machineset with providerSpec.publicIp set to true
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
 
-    Given I store the number of machines in the :num_to_restore clipboard
-    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
-
-    And I clone a machineset and name it "machineset-clone-27609"
+    Given I clone a machineset and name it "machineset-clone-27609"
 
     Then I run the :get admin command with:
      | resource      | machineset             |
@@ -153,7 +154,9 @@ Feature: Machine features testing
   Scenario: [MAO] Reconciling machine taints with nodes
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
-    
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
+
     Given I clone a machineset and name it "machineset-24363"
     And evaluation of `machine_set.machines.first.node_name` is stored in the :noderef_name clipboard
     And evaluation of `machine_set.machines.first.name` is stored in the :machine_name clipboard
@@ -182,16 +185,14 @@ Feature: Machine features testing
   Scenario Outline: Required configuration should be added to the ProviderSpec to enable spot instances
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
-
-    Given I store the number of machines in the :num_to_restore clipboard
-    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
+    And admin ensures machine number is restored after scenario
 
     #Create a spot machineset
     Given I use the "openshift-machine-api" project
     Given I create a spot instance machineset named "<machineset_name>" on <iaas_type>
     And evaluation of `machine_set.machines.first.node_name` is stored in the :noderef_name clipboard
     And evaluation of `machine_set.machines.first.name` is stored in the :machine_name clipboard
-    
+
     #Check machine and node were labelled as an `interruptible-instance`
     When I run the :describe admin command with:
       | resource | machine                |

--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -7,8 +7,10 @@ Feature: MachineHealthCheck Test Scenarios
   Scenario: Remediation should be applied when the unhealthyCondition 'Ready' is met
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
-    Given I use the "openshift-machine-api" project
-    And I clone a machineset and name it "machineset-25897"
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
+
+    Given I clone a machineset and name it "machineset-clone-25897"
 
     # Create MHC
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/cloud/mhc/mhc1.yaml" replacing paths:
@@ -39,8 +41,10 @@ Feature: MachineHealthCheck Test Scenarios
   Scenario: Create a machinehealthcheck when there is already an unhealthy machine
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-26311"
+    Given I clone a machineset and name it "machineset-clone-26311"
 
     # Create unhealthyCondition before createing a MHC
     Given I create the 'Ready' unhealthyCondition
@@ -63,8 +67,10 @@ Feature: MachineHealthCheck Test Scenarios
   Scenario: Create multiple MHCs to monitor same machineset
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-25734"
+    Given I clone a machineset and name it "machineset-clone-25734"
 
     # Create MHCs
     Given I run the steps 2 times:
@@ -89,10 +95,9 @@ Feature: MachineHealthCheck Test Scenarios
   Scenario: Use "maxUnhealthy" to prevent automated remediation
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
-    Given I store the number of machines in the :num_to_restore clipboard
-    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
-    Given I use the "openshift-machine-api" project
-    And I clone a machineset and name it "machineset-25691"
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
+    Given I clone a machineset and name it "machineset-clone-25691"
 
     # Create MHC
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/cloud/mhc/mhc1.yaml" replacing paths:

--- a/features/step_definitions/machine_healthcheck.rb
+++ b/features/step_definitions/machine_healthcheck.rb
@@ -32,8 +32,8 @@ end
 
 Then(/^the machine should be remediated$/) do
   # unhealthy machine and should be deleted
-  step %Q{I wait for the resource "node" named "<%= machine.node_name %>" to disappear within 900 seconds}
-  step %Q{I wait for the resource "machine" named "<%= machine.name %>" to disappear within 900 seconds}
+  #step %Q{I wait for the resource "node" named "<%= machine.node_name %>" to disappear within 900 seconds}
+  step %Q{I wait for the resource "machine" named "<%= machine.name %>" to disappear within 1200 seconds}
 
   # new machine and node should provisioned
   step %Q{the machineset should have expected number of running machines}

--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -59,9 +59,7 @@ Feature: Machine-api components upgrade tests
   Scenario: Scale up and scale down a machineSet after upgrade
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
-
-    Given I store the number of machines in the :num_to_restore clipboard
-    And admin ensures node number is restored to "<%= cb.num_to_restore %>" after scenario
+    And I use the "openshift-machine-api" project
 
     Given I clone a machineset and name it "machineset-clone-22612"
 

--- a/lib/openshift/machine.rb
+++ b/lib/openshift/machine.rb
@@ -42,5 +42,10 @@ module BushSlicer
         dig('status','providerStatus','instanceState')
       instance_state == 'running'
     end
+
+    def deleting?(user: nil, cached: true, quiet: false)
+      ! raw_resource(user: user, cached: cached, quiet: quiet).
+          dig('metadata', 'deletionTimestamp').nil?
+    end
   end
 end


### PR DESCRIPTION
As suggested by @sunzhaohua2 and @miyadav in test tear down we only have to wait machine to be deleted because machine will be deleted only after node is deleted. Updated the the code with fixes to several logic. Have been testing them for more than a week on different cloud.