### PR TITLE
auto OCP-32126

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -194,6 +194,7 @@ Feature: Machine features testing
       | k8s-app=termination-handler |
 
     Examples:
-      | iaas_type | machineset_name  |
-      | aws       | machineset-29199 | # @case_id OCP-29199
+      | iaas_type | machineset_name        |
+      | aws       | machineset-clone-29199 | # @case_id OCP-29199
+      | gcp       | machineset-clone-32126 | # @case_id OCP-32126
 

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -88,6 +88,8 @@ Given(/^I create a spot instance machineset and name it "([^"]*)" on (aws|gcp|az
   new_spec["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] = ms_name
   if iaas_type == 'aws'
     new_spec["spec"]["template"]["spec"]["providerSpec"]["value"]["spotMarketOptions"] = {}
+  elsif iaas_type == 'gcp'
+    new_spec["spec"]["template"]["spec"]["providerSpec"]["value"]["preemptible"] = true
   else
     raise "spot instance not supported on #{iaas_type}"
   end


### PR DESCRIPTION
Auto  OCP-32126: Required configuration should be added to the ProviderSpec to enable spot instances - GCP  

```
    [07:48:11] INFO> === End After Scenario: Required configuration should be added to the ProviderSpec to enable spot instances, Examples (#1) ===

1 scenario (1 passed)
15 steps (15 passed)
7m10.400s
```
