### PR TITLE
match test case based on absolute path

### DIFF
--- a/lib/polarshift/test_case.rb
+++ b/lib/polarshift/test_case.rb
@@ -130,7 +130,7 @@ module BushSlicer
           return false # no need for expensive checks once we are complete
         else
           scenario = ScenarioWrapper.new(test_case)
-          if automation_file == scenario.file &&
+          if File.absolute_path(scenario.file) == File.join(BushSlicer::HOME, automation_file) &&
              automation_scenario == scenario.name
             if automation_args && !scenario.example?
               logger.error "case #{id} mismatch with scenario type, will never run"


### PR DESCRIPTION
match test case based on absolute path

Certain test-runners (Rubymine) force the use of the abspath of the
`.feature` files on the cucumber command line.  If the `scenario.file`
is an abspath then testing strict string equaliy will fail.

Instead compare the absolute path with the `automation_file`
relative to `BushSlicer::HOME`

Example:
```
scenario.file = /home/rbrattai/workspace/verification-tests/features/tierN/networking/network-policy.feature
automation_file = features/tierN/networking/network-policy.feature
```
