### PR TITLE
fix OCP-23893

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -783,7 +783,7 @@ Given /^the subnet for primary interface on node is stored in the#{OPT_SYM} clip
 
   step "the default interface on nodes is stored in the clipboard"
   step "I run command on the node's sdn pod:", table(
-    "| bash | -c | ip a show \"<%= cb.interface %>\" \\| grep inet \\| grep -v inet6  \\| awk '{print $2}' |"
+    "| bash | -c | ip -4 -brief a show \"<%= cb.interface %>\" \\| awk '{print $3}' |"
   )
   raise "Failed to get the subnet range for the primary interface on the node" unless @result[:success]
   cb[cb_name] = @result[:response].chomp


### PR DESCRIPTION
The case failed in ipi-vsphere ci run due to in some node, there are two IPs.  Fix the codes to just catch the first one.

Re-run logs in ipi-vsphere.
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/102520/consoleFull

@zhaozhanqi @weliang1 @anuragthehatter @rbbratta 
