### PR TITLE
Default values for Different IaaS - aws/azure/gcp/ 

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -225,3 +225,81 @@ Feature: Machine features testing
       | name     | <%= cb.noderef_name %> |
     Then the step should succeed
     And the output should match "node-role.kubernetes.io/infra="
+
+  # @author miyadav@redhat.com
+  # @case_id OCP-32269
+  @admin
+  @destructive
+  Scenario: Implement defaulting machineset values for AWS
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    Then admin ensures machine number is restored after scenario
+
+    Given I store the last provisioned machine in the :machine clipboard
+    When evaluation of `machine(cb.machine).aws_ami_id` is stored in the :default_ami_id clipboard
+    And evaluation of `machine(cb.machine).aws_availability_zone` is stored in the :default_availability_zone clipboard
+    Then admin ensures "default-valued-32269" machineset is deleted after scenario
+
+    Given I obtain test data file "cloud/ms-aws/ms_default_values.yaml"
+    When I run oc create over "ms_default_values.yaml" replacing paths:
+      | n                                                                                         | openshift-machine-api                           |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %>     |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | default-valued-32269                            |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %>     |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["ami"]["id"]                        | <%= cb.default_ami_id %>                        |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["placement"]["availabilityZone"]    | <%= cb.default_availability_zone %>             |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | default-valued-32269                            |
+    Then the step should succeed
+
+  # @author miyadav@redhat.com
+  # @case_id OCP-33056
+  @admin
+  @destructive
+  Scenario: Implement defaulting machineset values for GCP
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    Then admin ensures machine number is restored after scenario
+   
+    Given I store the last provisioned machine in the :machine clipboard
+    When evaluation of `machine(cb.machine).gcp_region` is stored in the :default_region clipboard
+    And evaluation of `machine(cb.machine).gcp_zone` is stored in the :default_zone clipboard
+    Then admin ensures "default-valued-33056" machineset is deleted after scenario
+   
+    Given I obtain test data file "cloud/ms-gcp/ms_default_values.yaml"
+    When I run oc create over "ms_default_values.yaml" replacing paths:
+      | n                                                                                         | openshift-machine-api                           |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %>     |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | default-valued-33056                            |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %>     |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["region"]                           | <%= cb.default_region %>                        |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["zone"]                             | <%= cb.default_zone %>                          |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | default-valued-33056                            |
+    Then the step should succeed
+
+  # @author miyadav@redhat.com
+  # @case_id OCP-33058
+  @admin
+  @destructive
+  Scenario: Implement defaulting machineset values for azure 
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    Then admin ensures machine number is restored after scenario
+
+    Given I store the last provisioned machine in the :machine clipboard
+    Then evaluation of `machine(cb.machine).azure_location` is stored in the :default_location clipboard
+    And admin ensures "default-valued-33058" machineset is deleted after scenario
+
+    Given I obtain test data file "cloud/ms-azure/ms_default_values.yaml"
+    When I run oc create over "ms_default_values.yaml" replacing paths:
+      | n                                                                                         | openshift-machine-api                           |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %>     |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | default-valued-33058                            |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %>     |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["location"]                         | <%= cb.default_location %>                      |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | default-valued-33058                            |
+    Then the step should succeed
+
+

--- a/lib/openshift/infrastructure.rb
+++ b/lib/openshift/infrastructure.rb
@@ -5,6 +5,10 @@ module BushSlicer
     # Avoid API name in class name for dis particular class
     @kind = "Infrastructure"
 
+    def infra_name(user: nil, cached: true, quiet: false)
+      status_raw(user: user, cached: cached, quiet: quiet).dig("infrastructureName")
+    end
+
     def platform(user: nil, cached: true, quiet: false)
       status_raw(user: user, cached: cached, quiet: quiet).dig("platform")
     end

--- a/lib/openshift/machine.rb
+++ b/lib/openshift/machine.rb
@@ -43,6 +43,31 @@ module BushSlicer
       instance_state == 'running'
     end
 
+    def azure_location(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'location')
+    end
+
+    def gcp_region(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'region')
+    end
+
+    def gcp_zone(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'zone')
+    end
+
+    def aws_ami_id(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'ami','id')
+    end
+
+    def aws_availability_zone(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'placement','availabilityZone')
+    end
+
     def deleting?(user: nil, cached: true, quiet: false)
       ! raw_resource(user: user, cached: cached, quiet: quiet).
           dig('metadata', 'deletionTimestamp').nil?

