### PR TITLE
OVN: grep for port in list logical_switch_port

### DIFF
--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -15,25 +15,27 @@ Feature: OVN related networking scenarios
       | name=test-pods |
     And evaluation of `pod(0).name` is stored in the :pod1_name clipboard
     And evaluation of `pod(1).name` is stored in the :pod2_name clipboard
-    #Checking whether Kube API data is synced on OVN NB db which in this case are couple of pods
+    # Checking whether Kube API data is synced on OVN NB db which in this case are couple of pods
     Given I store the ovnkube-master "north" leader pod in the clipboard
     And evaluation of `pod.ip_url` is stored in the :ovn_nb_leader_ip clipboard
     And evaluation of `pod.node_name` is stored in the :ovn_nb_leader_node clipboard
-    And admin executes on the pod:
-      | bash | -c | ovn-nbctl list logical_switch_port |
+    # too much output, if we don't filter server-side this always fails
+    And admin executes on the pod "northd" container:
+      | bash | -c | ovn-nbctl list logical_switch_port \| grep -e "<%= cb.pod1_name %>" -e "<%= cb.pod2_name %>" |
     Then the step should succeed
     And the output should contain:
       | <%= cb.pod1_name %> |
       | <%= cb.pod2_name %> |
-    #Simulating a NB db crash
+    # Simulating a NB db crash
     Given I use the "<%= cb.ovn_nb_leader_node %>" node
     And I run commands on the host:
       | pkill -f OVN_Northbound |
     And admin waits for all pods in the "openshift-ovn-kubernetes" project to become ready up to 120 seconds
-    #Making sure the pod entries are synced again when NB db is re-created
+    # Making sure the pod entries are synced again when NB db is re-created
     Given I store the ovnkube-master "north" leader pod in the clipboard
-    Given admin executes on the pod:
-      | bash | -c | ovn-nbctl list logical_switch_port |
+    # too much output, if we don't filter server-side this always fails
+    And admin executes on the pod "northd" container:
+      | bash | -c | ovn-nbctl list logical_switch_port \| grep -e "<%= cb.pod1_name %>" -e "<%= cb.pod2_name %>" |
     Then the step should succeed
     And the output should contain:
       | <%= cb.pod1_name %> |
@@ -70,20 +72,22 @@ Feature: OVN related networking scenarios
     When I run the :create client command with:
       | f | pod-for-ping.json |
     Then the step should succeed
-    #Now scale up CNO pod to 1 and check whether hello-pod is synced to NB db
+    # Now scale up CNO pod to 1 and check whether hello-pod is synced to NB db
     Given I run the :scale admin command with:
       | resource | deployment                 |
       | name     | network-operator           |
       | replicas | 1                          |
       | n        | openshift-network-operator |
     Then the step should succeed
-    #A minimum wait for 30 seconds is tested to reflect CNO deployment to be effective which will then re-spawn ovn pods
+    # A minimum wait for 30 seconds is tested to reflect CNO deployment to be effective which will then re-spawn ovn pods
     Given 30 seconds have passed
-    And admin waits for all pods in the "openshift-ovn-kubernetes" project to become ready up to 60 seconds
-    #Checking whether Kube API data is synced on OVN NB db which in this case is a test-pod created in earlier steps
+    # This used to be 60 seconds but around the time of 4.6 60 seconds is no longer sufficient
+    And admin waits for all pods in the "openshift-ovn-kubernetes" project to become ready up to 120 seconds
+    # Checking whether Kube API data is synced on OVN NB db which in this case is a test-pod created in earlier steps
     Given I store the ovnkube-master "north" leader pod in the clipboard
-    And admin executes on the pod:
-      | bash | -c | ovn-nbctl list logical_switch_port |
+    # too much output, if we don't filter server-side this always fails
+    And admin executes on the pod "northd" container:
+      | bash | -c | ovn-nbctl list logical_switch_port \| grep hello-pod |
     Then the step should succeed
     And the output should contain:
       | hello-pod |
@@ -97,10 +101,11 @@ Feature: OVN related networking scenarios
     Given I have a project
     And evaluation of `project.name` is stored in the :hello_pod_project clipboard
     And I have a pod-for-ping in the project
-    #Checking whether Kube API data is synced on OVN NB db which in this case is a hello-pod created in earlier steps
+    # Checking whether Kube API data is synced on OVN NB db which in this case is a hello-pod created in earlier steps
     Given I store the ovnkube-master "north" leader pod in the clipboard
-    And admin executes on the pod:
-      | bash | -c | ovn-nbctl list logical_switch_port |
+    # too much output, if we don't filter server-side this always fails
+    And admin executes on the pod "northd" container:
+      | bash | -c | ovn-nbctl list logical_switch_port \| grep hello-pod |
     Then the step should succeed
     And the output should contain:
       | hello-pod |
@@ -124,7 +129,7 @@ Feature: OVN related networking scenarios
     And admin executes existing pods die with labels:
       | app=ovnkube-master |
     And I ensures "hello-pod" pod is deleted from the "<%= cb.hello_pod_project %>" project
-    #Now scale up CNO pod to 1 and check whether hello-pod status is synced to NB db means it should not present in the DB
+    # Now scale up CNO pod to 1 and check whether hello-pod status is synced to NB db means it should not present in the DB
     Given admin uses the "openshift-network-operator" project
     Given I run the :scale admin command with:
       | resource | deployment                 |
@@ -132,14 +137,16 @@ Feature: OVN related networking scenarios
       | replicas | 1                          |
       | n        | openshift-network-operator |
     Then the step should succeed
-    #A recommended wait for 30 seconds is tested to reflect CNO deployment to be in effect which will then re-spawn ovn pods
+    # A recommended wait for 30 seconds is tested to reflect CNO deployment to be in effect which will then re-spawn ovn pods
     Given 30 seconds have passed
-    And admin waits for all pods in the "openshift-ovn-kubernetes" project to become ready up to 60 seconds
+    # This used to be 60 seconds but around the time of 4.6 60 seconds is no longer sufficient
+    And admin waits for all pods in the "openshift-ovn-kubernetes" project to become ready up to 120 seconds
     Given I store the ovnkube-master "north" leader pod in the clipboard
-    And admin executes on the pod:
-      | bash | -c | ovn-nbctl list logical_switch_port |
+    # too much output, if we don't filter server-side this always fails
+    And admin executes on the pod "northd" container:
+      | bash | -c | ovn-nbctl list logical_switch_port \| grep hello-pod |
     Then the step should succeed
-    #making sure here that hello-pod absense is properly synced
+    # making sure here that hello-pod absense is properly synced
     And the output should not contain:
       | hello-pod |
 


### PR DESCRIPTION
It seems that `ovn-nbctl list logical_switch_port`
outputs too much info so if we don't grep
server-side the step now always fails

Without the `grep` `oc exec` fails witn the error:
```
E1008 07:03:23.823290  655435 v2.go:105] write tcp 172.16.16.22:41846->15.222.201.132:6443: write: connection reset by peer
```
Also change the wait for all pods in the "openshift-ovn-kubernetes" project
timeout to 60 seconds, because it is taking longer, maybe due to the
new OVN database checking