### PR TITLE
fix OCP-28859

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -252,11 +252,11 @@ Feature: MachineHealthCheck Test Scenarios
 
     Given I create the 'Ready' unhealthyCondition
 
+    And I wait up to 600 seconds for the steps to pass:
+    """
     When I run the :logs admin command with:
       | resource_name | <%= pod.name %>                |
       | c             | machine-healthcheck-controller |
-    Then the output should match:
-      | maxUnhealthy: 1%             |
-      | Short-circuiting remediation |
-
-
+    Then the output should contain:
+      | mhc-<%= machine_set.name %>: total targets: 1,  maxUnhealthy: 1%, unhealthy: 1. Short-circuiting remediation |
+    """


### PR DESCRIPTION
Sometimes this case will meet below error.  @jhou1 @miyadav Please help to take a look.
```
      [10:19:37] INFO> Exit Status: 0
      | resource_name | <%= pod.name %>                |
      | c             | machine-healthcheck-controller |
    Then the output should match:                                                           # features/step_definitions/common.rb:33
      | maxUnhealthy: 1%             |
      | Short-circuiting remediation |
      pattern not found: (?-mix:Short-circuiting remediation) (RuntimeError)
      /home/sunny/code/verification-tests/features/step_definitions/common.rb:103:in `block (3 levels) in <top (required)>'
      /home/sunny/code/verification-tests/features/step_definitions/common.rb:97:in `each'
      /home/sunny/code/verification-tests/features/step_definitions/common.rb:97:in `block (2 levels) in <top (required)>'
      /home/sunny/code/verification-tests/features/step_definitions/common.rb:56:in `each'
      /home/sunny/code/verification-tests/features/step_definitions/common.rb:56:in `/^(the|all)? outputs?( by order)? should( not)? (contain|match)(?: (\d+) times)?:$/'
      features/machine/machine_healthcheck.feature:258:in `Then the output should match:'
```