### PR TITLE
fix OCP-10941

### DIFF
--- a/features/cli/oc_idle.feature
+++ b/features/cli/oc_idle.feature
@@ -152,6 +152,7 @@ Feature: oc idle
       | idling.*openshift.io/idled-at |
 
   # @author chezhang@redhat.com
+  # @author minmli@redhat.com
   # @case_id OCP-10941
   Scenario: Idling service with dc
     Given I have a project
@@ -196,7 +197,7 @@ Feature: oc idle
       | resource | endpoints |
     Then the step should succeed
     And the output should match:
-      | idling-echo.*\d+.\d+.\d+.\d+:3090,\d+.\d+.\d+.\d+:3090,\d+.\d+.\d+.\d+:8675 |
+      | idling-echo.*\d+.\d+.\d+.\d+:(3090\|8675),\d+.\d+.\d+.\d+:(3090\|8675),\d+.\d+.\d+.\d+:(8675\|3090) |
     Given 2 pods become ready with labels:
       | app=idling-echo |
     When I run the :idle client command with:
@@ -215,7 +216,7 @@ Feature: oc idle
       | resource | endpoints |
     Then the step should succeed
     And the output should match:
-      | idling-echo.*\d+.\d+.\d+.\d+:3090,\d+.\d+.\d+.\d+:3090,\d+.\d+.\d+.\d+:8675 |
+      | idling-echo.*\d+.\d+.\d+.\d+:(3090\|8675),\d+.\d+.\d+.\d+:(3090\|8675),\d+.\d+.\d+.\d+:(8675\|3090) |
 
   # @author chezhang@redhat.com
   # @case_id OCP-11345


### PR DESCRIPTION
Fix the output match for OCP-10941, for the output is different between 4.6 and 4.5.
logs are: https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3-smoke/2353/console

@jhou1 @sunilcio @weinliu  Can you help to take a look? Thanks
