### PR TITLE
Add the test of clusterservicebroker

### DIFF
--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -6,6 +6,9 @@ Feature: Service-catalog related scenarios
   @destructive
   Scenario: service-catalog walkthrough example
     Given I have a project
+    When I run the :get admin command with:
+      | resource | clusterservicebroker |
+    Then the step should succeed
     And evaluation of `project.name` is stored in the :ups_broker_project clipboard
     And I create a new project
     And evaluation of `project.name` is stored in the :user_project clipboard


### PR DESCRIPTION
Let the run-test failed without "Test Execution will finish prematurely" if the cluster doesn't enable svcat.
test result:
**### 1. the cluster disable svcat**
   [09:38:42] INFO> Exit Status: 1
      | resource | clusterservicebroker |
    Then the step should succeed                                                                          # features/step_definitions/common.rb:4
      the step failed (RuntimeError)
      /home/jenkins/workspace/Runner-v3/features/step_definitions/common.rb:6:in `/^the step should( not)? (succeed|fail)$/'
      features/svc-catalog_asb/svc-catalog.feature:11:in `Then the step should succeed'
      [09:38:50] INFO> Exit Status: 0
      [09:38:50] INFO> === End After Scenario: service-catalog walkthrough example ===

Failing Scenarios:
cucumber -p polarshift -p dir_embedder features/svc-catalog_asb/svc-catalog.feature:7 # Scenario: service-catalog walkthrough example

1 scenario (1 failed)
34 steps (1 failed, 31 skipped, 2 passed)

### 2. the cluster enable svcat
# @case_id OCP-15600
  @admin @destructive
  Scenario: service-catalog walkthrough example                                                           # features/svc-catalog_asb/svc-catalog.feature:7
      [09:19:37] INFO> === Before Scenario: service-catalog walkthrough example ===
      [09:19:37] INFO> === End Before Scenario: service-catalog walkthrough example ===
    Given I have a project              
      [09:20:27] INFO> Exit Status: 1
      [09:20:27] INFO> Step: the step should fail
      [09:20:27] INFO> cleaning-up user testuser-0 projects
      [09:20:27] INFO> Shell Commands: oc delete projects --all --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_testuser-0.kubeconfig
      project.project.openshift.io "he-mn" deleted
      project.project.openshift.io "ty-07" deleted
      
      [09:20:27] INFO> Exit Status: 0
      [09:20:27] INFO> waiting up to 30 seconds for user clean-up to take place
      [09:20:33] INFO> REST delete_oauthaccesstoken for user 'BushSlicer::APIAccessor:testuser-0@ocp4', base_opts: {:options=>{:api_version=>"v1", :accept=>"application/json", :content_type=>"application/json", :oauth_token=>"AWwvV8mTXsObLjQWVW99VqCSfi7rcQjXSNgVlYyTKgE"}, :base_url=>"https://api.stage44-wduan.qe.devcluster.openshift.com:6443", :headers=>{"Accept"=>"<accept>", "Content-Type"=>"<content_type>", "Authorization"=>"Bearer <oauth_token>"}}, opts: {:token_to_delete=>"AWwvV8mTXsObLjQWVW99VqCSfi7rcQjXSNgVlYyTKgE"}
      [09:20:33] INFO> HTTP DELETE https://api.stage44-wduan.qe.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthaccesstokens/AWwvV8mTXsObLjQWVW99VqCSfi7rcQjXSNgVlYyTKgE
      [09:20:33] INFO> HTTP DELETE took 0.050 sec: 200 OK | application/json 235 bytes
      
      [09:20:33] INFO> Shell Commands: rm -r -f -- /home/jenkins/workspace/Runner-v3/workdir
      
      [09:20:33] INFO> Exit Status: 0
      [09:20:33] INFO> === End After Scenario: service-catalog walkthrough example ===

1 scenario (1 passed)
34 steps (34 passed)
0m57.101s

