### PR TITLE
update clusterlogforwarder to namespaced resource

### DIFF
--- a/features/logging/cluster_log_forwarder.feature
+++ b/features/logging/cluster_log_forwarder.feature
@@ -254,7 +254,7 @@ Feature: cluster log forwarder features
     Given I switch to cluster admin pseudo user
     And I use the "openshift-logging" project
     Given I obtain test data file "logging/clusterlogforwarder/<file>"
-    And admin ensures "instance" cluster_log_forwarder is deleted after scenario
+    And admin ensures "instance" cluster_log_forwarder is deleted from the "openshift-logging" project after scenario
     When I run the :create client command with:
       | f | <file> |
     Then the step should succeed

--- a/lib/openshift/cluster_log_forwarder.rb
+++ b/lib/openshift/cluster_log_forwarder.rb
@@ -1,8 +1,8 @@
 # represent a clusterlogforwarder object
-require 'openshift/cluster_resource'
+require 'openshift/project_resource'
 
 module BushSlicer
-  class ClusterLogForwarder < ClusterResource
+  class ClusterLogForwarder < ProjectResource
     RESOURCE = "clusterlogforwarders"
     
     def spec_raw(user: nil, quiet: false, cached: true)

--- a/testdata/logging/clusterlogforwarder/multiple_receiver/clusterlogforwarder.yaml
+++ b/testdata/logging/clusterlogforwarder/multiple_receiver/clusterlogforwarder.yaml
@@ -1,7 +1,8 @@
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:   
-  name: instance   
+  name: instance
+  namespace: openshift-logging
 spec:   
   outputs:     
   - name: fluentd-created-by-user

--- a/testdata/logging/logforwarding/rsyslog/insecure/rsyslogserver_configmap.yaml
+++ b/testdata/logging/logforwarding/rsyslog/insecure/rsyslogserver_configmap.yaml
@@ -20,3 +20,4 @@ data:
     }
     :programname, contains, "journal.system" /var/log/custom/infra.log
     :programname, contains, "k8s-audit.log" /var/log/custom/audit.log
+    :programname, contains, "openshift-audit.log" /var/log/custom/audit.log


### PR DESCRIPTION
Per https://bugzilla.redhat.com/show_bug.cgi?id=1884275, update clusterlogforwarder to namespaced resource.

@anpingli PTAL, thanks.