### PR TITLE
merger OCP-29389 into OCP-29199 

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -189,7 +189,7 @@ Feature: Machine features testing
 
     #Create a spot machineset
     Given I use the "openshift-machine-api" project
-    Given I create a spot instance machineset named "<machineset_name>" on <iaas_type>
+    Given I create a spot instance machineset and name it "<machineset_name>" on <iaas_type>
     And evaluation of `machine_set.machines.first.node_name` is stored in the :noderef_name clipboard
     And evaluation of `machine_set.machines.first.name` is stored in the :machine_name clipboard
 
@@ -204,6 +204,9 @@ Feature: Machine features testing
       | name     | <%= cb.noderef_name %> |
     Then the step should succeed
     And the output should match "machine.openshift.io/interruptible-instance="
+    And "machine-api-termination-handler" daemonset becomes ready in the "openshift-machine-api" project
+    And 1 pods become ready with labels:
+      | k8s-app=termination-handler |
 
     Examples:
       | iaas_type | machineset_name  |

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -76,7 +76,7 @@ Given(/^I clone a machineset and name it "([^"]*)"$/) do | ms_name |
   step %Q{the machineset should have expected number of running machines}
 end
 
-Given(/^I create a spot instance machineset named "([^"]*)" on (aws|gcp|azure)$/) do | ms_name, iaas_type |
+Given(/^I create a spot instance machineset and name it "([^"]*)" on (aws|gcp|azure)$/) do | ms_name, iaas_type |
   step %Q{I pick a random machineset to scale}
 
   ms_yaml = machine_set.raw_resource.to_yaml


### PR DESCRIPTION
I want to merge OCP-29389 into OCP-29199, and I will delete case OCP-29389. @jhou1 @miyadav Please help to review, thanks.

```
    [02:10:08] INFO> === End After Scenario: Required configuration should be added to the ProviderSpec to enable spot instances, Examples (#1) ===

1 scenario (1 passed)
15 steps (15 passed)
6m4.734s
```
