### PR TITLE
auto OCP-34718

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -328,3 +328,32 @@ Feature: Machine features testing
       | attempting to acquire leader lease  openshift-machine-api/cluster-api-provider |
     """
 
+  # @author zhsun@redhat.com
+  # @case_id OCP-34718
+  @admin
+  Scenario: Node labels and Affinity definition in PV should match	
+    Given I have a project
+
+    # Create a pvc
+    Given I obtain test data file "cloud/pvc-34718.yml"
+    When I run the :create client command with:
+      | f | pvc-34718.yml |
+    Then the step should succeed
+
+    # Create a pod
+    Given I obtain test data file "cloud/pod-34718.yml"
+    When I run the :create client command with:
+      | f | pod-34718.yml |
+    Then the step should succeed
+
+    #Check node labels and affinity definition in PV are match
+    Given the pod named "task-pv-pod" becomes ready
+    And I use the "<%= pod.node_name %>" node
+    And evaluation of `node.region` is stored in the :default_region clipboard
+    And evaluation of `node.zone` is stored in the :default_zone clipboard
+    When I run the :describe admin command with:
+      | resource | pv |
+    Then the step should succeed
+    And the output should contain:
+      | failure-domain.beta.kubernetes.io/zone in [<%= cb.default_zone %>]     |
+      | failure-domain.beta.kubernetes.io/region in [<%= cb.default_region %>] |

--- a/lib/openshift/node.rb
+++ b/lib/openshift/node.rb
@@ -173,6 +173,16 @@ module BushSlicer
       raw_resource(user: user, cached: cached, quiet: quiet).dig('spec', 'externalID')
     end
 
+    def region(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached, quiet: quiet).
+        dig('metadata', 'labels', 'failure-domain.beta.kubernetes.io/region')
+    end
+
+    def zone(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached, quiet: quiet).
+        dig('metadata', 'labels', 'failure-domain.beta.kubernetes.io/zone')
+    end
+
     def pods(user: nil, cached: true, quiet: false)
       unless cached && props[:pods]
         get_opts = {

--- a/testdata/cloud/pod-34718.yml
+++ b/testdata/cloud/pod-34718.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: task-pv-pod
+spec:
+  volumes:
+    - name: task-pv-storage
+      persistentVolumeClaim:
+        claimName: pvc-cloud
+  containers:
+    - name: task-pv-container
+      image: quay.io/openshifttest/hello-openshift@sha256:aaea76ff622d2f8bcb32e538e7b3cd0ef6d291953f3e7c9f556c1ba5baf47e2e
+      ports:
+        - containerPort: 80
+          name: "http-server"
+      volumeMounts:
+        - mountPath: "/mnt/rbd"
+          name: task-pv-storage

--- a/testdata/cloud/pvc-34718.yml
+++ b/testdata/cloud/pvc-34718.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-cloud
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
Auto OCP-34718: Node labels and Affinity definition in PV should match. This is for bug https://bugzilla.redhat.com/show_bug.cgi?id=1860128. @jhou1 @miyadav please help to review, thanks!
```
      [07:08:21] INFO> === End After Scenario: Node labels and Affinity definition in PV should match ===

1 scenario (1 passed)
18 steps (18 passed)
1m2.072s
```