### PR TITLE
OCP-12194 fix dc creating issue

### DIFF
--- a/features/cli/oc_volume.feature
+++ b/features/cli/oc_volume.feature
@@ -14,9 +14,9 @@ Feature: oc_volume.feature
       | secret_name | test-secret |
       | sa_name     | default     |
     Then the step should succeed
-    When I run the :run client command with:
-      | name         | mydc                                                                                                          |
-      | image        | quay.io/openshifttest/hello-openshift@sha256:424e57db1f2e8e8ac9087d2f5e8faea6d73811f0b6f96301bc94293680897073 |
+    When I run the :new_app_as_dc client command with:
+      | docker_image | quay.io/openshifttest/storage@sha256:a05b96d373be86f46e76817487027a7f5b8b5f87c0ac18a246b018df11529b40 |
+      | name         | mydc                                                                                                  |
     Then the step should succeed
     Given a pod becomes ready with labels:
       | deployment=mydc-1 |


### PR DESCRIPTION
@jhou1 @sunilcio @lyman9966  could you help to take a look?

[Last fix](https://github.com/openshift/verification-tests/pull/1180/files)  passed may because the env was not clean, old dc still existed. 

Fixing this by replacing the wrong step to a working one, creating a deploy config.

log: http://pastebin.test.redhat.com/886637