### PR TITLE
OCP-33040

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -197,6 +197,7 @@ Feature: Machine features testing
       | iaas_type | machineset_name        |
       | aws       | machineset-clone-29199 | # @case_id OCP-29199
       | gcp       | machineset-clone-32126 | # @case_id OCP-32126
+      | azure     | machineset-clone-33040 | # @case_id OCP-33040
 
   # @author zhsun@redhat.com
   # @case_id OCP-32620

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -90,6 +90,8 @@ Given(/^I create a spot instance machineset and name it "([^"]*)" on (aws|gcp|az
     new_spec["spec"]["template"]["spec"]["providerSpec"]["value"]["spotMarketOptions"] = {}
   elsif iaas_type == 'gcp'
     new_spec["spec"]["template"]["spec"]["providerSpec"]["value"]["preemptible"] = true
+  elsif iaas_type == 'azure'
+    new_spec["spec"]["template"]["spec"]["providerSpec"]["value"]["spotVMOptions"] = {}
   else
     raise "spot instance not supported on #{iaas_type}"
   end


### PR DESCRIPTION
Auto OCP-33040: Required configuration should be added to the ProviderSpec to enable spot instances - Azure @jhou1 @miyadav please help to review, thanks, tested locally it works well.