### PR TITLE
Update ruby to 2.5 when using ruby-ex repo to build

### DIFF
--- a/features/cli/oc_import_image.feature
+++ b/features/cli/oc_import_image.feature
@@ -159,7 +159,7 @@ Feature: oc import-image related feature
       | image_name | ruby-25-centos7:latest |
     Then the step should succeed
     When I run the :new_build client command with:
-      | image_stream | ruby-25-centos7                          |
+      | image_stream | ruby-25-centos7                       |
       | code         | https://github.com/sclorg/ruby-ex.git |
     Then the step should succeed
     When I run the :get client command with:
@@ -182,7 +182,7 @@ Feature: oc import-image related feature
       | reference-policy| local                  |
     Then the step should succeed
     When I run the :new_build client command with:
-      | image_stream | ruby-25-centos7                          |
+      | image_stream | ruby-25-centos7                       |
       | code         | https://github.com/sclorg/ruby-ex.git |
     Then the step should succeed
     When I run the :get client command with:

--- a/features/registry/is.feature
+++ b/features/registry/is.feature
@@ -96,7 +96,7 @@ Feature: Testing imagestream
     Given default image registry route is stored in the :registry_hostname clipboard
     Given certification for default image registry is stored to the :reg_crt_name clipboard
     When I run the :new_app_as_dc client command with:
-      | app_repo | ruby~https://github.com/sclorg/ruby-ex.git |
+      | app_repo | ruby:2.5~https://github.com/sclorg/ruby-ex.git |
     Then the step should succeed
     And the "ruby-ex-1" build was created
     And the "ruby-ex-1" build completes
@@ -139,7 +139,7 @@ Feature: Testing imagestream
     Given certification for default image registry is stored to the :reg_crt_name clipboard
 
     When I run the :new_app client command with:
-      | app_repo | ruby~https://github.com/sclorg/ruby-ex.git |
+	    | app_repo | ruby:2.5~https://github.com/sclorg/ruby-ex.git |
     Then the step should succeed
     And the "ruby-ex-1" build was created
     And the "ruby-ex-1" build completes
@@ -150,7 +150,7 @@ Feature: Testing imagestream
 
     Given I create a new project
     When I run the :new_app client command with:
-      | app_repo | ruby~https://github.com/sclorg/ruby-ex.git |
+	    | app_repo | ruby:2.5~https://github.com/sclorg/ruby-ex.git |
     Then the step should succeed
     And the "ruby-ex-1" build was created
     And the "ruby-ex-1" build completes

--- a/features/registry/remote.feature
+++ b/features/registry/remote.feature
@@ -9,7 +9,7 @@ Feature: remote registry related scenarios
       | user name       | system:anonymous |
     Then the step should succeed
     When I run the :new_build client command with:
-      | app_repo | ruby~https://github.com/sclorg/ruby-ex.git |
+	    | app_repo | ruby:2.5~https://github.com/sclorg/ruby-ex.git |
     Then the step should succeed
     And the "ruby-ex-1" build was created
     And the "ruby-ex-1" build completes
@@ -39,7 +39,7 @@ Feature: remote registry related scenarios
     Given I create a new project
     And evaluation of `project.name` is stored in the :u1p2 clipboard
     When I run the :new_build client command with:
-      | app_repo | ruby~https://github.com/sclorg/ruby-ex.git |
+	    | app_repo | ruby:2.5~https://github.com/sclorg/ruby-ex.git |
     Then the step should succeed
     And the "ruby-ex-1" build was created
     Then the "ruby-ex-1" build completes


### PR DESCRIPTION
Now ruby: latest is point to 2.7 in openshift project, build cases failed, devel have no idea how to update repo, so update cases to let pass.
@openshift/devexp-qe PTAL, thanks.

command: "oc new-app ruby~https://github.com/sclorg/ruby-ex" has below error:
STEP 8: RUN /usr/libexec/s2i/assemble
---> Installing application source ...
---> Building your Ruby application from source ...
---> Running 'bundle install --retry 2 --deployment --without development:test' ...
/opt/rh/rh-ruby27/root/usr/share/rubygems/rubygems.rb:275:in `find_spec_for_exe': Could not find 'bundler' (1.16.4) required by your /opt/app-root/src/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.16.4`
	from /opt/rh/rh-ruby27/root/usr/share/rubygems/rubygems.rb:294:in `activate_bin_path'
	from /opt/rh/rh-ruby27/root/usr/bin/bundle:23:in `<main>'
subprocess exited with status 1
subprocess exited with status 1
error: build error: error building at STEP "RUN /usr/libexec/s2i/assemble": exit status 1
