### PR TITLE
auto OCP-28956

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -204,7 +204,7 @@ Feature: MachineHealthCheck Test Scenarios
     Given I store the last provisioned machine in the :machine clipboard
 
     # Create MHC
-    When I run oc create over "<%= BushSlicer::HOME %>/features/tierN/testdata/cloud/mhc/mhc-master.yaml" replacing paths:
+    When I run oc create over "<%= BushSlicer::HOME %>/testdata/cloud/mhc/mhc-master.yaml" replacing paths:
       | ["metadata"]["name"]                                                            | mhc-master-machine-28956 |
       | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"] | <%= machine.cluster %>   |
     Then the step should succeed

--- a/lib/openshift/machine.rb
+++ b/lib/openshift/machine.rb
@@ -47,5 +47,10 @@ module BushSlicer
       ! raw_resource(user: user, cached: cached, quiet: quiet).
           dig('metadata', 'deletionTimestamp').nil?
     end
+    def cluster(user: nil, cached: true, quiet: false)
+      rr = raw_resource(user: user, cached: cached, quiet: quiet)
+      rr.dig('metadata', 'labels', 'machine.openshift.io/cluster-api-cluster')
+    end
+
   end
 end

--- a/lib/openshift/node.rb
+++ b/lib/openshift/node.rb
@@ -234,6 +234,11 @@ module BushSlicer
       }
     end
 
+    def machine_name(user: nil, cached: true, quiet: false)
+      obj = raw_resource(user: user, cached: cached, quiet: quiet)
+      return obj.dig("metadata", "annotations", "machine.openshift.io/machine").split('/')[1]
+    end
+
     # calculate how many pods can be schedulable on the node
     # based on resources requested
     private def max_pod_count_capacity(user: nil, cached: true, quiet: false, **pod_requests)

--- a/testdata/cloud/mhc/mhc-master.yaml
+++ b/testdata/cloud/mhc/mhc-master.yaml
@@ -1,0 +1,19 @@
+apiVersion: "machine.openshift.io/v1beta1"
+kind: "MachineHealthCheck"
+metadata:
+  name: mhc-master
+  namespace: openshift-machine-api
+spec:
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster:
+      machine.openshift.io/cluster-api-machine-role: master
+      machine.openshift.io/cluster-api-machine-type: master
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 300s
+  - type: Ready
+    status: Unknown
+    timeout: 300s
+  maxUnhealthy: 3


### PR DESCRIPTION
This is a temprary pr, the steps could pass, but after scenario when recovering the cluster it will get below error every time.
```
[06:50:18] INFO> After 35 iterations and 92 seconds:
      
      STDERR:
      Error from server (NotFound): machines.machine.openshift.io "master-machine-28956" not found
      
      [06:50:18] INFO> Shell Commands: oc get machines --output=yaml --kubeconfig=/home/sunny/workdir/bogon-sunny/ocp4_admin.kubeconfig -n openshift-machine-api
      apiVersion: v1
      items: []
      kind: List
      metadata:
        resourceVersion: ""
        selfLink: ""
      
      STDERR:
      Error from server: etcdserver: request timed out
      
      [06:50:32] INFO> Exit Status: 1
      [06:50:32] ERROR> apiVersion: v1
      items: []
      kind: List
      metadata:
        resourceVersion: ""
        selfLink: ""
      
      STDERR:
      Error from server: etcdserver: request timed out
      
      [06:50:32] ERROR> Test Execution will finish prematurely.
      cannot get machines for project openshift-machine-api (RuntimeError)
      /home/sunny/code/verification-tests/lib/openshift/project_resource.rb:233:in `get_matching'
      /home/sunny/code/verification-tests/features/step_definitions/machine.rb:63:in `block (2 levels) in <top (required)>'
      /home/sunny/code/verification-tests/lib/world.rb:432:in `block in after_scenario'
      /home/sunny/code/verification-tests/lib/world.rb:432:in `reverse_each'
      /home/sunny/code/verification-tests/lib/world.rb:432:in `after_scenario'
      /home/sunny/code/verification-tests/lib/manager.rb:35:in `clean_up'
      /home/sunny/code/verification-tests/features/support/env.rb:67:in `block (2 levels) in <top (required)>'
      /home/sunny/code/verification-tests/lib/base_helper.rb:131:in `capture_error'
      /home/sunny/code/verification-tests/features/support/env.rb:65:in `After'

Failing Scenarios:
cucumber -p devel -p _devel features/tierN/machine/machine_healthcheck.feature:46 # Scenario: Remediation should be skipped on master machine

1 scenario (1 failed)
24 steps (24 passed)
```
I have 2 questions.
1.  ` I store the last provisioned machine in the :machine clipboard` this step seems only get the machine which node status is Ready, if I create a new machine which node status is NotReady, I couldn't get it by this step.
2.  I have no idea why does this finish prematurely. @jhou1 Could you help to take a look, thanks.