### PR TITLE
fix OCP-27609

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -128,7 +128,7 @@ Feature: Machine features testing
 
     Given I clone a machineset and name it "machineset-clone-27609"
     Then as admin I successfully merge patch resource "machineset/machineset-clone-27609" with:
-      | {"spec":{"template": {"spec":{"providerSpec":{"value":{"publicIP": "true"}}}}}} |
+      | {"spec":{"template": {"spec":{"providerSpec":{"value":{"publicIP": true}}}}}} |
     And I scale the machineset to +2
     Then the machineset should have expected number of running machines
 


### PR DESCRIPTION
Fix OCP-27609. Because it couldn't provision instance successful,  and the machine couldn't be deleted. Finally will finish prematurely. Like error below:
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/97009/consoleFull

```
      [03:52:05] INFO> === End After Scenario: Scaling a machineset with providerSpec.publicIp set to true ===

1 scenario (1 passed)
8 steps (8 passed)
11m19.901s
```
@jhou1 @miyadav Help to take a look.