### PR TITLE
merger OCP-31315 into OCP-28108

### DIFF
--- a/features/machine/autoscaler.feature
+++ b/features/machine/autoscaler.feature
@@ -51,6 +51,17 @@ Feature: Cluster Autoscaler Tests
     """
     Then the machineset should have expected number of running machines
 
+    # Check autoscaler taints are deleted when min node is reached
+    Given I store the last provisioned machine in the :machine clipboard
+    And evaluation of `machine(cb.machine).node_name` is stored in the :noderef_name clipboard
+    When I run the :describe admin command with:
+      | resource | node                  |
+      | name     | <%= cb.noderef_name%> |
+    Then the step should succeed
+    And the output should not contain:
+      | DeletionCandidateOfClusterAutoscaler |
+      | ToBeDeletedByClusterAutoscaler       |
+
   # @author zhsun@redhat.com
   # @case_id OCP-21516
   @admin


### PR DESCRIPTION
I want to merger OCP-31315 into OCP-28108, and I will delete case OCP-31315. @jhou1 @miyadav Please help to review, thanks.
 OCP-31315: DeletionCandidateOfClusterAutoscaler and ToBeDeletedByClusterAutoscaler taints should be deleted when min nodes is reached
OCP-28108: Cluster could automatically scale up and scale down with ClusterAutoscaler deployed

```
     [08:50:49] INFO> === End After Scenario: Cluster should automatically scale up and scale down with clusterautoscaler deployed ===

1 scenario (1 passed)
25 steps (25 passed)
13m21.889s
```