### PR TITLE
accept insecure certs automatically for chrome

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -132,6 +132,7 @@ require_relative 'chrome_extension'
         end
       elsif @browser_type == :chrome
         logger.info "Launching Chrome"
+        chrome_caps[:accept_insecure_certs] = true
         if Integer === @scroll_strategy
           chrome_caps[:element_scroll_behavior] = @scroll_strategy
         end


### PR DESCRIPTION
Chrome should accept insecure certs by default to avoid error
![Screenshot from 2020-11-12 12-08-24](https://user-images.githubusercontent.com/12692381/98914363-8a477300-2503-11eb-98db-87d7387353c0.png)
