### PR TITLE
fix namespaces aos-qe-ci not found

### DIFF
--- a/features/upgrade/marketplace/upgrade.feature
+++ b/features/upgrade/marketplace/upgrade.feature
@@ -20,6 +20,7 @@ Feature: Marketplace related scenarios
     When I process and create:
       | f | <%= BushSlicer::HOME %>/testdata/olm/operatorsource-template.yaml |
       | p | NAME=test-operators                                               |
+      | p | NAMESPACE=openshift-marketplace                                   |
       | p | SECRET=                                                           |
       | p | DISPLAYNAME=Test Operators                                        |
       | p | REGISTRY=jiazha                                                   |


### PR DESCRIPTION
Set the value of the `NAMESPACE` instread of the default. to fix the errors below:
qe-openshift.usersys.redhat.com/userContent/cucushift/v3/2020/05/15/08:03:03/upgrade_Marketplace_-_prepare/console.html
```
WhenI process and create: ==>@  features/step_definitions/cli.rb:143
f	<%= BushSlicer::HOME %>/testdata/olm/operatorsource-template.yaml
p	NAME=test-operators
p	SECRET=
p	DISPLAYNAME=Test Operators
p	REGISTRY=jiazha
08:03:19 INFO> Shell Commands: oc process -f /home/jenkins/workspace/Runner-v3/testdata/olm/operatorsource-template.yaml -p NAME\=test-operators -p SECRET\= -p DISPLAYNAME\=Test\ Operators -p REGISTRY\=jiazha --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig
STDERR:
error: unable to process template
  namespaces "aos-qe-ci" not found
08:03:19 INFO> Exit Status: 1
```