### PR TITLE
fix OCP-25707

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -218,7 +218,7 @@ Feature: SDN related networking scenarios
   Scenario: ovs-vswitchd process must be running on all ovs pods
     Given I switch to cluster admin pseudo user
     When I run cmds on all ovs pods:
-      | pgrep ovs-vswitchd |
+      | pgrep | ovs-vswitchd |
     Then the step should succeed
 
   # @author huirwang@redhat.com

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -744,6 +744,8 @@ Given /^I run cmds on all ovs pods:$/ do | table |
     end
   end
   unless host_ovs
+    network_operator = BushSlicer::NetworkOperator.new(name: "cluster", env: env)
+    network_type = network_operator.network_type(user: admin)
     case network_type
     when "OpenShiftSDN"
       ovs_pods = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin)


### PR DESCRIPTION
Two issues in original codes when run in 4.3/4.4/4.5:
1. Missed the definition of network_type
2. Run the command not succeeded.
oc exec ovs-5mqmx   -n openshift-sdn  -- pgrep\ ovs-vswitchd
time="2020-09-21T06:33:28Z" level=error msg="exec failed: container_linux.go:349: starting container process caused \"exec: \\\"pgrep ovs-vswitchd\\\": executable file not found in $PATH\""
exec failed: container_linux.go:349: starting container process caused "exec: \"pgrep ovs-vswitchd\": executable file not found in $PATH"
command terminated with exit code 1


Fixed it and local run passed.
      
      [07:10:47] INFO> Exit Status: 0
      [07:10:47] INFO> === End After Scenario: ovs-vswitchd process must be running on all ovs pods ===

1 scenario (1 passed)
3 steps (3 passed)
15m26.494s
[07:10:47] INFO> === At Exit ===


@zhaozhanqi @anuragthehatter @weliang1 @rbbratta 