### PR TITLE
update 3 test cases according new features and fix all UI test failures

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -303,8 +303,8 @@ Feature: Pod related networking scenarios
     And evaluation of `service(cb.host_pod1.name).node_port(port: 8080)` is stored in the :nodeport clipboard
     #Creating a simple client pod to generate traffic from it towards the exposed node IP address
     Given I obtain test data file "networking/aosqe-pod-for-ping.json"
-    When I run the :create client command with:
-      | f | aosqe-pod-for-ping.json |
+    When I run oc create over "aosqe-pod-for-ping.json" replacing paths:
+      | ["spec"]["nodeName"] | <%= cb.nodes[0].name %> |
     Then the step should succeed
     Given a pod becomes ready with labels:
       | name=hello-pod |

--- a/lib/rules/web/admin_console/4.2/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.2/monitoring_alerts.xyaml
@@ -23,7 +23,10 @@ filter_alert:
 open_alert_detail:
   action: filter_alert
   action: click_alert_link_with_text
-
+check_alert_detail:
+  params:
+    content: alertname=Watchdog
+  action: check_page_contains
 perform_action_item:
   params:
     button_text: <item_text>

--- a/lib/rules/web/admin_console/4.2/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.2/monitoring_metrics.xyaml
@@ -1,3 +1,7 @@
+check_sample_query_area:
+  element:
+    selector:
+      xpath: //textarea[contains(text(),'sum_over_time')]
 click_primary_menu_developer_mode:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.3/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.3/monitoring_alerts.xyaml
@@ -23,7 +23,10 @@ filter_alert:
 open_alert_detail:
   action: filter_alert
   action: click_alert_link_with_text
-
+check_alert_detail:
+  params:
+    content: alertname=Watchdog
+  action: check_page_contains
 perform_action_item:
   params:
     button_text: <item_text>

--- a/lib/rules/web/admin_console/4.3/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.3/monitoring_metrics.xyaml
@@ -1,3 +1,7 @@
+check_sample_query_area:
+  element:
+    selector:
+      xpath: //textarea[contains(text(),'sum_over_time')]
 click_primary_menu_developer_mode:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.4/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.4/monitoring_alerts.xyaml
@@ -23,7 +23,10 @@ filter_alert:
 open_alert_detail:
   action: filter_alert
   action: click_alert_link_with_text
-
+check_alert_detail:
+  params:
+    content: alertname=Watchdog
+  action: check_page_contains
 perform_action_item:
   params:
     button_text: <item_text>

--- a/lib/rules/web/admin_console/4.4/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.4/monitoring_metrics.xyaml
@@ -1,3 +1,7 @@
+check_sample_query_area:
+  element:
+    selector:
+      xpath: //textarea[contains(text(),'sum_over_time')]
 click_primary_menu_developer_mode:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.5/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.5/monitoring_alerts.xyaml
@@ -32,6 +32,10 @@ filter_alert:
 open_alert_detail:
   action: filter_alert
   action: click_alert_link_with_text
+check_alert_detail:
+  params:
+    content: alertname=Watchdog
+  action: check_page_contains
 open_alertrules_detail:
   action: filter_alert
   action: click_alert_link_with_text

--- a/lib/rules/web/admin_console/4.5/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.5/monitoring_metrics.xyaml
@@ -1,3 +1,7 @@
+check_sample_query_area:
+  element:
+    selector:
+      xpath: //textarea[contains(text(),'sum_over_time')]
 click_primary_menu_developer_mode:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.6/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.6/monitoring_alerts.xyaml
@@ -30,8 +30,18 @@ filter_alert:
   action: clear_name_filter_if_exists
   action: set_input_class
 open_alert_detail:
+  action: Disable_all_filters
   action: filter_alert
   action: click_alert_link_with_text
+check_alert_detail:
+  params:
+    content: alertname=Watchdog
+  action: check_page_contains
+  action: check_alert_breadcrumb
+check_alert_breadcrumb:
+  params:
+    text: Alerts
+    link_url: /monitoring/alerts
 open_alertrules_detail:
   action: filter_alert
   action: click_alert_link_with_text
@@ -227,6 +237,7 @@ check_info_of_silence_detail_reg:
     alert_name: Watchdog
   action: check_silence_name
   action: check_silenced_alert_name
+  action: check_silence_breadcrumb
 check_silence_name:
   element:
     selector:
@@ -235,6 +246,11 @@ check_silenced_alert_name:
   element:
     selector:
       xpath: //a[contains(text(), '<alert_name>')]
+check_silence_breadcrumb:
+  params:
+    text: Silences
+    link_url: /monitoring/silences
+  action: check_link_and_text
 expire_alert_from_cog_menu: 
   action: filter_alert
   action: click_first_action_icon
@@ -249,23 +265,27 @@ open_alert_rule_from_detail:
 check_alert_rule_details:
   params:
     rule_name: Watchdog
-    expression: vector(1)
-    link: /monitoring/query-browser?query0=vector(1)
   action: check_rule_name
   action: check_ruel_expression
   action: check_active_alerts
+  action: check_rule_breadcrumb
 check_rule_name:
   element:
     selector:
       xpath: //dd[contains(text(), '<rule_name>')]
 check_ruel_expression:
   params:
-    text: <expression>
-    link_url: <link>
+    text: vector(1)
+    link_url: /monitoring/query-browser?query0=vector(1)
   action: check_link_and_text
 check_active_alerts:
   action: check_view_metrics
   action: check_alert_description_on_rule_detail
+check_rule_breadcrumb:
+  params:
+    text: Alerting Rules
+    link_url: /monitoring/alertrules
+  action: check_link_and_text
 check_view_metrics:
   params:
     text: View in Metrics

--- a/lib/rules/web/admin_console/4.6/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.6/monitoring_metrics.xyaml
@@ -1,3 +1,7 @@
+check_sample_query_area:
+  element:
+    selector:
+      xpath: //textarea[contains(text(),'sum_over_time')]
 click_primary_menu_developer_mode:
   element:
     selector:
@@ -73,7 +77,7 @@ check_query_input_text_area:
 click_promql_button:
   element:
     selector: &promql_button
-      xpath: //span[text()='<text>']/parent::button
+      xpath: //button[text()='<text>']
     op: click
 click_hide_promql_button:
   params:


### PR DESCRIPTION
Depend on PR:
https://github.com/openshift/cucushift/pull/8014
Updated 3 test cases
OCP-21124 - Show a detailed and complete view of an Alert
OCP-21132 - Show a detailed and complete view of an alerting rule
OCP-21192 - Show a detailed and complete view of Alertmanager Silence, "Firing Alerts" list is in Silence details page
Fixed failure for 3 cases
OCP-24343 - navigate to the query browser via the left side OpenShift console menu
https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-28106
https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-27830
v3 job:
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/127867/console
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/128188/console