### PR TITLE
Update csidriver version

### DIFF
--- a/testdata/storage/csi/csi-hostpath-driverinfo.yaml
+++ b/testdata/storage/csi/csi-hostpath-driverinfo.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1
+apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: hostpath.csi.k8s.io


### PR DESCRIPTION
OCP4.4 does not support v1 version.
And test that OCP4.6 can using v1beta1 version.
So Update this csidriver to v1beta1.
@qinpingli @duanwei33 Please help to review.