### PR TITLE
fix finish prematurely

### DIFF
--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -71,8 +71,10 @@ Then(/^admin ensures machine number is restored after scenario$/) do
     end
     
     machines_waiting_delete.each do | machine |
+      step %Q/I successfully merge patch resource "machine\/#{machine.name}" with:/, table(%{
+         | {"metadata":{"finalizers":[]}} |
+      })
       machine.ensure_deleted(user: user, wait: 1200)
-      raise "Unable to delete machine #{machine.name}" if machine.exists?(user: user)
     end
   }
 end

--- a/features/test/machine.feature
+++ b/features/test/machine.feature
@@ -1,0 +1,31 @@
+Feature: Machine features testing  
+  
+  # @author zhsun@redhat.com
+  @admin
+  Scenario Outline: Testing machine removal when finalizers are used
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
+    And I pick a random machineset to scale
+    # Create an invalid machineset
+    Given I run the :get admin command with:
+      | resource      | machineset              |
+      | resource_name | <%= machine_set.name %> |
+      | namespace     | openshift-machine-api   |
+      | o             | yaml                    |
+    Then the step should succeed
+    And I save the output to file> machineset-invalid.yaml
+    And I replace content in "machineset-invalid.yaml":
+      | <%= machine_set.name %> | machineset-invalid |
+      | <valid_field>           | <invalid_value>    |
+      | /replicas:.*/           | replicas: 1        |
+
+    When I run the :create admin command with:
+      | f | machineset-invalid.yaml |
+    Then the step should succeed
+    And admin ensures "machineset-invalid" machineset is deleted after scenario
+
+    Examples:
+      | valid_field                 | invalid_value                       |
+      | name: aws-cloud-credentials | name: aws-cloud-credentials-invalid | 


### PR DESCRIPTION
Sometimes due to network issue or bug or other reasons, machine cannot be deleted, which will cause finish prematurely.  such as https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/114190/consoleFull
This pr want to fix this by deleting machines' finalizers when the cluster is restored, this could ensure machine could be deleted. And I drafted a case that will always finish prematurely to test. 
But after I added this step, it also always finish prematurely although the machine stuck at "Deleting" could be deleted.  @jhou1 @miyadav @akostadinov Could you help to take a look how should I modify this step? Thanks!
```
      [09:07:19] INFO> Exit Status: 0
      [09:07:19] INFO> Shell Commands: oc patch machine machineset-invalid-6dpbf -p \{\"metadata\":\{\"finalizers\":\[\]\}\} --type=merge --kubeconfig=/home/sunny/workdir/localhost-sunny/ocp4_admin.kubeconfig
      machine.machine.openshift.io/machineset-invalid-6dpbf patched
      
      [09:07:21] INFO> Exit Status: 0
      [09:07:51] ERROR> Test Execution will finish prematurely.
      patch failed to apply at []! machineset.machine.openshift.io "machineset-invalid" deleted
       (RuntimeError)
      /home/sunny/code/verification-tests/features/step_definitions/cli.rb:243:in `/^(?:(as admin) )?I successfully(?: (\w+|<%=.+?%>))? patch resource "(.*)\/(.*)" with:$/'
      /home/sunny/code/verification-tests/features/step_definitions/machine.rb:74:in `block (3 levels) in <top (required)>'
      /home/sunny/code/verification-tests/features/step_definitions/machine.rb:73:in `each'
      /home/sunny/code/verification-tests/features/step_definitions/machine.rb:73:in `block (2 levels) in <top (required)>'
      /home/sunny/code/verification-tests/lib/world.rb:432:in `block in after_scenario'
      /home/sunny/code/verification-tests/lib/world.rb:432:in `reverse_each'
      /home/sunny/code/verification-tests/lib/world.rb:432:in `after_scenario'
      /home/sunny/code/verification-tests/lib/manager.rb:35:in `clean_up'
      /home/sunny/code/verification-tests/features/support/env.rb:67:in `block (2 levels) in <top (required)>'
      /home/sunny/code/verification-tests/lib/base_helper.rb:131:in `capture_error'
      /home/sunny/code/verification-tests/features/support/env.rb:65:in `After'
```