### PR TITLE
show systemctl status after restart

### DIFF
--- a/lib/platform/systemd_service.rb
+++ b/lib/platform/systemd_service.rb
@@ -111,6 +111,8 @@ module BushSlicer
         result = host.exec_admin("systemctl restart #{name}")
         results.push(result)
         unless result[:success]
+          # we should always check status if restart fails
+          host.exec_admin("systemctl status -l #{name}", quiet: false)
           if opts[:raise]
             raise "could not restart service #{name} on #{host.hostname}"
           end


### PR DESCRIPTION
Try to debug systemd restart failures by
running systemctl status after systemctl restart