--- a/testdata/cloud/ms-aws/ms_default_values.yaml
+++ b/testdata/cloud/ms-aws/ms_default_values.yaml
@@ -1,92 +1,9 @@
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
-  annotations:
-    machine.openshift.io/GPU: "0"
-    machine.openshift.io/memoryMb: "8192"
-    machine.openshift.io/vCPU: "2"
-  creationTimestamp: "2020-07-13T06:01:25Z"
-  generation: 1
   labels:
     machine.openshift.io/cluster-api-cluster:
-  managedFields:
-  - apiVersion: machine.openshift.io/v1beta1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:labels:
-          .: {}
-          f:machine.openshift.io/cluster-api-cluster: {}
-      f:spec:
-        .: {}
-        f:replicas: {}
-        f:selector:
-          .: {}
-          f:matchLabels:
-            .: {}
-            f:machine.openshift.io/cluster-api-cluster: {}
-            f:machine.openshift.io/cluster-api-machineset: {}
-        f:template:
-          .: {}
-          f:metadata:
-            .: {}
-            f:labels:
-              .: {}
-              f:machine.openshift.io/cluster-api-cluster: {}
-              f:machine.openshift.io/cluster-api-machine-role: {}
-              f:machine.openshift.io/cluster-api-machine-type: {}
-              f:machine.openshift.io/cluster-api-machineset: {}
-          f:spec:
-            .: {}
-            f:metadata: {}
-            f:providerSpec:
-              .: {}
-              f:value:
-                .: {}
-                f:ami: {}
-                f:apiVersion: {}
-                f:blockDevices: {}
-                f:credentialsSecret: {}
-                f:deviceIndex: {}
-                f:iamInstanceProfile: {}
-                f:instanceType: {}
-                f:kind: {}
-                f:metadata: {}
-                f:placement: {}
-                f:securityGroups: {}
-                f:subnet: {}
-                f:tags: {}
-                f:userDataSecret: {}
-      f:status: {}
-    manager: cluster-bootstrap
-    operation: Update
-    time: "2020-07-13T06:01:25Z"
-  - apiVersion: machine.openshift.io/v1beta1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:annotations:
-          .: {}
-          f:machine.openshift.io/GPU: {}
-          f:machine.openshift.io/memoryMb: {}
-          f:machine.openshift.io/vCPU: {}
-    manager: machine-controller-manager
-    operation: Update
-    time: "2020-07-13T06:13:06Z"
-  - apiVersion: machine.openshift.io/v1beta1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:status:
-        f:availableReplicas: {}
-        f:fullyLabeledReplicas: {}
-        f:observedGeneration: {}
-        f:readyReplicas: {}
-        f:replicas: {}
-    manager: machineset-controller
-    operation: Update
-    time: "2020-07-13T06:16:40Z"
-  name: default-valued-32269
-  namespace: openshift-machine-api
+  name: default-valued-32269           
 spec:
   replicas: 1
   selector:

--- a/testdata/cloud/ms-aws/ms_default_values.yaml
+++ b/testdata/cloud/ms-aws/ms_default_values.yaml
@@ -1,0 +1,116 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations:
+    machine.openshift.io/GPU: "0"
+    machine.openshift.io/memoryMb: "8192"
+    machine.openshift.io/vCPU: "2"
+  creationTimestamp: "2020-07-13T06:01:25Z"
+  generation: 1
+  labels:
+    machine.openshift.io/cluster-api-cluster:
+  managedFields:
+  - apiVersion: machine.openshift.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:machine.openshift.io/cluster-api-cluster: {}
+      f:spec:
+        .: {}
+        f:replicas: {}
+        f:selector:
+          .: {}
+          f:matchLabels:
+            .: {}
+            f:machine.openshift.io/cluster-api-cluster: {}
+            f:machine.openshift.io/cluster-api-machineset: {}
+        f:template:
+          .: {}
+          f:metadata:
+            .: {}
+            f:labels:
+              .: {}
+              f:machine.openshift.io/cluster-api-cluster: {}
+              f:machine.openshift.io/cluster-api-machine-role: {}
+              f:machine.openshift.io/cluster-api-machine-type: {}
+              f:machine.openshift.io/cluster-api-machineset: {}
+          f:spec:
+            .: {}
+            f:metadata: {}
+            f:providerSpec:
+              .: {}
+              f:value:
+                .: {}
+                f:ami: {}
+                f:apiVersion: {}
+                f:blockDevices: {}
+                f:credentialsSecret: {}
+                f:deviceIndex: {}
+                f:iamInstanceProfile: {}
+                f:instanceType: {}
+                f:kind: {}
+                f:metadata: {}
+                f:placement: {}
+                f:securityGroups: {}
+                f:subnet: {}
+                f:tags: {}
+                f:userDataSecret: {}
+      f:status: {}
+    manager: cluster-bootstrap
+    operation: Update
+    time: "2020-07-13T06:01:25Z"
+  - apiVersion: machine.openshift.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:machine.openshift.io/GPU: {}
+          f:machine.openshift.io/memoryMb: {}
+          f:machine.openshift.io/vCPU: {}
+    manager: machine-controller-manager
+    operation: Update
+    time: "2020-07-13T06:13:06Z"
+  - apiVersion: machine.openshift.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        f:availableReplicas: {}
+        f:fullyLabeledReplicas: {}
+        f:observedGeneration: {}
+        f:readyReplicas: {}
+        f:replicas: {}
+    manager: machineset-controller
+    operation: Update
+    time: "2020-07-13T06:16:40Z"
+  name: default-valued-32269
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster:
+      machine.openshift.io/cluster-api-machineset:
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster:
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset:
+    spec:
+      metadata: {}
+      taints:
+      - effect: "NoSchedule"
+        key: "mapi"
+        value: "mapi_test"
+      providerSpec:
+        value:
+          ami:
+            id: 
+          placement:
+            availabilityZone: 
+
+

