### PR TITLE
OCP-26035: use service.url to generate URL

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -82,13 +82,13 @@ Feature: Service related networking scenarios
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     And I have a pod-for-ping in the project
-    
+
     #Creating laodbalancer service that points to MCS IP
-    When I run the :create_service_loadbalancer client command with: 
+    When I run the :create_service_loadbalancer client command with:
       | name | <%= cb.ping_pod.name %>  |
-      | tcp  | 22623:8080               | 
+      | tcp  | 22623:8080               |
     Then the step should succeed
-    
+
     # Editing endpoint to point to master ip
     When I run the :patch client command with:
       | resource      | ep                         				      						   |
@@ -125,24 +125,24 @@ Feature: Service related networking scenarios
 
   # @author weliang@redhat.com
   # @case_id OCP-24668
-  Scenario: externalIP defined in service but no spec.externalIP defined	
-    Given I have a project 
+  Scenario: externalIP defined in service but no spec.externalIP defined
+    Given I have a project
     # Create a service with a externalIP
     Given I obtain test data file "networking/externalip_service1.json"
     When I run the :create client command with:
-      | f | externalip_service1.json | 
+      | f | externalip_service1.json |
     Then the step should fail
 
   # @author weliang@redhat.com
   # @case_id OCP-24669
   @admin
   @destructive
-  Scenario: externalIP defined in service with set ExternalIP in allowedCIDRs	
+  Scenario: externalIP defined in service with set ExternalIP in allowedCIDRs
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I store the schedulable nodes in the :nodes clipboard
     And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :hostip clipboard
-   
+
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["<%= cb.hostip %>/24"]}}}} |
@@ -162,15 +162,15 @@ Feature: Service related networking scenarios
     When I run oc create over "externalip_service1.json" replacing paths:
       | ["spec"]["externalIPs"][0] | <%= cb.hostip %> |
     Then the step should succeed
-    """ 
-    
+    """
+
     # Create a pod
     Given I obtain test data file "routing/caddy-docker.json"
     When I run the :create client command with:
       | f | caddy-docker.json |
     Then the step should succeed
     And the pod named "caddy-docker" becomes ready
- 
+
     # Curl externalIP:portnumber should pass
     When I execute on the pod:
       | /usr/bin/curl | --connect-timeout | 10 | <%= cb.hostip %>:27017 |
@@ -181,7 +181,7 @@ Feature: Service related networking scenarios
   # @case_id OCP-24692
   @admin
   @destructive
-  Scenario: A rejectedCIDRs inside an allowedCIDRs	 
+  Scenario: A rejectedCIDRs inside an allowedCIDRs
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["22.2.2.0/24"],"rejectedCIDRs":["22.2.2.0/25"]}}}} |
@@ -194,7 +194,7 @@ Feature: Service related networking scenarios
     """
 
     # Create a svc with externalIP/22.2.2.10 which is in 22.2.2.0/25
-    Given I have a project 
+    Given I have a project
     Given I obtain test data file "networking/externalip_service1.json"
     And I wait up to 300 seconds for the steps to pass:
     """
@@ -211,15 +211,15 @@ Feature: Service related networking scenarios
       | ["spec"]["externalIPs"][0] | 22.2.2.130 |
     Then the step should succeed
     """
- 
+
     # Create a pod
     Given I obtain test data file "routing/caddy-docker.json"
     When I run the :create client command with:
       | f | caddy-docker.json |
     Then the step should succeed
     And the pod named "caddy-docker" becomes ready
- 
-    # Curl externalIP:portnumber on new pod 
+
+    # Curl externalIP:portnumber on new pod
     When I execute on the pod:
       | /usr/bin/curl | -k | 22.2.2.130:27017 |
     Then the output should contain:
@@ -234,11 +234,11 @@ Feature: Service related networking scenarios
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I store the schedulable nodes in the :nodes clipboard
     And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :hostip clipboard
-   
+
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"rejectedCIDRs":["<%= cb.hostip %>/24"]}}}} |
- 
+
     # Clean-up required to erase above externalIP policy after testing done
     Given I register clean-up steps:
     """
@@ -260,11 +260,11 @@ Feature: Service related networking scenarios
   # @case_id OCP-24739
   @admin
   @destructive
-  Scenario: An allowedCIDRs inside an rejectedCIDRs	 
+  Scenario: An allowedCIDRs inside an rejectedCIDRs
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
-      | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["22.2.2.0/25"],"rejectedCIDRs":["22.2.2.0/24"]}}}} |                                                                                  
-   
+      | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["22.2.2.0/25"],"rejectedCIDRs":["22.2.2.0/24"]}}}} |
+
     # Clean-up required to erase above externalIP policy after testing done
     Given I register clean-up steps:
     """
@@ -273,7 +273,7 @@ Feature: Service related networking scenarios
     """
 
     # Create a svc with externalIP/22.2.2.10 which is in rejectedCIDRs
