### PR TITLE
increase service project wait timeout to 60s

### DIFF
--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -418,7 +418,8 @@ module BushSlicer
       unless @service_project
         project = Project.new(name: "tests-" + EXECUTOR_NAME.downcase, env: self)
         unless project.active?
-          project.wait_to_disappear(admin)
+          # 30 seconds is no longer enough
+          project.wait_to_disappear(admin, 60)
           res = project.create(by: admin, clean_up_registered: true)
           unless res[:success]
             raise "failed to create service project #{project.name}, see log"


### PR DESCRIPTION
30 seconds is not enough it seems

Scenario: SDN pod should be working well after the node service is restarted

seems to cause the `oc get projects` to take too long

```
      [04:46:32] INFO> Exit Status: 0
      [04:46:33] INFO> oc get projects tests-psiv43-cucushift-oc46-standard-agent-cl40f-0 --output=yaml --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig
      [04:47:03] INFO> After 19 iterations and 31 seconds:
      apiVersion: project.openshift.io/v1
      kind: Project
      status:
        conditions:
        - lastTransitionTime: "2020-10-14T04:35:13Z"
          message: 'Discovery failed for some groups, 1 failing: unable to retrieve the complete list of server APIs: custom.metrics.k8s.io/v1beta1: the server is currently unable to handle the request'
          reason: DiscoveryFailed
          status: "True"
          type: NamespaceDeletionDiscoveryFailure
        - lastTransitionTime: "2020-10-14T04:35:25Z"
          message: All legacy kube types successfully parsed
          reason: ParsedGroupVersions
          status: "False"
          type: NamespaceDeletionGroupVersionParsingFailure
        - lastTransitionTime: "2020-10-14T04:35:25Z"
          message: All content successfully deleted, may be waiting on finalization
          reason: ContentDeleted
          status: "False"
          type: NamespaceDeletionContentFailure
        - lastTransitionTime: "2020-10-14T04:35:25Z"
          message: All content successfully removed
          reason: ContentRemoved
          status: "False"
          type: NamespaceContentRemaining
        - lastTransitionTime: "2020-10-14T04:35:25Z"
          message: All content-preserving finalizers finished
          reason: ContentHasNoFinalizers
          status: "False"
          type: NamespaceFinalizersRemaining
        phase: Terminating

      [04:47:03] INFO> Shell Commands: oc new-project tests-psiv43-cucushift-oc46-standard-agent-cl40f-0 --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_admin.kubeconfig

      STDERR:
      Error from server (AlreadyExists): project.project.openshift.io "tests-psiv43-cucushift-oc46-standard-agent-cl40f-0" already exists

      [04:47:04] INFO> Exit Status: 1
      failed to create service project tests-psiv43-cucushift-oc46-standard-agent-cl40f-0, see log (RuntimeError)
      /home/jenkins/workspace/Runner-v3/lib/environment.rb:424:in `service_project'
      /home/jenkins/workspace/Runner-v3/lib/host.rb:848:in `service_project'
      /home/jenkins/workspace/Runner-v3/lib/host.rb:869:in `exec_raw'
      /home/jenkins/workspace/Runner-v3/lib/host.rb:488:in `mkdir'
```