### PR TITLE
OCP-33848: wait for nodeport svc

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -490,12 +490,9 @@ Feature: Service related networking scenarios
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"serviceNodePortRange": "30000-33000"}} |
     When I obtain test data file "networking/nodeport_service.json"
-    And I wait up to 300 seconds for the steps to pass:
-    """    
     When I run oc create over "nodeport_service.json" replacing paths:
       | ["items"][1]["spec"]["ports"][0]["nodePort"] | <%= cb.port %> |
-    Then the step should succeed
-    """
+    Given I wait for the "hello-pod" service to be created
     Given the pod named "hello-pod" becomes ready
     Given I select a random node's host
     When I run commands on the host:

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -82,13 +82,13 @@ Feature: Service related networking scenarios
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     And I have a pod-for-ping in the project
-    
+
     #Creating laodbalancer service that points to MCS IP
-    When I run the :create_service_loadbalancer client command with: 
+    When I run the :create_service_loadbalancer client command with:
       | name | <%= cb.ping_pod.name %>  |
-      | tcp  | 22623:8080               | 
+      | tcp  | 22623:8080               |
     Then the step should succeed
-    
+
     # Editing endpoint to point to master ip
     When I run the :patch client command with:
       | resource      | ep                         				      						   |
@@ -125,24 +125,24 @@ Feature: Service related networking scenarios
 
   # @author weliang@redhat.com
   # @case_id OCP-24668
-  Scenario: externalIP defined in service but no spec.externalIP defined	
-    Given I have a project 
+  Scenario: externalIP defined in service but no spec.externalIP defined
+    Given I have a project
     # Create a service with a externalIP
     Given I obtain test data file "networking/externalip_service1.json"
     When I run the :create client command with:
-      | f | externalip_service1.json | 
+      | f | externalip_service1.json |
     Then the step should fail
 
   # @author weliang@redhat.com
   # @case_id OCP-24669
   @admin
   @destructive
-  Scenario: externalIP defined in service with set ExternalIP in allowedCIDRs	
+  Scenario: externalIP defined in service with set ExternalIP in allowedCIDRs
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I store the schedulable nodes in the :nodes clipboard
     And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :hostip clipboard
-   
+
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["<%= cb.hostip %>/24"]}}}} |
@@ -162,15 +162,15 @@ Feature: Service related networking scenarios
     When I run oc create over "externalip_service1.json" replacing paths:
       | ["spec"]["externalIPs"][0] | <%= cb.hostip %> |
     Then the step should succeed
-    """ 
-    
+    """
+
     # Create a pod
     Given I obtain test data file "routing/caddy-docker.json"
     When I run the :create client command with:
       | f | caddy-docker.json |
     Then the step should succeed
     And the pod named "caddy-docker" becomes ready
- 
+
     # Curl externalIP:portnumber should pass
     When I execute on the pod:
       | /usr/bin/curl | --connect-timeout | 10 | <%= cb.hostip %>:27017 |
@@ -181,7 +181,7 @@ Feature: Service related networking scenarios
   # @case_id OCP-24692
   @admin
   @destructive
-  Scenario: A rejectedCIDRs inside an allowedCIDRs	 
+  Scenario: A rejectedCIDRs inside an allowedCIDRs
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["22.2.2.0/24"],"rejectedCIDRs":["22.2.2.0/25"]}}}} |
@@ -194,7 +194,7 @@ Feature: Service related networking scenarios
     """
 
     # Create a svc with externalIP/22.2.2.10 which is in 22.2.2.0/25
-    Given I have a project 
+    Given I have a project
     Given I obtain test data file "networking/externalip_service1.json"
     And I wait up to 300 seconds for the steps to pass:
     """
