### PR TITLE
update nodeport cases with localhost access

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -490,7 +490,7 @@ Feature: Service related networking scenarios
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"serviceNodePortRange": "30000-33000"}} |
     When I obtain test data file "networking/nodeport_service.json"
-    And I wait up to 120 seconds for the steps to pass:
+    And I wait up to 300 seconds for the steps to pass:
     """    
     When I run oc create over "nodeport_service.json" replacing paths:
       | ["items"][1]["spec"]["ports"][0]["nodePort"] | <%= cb.port %> |

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -497,25 +497,16 @@ Feature: Service related networking scenarios
     Then the step should succeed
     """
     Given the pod named "hello-pod" becomes ready
-    And evaluation of `pod.node_ip` is stored in the :hostip clipboard
-
-    Given I obtain test data file "networking/list_for_pods.json"
-    When I run oc create over "list_for_pods.json" replacing paths:
-      | ["items"][0]["spec"]["replicas"] | 1 |
-    Then the step should succeed
-    And a pod becomes ready with labels:
-      | name=test-pods |
-    When I execute on the pod:
-      | curl | <%= cb.hostip %>:<%= cb.port %> |
+    Given I select a random node's host
+    When I run commands on the host:    
+      | curl --connect-timeout 5 localhost:<%= cb.port %> |
     Then the step should succeed
     And the output should contain:
       | Hello OpenShift! |
     Given I ensure "hello-pod" service is deleted
-    When I execute on the pod:
-      | curl | <%= cb.hostip %>:<%= cb.port %> |
+    When I run commands on the host:    
+      | curl --connect-timeout 5 localhost:<%= cb.port %> |
     Then the step should fail
-    And the output should not contain:
-      | Hello OpenShift! |
 
   # @author zzhao@redhat.com
   # @case_id OCP-33850


### PR DESCRIPTION
due to the firewall restricted for different platform. update this scenario with localhost with specified nodeport
```
     
      Removing debug pod ...
      error: non-zero exit code from debug container
      
      [03:13:50] INFO> Exit Status: 1
      [03:13:50] INFO> Shell Commands: oc delete projects tests-dhcp-140-240-zzhao --wait=false --kubeconfig=/home/zzhao/workdir/dhcp-140-240-zzhao/ocp4_admin.kubeconfig
      project.project.openshift.io "tests-dhcp-140-240-zzhao" deleted
      
      [03:13:52] INFO> Exit Status: 0
      [03:13:52] INFO> Shell Commands: rm -r -f -- /home/zzhao/workdir/dhcp-140-240-zzhao
      
      [03:13:52] INFO> Exit Status: 0
      [03:13:52] INFO> === End After Scenario: User can expand the nodePort range by patch the serviceNodePortRange in network ===

1 scenario (1 passed)
13 steps (13 passed)
1m46.773s

```
@liangxia @pruan-rht 