### PR TITLE
rules update

### DIFF
--- a/lib/rules/web/admin_console/4.4/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.4/dashboards.xyaml
@@ -560,13 +560,13 @@ check_cluster_inventory_items:
   - selector:
       xpath: //div[contains(@class,'co-dashboard-card__header')]/*[text()='Cluster Inventory']
   - selector:
-      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Nodes')]
+      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Node')]
   - selector:
-      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Pods')]
+      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Pod')]
   - selector:
       xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Storage Class')]
   - selector:
-      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'PVCs')]
+      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'PVC')]
 check_matched_number_of_nodes:
   params:
     resource_type: nodes

--- a/lib/rules/web/admin_console/4.5/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.5/dashboards.xyaml
@@ -561,13 +561,13 @@ check_cluster_inventory_items:
   - selector:
       xpath: //div[contains(@class,'co-dashboard-card__header')]/*[text()='Cluster Inventory']
   - selector:
-      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Nodes')]
+      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Node')]
   - selector:
-      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Pods')]
+      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Pod')]
   - selector:
       xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Storage Class')]
   - selector:
-      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'PVCs')]
+      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'PVC')]
 check_matched_number_of_nodes:
   params:
     resource_type: nodes

--- a/lib/rules/web/admin_console/4.6/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.6/dashboards.xyaml
@@ -563,13 +563,13 @@ check_cluster_inventory_items:
   - selector:
       xpath: //div[contains(@class,'co-dashboard-card__header')]/*[text()='Cluster Inventory']
   - selector:
-      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Nodes')]
+      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Node')]
   - selector:
-      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Pods')]
+      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Pod')]
   - selector:
       xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'Storage Class')]
   - selector:
-      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'PVCs')]
+      xpath: //div[contains(@class,'co-inventory-card__item')]//a[contains(text(),'PVC')]
 check_matched_number_of_nodes:
   params:
     resource_type: nodes

--- a/lib/rules/web/admin_console/4.6/logs.xyaml
+++ b/lib/rules/web/admin_console/4.6/logs.xyaml
@@ -21,7 +21,7 @@ wait_log_window_loaded:
 check_log_content_contains:
   element:
     selector:
-      xpath: //div[contains(@class,'log-window__contents__text') and contains(.,'<log_content>')]
+      xpath: //div[contains(@class,'log-window__lines') and contains(.,'<log_content>')]
     timeout: 30
 check_some_context_missing_in_expanded_log_view:
   elements:
@@ -31,7 +31,7 @@ check_some_context_missing_in_expanded_log_view:
 check_required_context_shown_in_expanded_log_view:
   elements:
   - selector: &download_button
-      xpath: //button[contains(.,'Download')]
+      xpath: //a[contains(.,'Download')]
   - selector: &collapse_button
       xpath: //button[contains(.,'Collapse')]
   - selector: &toggle_steaming_paused_button

--- a/lib/rules/web/admin_console/4.6/node.xyaml
+++ b/lib/rules/web/admin_console/4.6/node.xyaml
@@ -32,17 +32,8 @@ check_role_column_header:
   params:
     column_name: Role
   action: check_column_header
-select_default_namespace_on_node_teminal:
-  elements:
-  - selector:
-      xpath: //button[@id='dropdown-selectbox']
-    op: click
-  - selector:
-      xpath: //span[text()='default']
-    op: click
 check_terminal_tab_on_node_page:
   action: click_terminal_tab
-  action: select_default_namespace_on_node_teminal
   action: check_use_host_binaries_message
 check_use_host_binaries_message:
   element:

--- a/lib/rules/web/admin_console/4.6/user_management.xyaml
+++ b/lib/rules/web/admin_console/4.6/user_management.xyaml
@@ -161,7 +161,7 @@ check_kebab_items_disabled_on_list_page:
   action: check_kebab_items_disabled
 check_no_action_button_on_resource_page:
   action: goto_one_dc_page
-  action: check_action_button_missing
+  action: check_kebab_items_disabled
 check_no_save_button_on_resource_page:
   action: click_yaml_tab
   action: check_save_button_missing


### PR DESCRIPTION
fixed
OCP-24281 RBAC check to normal operations for users with view access - rule update
OCP-20688 Check log streaming - rule update
OCP-28297 Cluster Inventory block has a full list of required items - remove `s` to reduce instability caused by single and plural nouns 
OCP-19722 Check nodes list columns and terminal tab - feature changed and there is no need to choose namespace, rule updated