### PR TITLE
auto OCP-32620

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -197,3 +197,30 @@ Feature: Machine features testing
       | iaas_type | machineset_name  |
       | aws       | machineset-29199 | # @case_id OCP-29199
 
+  # @author zhsun@redhat.com
+  # @case_id OCP-32620
+  @admin
+  @destructive
+  Scenario: Labels specified in a machineset should propagate to nodes
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    And admin ensures machine number is restored after scenario
+
+    Given I clone a machineset and name it "machineset-clone-32620"
+    Given as admin I successfully merge patch resource "machineset/machineset-clone-32620" with:
+      | {"spec":{"template":{"spec":{"metadata":{"labels":{"node-role.kubernetes.io/infra": ""}}}}}} |
+    Then the step should succeed
+
+    Given I scale the machineset to +1
+    Then the step should succeed
+    And the machineset should have expected number of running machines
+
+    #Check labels are propagate to nodes
+    Given I store the last provisioned machine in the :machine clipboard
+    And evaluation of `machine(cb.machine).node_name` is stored in the :noderef_name clipboard
+    When I run the :describe admin command with:
+      | resource | node                   |
+      | name     | <%= cb.noderef_name %> |
+    Then the step should succeed
+    And the output should match "node-role.kubernetes.io/infra="


### PR DESCRIPTION
auto OCP-32620: Labels specified in a machineset should propagate to nodes. @jhou1 @miyadav help to take a look. 
```
      [07:58:20] INFO> === End After Scenario: Labels specified in a machineset should propagate to nodes ===

1 scenario (1 passed)
15 steps (15 passed)
9m37.115s
```
