### PR TITLE
update check_link_and_text for stable js

### DIFF
--- a/lib/rules/web/admin_console/4.5/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.5/common_ui_elements.xyaml
@@ -427,11 +427,12 @@ uncheck_checkbox:
 check_link_and_text:
   element:
     selector:
-      xpath: //a[contains(.,'<text>')]
+      xpath: //a[@class='co-resource-item__resource-name' and contains(.,'<text>')]
   scripts: 
     - command: |
-        var encodedhref = document.querySelector("a[data-test-id='<text>']").href
-        return decodeURIComponent(encodedhref).endsWith("<link_url>")
+        var x = document.querySelector("a[class='co-resource-item__resource-name']")
+        var encodedhref = (x.innerHTML =="<text>" && x.href)
+        return decodeURIComponent(encodedhref).includes("<link_url>")
       expect_result: true
 click_link_with_text:
   element:


### PR DESCRIPTION
Params are using `innerHTML` text instead of `data-test-id` value, update the rule.
@yapei Please review, thanks!