### PR TITLE
Ensure pvc clean-up, regardless of test step failures

### DIFF
--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -12,6 +12,7 @@ Feature: NFS Persistent Volume
     And admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/auto/pv-retain.json" where:
       | ["metadata"]["name"]      | nfs-<%= project.name %>          |
       | ["spec"]["nfs"]["server"] | <%= service("nfs-service").ip %> |
+    Given I ensure "nfsc" pvc is deleted after scenario
     And I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/auto/pvc-rwx.json" replacing paths:
       | ["spec"]["volumeName"] | <%= pv.name %> |
     And the PV becomes :bound
@@ -42,7 +43,6 @@ Feature: NFS Persistent Volume
       | testfile_1 |
       | testfile_2 |
 
-    Given I ensure "nfsc" pvc is deleted
 
   # @author chaoyang@redhat.com
   @admin
@@ -119,6 +119,7 @@ Feature: NFS Persistent Volume
       | ["metadata"]["annotations"]["pv.beta.kubernetes.io/gid"] | abc123                           |
     Then the step should succeed
 
+    And I ensure "nfsc-<%= project.name %>" pvc is deleted after scenario
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwx.json" replacing paths:
       | ["metadata"]["name"]                         | nfsc-<%= project.name %> |
       | ["spec"]["resources"]["requests"]["storage"] | 1Gi                      |
@@ -139,5 +140,4 @@ Feature: NFS Persistent Volume
     And the output should contain:
       | Permission denied |
 
-   Given I ensure "nfspd-<%= project.name %>" pod is deleted
-   And I ensure "nfsc-<%= project.name %>" pvc is deleted
+    Given I ensure "nfspd-<%= project.name %>" pod is deleted

--- a/features/storage/persistent_volume.feature
+++ b/features/storage/persistent_volume.feature
@@ -22,6 +22,7 @@ Feature: Persistent Volume Claim binding policies
     Then the step should succeed
 
     # Create PVC with accessMode3
+    Given I ensure "nfsc" pvc is deleted after scenario
     When I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
       | ["spec"]["accessModes"][0] | <accessMode3> |
     Then the step should succeed
@@ -31,7 +32,6 @@ Feature: Persistent Volume Claim binding policies
     # Second PV can not bound
     And the "nfs1-<%= project.name %>" PV status is :available
 
-    Given I ensure "nfsc" pvc is deleted
 
     Examples:
       | accessMode1   | accessMode2   | accessMode3   |


### PR DESCRIPTION
Even some of the steps in the middle failed, e.g, pod failed to be ready for any reason, there will be clean-up for the PVC to unblock the clean-up of PV.

As a follow up of https://github.com/openshift/verification-tests/pull/1547

/cc @akostadinov @qinpingli @chao007 @duanwei33 