### PR TITLE
pod: allow specifying container in pod to execute on

### DIFF
--- a/features/step_definitions/pod.rb
+++ b/features/step_definitions/pod.rb
@@ -164,7 +164,7 @@ end
 # Called without the 'regardless...' parameter ir checks that pod reaches a
 #   ready status, then somehow dies. With the parameter it just makes sure
 #   pod os not there regardless of its current status.
-Given /^I wait for the pod(?: named "(.+)")? to die( regardless of current status)?$/ do |name, ignore_status|
+Given /^I wait for the pod#{OPT_QUOTED} to die( regardless of current status)?$/ do |name, ignore_status|
   ready_timeout = 15 * 60
   @result = pod(name).wait_till_ready(user, ready_timeout) unless ignore_status
   if ignore_status || @result[:success]
@@ -213,7 +213,7 @@ end
 
 # args can be a table where each cell is a command or an argument, or a
 #   multiline string where each line is a command or an argument
-When /^(I execute|admin executes) on the(?: "(.+?)")? pod:$/ do |by, pod_name, raw_args|
+When /^(I execute|admin executes) on the#{OPT_QUOTED} pod(?: #{QUOTED} container)?:$/ do |by, pod_name, container, raw_args|
   _user = by.split.first == "admin" ? admin : user
   if raw_args.respond_to? :raw
     # this is table, we don't mind dimentions used by user
@@ -223,7 +223,7 @@ When /^(I execute|admin executes) on the(?: "(.+?)")? pod:$/ do |by, pod_name, r
     args = raw_args.split("\n").map(&:strip)
   end
 
-  @result = pod(pod_name).exec(*args, as: _user)
+  @result = pod(pod_name).exec(*args, as: _user, container: container)
 end
 
 # wrapper around  oc logs, keep executing the command until we have an non-empty response

--- a/features/step_definitions/pod.rb
+++ b/features/step_definitions/pod.rb
@@ -164,7 +164,7 @@ end
 # Called without the 'regardless...' parameter ir checks that pod reaches a
 #   ready status, then somehow dies. With the parameter it just makes sure
 #   pod os not there regardless of its current status.
-Given /^I wait for the pod#{OPT_QUOTED} to die( regardless of current status)?$/ do |name, ignore_status|
+Given /^I wait for the#{OPT_QUOTED} pod to die( regardless of current status)?$/ do |name, ignore_status|
   ready_timeout = 15 * 60
   @result = pod(name).wait_till_ready(user, ready_timeout) unless ignore_status
   if ignore_status || @result[:success]


### PR DESCRIPTION
For OVN we sometimes need to execute on a specific container
in the pod in order to directly connect to the database over
unix socket and avoid SSL network connections.