### PR TITLE
Fix namespaces aos-qe-ci not found

### DIFF
--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -9,12 +9,11 @@ Feature: SCTP related scenarios
     And I store the number of worker nodes to the :num_workers clipboard
     
     Given I install machineconfigs load-sctp-module
+    Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
     Given I check load-sctp-module in <%= cb.num_workers %> workers
     """
-    
-    Given I have a project
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>       |
@@ -65,12 +64,11 @@ Feature: SCTP related scenarios
     And I store the number of worker nodes to the :num_workers clipboard
     
     Given I install machineconfigs load-sctp-module
+    Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
     Given I check load-sctp-module in <%= cb.num_workers %> workers
     """
-    
-    Given I have a project
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>       |
@@ -128,12 +126,11 @@ Feature: SCTP related scenarios
     And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ip clipboard
     
     Given I install machineconfigs load-sctp-module
+    Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
     Given I check load-sctp-module in <%= cb.num_workers %> workers
     """
-    
-    Given I have a project
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>       |
@@ -190,12 +187,11 @@ Feature: SCTP related scenarios
     And I store the number of worker nodes to the :num_workers clipboard
     
     Given I install machineconfigs load-sctp-module
+    Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
     Given I check load-sctp-module in <%= cb.num_workers %> workers
     """
-    
-    Given I have a project
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>       |


### PR DESCRIPTION

Sctp script randomly hit below namespaces error for different cases at different time.

19:34:20 INFO> Shell Commands: oc debug  --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig node/zhsun93regression-mhfr2-worker-centralus-1 -- lsmodSTDERR:
Error from server (NotFound): namespaces "aos-qe-ci" not found
19:34:31 INFO> Exit Status: 1

In old sctp script,  it call oc debug before creating a new project, and oc debug always to use namespaces "aos-qe-ci" which may conflict with other tasks using same namespaces.

The simple fixing is to create a new project then start to oc debug, in this way oc debug will use different namespaces.

Test log:
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3-smoke/2216/console

@zhaozhanqi @anuragthehatter @rbbratta @huiran0826