### PR TITLE
run cmd deprecated deploymentconfig, change to use dc template.

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -177,7 +177,7 @@ Given /^I have an ssh-git service in the(?: "([^ ]+?)")? project$/ do |project_n
     raise "project #{project_name} does not exist"
   end
 
-  @result = user.cli_exec(:run, name: "git-server", image: "aosqe/ssh-git-server-openshift")
+  @result = user.cli_exec(:create, f: "#{ENV['BUSHSLICER_HOME']}/testdata/templates/ssh-git/ssh-git-dc.yaml")
   raise "cannot run the ssh-git-server pod" unless @result[:success]
 
   @result = user.cli_exec(:set_probe, resource: "dc/git-server", readiness: true, open_tcp: "2022")
@@ -188,7 +188,7 @@ Given /^I have an ssh-git service in the(?: "([^ ]+?)")? project$/ do |project_n
 
   # wait to become available
   @result = BushSlicer::Pod.wait_for_labeled("deployment-config=git-server",
-                                            "run=git-server",
+                                            "name=git-server",
                                             count: 1,
                                             user: user,
                                             project: project,

--- a/testdata/templates/ssh-git/ssh-git-dc.yaml
+++ b/testdata/templates/ssh-git/ssh-git-dc.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: git-server
+spec:
+  replicas: 1
+  selector:
+    name: git-server
+  strategy:
+    type: Rolling
+  template:
+    metadata:
+      labels:
+        name: git-server
+      name: git-server
+    spec:
+      containers:
+      - image: aosqe/ssh-git-server-openshift
+        imagePullPolicy: IfNotPresent 
+        name: git-server
+        resources: {}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+  triggers:
+  - type: ConfigChange


### PR DESCRIPTION
Passed locally http://pastebin.test.redhat.com/868496
In 4.5, run cmd deprecated deploymentconfig, change to use dc template.
@openshift/devexp-qe please help review, thanks