### PR TITLE
fix oc logs for SDN, add --all-containers and --prefix options

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -492,7 +492,7 @@ Given /^I get the networking components logs of the node since "(.+)" ago$/ do |
     sdn_pod = cb.sdn_pod || BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
       pod.node_name == node.name
     }.first
-    @result = admin.cli_exec(:logs, resource_name: sdn_pod.name, n: "openshift-sdn", since: duration)
+    @result = admin.cli_exec(:logs, resource_name: sdn_pod.name, n: "openshift-sdn", c: "sdn", since: duration)
   when "OVNKubernetes"
     ovnkube_pod = cb.ovnkube_pod || BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
       pod.node_name == node_name

--- a/lib/rules/cli/4.4.yaml
+++ b/lib/rules/cli/4.4.yaml
@@ -537,10 +537,12 @@
 :logs:
   :cmd: oc logs <resource_name>
   :options:
+    :all_containers: --all-containers=<value>
     :c: -c <value>
     :f: -f
     :limit-bytes: --limit-bytes <value>
     :p: -p
+    :prefix: --prefix=<value>
     :since: --since <value>
     :since-time: --since-time <value>
     :tail: --tail <value>

--- a/lib/rules/cli/4.5.yaml
+++ b/lib/rules/cli/4.5.yaml
@@ -537,10 +537,12 @@
 :logs:
   :cmd: oc logs <resource_name>
   :options:
+    :all_containers: --all-containers=<value>
     :c: -c <value>
     :f: -f
     :limit-bytes: --limit-bytes <value>
     :p: -p
+    :prefix: --prefix=<value>
     :since: --since <value>
     :since-time: --since-time <value>
     :tail: --tail <value>


### PR DESCRIPTION
a `kube-rbac-proxy` container was added to the sdn pod,
so the regular `oc logs -l app=sdn` command won't work
anymore, we need to either specify the container or
use `--all-containers=true`

```
STDERR:
error: a container name must be specified for pod sdn-w7bwn, choose one of: [sdn kube-rbac-proxy]
```