### PR TITLE
exec_raw: remove extra bash -c

### DIFF
--- a/lib/host.rb
+++ b/lib/host.rb
@@ -848,9 +848,19 @@ module BushSlicer
       node.env.service_project
     end
 
+    def remove_bash_c(*commands)
+      flat = commands.flatten
+      flat.reject.with_index { |c, i|
+        (flat[i] == "bash" and (flat.length >= i + 1) and flat[i + 1] == "-c") or
+            (flat[i] == "-c" and (i - 1 >= 0) and flat[i - 1] == "bash")
+      }
+    end
+
     # @note execute commands without special setup
     def exec_raw(*commands, **opts)
       unless opts[:single]
+        # remove prepended `bash -c` because we already have a 'bash -c'
+        commands = remove_bash_c(*commands)
         commands = ["chroot", "/host/", "bash", "-c", commands_to_string(commands)]
       end
 


### PR DESCRIPTION
While swtiching from running OVS in a Pod to running
OVS on the host we need to run similar commands on host or pod,
but unfortunately when running in a pod we use `bash -c` to
do inline shell.  When running a command with `bash -c` in `oc debug`
on the host the command is already wrapped with a `chroot /host` and a
`bash -c cd #{workdir}` and the command is line split inside the `bash -c`

For example in the same test we have the two different commands

    When I run commands on the host:
      | iptables -S \| wc -l |
    When I run command on the node's sdn pod:
      | bash | -c | iptables -S \| wc -l |

Call trace:

`host.exec_admin` calls
```ruby
def exec_admin(*commands, **opts)
  exec_as(:admin, *commands, **opts)
```

 which checks if "root" and calls itself again with `nil` user

```ruby
if self[:user] == "root"
  return exec_as(nil, *commands, **opts)
```

then prepends `cd #{workdir}`

```
when nil, self[:user]
  # perform blind exec in workdir
  return exec_raw("cd '#{workdir}'", commands, **opts)
```

which prepends a chroot and a bash -c in `OCDebugAccessibleHost`

```ruby
unless opts[:single]
  commands = ["chroot", "/host/", "bash", "-c", commands_to_string(commands)]
```

Thus we end up with an invalid command because the inner bash -c is mangled.

```bash
   [01:02:47] INFO> Shell Commands: oc debug  node/compute.internal -- chroot /host/ bash -c cd\ \'/tmp/workdir/rbrattai-rbrattai\''
   'bash'
   '-c'
   'pgrep\ ovs-vswitchd
   bash: line 2: -c: command not found
   1272
```

Current proposed solution is to remove `bash -c` in host.exec_admin calls