### PR TITLE
Bug fix for the new changes in the latest oc version

### DIFF
--- a/features/cli/oc_volume.feature
+++ b/features/cli/oc_volume.feature
@@ -79,15 +79,15 @@ Feature: oc_volume.feature
     Then the step should succeed
 
     When I run the :get client command with:
-      | resource | dc/mydc                                                   |
-      | o        | jsonpath={.spec.template.spec.containers[*].volumeMounts} |
+      | resource | dc/mydc                              |
+      | o        | custom-columns=volume:..volumeMounts |
     Then the step should succeed
     And the output should contain 1 times:
       | name:secret |
 
     When I run the :get client command with:
-      | resource | rc/mydc-1                                                 |
-      | o        | jsonpath={.spec.template.spec.containers[*].volumeMounts} |
+      | resource | rc/mydc-1                            |
+      | o        | custom-columns=volume:..volumeMounts |
     Then the step should succeed
     And the output should contain 1 times:
       | name:secret |

--- a/features/step_definitions/pv.rb
+++ b/features/step_definitions/pv.rb
@@ -25,6 +25,8 @@ Given /^I save volume id from PV named "([^"]*)" in the#{OPT_SYM} clipboard$/ do
     cb[cbname] = @result[:parsed]['spec']['vsphereVolume']['volumePath']
   when @result[:parsed]['spec']['rbd']
     cb[cbname] = @result[:parsed]['spec']['rbd']['image']
+  when @result[:parsed]['spec']['csi']
+    cb[cbname] = @result[:parsed]['spec']['csi']['volumeHandle']
   else
     raise "Unknown persistent volume type."
   end

--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -183,7 +183,6 @@ Given(/^admin clones storage class #{QUOTED} from #{QUOTED} with:$/) do |target_
     | resource      | StorageClass |
     | resource_name | #{src_sc}    |
     | o             | yaml         |
-    | export        | true         |
   })
   sc_hash = YAML.load @result[:stdout]
 


### PR DESCRIPTION
1. oc get deployment service-ca -n openshift-service-ca  -o jsonpath={.spec.template.spec.containers[*].volumeMounts} cmd, in the latest version, it returns:
[{"mountPath":"/var/run/secrets/signing-key","name":"signing-key"},{"mountPath":"/var/run/configmaps/signing-cabundle","name":"signing-cabundle"}]
2. oc get cmd does not support export option now.
3. add the new volume type csi.

@duanwei33 @chao007  Please help review.