### PR TITLE
Fix upgrade-prepare without teardown

### DIFF
--- a/features/step_definitions/scc.rb
+++ b/features/step_definitions/scc.rb
@@ -108,15 +108,19 @@ Given /^SCC #{QUOTED} is (added to|removed from) the #{QUOTED} (user|group|servi
     @result = _admin.cli_exec(_command, **_opts)
     @result[:success]
   }
-  if @result[:success] && !no_teardown
-    teardown_add {
-      _res = nil
-      wait_for(60, interval: 5) {
-        _res = _admin.cli_exec(_teardown_command, **_opts)
-        _res[:success]
+  if @result[:success]
+    if no_teardown
+      logger.warn "No teardown to restore SCC of #{which} #{type}"
+    else
+      teardown_add {
+        _res = nil
+        wait_for(60, interval: 5) {
+          _res = _admin.cli_exec(_teardown_command, **_opts)
+          _res[:success]
+        }
+        raise "could not restore SCC of #{which} #{type}" unless _res[:success]
       }
-      raise "could not restore SCC of #{which} #{type}" unless _res[:success]
-    }
+    end
   else
     raise "could not give #{which} #{type} the #{scc} scc"
   end

--- a/features/test/scc.feature
+++ b/features/test/scc.feature
@@ -18,4 +18,16 @@ Feature: some SCC policy related scenarios
     Given SCC "privileged" is added to the "system:serviceaccounts:<%= user.name %>:aggregated-logging-fluentd" service account
     And cluster role "cluster-reader" is added to the "system:serviceaccounts:<%= user.name %>:aggregated-logging-fluentd" service account
     And cluster role "oauth-editor" is added to the "system:serviceaccounts:<%= user.name %>:logging-deployer" service account
-    Given I obtain test data file "logging_metrics/logging_deployer_configmap.yaml"
+
+  @admin
+  Scenario: test scc with teardown
+    Given I have a project
+    Given I create the serviceaccount "test1"
+    Given SCC "privileged" is added to the "test1" service account
+
+  @admin
+  @upgrade-prepare
+  Scenario: test scc without teardown
+    Given I have a project
+    Given I create the serviceaccount "test2"
+    Given SCC "privileged" is added to the "test2" service account without teardown


### PR DESCRIPTION
/cc @akostadinov @pruan-rht @chao007 
```
waiting for operation up to 3600 seconds..
    Given SCC "privileged" is added to the "csi-provisioner" service account without teardown                         # features/step_definitions/scc.rb:65
      [02:47:05] INFO> Shell Commands: oc adm policy add-scc-to-user privileged system:serviceaccount:csihostpath:csi-provisioner --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig
      securitycontextconstraints.security.openshift.io/privileged added to: ["system:serviceaccount:csihostpath:csi-provisioner"]
      
      [02:47:05] INFO> Exit Status: 0
      could not give csi-provisioner service account the privileged scc (RuntimeError)
      /home/jenkins/workspace/Runner-v3/features/step_definitions/scc.rb:121:in `/^SCC "(.+?)" is (added to|removed from) the "(.+?)" (user|group|service account)( without teardown)?$/'
      features/upgrade/storage/upgrade.feature:196:in `Given SCC "privileged" is added to the "csi-provisioner" service account without teardown'
```