### PR TITLE
Fix OCPQE-1448

### DIFF
--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -60,7 +60,7 @@ module BushSlicer
       fake_config = Tempfile.new("kubeconfig")
       fake_config.close
 
-      res = host.exec_as(user, "oc version -o yaml --kubeconfig=#{fake_config.path}")
+      res = host.exec_as(user, "oc version -o yaml --client --kubeconfig=#{fake_config.path}")
 
       fake_config.unlink
 


### PR DESCRIPTION
\# get `oc` version on some host running as some username
As the comment stated, we only need the client version, no need to wait to connect to server (so can also get rid of server connection issue).

/cc @pruan-rht @akostadinov @xingxingxia @barleyer 


```
$ ~/oc/oc-4.1.35-202002140309.git.0.7bfae40.el7 version -o yaml --client
clientVersion:
  buildDate: "2020-02-14T03:21:57Z"
  compiler: gc
  gitCommit: 7bfae4041
  gitTreeState: clean
  gitVersion: v4.1.35
  goVersion: go1.11.13
  major: "4"
  minor: 1+
  platform: linux/amd64

$ ~/oc/oc-4.2.20-202002140432.git.1.5dc67c9.el7 version -o yaml --client
clientVersion:
  buildDate: "2020-02-14T04:52:39Z"
  compiler: gc
  gitCommit: 7207690010f08f2ae526ee3300d4a18ea65997fe
  gitTreeState: clean
  gitVersion: v4.2.20
  goVersion: go1.12.8
  major: ""
  minor: ""
  platform: linux/amd64

$ ~/oc/oc-4.3.14-202004180552.git.1.a7a610a.el7 version -o yaml --client
clientVersion:
  buildDate: "2020-04-18T05:57:45Z"
  compiler: gc
  gitCommit: 4fb2d4d96e6b604f7d4ee49080238a5aec04dc4f
  gitTreeState: clean
  gitVersion: 4.3.14-202004180552-4fb2d4d
  goVersion: go1.12.12
  major: ""
  minor: ""
  platform: linux/amd64

$ ~/oc/oc-4.4.0-202005111349.git.1.8a0b552.el7 version -o yaml --client
clientVersion:
  buildDate: "2020-05-11T13:57:40Z"
  compiler: gc
  gitCommit: 2576e482bf003e34e67ba3d69edcf5d411cfd6f3
  gitTreeState: clean
  gitVersion: 4.4.0-202005111349-2576e48
  goVersion: go1.13.4
  major: ""
  minor: ""
  platform: linux/amd64

$ ~/oc/oc-4.5.0-202007240519.p0.git.3595.2a57ac7.el7 version -o yaml --client
clientVersion:
  buildDate: "2020-07-24T05:47:32Z"
  compiler: gc
  gitCommit: b66f2d3a6893be729f1b8660309a59c6e0b69196
  gitTreeState: clean
  gitVersion: 4.5.0-202007240519.p0-b66f2d3
  goVersion: go1.13.4
  major: ""
  minor: ""
  platform: linux/amd64

$ ~/oc/oc-4.6.0-202007290214.p0.git.3679.02da520.el7 version -o yaml --client
clientVersion:
  buildDate: "2020-07-29T02:38:20Z"
  compiler: gc
  gitCommit: 0180b33de52e9dbcd9735e6fdac1e51de875c581
  gitTreeState: clean
  gitVersion: 4.6.0-202007290214.p0-0180b33
  goVersion: go1.13.4
  major: ""
  minor: ""
  platform: linux/amd64

```