### PR TITLE
check ES status first

### DIFF
--- a/features/logging/kibana.feature
+++ b/features/logging/kibana.feature
@@ -25,7 +25,9 @@ Feature: Kibana related features
     And I perform the :kibana_find_index_pattern web action with:
       | index_pattern_name | project.<%= cb.proj.name %>.<%= cb.proj.uid %>.* |
     Then the step should succeed
-    And I log out kibana logging web console
+    When I run the :logout_kibana web action
+    Then the step should succeed
+    And I close the current browser
     Given cluster role "cluster-admin" is added to the "first" user
     Then I login to kibana logging web console
     Given evaluation of `[".operations.*", ".all", ".orphaned", "project.*"]` is stored in the :indices clipboard
@@ -37,7 +39,9 @@ Feature: Kibana related features
       | index_pattern_name | #{cb.index_name} |
     Then the step should succeed
     """
-    Then I log out kibana logging web console
+    When I run the :logout_kibana web action
+    Then the step should succeed
+    And I close the current browser
     And cluster role "cluster-admin" is removed from the "first" user
 
     And I login to kibana logging web console
@@ -171,11 +175,18 @@ Feature: Kibana related features
     And I perform the :kibana_find_index_pattern web action with:
       | index_pattern_name | .operations.* |
     Then the step should succeed
-    When I perform the :logout_kibana web action with:
-      | kibana_url | https://<%= cb.kibana_url %> |
+    When I run the :logout_kibana web action
     Then the step should succeed
     Given 10 seconds have passed
     When I access the "https://<%= cb.kibana_url %>" url in the web browser
+    Then the step should succeed
+    When I perform the :login_kibana web action with:
+      | username   | <%= user.name %>             |
+      | password   | <%= user.password %>         |
+      | idp        | <%= env.idp %>               |
+    Then the step should succeed
+    # click `Log in with OpenShift` button and login again
+    When I run the :logout_kibana web action 
     Then the step should succeed
     When I perform the :login_kibana web action with:
       | username   | <%= user.name %>             |

--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -144,6 +144,13 @@ Given /^I wait for clusterlogging(?: named "(.+)")? with #{QUOTED} log collector
   cl = cb.cluster_logging
   logger.info("### checking logging subcomponent status")
 
+  # check elasticsearch subcomponent is ready
+  logger.info("### checking logging subcomponent status: elasticsearch")
+  step %Q/a pod becomes ready with labels:/, table(%{
+    | component=elasticsearch |
+  })
+  cl.wait_until_es_is_ready
+
   # check log collector is ready.
   logger.info("### checking logging subcomponent status: log collector")
   if log_collector == "fluentd" then
@@ -157,12 +164,6 @@ Given /^I wait for clusterlogging(?: named "(.+)")? with #{QUOTED} log collector
     })
     cl.wait_until_rsyslog_is_ready
   end
-  # check elasticsearch subcomponent is ready
-  logger.info("### checking logging subcomponent status: elasticsearch")
-  step %Q/a pod becomes ready with labels:/, table(%{
-    | component=elasticsearch |
-  })
-  cl.wait_until_es_is_ready
 
   logger.info("### checking logging subcomponent status: kibana")
   step %Q/a pod becomes ready with labels:/, table(%{
@@ -285,8 +286,8 @@ Given /^I create clusterlogging instance with:$/ do | table |
     # to wait for the status informations to show up in the clusterlogging instance
     #sleep 10
     #step %Q/I wait for clusterlogging with "#{log_collector}" log collector to be functional in the project/
-    step %Q/I wait until "#{log_collector}" log collector is ready/
     step %Q/I wait until ES cluster is ready/
+    step %Q/I wait until "#{log_collector}" log collector is ready/
     step %Q/I wait until kibana is ready/
   end
 end

--- a/features/step_definitions/logging_metrics.rb
+++ b/features/step_definitions/logging_metrics.rb
@@ -28,14 +28,6 @@ Given /^I login to kibana logging web console$/ do
   browser.base_url = cb.logging_console_url
 end
 
-Given /^I log out kibana logging web console$/ do
-  cb.logging_console_url = route('kibana', service('kibana',project('openshift-logging', switch: false))).dns(by: admin)
-  step %Q/I perform the :logout_kibana web action with:/, table(%{
-    | kibana_url | https://<%= cb.logging_console_url %> |
-  })
-  browser.finalize
-end
-
 When /^I wait(?: (\d+) seconds)? for the #{QUOTED} index to appear in the ES pod(?: with labels #{QUOTED})?$/ do |seconds, index_name, pod_labels|
   if pod_labels
     labels = pod_labels

--- a/lib/rules/web/admin_console/4.1/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.1/logging_kibana.xyaml
@@ -20,7 +20,6 @@ click_log_in_with_openshift_button:
     op: click
 
 logout_kibana:
-  url: <kibana_url>
   elements:
     - selector:
         text: Log out

--- a/lib/rules/web/admin_console/4.2/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.2/logging_kibana.xyaml
@@ -20,7 +20,6 @@ click_log_in_with_openshift_button:
     op: click
 
 logout_kibana:
-  url: <kibana_url>
   elements:
     - selector:
         text: Log out

--- a/lib/rules/web/admin_console/4.3/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.3/logging_kibana.xyaml
@@ -20,7 +20,6 @@ click_log_in_with_openshift_button:
     op: click
 
 logout_kibana:
-  url: <kibana_url>
   elements:
     - selector:
         text: Log out

--- a/lib/rules/web/admin_console/4.4/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.4/logging_kibana.xyaml
@@ -20,7 +20,6 @@ click_log_in_with_openshift_button:
     op: click
 
 logout_kibana:
-  url: <kibana_url>
   elements:
     - selector:
         text: Log out


### PR DESCRIPTION
Start from 4.5, the fluentd and kibana are created after the ES, so I update the steps to check ES status first.

Besides, I add some steps to cover https://bugzilla.redhat.com/show_bug.cgi?id=1835578.

@anpingli PTAL, thanks.