### PR TITLE
helper function to get all master_nodes for a cluster

### DIFF
--- a/features/step_definitions/node.rb
+++ b/features/step_definitions/node.rb
@@ -603,6 +603,11 @@ Given /^ssh key for accessing nodes is copied to(?: the #{QUOTED} directory in)?
   raise "Error syncing files over to '#{pod.name}' pod '#{@result[:stderr]}'" unless @result[:success]
 end
 
+Given /^I store all master nodes to the#{OPT_SYM} clipboard$/ do |cb_name|
+  cb_name ||= :master_nodes
+  nodes = BushSlicer::Node.list(user: admin)
+  cb[cb_name] = nodes.select { |n| n.is_master? }
+end
 
 Given /^I store all worker nodes to the#{OPT_SYM} clipboard$/ do |cb_name|
   cb_name ||= :worker_nodes


### PR DESCRIPTION
works in tandum with https://github.com/openshift/cucushift/pull/7801, which depends on this PR