### PR TITLE
fix cirucular refrence in arg and indentation issue

### DIFF
--- a/lib/openshift/cluster_service_version.rb
+++ b/lib/openshift/cluster_service_version.rb
@@ -8,7 +8,9 @@ module BushSlicer
     # status phase=Succeeded and reason=InstallSucceeded;
     def ready?(user: nil, quiet: false, cached: false)
       res = get(user: user, quiet: quiet)
-      res[:success] = res[:parsed]["status"]["phase"] == "Succeeded" && res[:parsed]["status"]["reason"] == "InstallSucceeded" if res[:success]
+      if res[:success]
+        res[:success] = res[:parsed]["status"]["phase"] == "Succeeded" && res[:parsed]["status"]["reason"] == "InstallSucceeded"
+      end
       return res
     end
   end

--- a/lib/openshift/cluster_service_version.rb
+++ b/lib/openshift/cluster_service_version.rb
@@ -4,15 +4,12 @@ module BushSlicer
   class ClusterServiceVersion < ProjectResource
     RESOURCE = "clusterserviceversions"
 
-    # @return [BushSlicer::ResultHash] with :success depending on 
+    # @return [BushSlicer::ResultHash] with :success depending on
     # status phase=Succeeded and reason=InstallSucceeded;
-    def ready?(user: user, quiet: false, cached: false)
-    	res = get(user: user, quiet: quiet)
-    	if res[:success]
-    		res[:success] = 
-    			res[:parsed]["status"]["phase"] == "Succeeded" && res[:parsed]["status"]["reason"] == "InstallSucceeded"
-    	end
-    	return res
+    def ready?(user: nil, quiet: false, cached: false)
+      res = get(user: user, quiet: quiet)
+      res[:success] = res[:parsed]["status"]["phase"] == "Succeeded" && res[:parsed]["status"]["reason"] == "InstallSucceeded" if res[:success]
+      return res
     end
   end
 end


### PR DESCRIPTION
indentation was wrong
```
    def ready?(user: nil, quiet: false, cached: false)
    	res = get(user: user, quiet: quiet)
    	res[:success] = res[:parsed]["status"]["phase"] == "Succeeded" && res[:parsed]["status"]["reason"] == "InstallSucceeded" if res[:success]
    	return res
    end
```