--- a/testdata/cloud/ms-azure/ms_default_values.yaml
+++ b/testdata/cloud/ms-azure/ms_default_values.yaml
@@ -1,0 +1,122 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations:
+    machine.openshift.io/GPU: "0"
+    machine.openshift.io/memoryMb: "8192"
+    machine.openshift.io/vCPU: "2"
+  creationTimestamp: "2020-07-06T04:57:43Z"
+  generation: 1
+  labels:
+    machine.openshift.io/cluster-api-cluster:
+    machine.openshift.io/cluster-api-machine-role: worker
+    machine.openshift.io/cluster-api-machine-type: worker
+  managedFields:
+  - apiVersion: machine.openshift.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:machine.openshift.io/cluster-api-cluster: {}
+          f:machine.openshift.io/cluster-api-machine-role: {}
+          f:machine.openshift.io/cluster-api-machine-type: {}
+      f:spec:
+        .: {}
+        f:replicas: {}
+        f:selector:
+          .: {}
+          f:matchLabels:
+            .: {}
+            f:machine.openshift.io/cluster-api-cluster: {}
+            f:machine.openshift.io/cluster-api-machineset: {}
+        f:template:
+          .: {}
+          f:metadata:
+            .: {}
+            f:labels:
+              .: {}
+              f:machine.openshift.io/cluster-api-cluster: {}
+              f:machine.openshift.io/cluster-api-machine-role: {}
+              f:machine.openshift.io/cluster-api-machine-type: {}
+              f:machine.openshift.io/cluster-api-machineset: {}
+          f:spec:
+            .: {}
+            f:metadata: {}
+            f:providerSpec:
+              .: {}
+              f:value:
+                .: {}
+                f:apiVersion: {}
+                f:credentialsSecret: {}
+                f:image: {}
+                f:kind: {}
+                f:location: {}
+                f:managedIdentity: {}
+                f:metadata: {}
+                f:networkResourceGroup: {}
+                f:osDisk: {}
+                f:publicIP: {}
+                f:publicLoadBalancer: {}
+                f:resourceGroup: {}
+                f:subnet: {}
+                f:userDataSecret: {}
+                f:vmSize: {}
+                f:vnet: {}
+                f:zone: {}
+      f:status: {}
+    manager: cluster-bootstrap
+    operation: Update
+    time: "2020-07-06T04:57:43Z"
+  - apiVersion: machine.openshift.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:machine.openshift.io/GPU: {}
+          f:machine.openshift.io/memoryMb: {}
+          f:machine.openshift.io/vCPU: {}
+    manager: machine-controller-manager
+    operation: Update
+    time: "2020-07-06T05:10:51Z"
+  - apiVersion: machine.openshift.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        f:availableReplicas: {}
+        f:fullyLabeledReplicas: {}
+        f:observedGeneration: {}
+        f:readyReplicas: {}
+        f:replicas: {}
+    manager: machineset-controller
+    operation: Update
+    time: "2020-07-06T05:19:06Z"
+  name: default-valued-33058
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster:
+      machine.openshift.io/cluster-api-machineset:
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster:
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset:
+    spec:
+      metadata: {}
+      taints:
+      - effect: "NoSchedule"
+        key: "mapi"
+        value: "mapi_test"
+      providerSpec:
+        value:
+          location: 
+          osDisk:
+            diskSizeGB: 128
+
+

