### PR TITLE
Only check sctp module in worker nodes

### DIFF
--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -10,7 +10,7 @@ Feature: SCTP related scenarios
     Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
-    Given I check load-sctp-module in all nodes
+    Given I check load-sctp-module in all workers
     """
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:
@@ -63,7 +63,7 @@ Feature: SCTP related scenarios
     Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
-    Given I check load-sctp-module in all nodes
+    Given I check load-sctp-module in all workers
     """
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:
@@ -123,7 +123,7 @@ Feature: SCTP related scenarios
     Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
-    Given I check load-sctp-module in all nodes
+    Given I check load-sctp-module in all workers
     """
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:
@@ -182,7 +182,7 @@ Feature: SCTP related scenarios
     Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """
-    Given I check load-sctp-module in all nodes
+    Given I check load-sctp-module in all workers
     """
     Given I obtain test data file "networking/sctp/sctpserver.yaml"
     When I run oc create as admin over "sctpserver.yaml" replacing paths:

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1182,13 +1182,13 @@ Given /^I install machineconfigs load-sctp-module$/ do
   end
 end
 
-Given /^I check load-sctp-module in all nodes$/ do
+Given /^I check load-sctp-module in all workers$/ do
   ensure_admin_tagged
   _admin = admin
-  env.nodes.each do |node|
-    @result = node.host.exec_admin("lsmod \| grep sctp")
-    unless @result[:response].include? "sctp"
-      raise "no sctp module"
+  cb.workers.each do |workers|
+    @result = workers.host.exec_admin("cat /sys/module/sctp/initstate")
+    unless @result[:response].include? "live"
+      raise "No sctp module installed"
     end
   end
 end


### PR DESCRIPTION
Update sctp script to:
1. Only check sctp module in worker nodes, no need check sctp modules in all the nodes.

2. Add step wait up to 60 seconds for sctpserver pod too avoid randomly see below failure
 # sctpserver pod start to wait for sctp traffic
    When I run the :exec background client command with:                              # features/step_definitions/cli.rb:13
      [17:56:14] INFO> Shell Commands: oc exec sctpserver  --kubeconfig=/home/weliang/workdir/weliang-weliang/ocp4_testuser-0.kubeconfig --namespace=y2fh9  -- sh -c /usr/bin/nc\ -l\ 30102\ --sctp\ -k\ -m\ 5\ -w\ 60
      
      STDERR:
      sh: /usr/bin/nc: No such file or directory
      command terminated with exit code 127

Test logs: http://file.rdu.redhat.com/~weliang/sctp.log

@zhaozhanqi @anuragthehatter @rbbratta @huiran0826 