### PR TITLE
update external ES

### DIFF
--- a/testdata/logging/logforwarding/elasticsearch/secure/configmap.yaml
+++ b/testdata/logging/logforwarding/elasticsearch/secure/configmap.yaml
@@ -28,6 +28,8 @@ data:
     xpack.security.http.ssl.certificate: /usr/share/elasticsearch/config/secret/elasticsearch.crt
     xpack.security.http.ssl.certificate_authorities: [ "/usr/share/elasticsearch/config/secret/admin-ca" ]
     xpack.security.http.ssl.verification_mode: certificate
+  add-user.sh: |
+   curl -XPOST -k 'https://localhost:9200/_xpack/security/user/fluentd' -H "Content-Type: application/json" -d '{"password":"changeme","full_name":"Fluentd","email":"fluentd@clusterlogging.com","roles":["super_user"]}'
 kind: ConfigMap
 metadata:
   name: elasticsearch-server

--- a/testdata/logging/logforwarding/elasticsearch/secure/deployment.yaml
+++ b/testdata/logging/logforwarding/elasticsearch/secure/deployment.yaml
@@ -29,6 +29,13 @@ spec:
       - image: quay.io/openshifttest/elasticsearch@sha256:87538ba78df48470563796df1dbbf2e7bf407e97542830bfd395f912b15c07f0
         imagePullPolicy: IfNotPresent
         name: elasticsearch-server
+        readinessProbe:
+          exec:
+            command:
+            - sh 
+            - /usr/share/elasticsearch/config/add-user.sh
+          initialDelaySeconds: 5
+          periodSeconds: 5
         ports:
         - containerPort: 9300
           protocol: TCP
@@ -40,6 +47,9 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           subPath: elasticsearch.yml
+          name: elasticsearch-config
+        - mountPath: /usr/share/elasticsearch/config/add-user.sh
+          subPath: add-user.sh
           name: elasticsearch-config
         - mountPath: /usr/share/elasticsearch/config/secret
           name: certificates
@@ -59,4 +69,3 @@ spec:
       serviceAccountName: elasticsearch-server
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-


### PR DESCRIPTION
Currently, after deploy secured external ES sever, we need to create an user by manual, that means every time the  pod restarted, we all need to create user, that's may cause failure when run automation. Here update the deployment and configmap to make it add the user after the pod start automatically.

@anpingli PTAL, thanks.