### PR TITLE
fix issue running exec command with oc 4.5

### DIFF
--- a/features/step_definitions/logging_metrics.rb
+++ b/features/step_definitions/logging_metrics.rb
@@ -129,6 +129,7 @@ Given /^I check the #{QUOTED} prometheus rule in the #{QUOTED} project on the pr
     | n                | openshift-monitoring                                                                          |
     | container        | prometheus                                                                                    |
     | pod              | prometheus-k8s-0                                                                              |
+    | oc_opts_end      |                                                                                               |
     | exec_command     | cat                                                                                           |
     | exec_command_arg | /etc/prometheus/rules/prometheus-k8s-rulefiles-0/#{project_name}-#{prometheus_rule_name}.yaml |
   })


### PR DESCRIPTION
Quick fix for the issue when running `exec` command with oc 4.5.

@pruan-rht PTAL, thanks.