### PR TITLE
Fix OCP-14799

### DIFF
--- a/features/infrastructure/cluster-capacity.feature
+++ b/features/infrastructure/cluster-capacity.feature
@@ -1,13 +1,23 @@
 Feature: cluster-capacity related features
 
   # @author wjiang@redhat.com
+  # @author weinliu@redhat.com
   # @case_id OCP-14799
   @admin
   Scenario: Cluster capacity image support: Cluster capacity can work well with a simple pod
     Given environment has at least 2 schedulable nodes
     Given I have a project
+    Given I create the serviceaccount "cluster-capacity-sa"
+    And I give project admin role to the cluster-capacity-sa service account
+    Given I obtain test data file "infrastructure/cluster-capacity-cluster-role.yaml"
+    When I run the :create admin command with:
+      | f | cluster-capacity-cluster-role.yaml |
+    Then the step should succeed
+    When admin ensures "cluster-capacity-role" clusterrole is deleted after scenario
+    And cluster role "cluster-capacity-role" is added to the "system:serviceaccount:<%= project.name %>:cluster-capacity-sa" service account
+    Then the step should succeed
     Given I have a cluster-capacity pod in my project
-    Given I store the schedulable nodes in the :nodes clipboard
+    Given I store the schedulable workers in the :nodes clipboard
     Given evaluation of `cb.nodes.map {|n| n.max_pod_count_schedulable(cpu: convert_cpu("150m"), memory: convert_to_bytes("100Mi"))}.reduce(&:+)` is stored in the :expected_number_total clipboard
     When I run the :exec client command with:
       | pod               | cluster-capacity              |

--- a/features/step_definitions/admin.rb
+++ b/features/step_definitions/admin.rb
@@ -12,9 +12,10 @@ Given /^a secret is created for admin kubeconfig in current project$/ do
     f.write(@result[:response])
     f.close
     # secret name `admin-kubeconfig` must match template of e2e tests
-    @result = admin.cli_exec(:secret_new,
-                             secret_name: "admin-kubeconfig",
-                             source: "admin.kubeconfig=#{f.path}",
+    @result = admin.cli_exec(:create_secret,
+                             secret_type: "generic",
+                             name: "admin-kubeconfig",
+                             from_file: "admin.kubeconfig=#{f.path}",
                              n: project.name)
   end
 

--- a/testdata/infrastructure/cluster-capacity/cluster-capacity-pod.yaml
+++ b/testdata/infrastructure/cluster-capacity/cluster-capacity-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: cluster-capacity
-    image: openshift3/ose-cluster-capacity:v<%=env.get_version(user:user).first%>
+    image: quay.io/openshift/origin-cluster-capacity:latest
     volumeMounts:
     - mountPath: /test-pod
       name: test-volume


### PR DESCRIPTION
1.  Adding SA part to avoid access issue
2. Store shcedulable workers node only for masters are not counted in capacity
3. secret_new is deperated, re-write to using create_secret instead

running log on:
$ oc version
Client Version: 4.4.0-rc.10
Server Version: 4.5.0-rc.2
Kubernetes Version: v1.18.3+91d0edd

https://privatebin-it-iso.int.open.paas.redhat.com/?79d772b64ad3e7cf#ihVIjidhZrCQKV6V2g3KvYavN6AlI4gyz0UTA4VaSMk=

@jhou1 @sunilcio @lyman9966  could you help take a look?

