### PR TITLE
fix close tour on dev console

### DIFF
--- a/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
@@ -647,8 +647,8 @@ skip_dev_perspective_tour:
       xpath: //button[@id='tour-step-footer-secondary' and text()='Skip tour']
     op: click
   - selector:
-      xpath: //button[@id='tour-step-footer-primary' and text()='Close']
-    op: click
+      xpath: //b[contains(text(), 'Welcome to Dev')]
+    missing: true
 check_item_in_list:
   element:
     selector:


### PR DESCRIPTION
On 4.6 dev console, now the tour guide pop-up message box only need to click close button one time, not twice.
Caused many cases failed, Eg. http://ci-qe-openshift.usersys.redhat.com/userContent/cucushift/v3/2020/09/05/04:20:49/Check_route_list_and_detail_page/console.html

Updated for it and test on some cases:
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/146480/console

@yapei Please review. Thanks!