### PR TITLE
Update multicast pod to use quay.io/openshifttest/mcast-pod

### DIFF
--- a/testdata/networking/multicast-rc.json
+++ b/testdata/networking/multicast-rc.json
@@ -18,7 +18,7 @@
 	    "spec": {
 		"containers": [
 		    {
-			"image": "lihongan/mcast-pod",
+			"image": "quay.io/openshifttest/mcast-pod@sha256:d2497c6fe5226daf05f2a606fadb03d540cce8d0b49d5616440629ba939239ef",
 			"name": "mcast-pod"
 		    }
 		]


### PR DESCRIPTION
Update multicast pod to use quay.io/openshifttest/mcast-pod instead of lihongan/mcast-pod

Test log: https://privatebin-it-iso.int.open.paas.redhat.com/?348b8a406f722a56#7CoUxpdCgDSqH3cS9dJW6HBssRcyHxQzM2H2jPK8znPr

@zhaozhanqi @anuragthehatter @rbbratta @huiran0826