### PR TITLE
Disable unexpected repos

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.rhel7
+++ b/tools/jenkins/slaves/Dockerfile.rhel7
@@ -7,6 +7,7 @@ LABEL maintainer="AOS QE Team"
 
 RUN set -x && \
     yum repolist all && \
+    yum-config-manager --disable rhel-7-server-htb-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-extras-rpms && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \


### PR DESCRIPTION
The repo `rhel-7-server-htb-rpms` is enabled in our based image `openshift3/jenkins-slave-base-rhel7:v3.11` unexpected, causing several images updated unexpectedly, causing package conflict in our automation images building.

/cc @akostadinov @pruan-rht @jhou1 