### PR TITLE
update ocp-28630

### DIFF
--- a/features/upgrade/storage/upgrade.feature
+++ b/features/upgrade/storage/upgrade.feature
@@ -191,18 +191,10 @@ Feature: Storage upgrade tests
     When I run the :apply client command with:
       | f | csi-rbac.yaml | 
     Then the step should succeed
-    When I run the :oadm_policy_add_scc_to_user admin command with:
-      | scc           | privileged      |
-      |serviceaccount | csi-provisioner | 
-    When I run the :oadm_policy_add_scc_to_user admin command with:
-      | scc           | privileged   |
-      |serviceaccount | csi-attacher | 
-    When I run the :oadm_policy_add_scc_to_user admin command with:
-      | scc           | privileged      |
-      |serviceaccount | csi-snapshotter | 
-    When I run the :oadm_policy_add_scc_to_user admin command with:
-      | scc           | privileged |
-      |serviceaccount | csi-plugin | 
+    Given SCC "privileged" is added to the "csi-provisioner" service account without teardown
+    Given SCC "privileged" is added to the "csi-attacher" service account without teardown
+    Given SCC "privileged" is added to the "csi-snapshotter" service account without teardown
+    Given SCC "privileged" is added to the "csi-plugin" service account without teardown
 
     Given I obtain test data file "storage/csi/csi-hostpath-attacher.yaml"
     When I run the :apply client command with:

--- a/features/upgrade/storage/upgrade.feature
+++ b/features/upgrade/storage/upgrade.feature
@@ -191,10 +191,18 @@ Feature: Storage upgrade tests
     When I run the :apply client command with:
       | f | csi-rbac.yaml | 
     Then the step should succeed
-    Given SCC "privileged" is added to the "csi-provisioner" service account
-    Given SCC "privileged" is added to the "csi-attacher" service account
-    Given SCC "privileged" is added to the "csi-snapshotter" service account
-    Given SCC "privileged" is added to the "csi-plugin" service account
+    When I run the :oadm_policy_add_scc_to_user admin command with:
+      | scc           | privileged      |
+      |serviceaccount | csi-provisioner | 
+    When I run the :oadm_policy_add_scc_to_user admin command with:
+      | scc           | privileged   |
+      |serviceaccount | csi-attacher | 
+    When I run the :oadm_policy_add_scc_to_user admin command with:
+      | scc           | privileged      |
+      |serviceaccount | csi-snapshotter | 
+    When I run the :oadm_policy_add_scc_to_user admin command with:
+      | scc           | privileged |
+      |serviceaccount | csi-plugin | 
 
     Given I obtain test data file "storage/csi/csi-hostpath-attacher.yaml"
     When I run the :apply client command with:


### PR DESCRIPTION
`Given SCC "privileged" is added to the "csi-provisioner" service account` This step will restore scc 
` if @result[:success]
    teardown_add {
      _res = nil
      wait_for(60, interval: 5) {
        _res = _admin.cli_exec(_teardown_command, **_opts)
        _res[:success]
      }
      raise "could not restore SCC of #{which} #{type}" unless _res[:success]
    }
`
So After upgrade,  service account has no privileged scc.

@qinpingli @duanwei33 Please help to review.