### PR TITLE
remove oc debug default image for 4.5

### DIFF
--- a/lib/rules/cli/4.5.yaml
+++ b/lib/rules/cli/4.5.yaml
@@ -319,7 +319,7 @@
      :output: --output=<value>
      :template: --template=<value>
 :debug:
-  :cmd: oc debug --image quay.io/openshifttest/storage@sha256:a05b96d373be86f46e76817487027a7f5b8b5f87c0ac18a246b018df11529b40 <global_options>
+  :cmd: oc debug <global_options>
   :options:
      :c: -c <value>
      :dry_run: --dry-run
@@ -1331,7 +1331,7 @@
   :cmd: oc adm release info
   :options:
     :image_for: --image-for=<value>
-    :image_name: <value>    
+    :image_name: <value>
     :registry_config: --registry-config=<value>
 :oadm_router:
   :cmd: oc adm router <name>


### PR DESCRIPTION
use the  multus cluster image logic so we don't have to access quay.io

see #983 
