### PR TITLE
Remove pip and minio

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.centos
+++ b/tools/jenkins/slaves/Dockerfile.centos
@@ -27,9 +27,6 @@ RUN set -x && \
     chmod +x /usr/local/bin/chromedriver /usr/local/bin/geckodriver && \
     curl -sSL https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -o /tmp/epel-release-latest-7.noarch.rpm && \
     yum install -y /tmp/epel-release-latest-7.noarch.rpm && \
-    curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
-    python /tmp/get-pip.py && \
-    pip install minio && \
     mkdir -p $HOME/bin
 
 RUN scl enable rh-ruby26 "$HOME/bushslicer/tools/install_os_deps.sh"

--- a/tools/jenkins/slaves/Dockerfile.rhel7
+++ b/tools/jenkins/slaves/Dockerfile.rhel7
@@ -25,9 +25,6 @@ RUN set -x && \
     chmod +x /usr/local/bin/chromedriver /usr/local/bin/geckodriver && \
     curl -sSL https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -o /tmp/epel-release-latest-7.noarch.rpm && \
     yum install -y /tmp/epel-release-latest-7.noarch.rpm && \
-    curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
-    python /tmp/get-pip.py && \
-    pip install minio && \
     mkdir -p $HOME/bin
 
 # make sure context dir is at the repo root


### PR DESCRIPTION
pip and minio are added in https://github.com/openshift/verification-tests/pull/987

We also do install python3, pip and several other packages via pip in oc4x dockerfiles, so the decision is that we move them (python3 and so on from oc4x image, and pip, minio from cucushift-public image) into cucushift-base image, to reduce some duplicate effort and building resource/time.