### PR TITLE
no need for deep change into symkeys

### DIFF
--- a/tools/launch_instance.rb
+++ b/tools/launch_instance.rb
@@ -689,7 +689,7 @@ module BushSlicer
           raise "LAUNCHER_VARS not a mapping but #{launcher_vars.inspect}"
         end
       end
-      vars = Collections.deep_hash_symkeys vars
+      vars = Collections.hash_symkeys vars
       vars[:instances_name_prefix] = launched_instances_name_prefix
       vars[:variables_file] = config
       vars[:hosts] = hosts


### PR DESCRIPTION
/assign @jianlinliu

In the past we changed all keys in the variables files to symbols. This is only
needed on root level. A quick look doesn't show me existing usage where we need
keys to by `Symbol` type deeper in the maps.

Do you think we can merge this. There is potential for an issue if we expect symbols as keys deeper in some template.

WDYT?