### PR TITLE
Update some egressnetworkpolicy case to be compatiable with OVN 

### DIFF
--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -5,31 +5,30 @@ Feature: Egress-ingress related networking scenarios
   @admin
   @destructive
   Scenario: EgressNetworkPolicy will not take effect after delete it
-    Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
+    Given I save egress data file directory to the clipboard
+    And I save egress type to the clipboard
     When I execute on the pod:
       | curl           |
       | --head         |
       | www.google.com | 
     Then the step should succeed
     And the output should contain "HTTP/1.1 200" 
-    Given I obtain test data file "networking/egressnetworkpolicy/limit_policy.json"
+    Given I obtain test data file "networking/<%= cb.cb_egress_directory %>/limit_policy.json"
     When I run the :create admin command with:
       | f | limit_policy.json |
       | n | <%= project.name %> |
     Then the step should succeed
-    Given I select a random node's host 
     When I use the "<%= project.name %>" project
     When I execute on the pod:
       | curl | --connect-timeout | 5 | --head | www.google.com |
     Then the step should fail
     When I run the :delete admin command with:
-      | object_type       | egressnetworkpolicy |
-      | object_name_or_id | policy1             |
-      | n                 | <%= project.name %> |
+      | object_type       | <%= cb.cb_egress_type %> |
+      | object_name_or_id | --all                    |
+      | n                 | <%= project.name %>      |
     Then the step should succeed
-    Given I select a random node's host 
     When I use the "<%= project.name %>" project
     When I execute on the pod:
       | curl           |

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1180,3 +1180,35 @@ Given /^the mtu value "([^"]*)" is patched in CNO config according to the networ
       raise "Failed to clear mtu field from CNO" unless @result[:success]
   }
 end
+
+Given /^I save egress data file directory to the#{OPT_SYM} clipboard$/ do | cb_name |
+  ensure_admin_tagged
+  cb_name = "cb_egress_directory" unless cb_name
+  network_operator = BushSlicer::NetworkOperator.new(name: "cluster", env: env)
+  network_type = network_operator.network_type(user: admin)
+  case network_type
+  when "OVNKubernetes"
+    cb[cb_name]="ovn-egressfirewall"
+  when "OpenShiftSDN"
+    cb[cb_name]="egressnetworkpolicy"
+  else
+    raise "unknown network_type"
+  end
+  logger.info "The egressfirewall file directory path is stored to the #{cb_name} clipboard."
+end
+
+Given /^I save egress type to the#{OPT_SYM} clipboard$/ do | cb_name |
+  ensure_admin_tagged
+  cb_name = "cb_egress_type" unless cb_name
+  network_operator = BushSlicer::NetworkOperator.new(name: "cluster", env: env)
+  network_type = network_operator.network_type(user: admin)
+  case network_type
+  when "OVNKubernetes"
+    cb[cb_name] = "egressfirewall"
+  when "OpenShiftSDN"
+    cb[cb_name] = "egressnetworkpolicy"
+  else
+    raise "unknown network_type"
+  end
+  logger.info "The egressfirewall type is stored to the #{cb_name} clipboard."
+end

--- a/testdata/networking/ovn-egressfirewall/limit_policy.json
+++ b/testdata/networking/ovn-egressfirewall/limit_policy.json
@@ -1,0 +1,17 @@
+{
+    "kind": "EgressFirewall",
+    "apiVersion": "k8s.ovn.org/v1",
+    "metadata": {
+        "name": "default"
+    },
+    "spec": {
+        "egress": [
+            {
+                "type": "Deny",
+                "to": {
+                    "cidrSelector": "0.0.0.0/0"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Update some egressnetworkpolicy cases to be compatible with OVN egressfirewall
case:OCP-11639
SDN logs:https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/133929/console
OVN logs:https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/133871/console

@anuragthehatter @zhaozhanqi @weliang1 @rbbratta 