### PR TITLE
Add retry for oauth_bearer_token_challenge

### DIFF
--- a/lib/login.rb
+++ b/lib/login.rb
@@ -21,12 +21,17 @@ module BushSlicer
       debug_res = Http.request(**opts)
 
       # try challenging client auth
-      res = oauth_bearer_token_challenge(
-        server_url: env.api_endpoint_url,
-        user: user,
-        password: password,
-        proxy: env.client_proxy
-      )
+      res = {}
+      (1..3).each { |seconds|
+        res = oauth_bearer_token_challenge(
+          server_url: env.api_endpoint_url,
+          user: user,
+          password: password,
+          proxy: env.client_proxy
+        )
+        break if res[:success]
+        sleep (seconds * 30)
+      }
 
       if res[:exitstatus] == 401 && res[:headers]["link"]
         # looks like we are directed at using web auth of some sort


### PR DESCRIPTION
As described in https://bugzilla.redhat.com/show_bug.cgi?id=1890724, there are API server flappings, which can cause automation test execution job quit.

The server can recover itself after some time, we should continue the test as well, so add retry for oauth_bearer_token_challenge, or else we will fail with "Error getting bearer token"

/cc @akostadinov @pruan-rht @jhou1 @kasturinarra 