### PR TITLE
Forcing scenario to execute on specific node only

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1134,7 +1134,6 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     And the default interface on nodes is stored in the :default_interface clipboard
-    And evaluation of `node.name` is stored in the :target_node clipboard
     #Storing default interface mac address for comparison later with pods macs
     Given I run commands on the host:
       | ip addr show <%= cb.default_interface %> |
@@ -1151,9 +1150,9 @@ Feature: Multus-CNI related scenarios
     #Creating various pods and making sure their mac matches to default inf and they get unique IPs assigned
     #Creating pod1 absorbing above net-attach-def
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                       | pod1                    |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | myipvlan76              |
-      | ["spec"]["nodeName"]                                       | <%= cb.target_node %>   |
+      | ["metadata"]["name"]                                       | pod1             |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | myipvlan76       |
+      | ["spec"]["nodeName"]                                       | <%= node.name %> |
     Then the step should succeed
     And the pod named "pod1" becomes ready
     When I execute on the pod:
@@ -1165,9 +1164,9 @@ Feature: Multus-CNI related scenarios
     
     #Creating pod2 absorbing above net-attach-def
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                       | pod2                  |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | myipvlan76            |
-      | ["spec"]["nodeName"]                                       | <%= cb.target_node %> |
+      | ["metadata"]["name"]                                       | pod2             |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | myipvlan76       |
+      | ["spec"]["nodeName"]                                       | <%= node.name %> |
     Then the step should succeed
     And the pod named "pod2" becomes ready
     When I execute on the pod:
@@ -1177,7 +1176,7 @@ Feature: Multus-CNI related scenarios
     And evaluation of `@result[:response].match(/\h+:\h+:\h+:\h+:\h+:\h+/)[0]` is stored in the :pod2_net1_mac clipboard
     And the expression should be true> cb.pod2_net1_mac==cb.default_interface_mac
     And the expression should be true> !(cb.pod2_net1_ip==cb.pod1_net1_ip)
-    
+
   # @author weliang@redhat.com
   # @case_id OCP-28633
   @admin

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1144,8 +1144,8 @@ Feature: Multus-CNI related scenarios
     # Create the net-attach-def via cluster admin
     Given I have a project
     When I run oc create as admin over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/NetworkAttachmentDefinitions/ipvlan-host-local.yaml" replacing paths:
-      | ["metadata"]["name"]      | myipvlan76 											      								            |
-      | ["metadata"]["namespace"] | <%= project.name %> 															                            |    
+      | ["metadata"]["name"]      | myipvlan76                                                                                                                                                              |
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                     |
       | ["spec"] ["config"]       | '{ "cniVersion": "0.3.1", "name": "myipvlan76", "type": "ipvlan", "master": "<%= cb.default_interface %>", "ipam": { "type": "host-local", "subnet": "22.2.2.0/24" } }' |
     Then the step should succeed
 

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1133,7 +1133,6 @@ Feature: Multus-CNI related scenarios
   Scenario: Create pod with Multus ipvlan CNI plugin	
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
-    And I store all worker nodes to the :nodes clipboard
     And the default interface on nodes is stored in the :default_interface clipboard
     And evaluation of `node.name` is stored in the :target_node clipboard
     #Storing default interface mac address for comparison later with pods macs
@@ -1154,7 +1153,7 @@ Feature: Multus-CNI related scenarios
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
       | ["metadata"]["name"]                                       | pod1                    |
       | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | myipvlan76              |
-      | ["spec"]["nodeName"]                                       | "<%= cb.target_node %>" |
+      | ["spec"]["nodeName"]                                       | <%= cb.target_node %>   |
     Then the step should succeed
     And the pod named "pod1" becomes ready
     When I execute on the pod:
@@ -1166,9 +1165,9 @@ Feature: Multus-CNI related scenarios
     
     #Creating pod2 absorbing above net-attach-def
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
-      | ["metadata"]["name"]                                       | pod2                    |
-      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | myipvlan76              |
-      | ["spec"]["nodeName"]                                       | "<%= cb.target_node %>" |
+      | ["metadata"]["name"]                                       | pod2                  |
+      | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | myipvlan76            |
+      | ["spec"]["nodeName"]                                       | <%= cb.target_node %> |
     Then the step should succeed
     And the pod named "pod2" becomes ready
     When I execute on the pod:

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1135,9 +1135,9 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
     And the default interface on nodes is stored in the :default_interface clipboard
+    And evaluation of `node.name` is stored in the :target_node clipboard
     #Storing default interface mac address for comparison later with pods macs
-    Given I use the "<%= cb.nodes[0].name %>" node
-    And I run commands on the host:
+    Given I run commands on the host:
       | ip addr show <%= cb.default_interface %> |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\h+:\h+:\h+:\h+:\h+:\h+/)[0]` is stored in the :default_interface_mac clipboard
@@ -1154,7 +1154,7 @@ Feature: Multus-CNI related scenarios
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
       | ["metadata"]["name"]                                       | pod1                    |
       | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | myipvlan76              |
-      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %> |
+      | ["spec"]["nodeName"]                                       | "<%= cb.target_node %>" |
     Then the step should succeed
     And the pod named "pod1" becomes ready
     When I execute on the pod:
@@ -1168,7 +1168,7 @@ Feature: Multus-CNI related scenarios
     When I run oc create over "<%= BushSlicer::HOME %>/testdata/networking/multus-cni/Pods/generic_multus_pod.yaml" replacing paths:
       | ["metadata"]["name"]                                       | pod2                    |
       | ["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | myipvlan76              |
-      | ["spec"]["nodeName"]                                       | <%= cb.nodes[0].name %> |
+      | ["spec"]["nodeName"]                                       | "<%= cb.target_node %>" |
     Then the step should succeed
     And the pod named "pod2" becomes ready
     When I execute on the pod:
@@ -1178,7 +1178,7 @@ Feature: Multus-CNI related scenarios
     And evaluation of `@result[:response].match(/\h+:\h+:\h+:\h+:\h+:\h+/)[0]` is stored in the :pod2_net1_mac clipboard
     And the expression should be true> cb.pod2_net1_mac==cb.default_interface_mac
     And the expression should be true> !(cb.pod2_net1_ip==cb.pod1_net1_ip)
-
+    
   # @author weliang@redhat.com
   # @case_id OCP-28633
   @admin


### PR DESCRIPTION
Apparently this case depicted few failures when it ran on mixed node clusters. The reason is uniform cluster like with all RHCOS nodes, they share same master interface naming convention but if we add a RHEL worker to an existing uniform cluster, that might come up with different master interface name. We want to make sure we check IPVLAN functionality on a specific node only and that node master interface should be used in further configurations. Just a small change to alleviate CI failures.
@pruan-rht @weliang1 @rbbratta @zhaozhanqi @huiran0826 

Re-ran Logs: https://privatebin-it-iso.int.open.paas.redhat.com/?27da8e5f3fd5c146#TU8Y4xibWlmjhxQKjjwFIFHZqSfJ4o0bN5JPOIv3RPI=