### PR TITLE
update the nodeport pod and service with separate file

### DIFF
--- a/testdata/networking/nodeport_test_pod.yaml
+++ b/testdata/networking/nodeport_test_pod.yaml
@@ -1,0 +1,13 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: hello-pod
+  labels:
+    name: hello-pod
+spec:
+  containers:
+  - name: hello-pod
+    image: quay.io/openshifttest/hello-openshift@sha256:aaea76ff622d2f8bcb32e538e7b3cd0ef6d291953f3e7c9f556c1ba5baf47e2e
+    ports:
+    - containerPort: 8081

--- a/testdata/networking/nodeport_test_service.yaml
+++ b/testdata/networking/nodeport_test_service.yaml
@@ -1,0 +1,17 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: hello-pod
+  labels:
+    name: hello-pod
+spec:
+  ports:
+  - name: http
+    protocol: TCP
+    port: 27017
+    nodePort: 32998
+    targetPort: 8080
+  type: NodePort
+  selector:
+    name: hello-pod


### PR DESCRIPTION
update this with separate file for pod and service since the pod and service cannot create successfully at same time since before it always return with `exit 1`

```
horization"=>"Bearer <oauth_token>"}}, opts: {:token_to_delete=>"sha256~8nmjf_vi8x2PYJgBdWbFKqGxDdOYl9atxgU7-aar2pY"}
      [10:41:53] INFO> HTTP DELETE https://api.wsunawsnlb.qe.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthaccesstokens/sha256~8nmjf_vi8x2PYJgBdWbFKqGxDdOYl9atxgU7-aar2pY
      [10:41:54] INFO> HTTP DELETE took 0.992 sec: 200 OK | application/json 242 bytes
      
      [10:41:56] INFO> Shell Commands: oc debug  --kubeconfig=/home/zzhao/workdir/dhcp-140-240-zzhao/ocp4_admin.kubeconfig -n tests-dhcp-140-240-zzhao --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8f4882cff3c2f9521215eac681c5abda42876e3e955431c1387fb457940b8344 node/ip-10-0-148-59.us-east-2.compute.internal -- chroot /host/ bash -c rm\ -r\ -f\ --\ /tmp/workdir/dhcp-140-240-zzhao
      
      STDERR:
      Starting pod/ip-10-0-148-59us-east-2computeinternal-debug ...
      To use host binaries, run `chroot /host`
      
      Removing debug pod ...
      
      [10:42:00] INFO> Exit Status: 0
      [10:42:02] INFO> Shell Commands: oc debug  --kubeconfig=/home/zzhao/workdir/dhcp-140-240-zzhao/ocp4_admin.kubeconfig -n tests-dhcp-140-240-zzhao --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8f4882cff3c2f9521215eac681c5abda42876e3e955431c1387fb457940b8344 node/ip-10-0-148-59.us-east-2.compute.internal -- chroot /host/ bash -c ls\ -d\ --\ /tmp/workdir/dhcp-140-240-zzhao
      ls: cannot access '/tmp/workdir/dhcp-140-240-zzhao': No such file or directory
      
      STDERR:
      Starting pod/ip-10-0-148-59us-east-2computeinternal-debug ...
      To use host binaries, run `chroot /host`
      
      Removing debug pod ...
      
      [10:42:06] INFO> Exit Status: 0
      [10:42:06] INFO> Shell Commands: oc delete projects tests-dhcp-140-240-zzhao --wait=false --kubeconfig=/home/zzhao/workdir/dhcp-140-240-zzhao/ocp4_admin.kubeconfig
      project.project.openshift.io "tests-dhcp-140-240-zzhao" deleted
      
      [10:42:08] INFO> Exit Status: 0
      [10:42:08] INFO> Shell Commands: rm -r -f -- /home/zzhao/workdir/dhcp-140-240-zzhao
      
      [10:42:08] INFO> Exit Status: 0
      [10:42:08] INFO> === End After Scenario: User can expand the nodePort range by patch the serviceNodePortRange in network ===

1 scenario (1 passed)
18 steps (18 passed)
2m1.903s

```

@rbbratta  guess this time should resolve the issue. 
