### PR TITLE
Machine API co should go degraded if machine-controller pods crashes

### DIFF
--- a/features/step_definitions/meta_steps.rb
+++ b/features/step_definitions/meta_steps.rb
@@ -114,3 +114,22 @@ Given /^I repeat the following steps for each #{SYM} in cb\.([\w]+):$/ do |varna
   end
 end
 
+# To exit successfully if output is obtained - mapi
+Given /^I run the steps #{NUMBER} times or exit when co machine-api is degraded:$/ do |num, steps_string|
+  eval_regex = /\#\{(.+?)\}/
+  eval_found = steps_string =~ eval_regex
+  step %Q{evaluation of `cluster_operator('machine-api').condition(type: 'Degraded')` is stored in the :co_degraded clipboard}
+  begin
+    logger.dedup_start
+    (1..Integer(num)).each { |i|
+      cb.i = i
+      if eval_found && cb.co_degraded["status"]=="False"
+        steps steps_string.gsub(eval_regex) { |s| "<%= #{$1} %>"}
+      else
+        steps steps_string
+      end
+    }
+  ensure
+    logger.dedup_flush
+  end
+end


### PR DESCRIPTION
Getting below exception while running the test: 
.
.

Expand ERROR with argument: Given a pod becomes ready with labels:
  | api=clusterapi, k8s-app=controller |
When admin ensure "<%= pod.name %>" pod is deleted from the "openshift-machine-api" project
And the step should succeed
#<RuntimeError: what Pod are you talking about?>
    /home/jenkins/workspace/Runner-v3/lib/world.rb:313:in `project_resource'
.
.
Although for test purpose it works fine , the functionality that I want to test gets validated , but I need help in reviewing what is causing above and the overall code .
Job url - https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/175580/console
This is the related bug - https://bugzilla.redhat.com/show_bug.cgi?id=1859221