### PR TITLE
wait_till: fix failure case, return false instead of nil

### DIFF
--- a/lib/base_helper.rb
+++ b/lib/base_helper.rb
@@ -138,20 +138,33 @@ module BushSlicer
       # @param seconds [Numeric] the max number of seconds to try operation to
       #   succeed
       # @param interval [Numeric] the interval to wait between attempts
+      # @param stats [Hash] collect stats
+      # @param jitter_multiplier [Numeric] (value >= 1) used to generate
+      #   random jitter in the wait interval using the decorrelated jitter
+      #   algorithm from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+      #   Jitter helps reduce contention between simultaneous clients
       # @yield block the block will be yielded until it returns true or timeout
       #   is reached
-      def wait_for(seconds, interval: 1, stats: nil)
-        if seconds > 60
-          Kernel.puts("waiting for operation up to #{seconds} seconds..")
-        end
+      def wait_for(seconds, interval: 1, stats: nil, jitter_multiplier: 3)
         iterations = 0
-
         start = monotonic_seconds
+        # pre-compute deadline
+        deadline = start + seconds
         success = false
-        until monotonic_seconds - start > seconds
-          iterations += 1
-          success = yield and break
+        base_interval = interval
+        until monotonic_seconds > deadline
+          (success = yield) and break
+          # only print if we actually have to wait
+          if iterations == 0
+            Kernel.puts("waiting for operation up to #{seconds} seconds..")
+          end
+          if jitter_multiplier >= 1
+            # cap max wait at seconds remaining (deadline - monotonic_seconds)
+            interval = [(deadline - monotonic_seconds), rand(base_interval...(jitter_multiplier * interval))].min
+          end
           sleep interval
+          Kernel.puts("slept #{interval} seconds..")
+          iterations += 1
         end
 
         return success

--- a/lib/openshift/resource.rb
+++ b/lib/openshift/resource.rb
@@ -329,15 +329,17 @@ module BushSlicer
     #   get call
     # @note sub-class needs to implement the `#ready?` method
     def wait_till_ready(user, seconds)
-      res = nil
-      iterations = 0
-      start_time = monotonic_seconds
+      res = BushSlicer::ResultHash.new(:success => false)
+      stats = {}
 
-      success = wait_for(seconds) {
+      first_run = true
+      wait_for(seconds, stats: stats) {
         res = ready?(user: user, quiet: true)
 
-        logger.info res[:command] if iterations == 0
-        iterations = iterations + 1
+        if first_run
+          logger.info res[:command]
+          first_run = false
+        end
 
         unless ready_state_reachable?(user: user, cached: true, quiet: true)
           break
@@ -346,38 +348,38 @@ module BushSlicer
         res[:success]
       }
 
-      duration = monotonic_seconds - start_time
-      logger.info "After #{iterations} iterations and #{duration.to_i} " <<
-        "seconds:\n#{res[:response]}"
+      logger.info "After #{stats[:iterations]} iterations and #{stats[:full_seconds]} " <<
+                      "seconds:\n#{res[:response]}"
 
-      return res
+      res
     end
 
     # waits until resource status is reached
     # @note this method requires sub-class to define the `#status?` method
     def wait_till_status(status, user, seconds)
-      res = nil
-      iterations = 0
-      start_time = monotonic_seconds
+      res = BushSlicer::ResultHash.new(:success => false)
+      stats = {}
 
-      success = wait_for(seconds) {
+      first_run = true
+      wait_for(seconds, stats: stats) {
         res = status?(user: user, status: status, quiet: true)
 
-        logger.info res[:command] if iterations == 0
-        iterations = iterations + 1
+        if first_run
+          logger.info res[:command]
+          first_run = false
+        end
 
         # if build finished there's little chance to change status so exit early
-        if !status_reachable?(res[:matched_status], status)
+        unless status_reachable?(res[:matched_status], status)
           break
         end
         res[:success]
       }
 
-      duration = monotonic_seconds - start_time
-      logger.info "After #{iterations} iterations and #{duration.to_i} " <<
-        "seconds:\n#{res[:response]}"
+      logger.info "After #{stats[:iterations]} iterations and #{stats[:full_seconds]} " <<
+                      "seconds:\n#{res[:response]}"
 
-      return res
+      res
     end
 
     # @param from_status [Symbol] the status we currently see


### PR DESCRIPTION
In the `wait_till_*` functions if the timeout has already
expired before the first status check then we set
`res` to `nil` which causes the access `res[:response]`
to raise

```ruby
      undefined method `[]' for nil:NilClass (NoMethodError)
      verification-tests/lib/openshift/resource.rb:351:in `wait_till_ready'
```

This is not the correct error message.

The steps that call `wait_till_ready` have a more detailed error
message that indicates which exact resource failed.

```ruby
  @result = _resource.wait_till_ready(_user, timeout)
  unless @result[:success]
    raise %Q{#{type} "#{_resource.name}" did not become ready within } \
       "#{timeout} seconds"
  end
```

If we set `res = BushSlicer::ResultHash.new(:success => false)` then
`@result[:success]` will fail and we get a good error message

```ruby
RuntimeError: BushSlicer::Pod ovnkube-master-vw8v6 did not become ready within timeout
verification-tests/features/step_definitions/resources.rb:107:in `block (2 levels) in <top (required)>'
```

Also use `wait_for` `stats` to calculate duration