### PR TITLE
Using taints to prevent pods from scheduling to test nodes

### DIFF
--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -64,6 +64,8 @@ Given(/^I clone a machineset and name it "([^"]*)"$/) do | ms_name |
   new_spec["metadata"]["name"] = ms_name
   new_spec["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"] = ms_name
   new_spec["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] = ms_name
+  # Adding taints to machineset so that pods without toleration can not schedule to the nodes we provision
+  new_spec["spec"]["template"]["spec"]["taints"] = [{"effect": "NoSchedule","key": "mapi","value": "mapi_test"}]
   new_spec["spec"]["replicas"] = 1
   new_spec.delete("status")
 

--- a/lib/openshift/machine_set.rb
+++ b/lib/openshift/machine_set.rb
@@ -35,5 +35,10 @@ module BushSlicer
       rr = raw_resource(user: user, cached: cached, quiet: quiet)
       rr.dig('spec', 'selector', 'matchLabels', 'machine.openshift.io/cluster-api-cluster')
     end
+
+    def taints(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached, quiet: quiet).
+        dig('spec', 'taints')
+    end
   end
 end

--- a/testdata/cloud/autoscaler-auto-tmpl.yml
+++ b/testdata/cloud/autoscaler-auto-tmpl.yml
@@ -15,6 +15,10 @@ spec:
             memory: 500Mi
             cpu: 500m
       restartPolicy: Never
+      tolerations:
+      - key: mapi
+        value: mapi_test
+        effect: NoSchedule
   backoffLimit: 4
   completions: 100
   parallelism: 100

--- a/testdata/cloud/mhc/kubelet-killer-pod-43.yml
+++ b/testdata/cloud/mhc/kubelet-killer-pod-43.yml
@@ -20,3 +20,7 @@ spec:
   hostPID: true
   nodeName: $NAME
   restartPolicy: Never
+  tolerations:
+  - key: mapi
+    value: mapi_test
+    effect: NoSchedule

--- a/testdata/cloud/mhc/kubelet-killer-pod.yml
+++ b/testdata/cloud/mhc/kubelet-killer-pod.yml
@@ -20,3 +20,7 @@ spec:
   hostPID: true
   nodeName: $NAME
   restartPolicy: Never
+  tolerations:
+  - key: mapi
+    value: mapi_test
+    effect: NoSchedule


### PR DESCRIPTION
By adding taints, only our pods with toleration can schedule to the nodes we had scaled up. No other pods can schedule there and this prevents unexpected failures in other teams' tests. For example even though our tests run in destructive mode daemonset and statefulset can still schedule pods to our nodes. This pr prevents that.

Tested and it's working well. @sunzhaohua2 @miyadav PTAL