### PR TITLE
add specify for container

### DIFF
--- a/features/upgrade/workloads/scheduler-upgrade.feature
+++ b/features/upgrade/workloads/scheduler-upgrade.feature
@@ -35,9 +35,9 @@ Feature: scheduler with custom policy upgrade check
     Given evaluation of `@pods[0].name` is stored in the :schedulerpod clipboard
     When I run the :logs client command with:
       | resource_name | pod/<%=cb.schedulerpod %> |
+      | c             | kube-scheduler            |
     And the output should contain:
       | map[CheckNodeUnschedulable:{} CheckVolumeBinding:{} GeneralPredicates:{} MatchInterPodAffinity:{} MaxAzureDiskVolumeCount:{} MaxCSIVolumeCountPred:{} MaxEBSVolumeCount:{} MaxGCEPDVolumeCount:{} NoDiskConflict:{} NoVolumeZoneConflict:{} PodToleratesNodeTaints:{}] |
-      | map[BalancedResourceAllocation:1 ImageLocalityPriority:1 InterPodAffinityPriority:1 LeastRequestedPriority:1 NodeAffinityPriority:1 NodePreferAvoidPodsPriority:1 SelectorSpreadPriority:1 TaintTolerationPriority:1]                                                  |
 
 
   # @author knarra@redhat.com
@@ -64,6 +64,6 @@ Feature: scheduler with custom policy upgrade check
     Given evaluation of `@pods[0].name` is stored in the :schedulerpod clipboard
     When I run the :logs client command with:
       | resource_name | pod/<%=cb.schedulerpod %> |
+      | c             | kube-scheduler            |
     And the output should contain:
       | map[CheckNodeUnschedulable:{} CheckVolumeBinding:{} GeneralPredicates:{} MatchInterPodAffinity:{} MaxAzureDiskVolumeCount:{} MaxCSIVolumeCountPred:{} MaxEBSVolumeCount:{} MaxGCEPDVolumeCount:{} NoDiskConflict:{} NoVolumeZoneConflict:{} PodToleratesNodeTaints:{}] |
-      | map[BalancedResourceAllocation:1 ImageLocalityPriority:1 InterPodAffinityPriority:1 LeastRequestedPriority:1 NodeAffinityPriority:1 NodePreferAvoidPodsPriority:1 SelectorSpreadPriority:1 TaintTolerationPriority:1]                                                  |


### PR DESCRIPTION
@kasturinarra  The case will failed with ocp4.4. need to specify the container for `oc logs` .  And the output for ocp4.4 is also different from ocp4.6 . So short the output check. 

