### PR TITLE
[IPI on OSP] add funtions to operate network, subnet and router

### DIFF
--- a/lib/launchers/openstack.rb
+++ b/lib/launchers/openstack.rb
@@ -801,6 +801,17 @@ module BushSlicer
       return res[:parsed]["network"]
     end
 
+    # for example, update the name:
+    # update_network("<network_id>", name; "xxx")
+    def update_network(network_id, **kargs)
+      payload = {
+        network: kargs
+      }
+      res = self.rest_run(self.os_network_url + "/v2.0/networks/" + network_id, "PUT", payload, self.os_token)
+      raise res[:response] unless res[:success]
+      return res
+    end
+
     def delete_network(network_id)
       res = self.rest_run(self.os_network_url + "/v2.0/networks/" + network_id, "DELETE", {}, self.os_token)
       raise res[:response] unless res[:success]
@@ -818,6 +829,17 @@ module BushSlicer
       res = self.rest_run(self.os_network_url + "/v2.0/subnets", "POST", payload, self.os_token)
       raise res[:response] unless res[:success]
       return res[:parsed]["subnet"]
+    end
+
+    # for example, update the name:
+    # update_subnet("<network_id>", name: "xxx")
+    def update_subnet(subnet_id, **kargs)
+      payload = {
+        subnet: kargs
+      }
+      res = self.rest_run(self.os_network_url + "/v2.0/subnets/" + subnet_id, "PUT", payload, self.os_token)
+      raise res[:response] unless res[:success]
+      return res
     end
 
     def delete_subnet(subnet_id)

--- a/lib/launchers/openstack.rb
+++ b/lib/launchers/openstack.rb
@@ -790,6 +790,89 @@ module BushSlicer
       end
     end
 
+    def create_network(network_name)
+      payload = {
+        network: {
+          name: network_name
+        }
+      }
+      res = self.rest_run(self.os_network_url + "/v2.0/networks", "POST", payload, self.os_token)
+      raise res[:response] unless res[:success]
+      return res[:parsed]["network"]
+    end
+
+    def delete_network(network_id)
+      res = self.rest_run(self.os_network_url + "/v2.0/networks/" + network_id, "DELETE", {}, self.os_token)
+      raise res[:response] unless res[:success]
+      return res
+    end
+
+    def create_subnet(network_id, cidr)
+      payload = {
+        subnet: {
+          cidr: cidr,
+          ip_version: 4,
+          network_id: network_id
+        }
+      }
+      res = self.rest_run(self.os_network_url + "/v2.0/subnets", "POST", payload, self.os_token)
+      raise res[:response] unless res[:success]
+      return res[:parsed]["subnet"]
+    end
+
+    def delete_subnet(subnet_id)
+      res = self.rest_run(self.os_network_url + "/v2.0/subnets/" + subnet_id, "DELETE", {}, self.os_token)
+      raise res[:response] unless res[:success]
+      return res
+    end
+
+    # external_gateway_info have three fields
+    # {
+    #   network_id: "xxx",
+    #   "enable_snat": true,
+    #   external_fixed_ips: [
+    #     {
+    #       ip_address: "xxx",
+    #       subnet_id: "xxx"
+    #     }
+    #   ]
+    # }
+    def create_router(router_name, external_gateway_info)
+      payload = {
+        router: {
+          name: router_name,
+          external_gateway_info: external_gateway_info
+        }
+      }
+      res = self.rest_run(self.os_network_url + "/v2.0/routers", "POST", payload, self.os_token)
+      raise res[:response] unless res[:success]
+      return res[:parsed]["router"]
+    end
+
+    def delete_router(router_id)
+      res = self.rest_run(self.os_network_url + "/v2.0/routers/" + router_id, "DELETE", {}, self.os_token)
+      raise res[:response] unless res[:success]
+      return res
+    end
+
+    def link_subnet_to_router(router_id, subnet_id)
+      payload = {
+        subnet_id: subnet_id
+      }
+      res = self.rest_run(self.os_network_url + "/v2.0/routers/" + router_id + "/add_router_interface", "PUT", payload, self.os_token)
+      raise res[:response] unless res[:success]
+      return res[:parsed]
+    end
+
+    def unlink_subnet_from_router(router_id, subnet_id)
+      payload = {
+        subnet_id: subnet_id
+      }
+      res = self.rest_run(self.os_network_url + "/v2.0/routers/" + router_id + "/remove_router_interface", "PUT", payload, self.os_token)
+      raise res[:response] unless res[:success]
+      return res[:parsed]
+    end
+
     def get_networks
       res = self.rest_run(self.os_network_url + "/v2.0/networks", "GET", {}, self.os_token)
       raise res[:response] unless res[:success]


