### PR TITLE
Fix OCP-13025

### DIFF
--- a/features/upgrade/build/build-upgrade.feature
+++ b/features/upgrade/build/build-upgrade.feature
@@ -7,10 +7,10 @@ Feature: build related upgrade check
     When I run the :new_project client command with:
       | project_name | build-upgrade |
     Then the step should succeed
-    When I run the :new_app client command with:
+    When I run the :new_app_as_dc client command with:
       | app_repo | openshift/ruby~https://github.com/openshift/ruby-ex |
     Then the step should succeed
-    When I run the :new_app client command with:
+    When I run the :new_app_as_dc client command with:
       | app_repo | openshift/ruby:2.5~https://github.com/openshift/ruby-hello-world |
       | strategy | docker                                                           |
     Then the step should succeed
@@ -39,44 +39,3 @@ Feature: build related upgrade check
     Then the step should succeed
     And status becomes :running of 1 pods labeled:
       | deployment=ruby-hello-world-2 |
-
-  # @author wewang@redhat.com
-  @upgrade-prepare
-  @users=upuser1,upuser2
-  Scenario: Check docker and sti build works well before and after upgrade test - prepare
-    Given I switch to the first user
-    When I run the :new_project client command with:
-      | project_name | build-upgrade |
-    Then the step should succeed
-    When I run the :new_app client command with:
-      | app_repo | openshift/ruby~https://github.com/openshift/ruby-ex |
-    Then the step should succeed
-    When I run the :new_app client command with:
-      | app_repo | openshift/ruby:2.5~https://github.com/openshift/ruby-hello-world |
-      | strategy | docker                                                           |
-    Then the step should succeed
-    Given I use the "build-upgrade" project
-    Then the "ruby-ex-1" build completed
-    And the "ruby-hello-world-1" build completed
-
-  # @author wewang@redhat.com
-  # @case_id OCP-31248
-  @upgrade-check
-  @users=upuser1,upuser2
-  Scenario: Check docker and sti build works well before and after upgrade test 
-    Given I switch to the first user
-    When I use the "build-upgrade" project
-    And status becomes :running of 1 pods labeled:
-      | deployment=ruby-ex |
-    And status becomes :running of 1 pods labeled:
-      | deployment=ruby-hello-world |
-    When I run the :start_build client command with:
-      | buildconfig | ruby-ex |
-    Then the step should succeed
-    And status becomes :running of 1 pods labeled:
-      | deployment=ruby-ex |
-    When I run the :start_build client command with:
-      | buildconfig | ruby-hello-world |
-    Then the step should succeed
-    And status becomes :running of 1 pods labeled:
-      | deployment=ruby-hello-world |

--- a/lib/rules/cli/4.1.yaml
+++ b/lib/rules/cli/4.1.yaml
@@ -587,6 +587,7 @@
     :image_stream: --image-stream=<value>
     :name: --name=<value>
     :source_spec: <value>
+    :strategy: --strategy=<value>
 :new_build:
   :cmd: oc new-build
   :options:

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -588,6 +588,7 @@
     :image_stream: --image-stream=<value>
     :name: --name=<value>
     :source_spec: <value>
+    :strategy: --strategy=<value>
 :new_build:
   :cmd: oc new-build
   :options:

--- a/lib/rules/cli/4.5.yaml
+++ b/lib/rules/cli/4.5.yaml
@@ -581,6 +581,7 @@
     :image_stream: --image-stream=<value>
     :name: --name=<value>
     :source_spec: <value>
+    :strategy: --strategy=<value>
 :new_build:
   :cmd: oc new-build
   :options:


### PR DESCRIPTION
upgrade from 4.4 to 4.5: 
upgrade-prepare using oc 4.4 client , it passed [log](https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/98313/)
upgrade-check  using 4.5 client also passed [log](https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/98314/console)
@openshift/devexp-qe pls review it, thanks