### PR TITLE
change image to sha256 format for disconnected cluster testing

### DIFF
--- a/testdata/cloud/autoscaler-auto-tmpl.yml
+++ b/testdata/cloud/autoscaler-auto-tmpl.yml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: work
-        image: busybox
+        image: quay.io/openshifttest/busybox@sha256:afe605d272837ce1732f390966166c2afff5391208ddd57de10942748694049d
         command: ["sleep",  "300"]
         resources:
           requests:

--- a/testdata/cloud/mhc/kubelet-killer-pod-43.yml
+++ b/testdata/cloud/mhc/kubelet-killer-pod-43.yml
@@ -11,7 +11,7 @@ spec:
     - pkill
     - -STOP
     - hyperkube
-    image: busybox
+    image: quay.io/openshifttest/busybox@sha256:afe605d272837ce1732f390966166c2afff5391208ddd57de10942748694049d
     imagePullPolicy: Always
     name: kubelet-killer
     securityContext:

--- a/testdata/cloud/mhc/kubelet-killer-pod.yml
+++ b/testdata/cloud/mhc/kubelet-killer-pod.yml
@@ -11,7 +11,7 @@ spec:
     - pkill
     - -STOP
     - kubelet
-    image: busybox
+    image: quay.io/openshifttest/busybox@sha256:afe605d272837ce1732f390966166c2afff5391208ddd57de10942748694049d
     imagePullPolicy: Always
     name: kubelet-killer
     securityContext:


### PR DESCRIPTION
@jhou1 @miyadav please help to take a look, I have changed all images to sha256 format to support disconnected cluster testing, or we will get `ImagePullBackOff`.