@@ -211,15 +211,15 @@ Feature: Service related networking scenarios
       | ["spec"]["externalIPs"][0] | 22.2.2.130 |
     Then the step should succeed
     """
- 
+
     # Create a pod
     Given I obtain test data file "routing/caddy-docker.json"
     When I run the :create client command with:
       | f | caddy-docker.json |
     Then the step should succeed
     And the pod named "caddy-docker" becomes ready
- 
-    # Curl externalIP:portnumber on new pod 
+
+    # Curl externalIP:portnumber on new pod
     When I execute on the pod:
       | /usr/bin/curl | -k | 22.2.2.130:27017 |
     Then the output should contain:
@@ -234,11 +234,11 @@ Feature: Service related networking scenarios
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I store the schedulable nodes in the :nodes clipboard
     And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :hostip clipboard
-   
+
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"rejectedCIDRs":["<%= cb.hostip %>/24"]}}}} |
- 
+
     # Clean-up required to erase above externalIP policy after testing done
     Given I register clean-up steps:
     """
@@ -260,11 +260,11 @@ Feature: Service related networking scenarios
   # @case_id OCP-24739
   @admin
   @destructive
-  Scenario: An allowedCIDRs inside an rejectedCIDRs	 
+  Scenario: An allowedCIDRs inside an rejectedCIDRs
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
-      | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["22.2.2.0/25"],"rejectedCIDRs":["22.2.2.0/24"]}}}} |                                                                                  
-   
+      | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["22.2.2.0/25"],"rejectedCIDRs":["22.2.2.0/24"]}}}} |
+
     # Clean-up required to erase above externalIP policy after testing done
     Given I register clean-up steps:
     """
@@ -273,7 +273,7 @@ Feature: Service related networking scenarios
     """
 
     # Create a svc with externalIP/22.2.2.10 which is in rejectedCIDRs
-    Given I have a project 
+    Given I have a project
     Given I obtain test data file "networking/externalip_service1.json"
     And I wait up to 300 seconds for the steps to pass:
     """
@@ -295,24 +295,24 @@ Feature: Service related networking scenarios
   # @case_id OCP-24691
   @admin
   @destructive
-  Scenario: Defined Multiple allowedCIDRs 
+  Scenario: Defined Multiple allowedCIDRs
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I store the schedulable nodes in the :nodes clipboard
     And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :host1ip clipboard
     And the Internal IP of node "<%= cb.nodes[1].name %>" is stored in the :host2ip clipboard
-    
+
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["<%= cb.host1ip %>/24","<%= cb.host2ip %>/24"]}}}} |
-  
+
     # Clean-up required to erase above externalIP policy after testing done
     Given I register clean-up steps:
     """
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"allowedCIDRs":null }}}} |
     """
-    
+
     # Create a svc with externalIP
     Given I switch to the first user
     Given I obtain test data file "networking/externalip_service1.json"
@@ -329,13 +329,13 @@ Feature: Service related networking scenarios
       | f | caddy-docker.json |
     Then the step should succeed
     And the pod named "caddy-docker" becomes ready
- 
-    # Curl externalIP:portnumber from pod 
+
+    # Curl externalIP:portnumber from pod
     When I execute on the pod:
       | /usr/bin/curl | --connect-timeout | 10 | <%= cb.host1ip %>:27017 |
     Then the output should contain:
       | Hello-OpenShift-1 http-8080 |
-    
+
     # Delete created pod and svc
     When I run the :delete client command with:
       | object_type | all |
@@ -350,15 +350,15 @@ Feature: Service related networking scenarios
       | ["spec"]["externalIPs"][0] | <%= cb.host2ip %> |
     Then the step should succeed
     """
-    
+
     # Create a pod
     Given I obtain test data file "routing/caddy-docker.json"
     When I run the :create client command with:
       | f | caddy-docker.json |
     Then the step should succeed
     And the pod named "caddy-docker" becomes ready
- 
-    # Curl externalIP:portnumber on new pod 
+
+    # Curl externalIP:portnumber on new pod
     When I execute on the pod:
       | /usr/bin/curl | --connect-timeout | 10 | <%= cb.host2ip %>:27017 |
     Then the output should contain:
@@ -459,7 +459,7 @@ Feature: Service related networking scenarios
       | name     | <%= cb.subject_node %> |
     Then the step should succeed
     And the output should contain "mtu-too-small"
-    #Starting NetworkManager to roll out original system MTU 
+    #Starting NetworkManager to roll out original system MTU
     Given I use the "<%= cb.subject_node %>" node
     And I run commands on the host:
       | systemctl start NetworkManager |
