### PR TITLE
Add machineconfig method to machine_config_pool

### DIFF
--- a/features/node/seccomp.feature
+++ b/features/node/seccomp.feature
@@ -32,7 +32,7 @@ Feature: Secure Computing Test Scenarios
     # Wait for machineconfigpool to roll out the new machineconfig
     Given I wait up to 900 seconds for the steps to pass:
     """
-    Then the expression should be true> machine_config_pool('worker').raw_resource(cached: false).dig('status', 'configuration', 'source').select { |c| c['name'] == 'custom-seccomp' }.empty? == false
+    Then the expression should be true> machine_config_pool('worker').machineconfig('custom-seccomp', cached: false).empty? == false
     Then the expression should be true> machine_config_pool('worker').condition(type: 'Updating', cached: false)["status"] == "False"
     """
 

--- a/lib/openshift/machine_config_pool.rb
+++ b/lib/openshift/machine_config_pool.rb
@@ -8,5 +8,10 @@ module BushSlicer
       rr = raw_resource(user: user, cached: cached, quiet: quiet).dig("spec")
       MachineConfigPoolSpec.new rr
     end
+
+    def machineconfig(mc_name, user: nil, cached: true, quiet: false)
+      rr = raw_resource(user: user, cached: cached, quiet: quiet).dig('status', 'configuration', 'source')
+      rr.select { |c| c["name"] == mc_name }
+    end
   end
 end


### PR DESCRIPTION
As a follow up of https://github.com/openshift/verification-tests/pull/1460#discussion_r475857294, remove the direct usage of `raw_resource`. 

@akostadinov @pruan-rht PTAL

```
      [05:50:46] INFO> === End After Scenario: Using Secure Computing Profiles with Pod Annotations ===

1 scenario (1 passed)
14 steps (14 passed)
9m51.645s
```