### PR TITLE
Fix exec on sdn pods

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -623,7 +623,7 @@ Given /^I run command on the#{OPT_QUOTED} node's sdn pod:$/ do |node_name, table
       pod.node_name == node_name
     }.first
     cache_resources sdn_pod
-    @result = sdn_pod.exec(network_cmd, as: admin)
+    @result = sdn_pod.exec(network_cmd, container: "sdn", as: admin)
   when "OVNKubernetes"
     ovnkube_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
       pod.node_name == node_name


### PR DESCRIPTION
In 4.6, there are two containers in sdn pod, the original exec command failed as not clearly identify which containers the command run. 

Specify the "sdn" container to execute the command.

Snippet of the result:
 [08:39:04] INFO> Shell Commands: oc exec sdn-2v6mn  --kubeconfig=/Users/hrwang/workdir/huiran-mac-hrwang/ocp4_admin.kubeconfig -n openshift-sdn  --container=sdn -- bash -c ip\ -4\ -brief\ a\ show\ \"ens192\"\ \|\ awk\ \'\{print\ \$3\}\'
      136.144.52.213/26
      
      [08:39:06] INFO> Exit Status: 0 


@zhaozhanqi @anuragthehatter @weliang1 @rbbratta 