### PR TITLE
Bug fix for connection with openstack

### DIFF
--- a/lib/launchers/openstack.rb
+++ b/lib/launchers/openstack.rb
@@ -257,9 +257,12 @@ module BushSlicer
       return @os_volumes_url if @os_volumes_url
       for service in os_service_catalog
         if service['type'] == "volumev2"
-          @os_volumes_url = service['endpoints'][0]['publicURL'] ||
-            service['endpoints'][0]['url']
-          return @os_volumes_url
+          for item in service['endpoints']
+            if item['interface'] == 'public'
+              @os_volumes_url = item['url']
+              return @os_volumes_url
+            end
+          end
         end
       end
       raise "could not find volumes API URL in service catalog:\n#{os_service_catalog.to_yaml}"


### PR DESCRIPTION
@duanwei33 @pruan-rht Please help review.

This is the test log:
   And I verify that the IAAS volume with id "<%= cb.volumeID %>" was deleted                        # features/step_definitions/pv.rb:187
      [11:54:08] INFO> Shell Commands: oc get infrastructures.config.openshift.io cluster --output=yaml --kubeconfig=/root/workdir/Tester-OCP-qinping/ocp4_admin.kubeconfig
      <--snip-->
      [11:54:19] INFO> HTTP GET took 1.624 sec: 404 Not Found
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    [11:54:19] INFO> === After Scenario: dynamic provisioning, Examples (#1) ===
    [11:54:19] INFO> cleaning-up user testuser-21 projects
    [11:54:21] INFO> Shell Commands: oc delete projects --all --kubeconfig=/root/workdir/Tester-OCP-qinping/ocp4_testuser-21.kubeconfig
    project.project.openshift.io "u7w9z" deleted
    
    [11:54:31] INFO> Exit Status: 0
    [11:54:31] INFO> waiting up to 30 seconds for user clean-up to take place
    <--snip-->
    [11:54:56] INFO> Exit Status: 1
    [11:54:56] INFO> Shell Commands: oc delete projects tests-tester-ocp-qinping --wait=false --kubeconfig=/root/workdir/Tester-OCP-qinping/ocp4_admin.kubeconfig
    project.project.openshift.io "tests-tester-ocp-qinping" deleted
    
    [11:54:58] INFO> Exit Status: 0
    [11:54:58] INFO> Shell Commands: rm -r -f -- /root/workdir/Tester-OCP-qinping
    
    [11:54:58] INFO> Exit Status: 0
    [11:54:58] INFO> === End After Scenario: dynamic provisioning, Examples (#1) ===

1 scenario (1 passed)
21 steps (21 passed)
2m46.149s
[11:54:58] INFO> === At Exit ===
