### PR TITLE
resource existance output has changed for 4.5

### DIFF
--- a/lib/openshift/resource.rb
+++ b/lib/openshift/resource.rb
@@ -43,7 +43,7 @@ module BushSlicer
       result.clear.merge!(get(user: user, quiet: quiet))
       if result[:success]
         return true
-      elsif result[:response] =~ /not found/ or result[:response] =~ /doesn't/
+      elsif result[:response] =~ /not found/ or result[:response] =~ /doesn't have/
         return false
       else
         # e.g. when called by user without rights to list Resource

--- a/lib/openshift/resource.rb
+++ b/lib/openshift/resource.rb
@@ -43,7 +43,7 @@ module BushSlicer
       result.clear.merge!(get(user: user, quiet: quiet))
       if result[:success]
         return true
-      elsif result[:response] =~ /not found/
+      elsif result[:response] =~ /not found/ or result[:response] =~ /doesn't/
         return false
       else
         # e.g. when called by user without rights to list Resource


### PR DESCRIPTION
the output of for `oc get <resource> <resource_name>` seems to have changed from 4.4 and 4.5 ```
### 4.5
pruan@fedora-vm ~ $ oc get meteringconfig openshift-metering -n openshift-metering
error: the server doesn't have a resource type "meteringconfig"
pruan@fedora-vm ~ $ oc version
Client Version: 4.4.0-rc.8
Server Version: 4.5.0-0.nightly-2020-06-10-224736
Kubernetes Version: v1.18.3+91d0edd

##### 4.4
pruan@fedora-vm ~ $ oc version
Client Version: 4.4.0-rc.8
Server Version: 4.4.8
Kubernetes Version: v1.17.1+3f6f40d
pruan@fedora-vm ~ $ oc get meteringconfig openshift-metering -n openshift-metering
Error from server (NotFound): meteringconfigs.metering.openshift.io "openshift-metering" not found
```