### PR TITLE
fix issue: fluentd is not ready

### DIFF
--- a/features/logging/elasticsearch.feature
+++ b/features/logging/elasticsearch.feature
@@ -44,7 +44,10 @@ Feature: Elasticsearch related tests
     And the expression should be true> cluster_logging('instance').logstore_storage_class_name == cb.default_sc.name
     Given I wait for the "elasticsearch" elasticsearches to appear
     And the expression should be true> elasticsearch('elasticsearch').nodes[0]['storage']['storageClassName'] == cb.default_sc.name
-    Given I wait for clusterlogging with "fluentd" log collector to be functional in the project
+    #Given I wait for clusterlogging with "fluentd" log collector to be functional in the project
+    Given I wait until ES cluster is ready
+    And I wait until "fluentd" log collector is ready
+    And I wait until kibana is ready
     Given I wait up to 300 seconds for the steps to pass:
     """
     Given evaluation of `elasticsearch('elasticsearch').nodes[0]['genUUID']` is stored in the :gen_uuid clipboard

--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -159,10 +159,7 @@ Given /^I wait for clusterlogging(?: named "(.+)")? with #{QUOTED} log collector
     })
     cl.wait_until_fluentd_is_ready
   else
-    step %Q/a pod becomes ready with labels:/, table(%{
-      | component=rsyslog |
-    })
-    cl.wait_until_rsyslog_is_ready
+    raise "unknow log collector"
   end
 
   logger.info("### checking logging subcomponent status: kibana")
@@ -305,7 +302,6 @@ Given /^I delete the clusterlogging instance$/ do
   step %Q/I wait for the resource "deployment" named "kibana" to disappear/
   step %Q/I wait for the resource "elasticsearch" named "elasticsearch" to disappear/
   step %Q/I wait for the resource "cronjob" named "curator" to disappear/
-  step %Q/I wait for the resource "daemonset" named "rsyslog" to disappear/
   step %Q/I wait for the resource "daemonset" named "fluentd" to disappear/
   step %Q/all existing pods die with labels:/, table(%{
     | component=elasticsearch |

--- a/lib/openshift/cluster_logging.rb
+++ b/lib/openshift/cluster_logging.rb
@@ -29,32 +29,12 @@ module BushSlicer
       collection_raw(user: user, cached: cached, quiet: quiet)['logs']
     end
 
-    private def rsyslog_status_raw(user: nil, cached: true, quiet: false)
-      collection_status_raw(user: user, cached: cached, quiet: quiet)['rsyslogStatus']
-    end
-
     private def fluentd_status_raw(user: nil, cached: true, quiet: false)
       collection_status_raw(user: user, cached: cached, quiet: quiet)['fluentdStatus']
     end
 
     private def curator_status_raw(user: nil, cached: true, quiet: false)
       self.curation(user: user, cached: cached, quiet: quiet)['curatorStatus']
-    end
-
-    private def rsyslog_pods(user: nil, cached: true, quiet: false)
-      rsyslog_status_raw(user: user, cached: cached, quiet: quiet)['pods']
-    end
-
-    private def rsyslog_ready_pod_names(user: nil, cached: true, quiet: false)
-      rsyslog_pods(user: user, cached: cached, quiet: quiet)['ready']
-    end
-
-    private def rsyslog_failed_pod_names(user: nil, cached: true, quiet: false)
-      rsyslog_pods(user: user, cached: cached, quiet: quiet)['failed']
-    end
-
-    private def rsyslog_notready_pod_names(user: nil, cached: true, quiet: false)
-      rsyslog_pods(user: user, cached: cached, quiet: quiet)['notReady']
     end
 
     private def fluentd_pods(user: nil, cached: true, quiet: false)
@@ -100,24 +80,9 @@ module BushSlicer
       kibana_status(user: user, cached: cached, quiet: quiet).first['pods']
     end
 
-    # higher level methods
-    def rsyslog_ready?(user: nil, cached: true, quiet: false)
-      rsyslog_nodes = rsyslog_status_raw(user: user, cached: cached, quiet: quiet)['Nodes'].keys.sort
-      rsyslog_nodes == rsyslog_ready_pod_names && rsyslog_failed_pod_names.count == 0 && rsyslog_notready_pod_names.count == 0
-    end
-
     def fluentd_ready?(user: nil, cached: true, quiet: false)
       fluentd_nodes = fluentd_status_raw(user: user, cached: cached, quiet: quiet)['nodes'].keys.sort
-      fluentd_nodes == fluentd_ready_pod_names && fluentd_failed_pod_names.count == 0 && fluentd_notready_pod_names.count == 0
-    end
-
-    def wait_until_rsyslog_is_ready(user: nil, quiet: false, timeout: 5*60)
-      success = wait_for(timeout) {
-        rsyslog_ready?(user: user, cached: false, quiet: quiet)
-      }
-      unless success
-        raise "rsyslog did not become ready within #{timeout} seconds"
-      end
+      fluentd_nodes == fluentd_ready_pod_names.sort && fluentd_failed_pod_names.count == 0 && fluentd_notready_pod_names.count == 0
     end
 
     def wait_until_fluentd_is_ready(user: nil, quiet: false, timeout: 5*60)


### PR DESCRIPTION
Fix the below issue and remove collector type `rsyslog` since we never support it.
```
fluentd did not become ready within 300 seconds
RuntimeError
/home/jenkins/workspace/Runner-v3/lib/openshift/cluster_logging.rb:128:in `wait_until_fluentd_is_ready'
/home/jenkins/workspace/Runner-v3/features/step_definitions/logging.rb:160:in `/^I wait for clusterlogging(?: named "(.+)")? with "(.+?)" log collector to be functional in the(?: "(.+?)")? project$/'
features/logging/elasticsearch.feature:47:in `Given I wait for clusterlogging with "fluentd" log collector to be functional in the project'
```

Log: https://url.corp.redhat.com/3153b7e

@anpingli @pruan-rht PTAL, thanks.