--- a/testdata/cloud/ms-azure/ms_default_values.yaml
+++ b/testdata/cloud/ms-azure/ms_default_values.yaml
@@ -1,99 +1,11 @@
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
-  annotations:
-    machine.openshift.io/GPU: "0"
-    machine.openshift.io/memoryMb: "8192"
-    machine.openshift.io/vCPU: "2"
-  creationTimestamp: "2020-07-06T04:57:43Z"
-  generation: 1
   labels:
     machine.openshift.io/cluster-api-cluster:
     machine.openshift.io/cluster-api-machine-role: worker
     machine.openshift.io/cluster-api-machine-type: worker
-  managedFields:
-  - apiVersion: machine.openshift.io/v1beta1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:labels:
-          .: {}
-          f:machine.openshift.io/cluster-api-cluster: {}
-          f:machine.openshift.io/cluster-api-machine-role: {}
-          f:machine.openshift.io/cluster-api-machine-type: {}
-      f:spec:
-        .: {}
-        f:replicas: {}
-        f:selector:
-          .: {}
-          f:matchLabels:
-            .: {}
-            f:machine.openshift.io/cluster-api-cluster: {}
-            f:machine.openshift.io/cluster-api-machineset: {}
-        f:template:
-          .: {}
-          f:metadata:
-            .: {}
-            f:labels:
-              .: {}
-              f:machine.openshift.io/cluster-api-cluster: {}
-              f:machine.openshift.io/cluster-api-machine-role: {}
-              f:machine.openshift.io/cluster-api-machine-type: {}
-              f:machine.openshift.io/cluster-api-machineset: {}
-          f:spec:
-            .: {}
-            f:metadata: {}
-            f:providerSpec:
-              .: {}
-              f:value:
-                .: {}
-                f:apiVersion: {}
-                f:credentialsSecret: {}
-                f:image: {}
-                f:kind: {}
-                f:location: {}
-                f:managedIdentity: {}
-                f:metadata: {}
-                f:networkResourceGroup: {}
-                f:osDisk: {}
-                f:publicIP: {}
-                f:publicLoadBalancer: {}
-                f:resourceGroup: {}
-                f:subnet: {}
-                f:userDataSecret: {}
-                f:vmSize: {}
-                f:vnet: {}
-                f:zone: {}
-      f:status: {}
-    manager: cluster-bootstrap
-    operation: Update
-    time: "2020-07-06T04:57:43Z"
-  - apiVersion: machine.openshift.io/v1beta1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:annotations:
-          .: {}
-          f:machine.openshift.io/GPU: {}
-          f:machine.openshift.io/memoryMb: {}
-          f:machine.openshift.io/vCPU: {}
-    manager: machine-controller-manager
-    operation: Update
-    time: "2020-07-06T05:10:51Z"
-  - apiVersion: machine.openshift.io/v1beta1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:status:
-        f:availableReplicas: {}
-        f:fullyLabeledReplicas: {}
-        f:observedGeneration: {}
-        f:readyReplicas: {}
-        f:replicas: {}
-    manager: machineset-controller
-    operation: Update
-    time: "2020-07-06T05:19:06Z"
-  name: default-valued-33058
-  namespace: openshift-machine-api
+  name: default-valued-33058   
 spec:
   replicas: 1
   selector:

--- a/testdata/cloud/ms-gcp/ms_default_values.yaml
+++ b/testdata/cloud/ms-gcp/ms_default_values.yaml
@@ -1,0 +1,112 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations:
+    machine.openshift.io/memoryMb: "15360"
+    machine.openshift.io/vCPU: "4"
+  creationTimestamp: "2020-07-06T04:32:32Z"
+  generation: 1
+  labels:
+    machine.openshift.io/cluster-api-cluster:
+  managedFields:
+  - apiVersion: machine.openshift.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:machine.openshift.io/cluster-api-cluster: {}
+      f:spec:
+        .: {}
+        f:replicas: {}
+        f:selector:
+          .: {}
+          f:matchLabels:
+            .: {}
+            f:machine.openshift.io/cluster-api-cluster: {}
+            f:machine.openshift.io/cluster-api-machineset: {}
+        f:template:
+          .: {}
+          f:metadata:
+            .: {}
+            f:labels:
+              .: {}
+              f:machine.openshift.io/cluster-api-cluster: {}
+              f:machine.openshift.io/cluster-api-machine-role: {}
+              f:machine.openshift.io/cluster-api-machine-type: {}
+              f:machine.openshift.io/cluster-api-machineset: {}
+          f:spec:
+            .: {}
+            f:metadata: {}
+            f:providerSpec:
+              .: {}
+              f:value:
+                .: {}
+                f:apiVersion: {}
+                f:canIPForward: {}
+                f:credentialsSecret: {}
+                f:deletionProtection: {}
+                f:disks: {}
+                f:kind: {}
+                f:machineType: {}
+                f:metadata: {}
+                f:networkInterfaces: {}
+                f:projectID: {}
+                f:region: {}
+                f:serviceAccounts: {}
+                f:tags: {}
+                f:userDataSecret: {}
+                f:zone: {}
+      f:status: {}
+    manager: cluster-bootstrap
+    operation: Update
+    time: "2020-07-06T04:32:32Z"
+  - apiVersion: machine.openshift.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:machine.openshift.io/memoryMb: {}
+          f:machine.openshift.io/vCPU: {}
+    manager: machine-controller-manager
+    operation: Update
+    time: "2020-07-06T04:58:24Z"
+  - apiVersion: machine.openshift.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        f:availableReplicas: {}
+        f:fullyLabeledReplicas: {}
+        f:observedGeneration: {}
+        f:readyReplicas: {}
+        f:replicas: {}
+    manager: machineset-controller
+    operation: Update
+    time: "2020-07-06T05:02:11Z"
+  name: default-valued-33056
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster:
+      machine.openshift.io/cluster-api-machineset:
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster:
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset:
+    spec:
+      metadata: {}
+      taints:
+      - effect: "NoSchedule"
+        key: "mapi"
+        value: "mapi_test"
+      providerSpec:
+        value:
+          region: 
+          zone: 
+

