### PR TITLE
Update SCTP cases

### DIFF
--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -5,14 +5,12 @@ Feature: SCTP related scenarios
   @admin
   @destructive
   Scenario: Establish pod to pod SCTP connections
-    Given I store the workers in the :workers clipboard
-    And I store the number of worker nodes to the :num_workers clipboard
-    
+    Given I store the workers in the :workers clipboard    
     Given I install machineconfigs load-sctp-module
     Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
-    Given I check load-sctp-module in <%= cb.num_workers %> workers
+    Given I check load-sctp-module in all nodes
     """
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:
@@ -60,14 +58,12 @@ Feature: SCTP related scenarios
   @admin
   @destructive
   Scenario: Expose SCTP ClusterIP Services
-    Given I store the workers in the :workers clipboard
-    And I store the number of worker nodes to the :num_workers clipboard
-    
+    Given I store the workers in the :workers clipboard    
     Given I install machineconfigs load-sctp-module
     Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
-    Given I check load-sctp-module in <%= cb.num_workers %> workers
+    Given I check load-sctp-module in all nodes
     """
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:
@@ -122,14 +118,12 @@ Feature: SCTP related scenarios
   @destructive
   Scenario: Expose SCTP NodePort Services
     Given I store the workers in the :workers clipboard
-    And I store the number of worker nodes to the :num_workers clipboard
-    And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ip clipboard
-    
+    And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ip clipboard  
     Given I install machineconfigs load-sctp-module
     Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
-    Given I check load-sctp-module in <%= cb.num_workers %> workers
+    Given I check load-sctp-module in all nodes
     """
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:
@@ -183,14 +177,12 @@ Feature: SCTP related scenarios
   @admin
   @destructive
   Scenario: Networkpolicy allow SCTP Client
-    Given I store the workers in the :workers clipboard
-    And I store the number of worker nodes to the :num_workers clipboard
-    
+    Given I store the workers in the :workers clipboard    
     Given I install machineconfigs load-sctp-module
     Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
-    Given I check load-sctp-module in <%= cb.num_workers %> workers
+    Given I check load-sctp-module in all nodes
     """
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1157,20 +1157,14 @@ Given /^I install machineconfigs load-sctp-module$/ do
   end
 end
 
-Given /^I check load-sctp-module in #{NUMBER} workers$/ do | workers_num |
+Given /^I check load-sctp-module in all nodes$/ do 
   ensure_admin_tagged
   _admin = admin
-  $i = 0
-  $num = Integer(workers_num)
-  while $i < $num  do
-    step %Q{I run the :debug admin command with:}, table(%{
-      | resource     | node/<%= cb.workers[#$i].name %> |
-      | oc_opts_end  |                                  |
-      | exec_command | lsmod                            |
-    })
-    step %Q/the step should succeed/
-    step %Q/the outputs should contain "sctp"/
-    $i +=1
+  env.nodes.each do |node|
+    @result = node.host.exec_admin("lsmod \| grep sctp")
+    unless @result[:response].include? "sctp"
+      raise "no sctp module"
+    end
   end
 end
 


### PR DESCRIPTION
When using oc debug node to grep sctp, automation will fail intermittently on step of "lsmod | grep sctp". 
Update scripts to use "host.exec_admin" to grep sctp module in each nodes. 

Test log: http://file.rdu.redhat.com/~weliang/sctp_testlog.txt

@zhaozhanqi @anuragthehatter @rbbratta @huiran0826 