### PR TITLE
OCP-19470 fix Change clusterrole to build-strategy-custom

### DIFF
--- a/features/upgrade/api_auth/upgrade.feature
+++ b/features/upgrade/api_auth/upgrade.feature
@@ -135,11 +135,11 @@ Feature: apiserver and auth related upgrade check
     And the output should not contain:
       | autoupdate: "false" |
     # Make some changes on clusterrole resources before upgrade
-    Given as admin I successfully patch resource "clusterrole.rbac/system:build-strategy-docker" with:
-      | {"rules": [{"apiGroups": ["","build.openshift.io"],"resources": ["builds/docker","builds/optimizeddocker"],"verbs": [ "get" ]}] } |
+    Given as admin I successfully patch resource "clusterrole.rbac/system:build-strategy-custom" with:
+      | {"rules": [{"apiGroups": ["","build.openshift.io"],"resources": ["builds/custom"],"verbs": [ "get" ]}] } |
     When I run the :get admin command with:
       | resource      | clusterroles.rbac            |
-      | resource_name | system:build-strategy-docker |
+      | resource_name | system:build-strategy-custom |
       | o             | yaml                         |
     Then the expression should be true> !@result[:parsed]['rules'][0]['verbs'].include? "create"
     And the expression should be true> @result[:parsed]['rules'][0]['verbs'][0] == "get"
@@ -160,13 +160,11 @@ Feature: apiserver and auth related upgrade check
     # Checking original clusterrole resources recovered after upgraded
     When I run the :get admin command with:
       | resource      | clusterroles.rbac            |
-      | resource_name | system:build-strategy-docker |
+      | resource_name | system:build-strategy-custom |
       | o             | yaml                         |
     Then the expression should be true> @result[:parsed]['rules'][0]['verbs'][0] == "get"
     And the expression should be true> @result[:parsed]['rules'][1]['verbs'][0] == "create"
     And the expression should be true> @result[:parsed]['rules'][2]['verbs'][0] == "create"
-    And the expression should be true> @result[:parsed]['rules'][3]['verbs'][0] == "create"
-    And the expression should be true> @result[:parsed]['rules'][4]['verbs'][0] == "create"
     When I run the :get admin command with:
       | resource      | clusterrolebinding.rbac     |
       | resource_name | system:oauth-token-deleters |


### PR DESCRIPTION
The case OCP-19470 is a destructive one, if it run before case OCP-13025, the original code will forbid build strategy Docker cluster role, the case OCP-13025 will run into error. To change clusterrole to build-strategy-custom, will avoid this.

Run passed case result of upgrade-prepare: -Jenkins server-/job/Runner-v3/100682/console
Run passed case result of upgrade-check: -Jenkins server-/job/Runner-v3/100732/console
