### PR TITLE
Fix OCP-31241

### DIFF
--- a/features/cli/oc_set_probe.feature
+++ b/features/cli/oc_set_probe.feature
@@ -196,9 +196,8 @@ Feature: oc_set_probe.feature
       | resource | pod              |
       | l        | deployment=mysql |
     Then the output should match:
-      | Readiness      |
-      | tcp-socket :33 |
-      | probe failed   |
+      | Readiness       |
+      | tcp-socket :33  |
     """
 
   # @author wewang@redhat.com


### PR DESCRIPTION
Some versions are not include info "probe failed", so updated it
[Pass log](https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/100644/console)
@openshift/devexp-qe ptal, thanks