### PR TITLE
Update the step to avoid choosing a master node

### DIFF
--- a/features/step_definitions/project.rb
+++ b/features/step_definitions/project.rb
@@ -164,7 +164,8 @@ Given /^admin creates a project with a random schedulable node selector$/ do
     | project_name  | #{project_name}       |
     | node_selector | #{project_name}=label |
     })
-  step %Q/I select a random node's host/
+  step %Q/I store the ready and schedulable workers in the :nodes clipboard/
+  step %Q/I use the "<%= cb.nodes[0].name %>" node/
   step %Q/label "<%= project.name %>=label" is added to the "<%= node.name %>" node/
   step %Q/I switch to cluster admin pseudo user/
   step %Q/I use the "<%= project.name %>" project/

--- a/features/step_definitions/project.rb
+++ b/features/step_definitions/project.rb
@@ -165,7 +165,6 @@ Given /^admin creates a project with a random schedulable node selector$/ do
     | node_selector | #{project_name}=label |
     })
   step %Q/I store the ready and schedulable workers in the :nodes clipboard/
-  step %Q/I use the "<%= cb.nodes[0].name %>" node/
   step %Q/label "<%= project.name %>=label" is added to the "<%= node.name %>" node/
   step %Q/I switch to cluster admin pseudo user/
   step %Q/I use the "<%= project.name %>" project/


### PR DESCRIPTION
Before the update,  the node chosen might be a master node, in OCP4.x, the pod without tolerations created in this project can not be scheduled successfully. 