@@ -498,13 +498,13 @@ Feature: Service related networking scenarios
     """
     Given the pod named "hello-pod" becomes ready
     Given I select a random node's host
-    When I run commands on the host:    
+    When I run commands on the host:
       | curl --connect-timeout 5 localhost:<%= cb.port %> |
     Then the step should succeed
     And the output should contain:
       | Hello OpenShift! |
     Given I ensure "hello-pod" service is deleted
-    When I run commands on the host:    
+    When I run commands on the host:
       | curl --connect-timeout 5 localhost:<%= cb.port %> |
     Then the step should fail
 


### PR DESCRIPTION


We are testing a nodeport out of the standard range
so the create always returns a warning and exit status 1
but the actual service is actually created

The loop won't work because the `hello-pod` is already created
and the command will still continue to show the warning and
return exit status 1.

Instead of retrying, instead use the wait for service ready step
and then wait for the pod.

Failures when trying the loop, we can see that `hello-pod` is created,
but when retrying we get `AlreadyExists`

```
    And I wait up to 300 seconds for the steps to pass:                                             # features/step_definitions/meta_steps.rb:33
      [03:04:14] INFO> {"apiVersion":"v1","kind":"List","items":[{"kind":"Pod","apiVersion":"v1","metadata":{"name":"hello-pod","labels":{"name":"hello-pod"}},"spec":{"containers":[{"name":"hello-pod","image":"aosqe/hello-openshift","ports":[{"containerPort":8081}]}]}},{"kind":"Service","apiVersion":"v1","metadata":{"name":"hello-pod","labels":{"name":"hello-pod"}},"spec":{"ports":[{"name":"http","protocol":"TCP","port":27017,"nodePort":32929,"targetPort":8081}],"type":"NodePort","selector":{"name":"hello-pod"}}}]}
      [03:04:14] INFO> Shell Commands: oc create -f - --kubeconfig
      pod/hello-pod created

      STDERR:
      The Service "hello-pod" is invalid: spec.ports[0].nodePort: Invalid value: 32929: provided port is not in the valid range. The range of valid ports is 30000-32767

      [03:04:15] INFO> Exit Status: 1
      [03:04:16] INFO> {"apiVersion":"v1","kind":"List","items":[{"kind":"Pod","apiVersion":"v1","metadata":{"name":"hello-pod","labels":{"name":"hello-pod"}},"spec":{"containers":[{"name":"hello-pod","image":"aosqe/hello-openshift","ports":[{"containerPort":8081}]}]}},{"kind":"Service","apiVersion":"v1","metadata":{"name":"hello-pod","labels":{"name":"hello-pod"}},"spec":{"ports":[{"name":"http","protocol":"TCP","port":27017,"nodePort":32929,"targetPort":8081}],"type":"NodePort","selector":{"name":"hello-pod"}}}]}
      [03:04:16] INFO> Shell Commands: oc create -f - --kubeconfig

      STDERR:
      Error from server (AlreadyExists): pods "hello-pod" already exists
      Error from server (Invalid): Service "hello-pod" is invalid: spec.ports[0].nodePort: Invalid value: 32929: provided port is not in the valid range. The range of valid ports is 30000-32767

      INFO> last 4 messages repeated 81 times
      [03:06:53] INFO> Exit Status: 1
      [03:06:54] INFO> {"apiVersion":"v1","kind":"List","items":[{"kind":"Pod","apiVersion":"v1","metadata":{"name":"hello-pod","labels":{"name":"hello-pod"}},"spec":{"containers":[{"name":"hello-pod","image":"aosqe/hello-openshift","ports":[{"containerPort":8081}]}]}},{"kind":"Service","apiVersion":"v1","metadata":{"name":"hello-pod","labels":{"name":"hello-pod"}},"spec":{"ports":[{"name":"http","protocol":"TCP","port":27017,"nodePort":32929,"targetPort":8081}],"type":"NodePort","selector":{"name":"hello-pod"}}}]}
      [03:06:54] INFO> Shell Commands: oc create -f - --kubeconfig
      service/hello-pod created

      STDERR:
      Error from server (AlreadyExists): pods "hello-pod" already exists

      [03:06:55] INFO> Exit Status: 1
