### PR TITLE
Automate OCP-31331

### DIFF
--- a/features/upgrade/storage/upgrade.feature
+++ b/features/upgrade/storage/upgrade.feature
@@ -139,3 +139,32 @@ Feature: Storage upgrade tests
       | ls | /mnt/storage |
     Then the output should contain:
       | test-upgrade |
+
+  # @author wduan@redhat.com
+  # @case_id OCP-31331
+  @upgrade-prepare
+  @users=upuser1,upuser2
+  @admin
+  Scenario: Cluster operator storage should be in correct status after upgrade - prepare
+    Given I switch to cluster admin pseudo user
+    # Check cluster operator storage should be in correct status
+    Given the expression should be true> cluster_operator('storage').condition(type: 'Progressing')['status'] == "False"
+    Given the expression should be true> cluster_operator('storage').condition(type: 'Available')['status'] == "True"
+    Given the expression should be true> cluster_operator('storage').condition(type: 'Degraded')['status'] == "False"
+    Given the expression should be true> cluster_operator('storage').condition(type: 'Upgradeable')['status'] == "True"
+
+  # @author wduan@redhat.com
+  @upgrade-check
+  @users=upuser1,upuser2
+  @admin
+  Scenario: Cluster operator storage should be in correct status after upgrade
+    Given I switch to cluster admin pseudo user
+    # Check storage operator version after upgraded
+    Given the "storage" operator version matches the current cluster version
+
+    # Check cluster operator storage should be in correct status
+    Given the expression should be true> cluster_operator('storage').condition(type: 'Progressing')['status'] == "False"
+    Given the expression should be true> cluster_operator('storage').condition(type: 'Available')['status'] == "True"
+    Given the expression should be true> cluster_operator('storage').condition(type: 'Degraded')['status'] == "False"
+    Given the expression should be true> cluster_operator('storage').condition(type: 'Upgradeable')['status'] == "True"
+


### PR DESCRIPTION
Currently, iscsi provisioner doesn’t work smoothly during upgrade, this case is only performed on BareMetal before upgrade and after upgrade (v.s. OCP-23501):
1. The cluster operator storage should be in the correct status before and after the upgrade.
2. The cluster operator storage operator version should match the current cluster version after upgrade


[pass log](https://privatebin-it-iso.int.open.paas.redhat.com/?efbbf8b6ed07e308#zlCHYPHk07qHFuHZi+q8sFzaiilIWxZwOqBPok4/cCc=)

