### PR TITLE
fix issue: get empty genUUID

### DIFF
--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -56,7 +56,11 @@ Feature: cluster-logging-operator related test
     And I wait for the "elasticsearch" elasticsearches to appear up to 300 seconds
     And the expression should be true> cluster_logging('instance').logstore_node_count == 2
     And the expression should be true> elasticsearch('elasticsearch').nodes[0]['nodeCount'] == 2
+    Given I wait up to 300 seconds for the steps to pass:
+    """
     Given evaluation of `elasticsearch('elasticsearch').nodes[0]['genUUID']` is stored in the :gen_uuid_1 clipboard
+    And the expression should be true> cb.gen_uuid_1 != nil
+    """
     Then I wait for the "elasticsearch-cdm-<%= cb.gen_uuid_1 %>-1" deployment to appear up to 300 seconds
     And I wait for the "elasticsearch-cdm-<%= cb.gen_uuid_1 %>-2" deployment to appear up to 300 seconds
     When I run the :patch client command with:

--- a/features/logging/elasticsearch.feature
+++ b/features/logging/elasticsearch.feature
@@ -45,7 +45,11 @@ Feature: Elasticsearch related tests
     Given I wait for the "elasticsearch" elasticsearches to appear
     And the expression should be true> elasticsearch('elasticsearch').nodes[0]['storage']['storageClassName'] == cb.default_sc.name
     Given I wait for clusterlogging with "fluentd" log collector to be functional in the project
-    And evaluation of `elasticsearch('elasticsearch').nodes[0]["genUUID"]` is stored in the :gen_uuid clipboard
+    Given I wait up to 300 seconds for the steps to pass:
+    """
+    Given evaluation of `elasticsearch('elasticsearch').nodes[0]['genUUID']` is stored in the :gen_uuid clipboard
+    And the expression should be true> cb.gen_uuid != nil
+    """
     Given a pod becomes ready with labels:
       | component=elasticsearch |
     And the expression should be true> pod.volume_claims.first.name.include? "elasticsearch-elasticsearch-cdm" and pod.volume_claims.first.name.include? cb.gen_uuid


### PR DESCRIPTION
To fix the below failure:
```
I wait for the "elasticsearch-cdm-<%= cb.es_genuuid %>-1" deployment to appear ==>@  features/step_definitions/resources.rb:144
06:00:56 INFO> oc get deployments elasticsearch-cdm--1 --output=yaml --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig --namespace=openshift-logging
06:01:56 INFO> After 44 iterations and 60 seconds:

STDERR:
Error from server (NotFound): deployments.apps "elasticsearch-cdm--1" not found
```
@anpingli PTAL, thanks.