### PR TITLE
Fix gecokdriver download url

### DIFF
--- a/tools/openshift-ci/Dockerfile.centos
+++ b/tools/openshift-ci/Dockerfile.centos
@@ -8,12 +8,12 @@ USER root
 ADD . /verification-tests/
 
 RUN set -x && \
+    yum -y update && \
     SCL_BASE_PKGS="centos-release-scl scl-utils-build" && \
     INSTALL_PKGS="rh-ruby26 rh-ruby26-ruby-devel rh-git218 bsdtar" && \
-    yum -y update && \
     yum install -y --enablerepo=centosplus --setopt=skip_missing_names_on_install=False $SCL_BASE_PKGS && \
     yum install -y --enablerepo=centosplus --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-    GECKODRIVER_DOWNLOAD_URL="$(curl -sSL https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep -Eo 'http.*linux64.tar.gz' | sed -E 's/.*(https[^"]*).*/\1/')" && \
+    GECKODRIVER_DOWNLOAD_URL="$(curl -sSL https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep -Eo 'http.*linux64.tar.gz' | sed -E 's/.*(https[^"]*).*/\1/' | head -1)" && \
     curl -sSL "$GECKODRIVER_DOWNLOAD_URL" | bsdtar -xvf - -C /usr/local/bin && \
     chmod +x /usr/local/bin/geckodriver && \
     curl -sSL https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -o /tmp/epel-release-latest-7.noarch.rpm && \


### PR DESCRIPTION
```
$ curl -sSL https://api.github.com/repos/mozilla/geckodriver/releases/latest  > geckodriver
$ grep -Eo 'http.*linux64.tar.gz'  geckodriver | sed -E 's/.*(https[^"]*).*/\1/'
https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
```
/cc @pruan-rht @akostadinov @jhou1 

Currently this is blocking auto merge in this repo.