### PR TITLE
Skip google-chrome repo if unavailable

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.rhel7
+++ b/tools/jenkins/slaves/Dockerfile.rhel7
@@ -18,6 +18,7 @@ RUN set -x && \
     yum install -y --setopt=skip_missing_names_on_install=False,tsflags=nodocs $SCL_BASE_PKGS && \
     yum install -y --setopt=skip_missing_names_on_install=False,tsflags=nodocs $INSTALL_PKGS && \
     yum install -y --setopt=tsflags=nodocs https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm && \
+    yum-config-manager --save --setopt=google-chrome.skip_if_unavailable=true && \
     CHROMEDRIVER_URL="https://chromedriver.storage.googleapis.com" && \
     CHROMEDRIVER_VERSION=$(curl -sSL "$CHROMEDRIVER_URL/LATEST_RELEASE") && \
     curl -sSL "$CHROMEDRIVER_URL/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" | bsdtar --no-same-owner --no-same-permissions -xvf - -C /usr/local/bin && \


### PR DESCRIPTION
/cc @akostadinov @pruan-rht 

Failed to build ocxx image due to the repo unavailable
```
--> RUN curl https://***/jenkins-jcasc-n/-/raw/master/agents/dockerfiles/cucushift-oc42/aos-devel-4_2.repo -o /etc/yum.repos.d/puddle.repo &&     yum -y install atomic-enterprise-service-catalog-svcat openshift-clients &&     yum clean all -y &&     rm -rf /var/cache/yum /tmp/*
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   156  100   156    0     0    587      0 --:--:-- --:--:-- --:--:--   590
Loaded plugins: ovl, product-id, search-disabled-repos, subscription-manager
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
Trying other mirror.
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
Trying other mirror.
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
Trying other mirror.
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
Trying other mirror.
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
Trying other mirror.
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
Trying other mirror.
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
Trying other mirror.
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
Trying other mirror.
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
Trying other mirror.
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
Trying other mirror.


 One of the configured repositories failed (google-chrome),
 and yum doesn't have enough cached data to continue. At this point the only
 safe thing yum can do is fail. There are a few ways to work "fix" this:

     1. Contact the upstream for the repository and get them to fix the problem.

     2. Reconfigure the baseurl/etc. for the repository, to point to a working
        upstream. This is most often useful if you are using a newer
        distribution release than is supported by the repository (and the
        packages for the previous distribution release still work).

     3. Run the command with the repository temporarily disabled
            yum --disablerepo=google-chrome ...

     4. Disable the repository permanently, so yum won't use it by default. Yum
        will then just ignore the repository until you permanently enable it
        again or use --enablerepo for temporary usage:

            yum-config-manager --disable google-chrome
        or
            subscription-manager repos --disable=google-chrome

     5. Configure the failing repository to be skipped, if it is unavailable.
        Note that yum will try to contact the repo. when it runs most commands,
        so will have to try and fail each time (and thus. yum will be be much
        slower). If it is a very temporary problem though, this is often a nice
        compromise:

            yum-config-manager --save --setopt=google-chrome.skip_if_unavailable=true

failure: repodata/repomd.xml from google-chrome: [Errno 256] No more mirrors to try.
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
http://dl.google.com/linux/chrome/rpm/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 503 - Service Unavailable
error: build error: running 'curl https://***/jenkins-jcasc-n/-/raw/master/agents/dockerfiles/cucushift-oc42/aos-devel-4_2.repo -o /etc/yum.repos.d/puddle.repo &&     yum -y install atomic-enterprise-service-catalog-svcat openshift-clients &&     yum clean all -y &&     rm -rf /var/cache/yum /tmp/*' failed with exit code 1

```