--- a/testdata/cloud/ms-gcp/ms_default_values.yaml
+++ b/testdata/cloud/ms-gcp/ms_default_values.yaml
@@ -1,91 +1,9 @@
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
-  annotations:
-    machine.openshift.io/memoryMb: "15360"
-    machine.openshift.io/vCPU: "4"
-  creationTimestamp: "2020-07-06T04:32:32Z"
-  generation: 1
   labels:
     machine.openshift.io/cluster-api-cluster:
-  managedFields:
-  - apiVersion: machine.openshift.io/v1beta1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:labels:
-          .: {}
-          f:machine.openshift.io/cluster-api-cluster: {}
-      f:spec:
-        .: {}
-        f:replicas: {}
-        f:selector:
-          .: {}
-          f:matchLabels:
-            .: {}
-            f:machine.openshift.io/cluster-api-cluster: {}
-            f:machine.openshift.io/cluster-api-machineset: {}
-        f:template:
-          .: {}
-          f:metadata:
-            .: {}
-            f:labels:
-              .: {}
-              f:machine.openshift.io/cluster-api-cluster: {}
-              f:machine.openshift.io/cluster-api-machine-role: {}
-              f:machine.openshift.io/cluster-api-machine-type: {}
-              f:machine.openshift.io/cluster-api-machineset: {}
-          f:spec:
-            .: {}
-            f:metadata: {}
-            f:providerSpec:
-              .: {}
-              f:value:
-                .: {}
-                f:apiVersion: {}
-                f:canIPForward: {}
-                f:credentialsSecret: {}
-                f:deletionProtection: {}
-                f:disks: {}
-                f:kind: {}
-                f:machineType: {}
-                f:metadata: {}
-                f:networkInterfaces: {}
-                f:projectID: {}
-                f:region: {}
-                f:serviceAccounts: {}
-                f:tags: {}
-                f:userDataSecret: {}
-                f:zone: {}
-      f:status: {}
-    manager: cluster-bootstrap
-    operation: Update
-    time: "2020-07-06T04:32:32Z"
-  - apiVersion: machine.openshift.io/v1beta1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:annotations:
-          .: {}
-          f:machine.openshift.io/memoryMb: {}
-          f:machine.openshift.io/vCPU: {}
-    manager: machine-controller-manager
-    operation: Update
-    time: "2020-07-06T04:58:24Z"
-  - apiVersion: machine.openshift.io/v1beta1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:status:
-        f:availableReplicas: {}
-        f:fullyLabeledReplicas: {}
-        f:observedGeneration: {}
-        f:readyReplicas: {}
-        f:replicas: {}
-    manager: machineset-controller
-    operation: Update
-    time: "2020-07-06T05:02:11Z"
-  name: default-valued-33056
-  namespace: openshift-machine-api
+  name: default-valued-33056           
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
    [10:57:16] INFO> Shell Commands: rm -r -f -- /root/workdir/d63db26e8a09-
    
    [10:57:16] INFO> Exit Status: 0
    [10:57:16] INFO> === End After Scenario: Implement defaulting machineset values for AWS/GCP/Azure/Vsphere, Examples (#1) ===

1 scenario (1 passed)
8 steps (8 passed)

Has flakes