### PR TITLE
Fix resource type of NetworkAttachmentDefinition

### DIFF
--- a/lib/openshift/network_attachment_definition.rb
+++ b/lib/openshift/network_attachment_definition.rb
@@ -1,8 +1,6 @@
-require 'openshift/cluster_resource'
-
 module BushSlicer
   # represents an Object
-  class NetworkAttachmentDefinition < ClusterResource
+  class NetworkAttachmentDefinition < ProjectResource
     RESOURCE = 'networkattachmentdefinition.k8s.cni.cncf.io'
 
   end


### PR DESCRIPTION
Fix https://github.com/openshift/verification-tests/pull/1380#discussion_r494296702

```
$ oc api-resources | grep -E 'NAME|attachment'
NAME                                  SHORTNAMES       APIGROUP                              NAMESPACED   KIND
network-attachment-definitions        net-attach-def   k8s.cni.cncf.io                       true         NetworkAttachmentDefinition

```