### PR TITLE
Bugfix for making nfs pv is valid for ipv4 and ipv6

### DIFF
--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -10,9 +10,9 @@ Feature: NFS Persistent Volume
 
     Given I obtain test data file "storage/nfs/auto/pv-retain.json"
     Given admin creates a PV from "pv-retain.json" where:
-      | ["metadata"]["name"]         | pv-<%= project.name %>           |
-      | ["spec"]["nfs"]["server"]    | <%= service("nfs-service").ip %> |
-      | ["spec"]["storageClassName"] | sc-<%= project.name %>           |
+      | ["metadata"]["name"]         | pv-<%= project.name %>                 |
+      | ["spec"]["nfs"]["server"]    | "<%= service("nfs-service").ip_url %>" |
+      | ["spec"]["storageClassName"] | sc-<%= project.name %>                 |
     Given I obtain test data file "storage/nfs/auto/pvc-rwx.json"
     And I create a dynamic pvc from "pvc-rwx.json" replacing paths:
       | ["spec"]["volumeName"]       | <%= pv.name %>         |
@@ -62,11 +62,11 @@ Feature: NFS Persistent Volume
 
     Given I obtain test data file "storage/nfs/pv-gid.json"
     When admin creates a PV from "pv-gid.json" where:
-      | ["spec"]["nfs"]["server"]                                | <%= service("nfs-service").ip %> |
-      | ["spec"]["nfs"]["path"]                                  | /                                |
-      | ["spec"]["capacity"]["storage"]                          | 1Gi                              |
-      | ["metadata"]["name"]                                     | nfs-<%= project.name %>          |
-      | ["metadata"]["annotations"]["pv.beta.kubernetes.io/gid"] | "<pv-gid>"                       |
+      | ["spec"]["nfs"]["server"]                                | "<%= service("nfs-service").ip_url %>" |
+      | ["spec"]["nfs"]["path"]                                  | /                                      |
+      | ["spec"]["capacity"]["storage"]                          | 1Gi                                    |
+      | ["metadata"]["name"]                                     | nfs-<%= project.name %>                |
+      | ["metadata"]["annotations"]["pv.beta.kubernetes.io/gid"] | "<pv-gid>"                             |
     Then the step should succeed
 
     Given I obtain test data file "storage/nfs/claim-rwx.json"
@@ -124,17 +124,17 @@ Feature: NFS Persistent Volume
 
     Given I obtain test data file "storage/nfs/pv-gid.json"
     Given admin creates a PV from "pv-gid.json" where:
-      | ["spec"]["nfs"]["server"]                                | <%= service("nfs-service").ip %> |
-      | ["spec"]["nfs"]["path"]                                  | /                                |
-      | ["spec"]["capacity"]["storage"]                          | 1Gi                              |
-      | ["metadata"]["name"]                                     | nfs-<%= project.name %>          |
-      | ["metadata"]["annotations"]["pv.beta.kubernetes.io/gid"] | abc123                           |
+      | ["spec"]["nfs"]["server"]                                | "<%= service("nfs-service").ip_url %>" |
+      | ["spec"]["nfs"]["path"]                                  | /                                      |
+      | ["spec"]["capacity"]["storage"]                          | 1Gi                                    |
+      | ["metadata"]["name"]                                     | nfs-<%= project.name %>                |
+      | ["metadata"]["annotations"]["pv.beta.kubernetes.io/gid"] | abc123                                 |
     Then the step should succeed
 
     Given I obtain test data file "storage/nfs/claim-rwx.json"
     When I create a manual pvc from "claim-rwx.json" replacing paths:
       | ["metadata"]["name"]                         | mypvc |
-      | ["spec"]["resources"]["requests"]["storage"] | 1Gi                      |
+      | ["spec"]["resources"]["requests"]["storage"] | 1Gi   |
     Then the step should succeed
     And the "mypvc" PVC becomes bound to the "nfs-<%= project.name %>" PV
 
@@ -143,7 +143,7 @@ Feature: NFS Persistent Volume
     Given I obtain test data file "storage/nfs/security/pod-supplementalgroup.json"
     When I run oc create over "pod-supplementalgroup.json" replacing paths:
       | ["metadata"]["name"]                                         | mypod |
-      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc  |
+      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc |
     Then the step should succeed
     And the pod named "mypod" becomes ready
 

--- a/lib/openshift/service.rb
+++ b/lib/openshift/service.rb
@@ -112,5 +112,11 @@ module BushSlicer
       rr.dig('status', 'loadBalancer', 'ingress')
     end
 
+    # @return [String] string IP if IPv4 or [IP] if IPv6
+    def ip_url(user: nil, cached: true, quiet: false)
+      raw_ip = ip(user: user, cached: cached, quiet: quiet)
+      return raw_ip.include?(":") ? "[#{raw_ip}]" : raw_ip
+    end
+
   end
 end


### PR DESCRIPTION
@zhaozhanqi  @duanwei33 @chao007 Please help review, thx!

IPV4 test result:
```
Given admin creates a PV from "pv-retain.json" where:           # features/step_definitions/pv.rb:147
      [06:03:51] INFO> Creating PV:
      ---
      apiVersion: v1
      kind: PersistentVolume
      metadata:
        name: pv-84fjp
      spec:
        capacity:
          storage: 5Gi
        accessModes:
        - ReadWriteMany
        nfs:
          path: "/"
          server: 172.30.131.179
        persistentVolumeReclaimPolicy: Retain
        storageClassName: sc-84fjp
```

IPV6 test result(it's a fake ipv6 test, just set the raw ip manually):
```
Given admin creates a PV from "pv-retain.json" where:           # features/step_definitions/pv.rb:147
      [06:49:43] INFO> Creating PV:
      ---
      apiVersion: v1
      kind: PersistentVolume
      metadata:
        name: pv-wy4ul
      spec:
        capacity:
          storage: 5Gi
        accessModes:
        - ReadWriteMany
        nfs:
          path: "/"
          server: "[ad:ef:10:11]"
        persistentVolumeReclaimPolicy: Retain
        storageClassName: sc-wy4ul

```