### PR TITLE
mhc validation before sending data to server to create mhc resource

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -260,3 +260,19 @@ Feature: MachineHealthCheck Test Scenarios
     Then the output should contain:
       | mhc-<%= machine_set.name %>: total targets: 1,  maxUnhealthy: 1%, unhealthy: 1. Short-circuiting remediation |
     """
+
+  # @author miyadav@redhat.com
+  # @case_id OCP-33714
+  @admin
+  Scenario: Leverage OpenAPI validation within MHC
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    Then I use the "openshift-machine-api" project
+
+    # Create MHC with malformed unhealthy nodes value and empty selectors
+    Given I obtain test data file "cloud/mhc/mhc_malformed.yaml"
+    When I run the :create client command with:
+      | f | mhc_malformed.yaml | 
+    Then the output should contain:
+      | The MachineHealthCheck "mhc-malformed" is invalid: |
+


### PR DESCRIPTION
[New requirement for 4.6 ](https://issues.redhat.com/browse/OCPCLOUD-911)
Closing this one - https://github.com/openshift/verification-tests/pull/1411 , as it might results in failing cases for 4.5 , so instead I have kept 4.5 as is and new case for 4.6 , once  backported will remove 4.5 case .

Here are the results - 
      [05:21:16] INFO> Exit Status: 0
    And I switch to cluster admin pseudo user                       # features/step_definitions/user.rb:13
waiting for operation up to 3600 seconds..
    Then I use the "openshift-machine-api" project                  # features/step_definitions/project.rb:97
      [05:21:16] INFO> Shell Commands: oc project openshift-machine-api --config=/root/workdir/26351978eef8-/ocp4_admin.kubeconfig
      Now using project "openshift-machine-api" on server "https://api.miyadav-j911.qe.gcp.devcluster.openshift.com:6443".
      
      [05:21:18] INFO> Exit Status: 0
      # Create MHC with malformed unhealthy nodes value and empty selectors
    Given I obtain test data file "cloud/mhc/mhc_malformed.yaml"    # features/step_definitions/file.rb:1
waiting for operation up to 3600 seconds..
    When I run oc create over "mhc_malformed.yaml" replacing paths: # features/step_definitions/cli.rb:60
      [05:21:18] INFO> {"apiVersion":"machine.openshift.io/v1beta1","kind":"MachineHealthCheck","metadata":{"name":"mhc-malformed","namespace":"openshift-machine-api"},"spec":{"selector":{},"unhealthyConditions":[{"type":"Ready","status":"False","timeout":"300s"},{"type":"Ready","status":"Unknown","timeout":"300s"}],"maxUnhealthy":"3%0"}}
      [05:21:18] INFO> Shell Commands: oc create -f - --config=/root/workdir/26351978eef8-/ocp4_admin.kubeconfig
      
      STDERR:
      The MachineHealthCheck "mhc-malformed" is invalid: spec.maxUnhealthy: Invalid value: "": spec.maxUnhealthy in body should match '^((100|[0-9]{1,2})%|[0-9]+)$'
      
      [05:21:20] INFO> Exit Status: 1
      | n | openshift-machine-api |
    Then the output should contain:                                 # features/step_definitions/common.rb:33
      | The MachineHealthCheck "mhc-malformed" is invalid: |
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [05:21:20] INFO> === After Scenario: Leverage OpenAPI validation within MHC ===
      [05:21:20] INFO> Shell Commands: rm -r -f -- /root/workdir/26351978eef8-
      
      [05:21:20] INFO> Exit Status: 0
      [05:21:20] INFO> === End After Scenario: Leverage OpenAPI validation within MHC ===

1 scenario (1 passed)
6 steps (6 passed)
0m8.040s
[05:21:20] INFO> === At Exit ===
