### PR TITLE
oc inspect co/machine-api and clusterautoscaler - OCP29344

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -197,3 +197,22 @@ Feature: Machine features testing
       | iaas_type | machineset_name  |
       | aws       | machineset-29199 | # @case_id OCP-29199
 
+  # @author miyadav@redhat.com
+  # @case_id OCP29344
+  @admin
+  Scenario: [BZ1817860] Validation of `oc adm inspect co/xx` command
+    Given I switch to cluster admin pseudo user
+    Then I saved following keys to list in :resourcesid clipboard:
+      | machine-api        | |
+      | cluster-autoscaler | |
+
+    And I use the "openshift-machine-api" project
+    Then I repeat the following steps for each :id in cb.resourcesid:
+    """
+    When I run the :oadm_inspect admin command with:
+      | resource_type | co       |
+      | resource_name | #{cb.id} |
+    Then the output should contain "Wrote inspect data to inspect.local"
+    And the step should succeed
+    """
+    


### PR DESCRIPTION
Output of the run : 
      
      [11:41:47] INFO> Exit Status: 0
      [11:41:47] INFO> Shell Commands: oc project openshift-machine-api --config=/root/workdir/8093f2c2aaf7-/ocp4_admin.kubeconfig
      Now using project "openshift-machine-api" on server "https://api.miyadav-0601.qe.devcluster.openshift.com:6443".
      
      [11:41:49] INFO> Exit Status: 0
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    Then I repeat the following steps for each :id in cb.resourcesid: # features/step_definitions/meta_steps.rb:99
      [11:41:49] INFO> Shell Commands: oc adm inspect co machine-api --config=/root/workdir/8093f2c2aaf7-/ocp4_admin.kubeconfig
      Gathering data for ns/openshift-machine-api...
      Wrote inspect data to inspect.local.8189999572219288448.
      
      [11:43:06] INFO> Exit Status: 0
      [11:43:06] INFO> Shell Commands: oc adm inspect co cluster-autoscaler --config=/root/workdir/8093f2c2aaf7-/ocp4_admin.kubeconfig
      Gathering data for ns/openshift-machine-api...
      Wrote inspect data to inspect.local.2408582362925916848.
      
      [11:44:16] INFO> Exit Status: 0
      """
      When I run the :oadm_inspect admin command with:
        | resource_type | co       | 
        | resource_name | #{cb.id} |
      Then the output should contain "Wrote inspect data to inspect.local"
      And the step should succeed
      """
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [11:44:16] INFO> === After Scenario: [BZ1817860] Validation of `oc adm inspect co/xx` command ===
      [11:44:16] INFO> Shell Commands: rm -r -f -- /root/workdir/8093f2c2aaf7-
      
      [11:44:16] INFO> Exit Status: 0
      [11:44:16] INFO> === End After Scenario: [BZ1817860] Validation of `oc adm inspect co/xx` command ===

1 scenario (1 passed)
4 steps (4 passed)
2m30.609s
[11:44:16] INFO> === At Exit ===
