### PR TITLE
some fixes

### DIFF
--- a/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
@@ -636,6 +636,14 @@ wait_table_loaded:
     selector:
       xpath: //table//tr
     timeout: 30
+skip_dev_perspective_tour:
+  elements:
+  - selector:
+      xpath: //button[@id='tour-step-footer-secondary' and text()='Skip tour']
+    op: click
+  - selector:
+      xpath: //button[@id='tour-step-footer-primary' and text()='Close']
+    op: click
 check_item_in_list:
   element:
     selector:

--- a/lib/rules/web/admin_console/base/login.xyaml
+++ b/lib/rules/web/admin_console/base/login.xyaml
@@ -9,10 +9,13 @@ verify_logged_in_admin_console:
     selector: |-
       var ns = window.localStorage['exp'];
       return ns ? document.documentElement : null;
-    timeout: 120
-  scripts:
-  - command: return window.localStorage['exp']
-    expect_result: true
+    timeout: 180
+  action:
+    if_element:
+      selector:
+        xpath: //div[@id='guided-tour-modal']//button[text()='Skip tour']
+      timeout: 120
+    ref: skip_dev_perspective_tour
 click_console_selector:
   element:
     selector:


### PR DESCRIPTION
Due to the recent console changes, a dev console tour pop-up is appeared once a normal user logged in. This has caused all normal cases failed like:
```
 [03:41:20] WARN> #<Selenium::WebDriver::Error::ElementClickInterceptedError: element click intercepted: Element <button id="yaml-create" data-test="yaml-create" aria-disabled="false" class="pf-c-button pf-m-primary" type="button" data-ouia-component-type="PF4/Button" data-ouia-safe="true" data-ouia-component-id="63">...</button> is not clickable at point (1331, 165). Other element would receive the click: <div class="pf-l-bullseye">...</div>
        (Session info: chrome=84.0.4147.89)>
      [03:41:50] ERROR> #<Watir::Exception::UnknownObjectException: element located, but timed out after 30 seconds, waiting for #<Watir::Button: located: true; {:xpath=>"//button[contains(.,'Create Persistent Volume Claim')]", :index=>0, :tag_name=>"button"}> to be present>
```

```
      [03:46:13] INFO> running web action set_secret_name ... 
      [03:46:13] INFO> element..
      [03:46:14] INFO> found 1 input elements with selector: {:id=>"secret-name"}
      [03:46:44] ERROR> #<Watir::Exception::UnknownObjectException: element located, but timed out after 30 seconds, waiting for #<Watir::Input: located: true; {:id=>"secret-name", :tag_name=>"input", :index=>0}> to be present>
```

So in this PR, I closed the pop-up once a normal user is logged in to bypass the error
Here are the logs for comparison:
[before the fix](https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/130926/consoleFull)
[after the fix](https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/131846/consoleFull)

@yanpzhan  @xiaocwan  Help review the changes