### PR TITLE
check inf first and then perform operation

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -733,7 +733,7 @@ Given /^the bridge interface named "([^"]*)" is deleted from the "([^"]*)" node$
   ensure_admin_tagged
   node = node(node_name)
   host = node.host
-  @result = host.exec_admin("/sbin/ip link delete #{bridge_name}")
+  @result = host.exec_admin("if ip addr show  #{bridge_name};then ip link delete #{bridge_name};else echo #{bridge_name} does not exist on this node;fi")
   raise "Failed to delete bridge interface" unless @result[:success]
 end
 

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -731,9 +731,13 @@ end
 
 Given /^the bridge interface named "([^"]*)" is deleted from the "([^"]*)" node$/ do |bridge_name, node_name|
   ensure_admin_tagged
+  check_and_delete_inf= %Q(if ip addr show  #{bridge_name};
+                           then 
+                              ip link delete #{bridge_name};
+                           fi)
   node = node(node_name)
   host = node.host
-  @result = host.exec_admin("if ip addr show  #{bridge_name};then ip link delete #{bridge_name};else echo #{bridge_name} does not exist on this node;fi")
+  @result = host.exec_admin(check_and_delete_inf)
   raise "Failed to delete bridge interface" unless @result[:success]
 end
 


### PR DESCRIPTION
Quick fix to avoid few test execution premature errors we have been seeing few times or rarely due to this particular step. In test env like all-in-one (node acting as both worker and master). a test interface or bridge is tried to be deleted couple of times and hence tests exit prematurely when it tries to delete an already deleted interface or bridge. This will solve this issue. Thanks
re-ran the tests to make sure
@rbbratta @zhaozhanqi @weliang1 @huiran0826 