### PR TITLE
Fix ocp-13065 test flake

### DIFF
--- a/features/upgrade/node/scc.feature
+++ b/features/upgrade/node/scc.feature
@@ -3,7 +3,7 @@ Feature: Seccomp part of SCC policy should be kept and working after upgrade
   # @author sunilc@redhat.com
   @upgrade-prepare
   @admin
-  Scenario: Upgrade - Seccomp part of SCC policy should be kept and working after upgrade - prepare
+  Scenario: Seccomp part of SCC policy should be kept and working after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "node/scc.yaml"   
     When I run the :create client command with:
@@ -14,6 +14,6 @@ Feature: Seccomp part of SCC policy should be kept and working after upgrade
   # @case_id OCP-13065
   @upgrade-check
   @admin
-  Scenario: Upgrade - Make sure seccomp part of SCC policy is kept after upgrade 
+  Scenario: Seccomp part of SCC policy should be kept and working after upgrade
     Given I switch to cluster admin pseudo user
     Given admin checks that the "seccomp" scc exists    


### PR DESCRIPTION
Fixes **OCP-13065 - could not find all scenarios**,  [build url](https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/106318/console)

Scenarios names should be consistent in upgrade-prepare and upgrade-check to make sure test gets executed before and after upgrade. 

Example:

upgrade-prepare: Seccomp part of SCC policy should be kept and working after upgrade - prepare
upgrade-check: Seccomp part of SCC policy should be kept and working after upgrade