### PR TITLE
handle SIGTERM to not delay pod deletion

### DIFF
--- a/testdata/networking/multus-cni/Pods/generic_multus_pod_net_raw.yaml
+++ b/testdata/networking/multus-cni/Pods/generic_multus_pod_net_raw.yaml
@@ -3,9 +3,14 @@ kind: Pod
 metadata:
   name: test-pod
   annotations:
-    k8s.v1.cni.cncf.io/networks: test
+    k8s.v1.cni.cncf.io/networks: bridgevlan100
 spec:
   containers:
   - name: test-pod
     command: ["/bin/bash", "-c", "trap 'kill $(jobs -p); exit 0' TERM ; sleep 2000000000000 & wait"]
     image: quay.io/openshifttest/hello-sdn@sha256:d5785550cf77b7932b090fcd1a2625472912fb3189d5973f177a5a2c347a1f95
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+

--- a/testdata/networking/multus-cni/Pods/multus-default-route-pod.yaml
+++ b/testdata/networking/multus-cni/Pods/multus-default-route-pod.yaml
@@ -10,5 +10,5 @@ metadata:
 spec:
   containers:
   - name: multus-default-route-pod
-    command: ["/bin/bash", "-c", "sleep 2000000000000"]
+    command: ["/bin/bash", "-c", "trap 'kill $(jobs -p); exit 0' TERM ; sleep 2000000000000 & wait"]
     image: quay.io/openshifttest/hello-sdn@sha256:d5785550cf77b7932b090fcd1a2625472912fb3189d5973f177a5a2c347a1f95

--- a/testdata/networking/sctp/sctpclient.yaml
+++ b/testdata/networking/sctp/sctpclient.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: sctpclient
-      image: quay.io/openshifttest/ubi@sha256:cd014e94a9a2af4946fc1697be604feb97313a3ceb5b4d821253fcdb6b6159ee 
-      command: ["/bin/sh", "-c"]
+      image: quay.io/openshifttest/ubi@sha256:cd014e94a9a2af4946fc1697be604feb97313a3ceb5b4d821253fcdb6b6159ee
+      command: ["/bin/bash", "-c"]
       args:
-        ["dnf install -y nc && sleep inf"]
+        ["dnf install -y nc && trap 'kill $(jobs -p); exit 0' TERM ; sleep inf & wait"]

--- a/testdata/networking/sctp/sctpserver.yaml
+++ b/testdata/networking/sctp/sctpserver.yaml
@@ -8,9 +8,9 @@ spec:
   containers:
     - name: sctpserver
       image: quay.io/openshifttest/ubi@sha256:cd014e94a9a2af4946fc1697be604feb97313a3ceb5b4d821253fcdb6b6159ee
-      command: ["/bin/sh", "-c"]
+      command: ["/bin/bash", "-c"]
       args:
-        ["dnf install -y nc && sleep inf"]
+        ["dnf install -y nc && trap 'kill $(jobs -p); exit 0' TERM ; sleep inf & wait"]
       ports:
         - containerPort: 30102
           name: sctpserver


### PR DESCRIPTION
Pods run the entrypoint as PID 1, whatever process is run as PID 1 won't receive SIGTERM and won't shutdown quickly (< 1min)

We need to trap SIGTERM and exit immediately

See:
https://github.com/openshift/cluster-network-operator/pull/859/files#diff-6f3fb59cc9404c296e2f7aa6b442137bdb2d4559ced7bfc51b7a188c2b64233fR65

https://github.com/openshift/cluster-dns-operator/issues/65

We should:
> Listen for SIGTERM explicitly
> Always `sleep X & wait` instead of just `sleep X`

https://vagga.readthedocs.io/en/latest/pid1mode.html
https://hynek.me/articles/docker-signals/

The current `["/bin/bash", "-c", "sleep 2000000000000"]` is causing us to sleep ~42 seconds each time we delete the pod.

So we need to trap SIGTERM and then exit
```shell
    command: ["/bin/bash", "-c", "trap 'kill $(jobs -p); exit 0' TERM ; sleep 2000000000000 & wait"]
```

Time to delete for  `["/bin/bash", "-c", "sleep 2000000000000"]`

```
pod "test-pod" deleted

real    0m41.459s
user    0m0.175s
sys     0m0.050s
```

Time to delete for `["/bin/bash", "-c", "trap 'kill $(jobs -p); exit 0' TERM ; sleep 2000000000000 & wait"]`

```
pod "test-pod" deleted

real    0m2.738s
user    0m0.186s
sys     0m0.057s
```

averages over 20 runs with
```
for f in {1..20} ; do oc create -f generic_multus_pod.yaml ; oc wait --for=condition=Ready pod/test-pod ; time oc delete pod test-pod ; done
grep -P -o '(?<=real    0m)[^s]+'  | awk '{ sum += $1; n++ } END { if (n > 0) print sum / n; }'
```

`["/bin/bash", "-c", "sleep 2000000000000"]`
36.317s

`["/bin/bash", "-c", "trap 'kill $(jobs -p); exit 0' TERM ; sleep 2000000000000 & wait"]`
6.9327

Not handling SIGTERM is probably costing us ~30s every time we delete a project with a sleeping Pod after the test.