-    Given I have a project 
+    Given I have a project
     Given I obtain test data file "networking/externalip_service1.json"
     And I wait up to 300 seconds for the steps to pass:
     """
@@ -295,24 +295,24 @@ Feature: Service related networking scenarios
   # @case_id OCP-24691
   @admin
   @destructive
-  Scenario: Defined Multiple allowedCIDRs 
+  Scenario: Defined Multiple allowedCIDRs
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I store the schedulable nodes in the :nodes clipboard
     And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :host1ip clipboard
     And the Internal IP of node "<%= cb.nodes[1].name %>" is stored in the :host2ip clipboard
-    
+
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["<%= cb.host1ip %>/24","<%= cb.host2ip %>/24"]}}}} |
-  
+
     # Clean-up required to erase above externalIP policy after testing done
     Given I register clean-up steps:
     """
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"allowedCIDRs":null }}}} |
     """
-    
+
     # Create a svc with externalIP
     Given I switch to the first user
     Given I obtain test data file "networking/externalip_service1.json"
@@ -329,13 +329,13 @@ Feature: Service related networking scenarios
       | f | caddy-docker.json |
     Then the step should succeed
     And the pod named "caddy-docker" becomes ready
- 
-    # Curl externalIP:portnumber from pod 
+
+    # Curl externalIP:portnumber from pod
     When I execute on the pod:
       | /usr/bin/curl | --connect-timeout | 10 | <%= cb.host1ip %>:27017 |
     Then the output should contain:
       | Hello-OpenShift-1 http-8080 |
-    
+
     # Delete created pod and svc
     When I run the :delete client command with:
       | object_type | all |
@@ -350,15 +350,15 @@ Feature: Service related networking scenarios
       | ["spec"]["externalIPs"][0] | <%= cb.host2ip %> |
     Then the step should succeed
     """
-    
+
     # Create a pod
     Given I obtain test data file "routing/caddy-docker.json"
     When I run the :create client command with:
       | f | caddy-docker.json |
     Then the step should succeed
     And the pod named "caddy-docker" becomes ready
- 
-    # Curl externalIP:portnumber on new pod 
+
+    # Curl externalIP:portnumber on new pod
     When I execute on the pod:
       | /usr/bin/curl | --connect-timeout | 10 | <%= cb.host2ip %>:27017 |
     Then the output should contain:
@@ -377,7 +377,7 @@ Feature: Service related networking scenarios
   And a pod becomes ready with labels:
     | name=test-pods |
   Given I use the "test-service" service
-  And evaluation of `service.ip(user: user)` is stored in the :service_ip clipboard
+  And evaluation of `service.url(user: user)` is stored in the :service_url clipboard
   # Checking idling unidling manually to make sure it works fine
   When I run the :idle client command with:
     | svc_name | test-service |
@@ -385,11 +385,14 @@ Feature: Service related networking scenarios
   And the output should contain:
     | The service "<%= project.name %>/test-service" has been marked as idled |
   Given I have a pod-for-ping in the project
+  And I wait up to 30 seconds for the steps to pass:
+  """
   When I execute on the pod:
-    | /usr/bin/curl | --connect-timeout | 30 | <%= cb.service_ip %>:27017 |
+    | /usr/bin/curl | --connect-timeout | 30 | <%= cb.service_url %> |
   Then the step should succeed
   And the output should contain:
     | Hello OpenShift |
+  """
 
   # @author huirwang@redhat.com
   # @case_id OCP-11645
@@ -462,7 +465,7 @@ Feature: Service related networking scenarios
     Then the step should succeed
     And the output should contain "mtu-too-small"
     """
-    #Starting NetworkManager to roll out original system MTU 
+    #Starting NetworkManager to roll out original system MTU
     Given I use the "<%= cb.subject_node %>" node
     And I run commands on the host:
       | systemctl start NetworkManager |
@@ -500,7 +503,7 @@ Feature: Service related networking scenarios
     Then the step should succeed
     When I obtain test data file "networking/nodeport_test_service.yaml"
     And I wait up to 600 seconds for the steps to pass:
-    """    
+    """
     When I run oc create over "nodeport_test_service.yaml" replacing paths:
       | ["spec"]["ports"][0]["nodePort"] | <%= cb.port %> |
     Then the step should succeed


### PR DESCRIPTION
`service.url` has been fixed to IPv6 bracket encode
addresses, e.g.`[fd::1]:1234` etc.

We don't want to use `service.ip` because it doesn't
work for IPv6 URLs that need brackets