### PR TITLE
Bug fix for azure connection and get disk by name

### DIFF
--- a/lib/iaas/iaas.rb
+++ b/lib/iaas/iaas.rb
@@ -69,8 +69,18 @@ module BushSlicer
     end
 
     def self.init_azure(env)
-      # secret = Secret.new(name: "azure-credentials", project: project('kube-system'))
-      raise "TODO init azure"
+      secret = Secret.new(name: "azure-credentials", project: Project.new(name: 'kube-system', env: env))
+      auth = {}
+      auth[:tenant_id] = secret.value_of("azure_tenant_id", user: :admin)
+      auth[:client_id] = secret.value_of("azure_client_id", user: :admin)
+      auth[:client_secret] = secret.value_of("azure_client_secret", user: :admin)
+
+      return BushSlicer::Azure.new(
+        :location => secret.value_of("azure_region", user: :admin),
+        :subscription_id => secret.value_of("azure_subscription_id", user: :admin),
+	:auth => auth,
+	:resource_group => secret.value_of("azure_resourcegroup", user: :admin)
+      )
     end
   end
 end

--- a/lib/iaas/iaas.rb
+++ b/lib/iaas/iaas.rb
@@ -78,8 +78,8 @@ module BushSlicer
       return BushSlicer::Azure.new(
         :location => secret.value_of("azure_region", user: :admin),
         :subscription_id => secret.value_of("azure_subscription_id", user: :admin),
-	:auth => auth,
-	:resource_group => secret.value_of("azure_resourcegroup", user: :admin)
+        :auth => auth,
+        :resource_group => secret.value_of("azure_resourcegroup", user: :admin)
       )
     end
   end

--- a/lib/launchers/azure.rb
+++ b/lib/launchers/azure.rb
@@ -212,12 +212,14 @@ module BushSlicer
     # @raise on communication error
     def get_volume_by_id(id)
       name = id.split("/")[-1]
-      res = "exist"
+      res = "volume " + id + " exists"
       begin
       compute_client.disks.get(azure_config[:resource_group], name)
       rescue MsRestAzure::AzureOperationError => e
-	if e.response.status == 404
+        if e.response.status == 404
           res = nil
+        else
+          res = e.response
         end
       end
       return res

--- a/lib/launchers/azure.rb
+++ b/lib/launchers/azure.rb
@@ -211,7 +211,16 @@ module BushSlicer
     # @return [TODO, nil] returns nil when not found
     # @raise on communication error
     def get_volume_by_id(id)
-      TODO
+      name = id.split("/")[-1]
+      res = "exist"
+      begin
+      compute_client.disks.get(azure_config[:resource_group], name)
+      rescue MsRestAzure::AzureOperationError => e
+	if e.response.status == 404
+          res = nil
+        end
+      end
+      return res
     end
 
     # @param names [String, Array<String>] one or more names to launch


### PR DESCRIPTION
@duanwei33  @pruan-rht Please help review.

logs:
        And I verify that the IAAS volume with id "<%= cb.volumeID %>" was deleted                        # features/step_definitions/pv.rb:187
      [10:03:32] INFO> Shell Commands: oc get infrastructures.config.openshift.io cluster --output=yaml --kubeconfig=/root/workdir/Tester-OCP-qinping/ocp4_admin.kubeconfig
     <--skip-->
      
      [10:03:36] INFO> Exit Status: 0
      [10:03:36] INFO> Shell Commands: oc get secrets azure-credentials --output=yaml --kubeconfig=/root/workdir/Tester-OCP-qinping/ocp4_admin.kubeconfig --namespace=kube-system
      <--skip-->
      
      [10:03:38] INFO> Exit Status: 0
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    [10:03:42] INFO> === After Scenario: dynamic provisioning, Examples (#4) ===
