### PR TITLE
OCP-25787 quick fix

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -335,12 +335,12 @@ Feature: SDN related networking scenarios
     And the output should contain "connected"
     #Checking controller iteration 2
     When I execute on the "<%= cb.ovn_master_pod %>" pod:
-      | ls -l /var/run/ovn/ |
+      | bash | -c | ls -l /var/run/ovn/ |
     Then the step should succeed
     And evaluation of `@result[:response].match(/ovn-controller.\d*\.ctl/)[0]` is stored in the :controller_pid_file clipboard
     #Checking controller iteration 3
     When I execute on the "<%= cb.ovn_master_pod %>" pod:
-      | ovn-appctl -t /var/run/ovn/<%= cb.controller_pid_file %> connection-status |
+      | bash | -c | ovn-appctl -t /var/run/ovn/<%= cb.controller_pid_file %> connection-status |
     Then the step should succeed
     And the output should contain "connected"
     #Checking controller iteration 4


### PR DESCRIPTION
bash c to enable treating string with pmtrs as a whole single command
This will fix glitches in OCP-25787
@pruan-rht (same as #1615 which was closed to to squashing issue)