### PR TITLE
Defaulting machinset values in vsphere cluster

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -357,3 +357,42 @@ Feature: Machine features testing
     And the output should contain:
       | failure-domain.beta.kubernetes.io/zone in [<%= cb.default_zone %>]     |
       | failure-domain.beta.kubernetes.io/region in [<%= cb.default_region %>] |
+
+  # @author miyadav@redhat.com
+  # @case_id OCP-33380
+  @admin
+  @destructive
+  Scenario: Implement defaulting machineset values for vsphere
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+    Then admin ensures machine number is restored after scenario
+
+    Given I store the last provisioned machine in the :machine clipboard
+    And evaluation of `machine(cb.machine).vsphere_datacenter` is stored in the :datacenter clipboard
+    And evaluation of `machine(cb.machine).vsphere_datastore` is stored in the :datastore clipboard
+    And evaluation of `machine(cb.machine).vsphere_folder` is stored in the :folder clipboard
+    And evaluation of `machine(cb.machine).vsphere_resourcePool` is stored in the :resourcePool clipboard
+    And evaluation of `machine(cb.machine).vsphere_server` is stored in the :server clipboard
+    And evaluation of `machine(cb.machine).vsphere_diskGiB` is stored in the :diskGiB clipboard
+    And evaluation of `machine(cb.machine).vsphere_memoryMiB` is stored in the :memoryMiB clipboard
+    And evaluation of `machine(cb.machine).vsphere_template` is stored in the :template clipboard
+    Then admin ensures "default-valued-33380" machineset is deleted after scenario
+
+    Given I obtain test data file "cloud/ms-vsphere/ms_default_values.yaml"
+    When I run oc create over "ms_default_values.yaml" replacing paths:
+      | n                                                                                         | openshift-machine-api                           |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %>     |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | default-valued-33380                            |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %>     |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["workspace"]["datacenter"]          | <%= cb.datacenter %>                            |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["workspace"]["datastore"]           | <%= cb.datastore %>                             |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["workspace"]["folder"]              | <%= cb.folder %>                                |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["workspace"]["resourcePool"]        | <%= cb.resourcePool %>                          |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["workspace"]["server"]              | <%= cb.server %>                                |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["diskGiB"]                          | <%= cb.diskGiB %>                               |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["memoryMiB"]                        | <%= cb.memoryMiB %>                             |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["template"]                         | <%= cb.template %>                              |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | default-valued-33380                            |
+    Then the step should succeed
+     

--- a/lib/openshift/machine.rb
+++ b/lib/openshift/machine.rb
@@ -68,6 +68,46 @@ module BushSlicer
          dig('spec', 'providerSpec', 'value', 'placement','availabilityZone')
     end
 
+    def vsphere_datacenter(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'workspace', 'datacenter')
+    end
+
+    def vsphere_datastore(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'workspace', 'datastore')
+    end
+
+    def vsphere_folder(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'workspace', 'folder')
+    end
+
+    def vsphere_resourcePool(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'workspace', 'resourcePool')
+    end
+
+    def vsphere_server(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'workspace', 'server')
+    end
+
+    def vsphere_diskGiB(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'diskGiB')
+    end
+
+    def vsphere_memoryMiB(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'memoryMiB')
+    end
+    
+    def vsphere_template(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'template')
+    end
+
     def deleting?(user: nil, cached: true, quiet: false)
       ! raw_resource(user: user, cached: cached, quiet: quiet).
           dig('metadata', 'deletionTimestamp').nil?

--- a/testdata/cloud/ms-vsphere/ms_default_values.yaml
+++ b/testdata/cloud/ms-vsphere/ms_default_values.yaml
@@ -1,0 +1,42 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster:
+    machine.openshift.io/cluster-api-machine-role: worker
+    machine.openshift.io/cluster-api-machine-type: worker
+  name: default-valued-33380
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster:
+      machine.openshift.io/cluster-api-machineset:
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster:
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset:
+    spec:
+      metadata: {}
+      taints:
+      - effect: "NoSchedule"
+        key: "mapi"
+        value: "mapi_test"
+      providerSpec:
+        value:
+           network:
+              devices:
+              - networkName: VM Network
+           template:
+           diskGiB:
+           memoryMiB:
+           workspace:
+              datacenter:
+              datastore:
+              folder:
+              resourcePool:
+              server:
+


### PR DESCRIPTION
Validation is passed .
.
      [13:11:31] INFO> Exit Status: 1
      [13:11:31] INFO> Shell Commands: rm -r -f -- /home/jenkins/workspace/Runner-v3/workdir
      
      [13:11:31] INFO> Exit Status: 0
      [13:11:31] INFO> === End After Scenario: Implement defaulting machineset values for vsphere ===

1 scenario (1 passed)
17 steps (17 passed)
0m26.773s

Randomized with seed 21881
[13:11:32] INFO> === At Exit ===
Archiving artifacts
Finished: SUCCESS
Job URL - https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/174961/console
This is related to - https://issues.redhat.com/browse/OCPCLOUD-883