### PR DESCRIPTION
```
[1] pry(#<BushSlicer::DefaultWorld>)> iaas = iaas_by_service("openstack_upshift")
[2] pry(#<BushSlicer::DefaultWorld>)> network = iaas.create_network("wjiang_test_user_defined")
=> {"ipv6_address_scope"=>nil,
 "revision_number"=>3,
 "port_security_enabled"=>true,
 "id"=>"21e90ca6-b7f8-425c-95ae-0e8b5942bd1a",
 "router:external"=>false,
 "availability_zone_hints"=>[],
 "availability_zones"=>[],
 "ipv4_address_scope"=>nil,
 "shared"=>false,
 "project_id"=>"542c6ebd48bf40fa857fc245c7572e30",
 "l2_adjacency"=>true,
 "status"=>"ACTIVE",
 "subnets"=>[],
 "description"=>"",
 "tags"=>[],
 "updated_at"=>"2020-05-20T09:45:43Z",
 "is_default"=>false,
 "name"=>"wjiang_test_user_defined",
 "qos_policy_id"=>nil,
 "admin_state_up"=>true,
 "tenant_id"=>"542c6ebd48bf40fa857fc245c7572e30",
 "created_at"=>"2020-05-20T09:45:43Z",
 "mtu"=>1450}
[3] pry(#<BushSlicer::DefaultWorld>)> subnet = iaas.create_subnet(network["id"], "192.168.0.0/24")
=> {"service_types"=>[],
 "description"=>"",
 "enable_dhcp"=>true,
 "tags"=>[],
 "network_id"=>"21e90ca6-b7f8-425c-95ae-0e8b5942bd1a",
 "tenant_id"=>"542c6ebd48bf40fa857fc245c7572e30",
 "created_at"=>"2020-05-20T09:46:09Z",
 "dns_nameservers"=>[],
 "updated_at"=>"2020-05-20T09:46:09Z",
 "gateway_ip"=>"192.168.0.1",
 "ipv6_ra_mode"=>nil,
 "allocation_pools"=>[{"start"=>"192.168.0.2", "end"=>"192.168.0.254"}],
 "host_routes"=>[],
 "revision_number"=>0,
 "ip_version"=>4,
 "ipv6_address_mode"=>nil,
 "cidr"=>"192.168.0.0/24",
 "project_id"=>"542c6ebd48bf40fa857fc245c7572e30",
 "id"=>"79ec85af-b84d-49f1-bfc7-d7bf22ce8875",
 "subnetpool_id"=>nil,
 "name"=>""}
[4] pry(#<BushSlicer::DefaultWorld>)> iaas.link_subnet_to_router("bfefd53e-46a4-4cfa-b2f2-b38f5dece78d",subnet["id"])
=> {"network_id"=>"21e90ca6-b7f8-425c-95ae-0e8b5942bd1a",
 "tenant_id"=>"542c6ebd48bf40fa857fc245c7572e30",
 "subnet_id"=>"79ec85af-b84d-49f1-bfc7-d7bf22ce8875",
 "subnet_ids"=>["79ec85af-b84d-49f1-bfc7-d7bf22ce8875"],
 "port_id"=>"e4e5e209-47c6-4799-8287-525af4b92cd6",
 "id"=>"bfefd53e-46a4-4cfa-b2f2-b38f5dece78d"}
[5] pry(#<BushSlicer::DefaultWorld>)> iaas.unlink_subnet_from_router("bfefd53e-46a4-4cfa-b2f2-b38f5dece78d",subnet["id"])
=> {"network_id"=>"21e90ca6-b7f8-425c-95ae-0e8b5942bd1a",
 "tenant_id"=>"542c6ebd48bf40fa857fc245c7572e30",
 "subnet_id"=>"79ec85af-b84d-49f1-bfc7-d7bf22ce8875",
 "subnet_ids"=>["79ec85af-b84d-49f1-bfc7-d7bf22ce8875"],
 "port_id"=>"e4e5e209-47c6-4799-8287-525af4b92cd6",
 "id"=>"bfefd53e-46a4-4cfa-b2f2-b38f5dece78d"}
[6] pry(#<BushSlicer::DefaultWorld>)> 
[7] pry(#<BushSlicer::DefaultWorld>)> iaas.delete_subnet(subnet["id"])
[8] pry(#<BushSlicer::DefaultWorld>)>
[9] pry(#<BushSlicer::DefaultWorld>)> iaas.delete_network(network["id"])
```

References:
1. https://docs.openstack.org/api-ref/network/v2/
2. https://docs.openstack.org/ocata/user-guide/cli-create-and-manage-networks.html