### PR TITLE
Increase wait time

### DIFF
--- a/features/node/seccomp.feature
+++ b/features/node/seccomp.feature
@@ -30,7 +30,7 @@ Feature: Secure Computing Test Scenarios
     And admin ensures "custom-seccomp" machineconfig is deleted after scenario
 
     # Wait for machineconfigpool to roll out the new machineconfig
-    Given I wait up to 900 seconds for the steps to pass:
+    Given I wait up to 1200 seconds for the steps to pass:
     """
     Then the expression should be true> machine_config_pool('worker').raw_resource(cached: false).dig('status', 'configuration', 'source').select { |c| c['name'] == 'custom-seccomp' }.empty? == false
     Then the expression should be true> machine_config_pool('worker').condition(type: 'Updating', cached: false)["status"] == "False"


### PR DESCRIPTION
With the previous PR the pass ratio of test case OCP-32065 has increased, but occasionally it fails. I looked at all the test logs of the failure, they are all failing because mcp did not successfully roll out within 900 seconds. Now increase the wait to 1200 seconds and hopefully we can see improvements.

![image](https://user-images.githubusercontent.com/2202520/91286020-80de2280-e7c0-11ea-868a-11eda6b0aa25.png)

@sunilcio @weinliu @lyman9966 PTAL.