### PR TITLE
fix ocp-13022

### DIFF
--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -20,7 +20,7 @@ Feature: Node components upgrade tests
     Then the output should match:
       | master.*False\\s+True\\s+False |
     """
-    And I wait up to 1200 seconds for the steps to pass:
+    And I wait up to 1980 seconds for the steps to pass:
     """
     When I run the :get client command with:
       | resource | machineconfigpool |

--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -16,16 +16,18 @@ Feature: Node components upgrade tests
     And I wait up to 30 seconds for the steps to pass:
     """
     When I run the :get client command with:
-      | resource | machineconfigpool |
+      | resource      | machineconfigpool |
+      | resource_name | master            |
     Then the output should match:
-      | master.*False\\s+True\\s+False |
+      | .*False\\s+True\\s+False |
     """
     And I wait up to 1980 seconds for the steps to pass:
     """
     When I run the :get client command with:
-      | resource | machineconfigpool |
+      | resource      | machineconfigpool |
+      | resource_name | master            |
     Then the output should match:
-      | master.*True\\s+False\\s+False |
+      | .*True\\s+False\\s+False |
     """
     Given I store the masters in the :masters clipboard
     And I use the "<%= cb.masters[0].name %>" node


### PR DESCRIPTION
I extend the waiting time of machineconfigpool check from 20mins to 33 mins. Because one master needs about 9-10mins to finish kubeletconfig sync and restart according to UpgradeCI log(Though it only cost about 5 mins per master in manual test), so I leave 11 mins per master and it's should be secure.