### PR TITLE
update test ingresscontroller to use NodePort instead of HostNetwork

### DIFF
--- a/testdata/routing/operator/ingressctl-nsowner.yaml
+++ b/testdata/routing/operator/ingressctl-nsowner.yaml
@@ -9,13 +9,6 @@ spec:
   domain: nsowner.example.com
   replicas: 1
   endpointPublishingStrategy:
-    type: HostNetwork
+    type: NodePortService
   routeAdmission:
     namespaceOwnership: InterNamespaceAllowed
-  nodePlacement:
-    nodeSelector:
-      matchLabels:
-        beta.kubernetes.io/os: linux
-    tolerations:
-    - effect: NoSchedule
-      operator: Exists


### PR DESCRIPTION
`HostNetwork` might causes port conflict (rarely but possibly) when running parallel CI jobs on some platforms, so replace it with `NodePortService`, and `nodePlacement` part is not required any more.

@quarterpin please help review.

