### PR TITLE
OCP-18482: Modify testdata file locations

### DIFF
--- a/features/routing/rate-limit.feature
+++ b/features/routing/rate-limit.feature
@@ -22,7 +22,7 @@ Feature: Testing haproxy rate limit related features
     When I run the :create client command with:
       | f | <service> |
     Then the step should succeed
-    Given I obtain test data file "routing/<route>"
+    Given I obtain test data file "routing/routetimeout/<route>"
     When I run the :create client command with:
       | f | <route> |
     Then the step should succeed
@@ -44,7 +44,7 @@ Feature: Testing haproxy rate limit related features
 
     Examples:
       | route_type | route_name         | service                        | route                          | resolve_str               | url                           | pass_num |
-      | unsecure   | route              | unsecure/service_unsecure.json | unsecure/route_unsecure.json   | unsecure.example.com:80   | http://unsecure.example.com   | 1        |
-      | edge       | secured-edge-route | edge/service_unsecure.json     | edge/route_edge.json           | test-edge.example.com:443 | https://test-edge.example.com | 2        |
-      | reen       | route-reencrypt    | reencrypt/service_secure.json  | reencrypt/route_reencrypt.json | test-reen.example.com:443 | https://test-reen.example.com | 3        |
+      | unsecure   | route              | unsecure-service_unsecure.json | unsecure-route_unsecure.json   | unsecure.example.com:80   | http://unsecure.example.com   | 1        |
+      | edge       | secured-edge-route | edge-service_unsecure.json     | edge-route_edge.json           | test-edge.example.com:443 | https://test-edge.example.com | 2        |
+      | reen       | route-reencrypt    | reencrypt-service_secure.json  | reencrypt-route_reencrypt.json | test-reen.example.com:443 | https://test-reen.example.com | 3        |
 

--- a/testdata/routing/routetimeout/edge-route_edge.json
+++ b/testdata/routing/routetimeout/edge-route_edge.json
@@ -1,0 +1,1 @@
+../../../testdata/routing/edge/route_edge.json

--- a/testdata/routing/routetimeout/edge-service_unsecure.json
+++ b/testdata/routing/routetimeout/edge-service_unsecure.json
@@ -1,0 +1,1 @@
+edge/service_unsecure.json

--- a/testdata/routing/routetimeout/reencrypt-route_reencrypt.json
+++ b/testdata/routing/routetimeout/reencrypt-route_reencrypt.json
@@ -1,0 +1,1 @@
+../../../testdata/routing/reencrypt/route_reencrypt.json

--- a/testdata/routing/routetimeout/reencrypt-service_secure.json
+++ b/testdata/routing/routetimeout/reencrypt-service_secure.json
@@ -1,0 +1,1 @@
+reencrypt/service_secure.json

--- a/testdata/routing/routetimeout/unsecure-route_unsecure.json
+++ b/testdata/routing/routetimeout/unsecure-route_unsecure.json
@@ -1,0 +1,1 @@
+../../../testdata/routing/unsecure/route_unsecure.json

--- a/testdata/routing/routetimeout/unsecure-service_unsecure.json
+++ b/testdata/routing/routetimeout/unsecure-service_unsecure.json
@@ -1,0 +1,1 @@
+unsecure/service_unsecure.json


### PR DESCRIPTION
In order to effectively utilize the `Obtain` expression, soft links to the relevant test data files have been added to ensure the test cases get executed properly. In the current state, without this change, the `Examples` expression basically passes the raw values for the variables in the steps which cause `file/directory not found` error to occur when fetching the test data files and the execution fails. 

Due to some transient environment issues as of writing, I will share the V3-runner test with the modified test case, shortly. 