### PR TITLE
add debug step to isolate the auth issue

### DIFF
--- a/lib/login.rb
+++ b/lib/login.rb
@@ -11,6 +11,15 @@ module BushSlicer
     # @param [String] user the username we want token for
     # @return [String]
     def new_token_by_password(user:, password:, env:)
+      # just print HTTP GET result of console route for further debugging
+      # should check if console route accessible when reporting "Error getting bearer token"
+      # if console_url is accessible then it is likely Auth issue
+      # if console_url is inaccessible then likely network related issue including ingress, snd or platform flake
+      console_url = env.api_endpoint_url.delete_suffix(':6443').gsub(/api/, 'console-openshift-console.apps')
+      opts = {:url => console_url, :method => "GET" }
+      opts[:proxy] = env.client_proxy if env.client_proxy
+      debug_res = Http.request(**opts)
+
       # try challenging client auth
       res = oauth_bearer_token_challenge(
         server_url: env.api_endpoint_url,


### PR DESCRIPTION
This step is for further debugging the `Error getting bearer token` issue during login procedure.
The new added step is harmless and won't block the test execution but just print the result of HTTP.GET of console url before starting the login with normal user.  

Example:
```
   Given I have a project                                                                # features/step_definitions/project.rb:7
      [02:06:29] INFO> HTTP GET https://console-openshift-console.apps.hongli-pl212.qe.gcp.devcluster.openshift.com
      [02:06:35] INFO> HTTP GET took 5.942 sec: 200 OK | text/html 3372 bytes
      
      [02:06:35] INFO> HTTP GET https://api.hongli-pl212.qe.gcp.devcluster.openshift.com:6443/.well-known/oauth-authorization-server
      [02:06:41] INFO> HTTP GET took 5.707 sec: 200 OK | application/json 672 bytes
      
      [02:06:41] INFO> HTTP GET testuser-46@https://oauth-openshift.apps.hongli-pl212.qe.gcp.devcluster.openshift.com/oauth/authorize
      [02:06:47] INFO> HTTP GET took 5.925 sec: 503 Service Unavailable
      [02:06:47] ERROR> #<RuntimeError: Error getting bearer token, see log>
```
The example output can tell that Auth has issue but console is still accessible.

@xingxingxia @jhou1 @pruan-rht please help take a look. thanks