### PR TITLE
Improved cases 33714, added 34095 to have timeout validations

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -260,19 +260,44 @@ Feature: MachineHealthCheck Test Scenarios
     Then the output should contain:
       | mhc-<%= machine_set.name %>: total targets: 1,  maxUnhealthy: 1%, unhealthy: 1. Short-circuiting remediation |
     """
-
+    
   # @author miyadav@redhat.com
   # @case_id OCP-33714
   @admin
-  Scenario: Leverage OpenAPI validation within MHC
+  Scenario Outline: Leverage OpenAPI validation within MHC
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project
 
-    # Create MHC with malformed unhealthy nodes value and empty selectors
-    Given I obtain test data file "cloud/mhc/mhc_malformed.yaml"
-    When I run the :create client command with:
-      | f | mhc_malformed.yaml | 
+    Given I obtain test data file "cloud/mhc/mhc_validations.yaml"
+    When I run oc create over "mhc_validations.yaml" replacing paths:
+      | ["spec"]["maxUnhealthy"] | <maxUnhealthy> |
     Then the output should contain:
-      | The MachineHealthCheck "mhc-malformed" is invalid: |
+      | maxUnhealthy: Invalid value: "": spec.maxUnhealthy in body should match '^((100|[0-9]{1,2})%|[0-9]+)$ |
 
+   Examples:
+      | maxUnhealthy |
+      |  -2a         |
+      | "10t%"       |
+      | "-2%"        |
+      |  -2%         |
+
+  # @author miyadav@redhat.com
+  # @case_id OCP-34095
+  @admin
+  Scenario Outline: [mhc] timeout field without units(h,m,s) shoud not be allowed to be stored
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    Then I use the "openshift-machine-api" project
+
+    Given I obtain test data file "cloud/mhc/mhc_validations.yaml"
+    When I run oc create over "mhc_validations.yaml" replacing paths:
+      | ["spec"]["unhealthyConditions"][0]["timeout"] | <timeout> |
+    Then the output should contain:
+      | timeout: Invalid value: "": spec.unhealthyConditions.timeout in body should match '^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$'|
+
+   Examples:
+      | timeout |
+      | "3"     |
+      | "3t"    |
+ 

--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -260,7 +260,6 @@ Feature: MachineHealthCheck Test Scenarios
     Then the output should contain:
       | mhc-<%= machine_set.name %>: total targets: 1,  maxUnhealthy: 1%, unhealthy: 1. Short-circuiting remediation |
     """
-    
   # @author miyadav@redhat.com
   # @case_id OCP-33714
   @admin
@@ -273,7 +272,7 @@ Feature: MachineHealthCheck Test Scenarios
     When I run oc create over "mhc_validations.yaml" replacing paths:
       | ["spec"]["maxUnhealthy"] | <maxUnhealthy> |
     Then the output should contain:
-      | maxUnhealthy: Invalid value: "": spec.maxUnhealthy in body should match '^((100|[0-9]{1,2})%|[0-9]+)$ |
+      | maxUnhealthy: Invalid value: "": spec.maxUnhealthy |
 
    Examples:
       | maxUnhealthy |
@@ -294,7 +293,7 @@ Feature: MachineHealthCheck Test Scenarios
     When I run oc create over "mhc_validations.yaml" replacing paths:
       | ["spec"]["unhealthyConditions"][0]["timeout"] | <timeout> |
     Then the output should contain:
-      | timeout: Invalid value: "": spec.unhealthyConditions.timeout in body should match '^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$'|
+      | timeout: Invalid value: "": spec.unhealthyConditions.timeout |
 
    Examples:
       | timeout |

--- a/testdata/cloud/mhc/mhc_validations.yaml
+++ b/testdata/cloud/mhc/mhc_validations.yaml
@@ -1,0 +1,16 @@
+apiVersion: "machine.openshift.io/v1beta1"
+kind: "MachineHealthCheck"
+metadata:
+  name: mhc-malformed
+  namespace: openshift-machine-api
+spec:
+  selector: {}
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 300s
+  - type: Ready
+    status: Unknown
+    timeout: 300s
+  maxUnhealthy: 3
+


### PR DESCRIPTION
It has testcases to cover - [Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1865779 ) and a related story

Working fine
results at - https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/134723/console

@jhou1  @sunzhaohua2  PTAL ...
