### PR TITLE
OCP-28718 - Configurable timeout for mhc 

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -130,3 +130,41 @@ Feature: MachineHealthCheck Test Scenarios
       | mhc-<%= machine_set.name %>-1: total targets: 1,  maxUnhealthy: 0, unhealthy: 1. Short-circuiting remediation   |
       | mhc-<%= machine_set.name %>-2: total targets: 1,  maxUnhealthy: 90%, unhealthy: 1. Short-circuiting remediation |
     """
+
+  # @author miyadav@redhat.com
+  # @case_id OCP-28718
+  @admin
+  @destructive
+  Scenario: [MHC] - Machine Node startup timeout should be configurable
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    Then I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
+
+    Given I clone a machineset and name it "machineset-clone-28718"
+
+    # Create MHC with configurable node startup timeout
+    When I run oc create over "<%= BushSlicer::HOME %>/testdata/cloud/mhc/mhc_configurabletimeout.yaml" replacing paths:
+      | n                                                                                  | openshift-machine-api       |
+      | ["metadata"]["name"]                                                               | mhc-<%= machine_set.name %> |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]    | <%= machine_set.cluster %>  |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"] | <%= machine_set.name %>     |
+      | ["spec"]["nodeStartupTimeout" ]                                                    | 15m                         |
+    Then the step should succeed
+    And I ensure "mhc-<%= machine_set.name %>" machinehealthcheck is deleted after scenario
+    
+    Given I create the 'Ready' unhealthyCondition
+    Then a pod becomes ready with labels:
+     | api=clusterapi, k8s-app=controller |
+
+    And I wait up to 600 seconds for the steps to pass:
+    """
+     When I run the :logs admin command with:
+     | resource_name | <%= pod.name %>                |
+     | c             | machine-healthcheck-controller |
+    Then the output should contain:
+     | Ensuring a requeue happens in 15m0  |
+    """
+   Then the machine should be remediated
+
+   

--- a/testdata/cloud/mhc/mhc_configurabletimeout.yaml
+++ b/testdata/cloud/mhc/mhc_configurabletimeout.yaml
@@ -1,0 +1,22 @@
+apiVersion: "machine.openshift.io/v1beta1"
+kind: "MachineHealthCheck"
+metadata:
+  name: mhc1
+  namespace: openshift-machine-api
+spec:
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster:
+      machine.openshift.io/cluster-api-machine-role: worker
+      machine.openshift.io/cluster-api-machine-type: worker
+      machine.openshift.io/cluster-api-machineset:
+  nodeStartupTimeout: 10m
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 300s
+  - type: Ready
+    status: Unknown
+    timeout: 300s
+  maxUnhealthy: 3
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPCLOUD-774

V3 runner link - https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/92814/console



