### PR TITLE
Fix error when creating STDIN: namespaces aos-qe-ci not found.

### DIFF
--- a/features/admin/scc.feature
+++ b/features/admin/scc.feature
@@ -33,7 +33,7 @@ Feature: SCC policy related scenarios
   @destructive
   Scenario: Create or update scc with illegal capability name should fail with prompt message
     Given I have a project
-    Given I switch to cluster admin pseudo user
+    Given cluster role "cluster-admin" is added to the "first" user
     Given admin ensures "scc-<%= project.name %>" scc is deleted after scenario
     Given I obtain test data file "authorization/scc/scc_capabilities.yaml"
     When I run oc create over "scc_capabilities.yaml" replacing paths:


### PR DESCRIPTION
```
oc create -f - --kubeconfig=***/ocp4_admin.kubeconfig

STDERR:
Error from server (NotFound): error when creating "STDIN": namespaces "aos-qe-ci" not found
```

@xingxingxia @rhpmali PTAL!

https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/138022/console