### PR TITLE
 Negative test for Azure Disconnected cluster to not allow publicIp

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -410,4 +410,22 @@ Feature: Machine features testing
       | default-valued-33380         | <%= cb.template %>                        | <%= cb.diskGiB %> | # @case_id OCP-33380
       | default-valued-windows-35421 | 1909-template-docker-ssh-upgraded-vmtools | 135               | # @case_id OCP-35421
 
+  # @author miyadav@redhat.com
+  # @case_id OCP-36489
+  @admin
+  Scenario: [Azure] Machineset should not be created when publicIP:true in disconnected Azure enviroment
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    Then I use the "openshift-machine-api" project
+
+    Given I obtain test data file "cloud/ms-azure/ms_disconnected_env.yaml"
+    When I run oc create over "ms_disconnected_env.yaml" replacing paths:
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %> |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | disconnected-azure-36489                    |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %> |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | disconnected-azure-36489                    |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["publicIP"]                         | true                                        |
+
+    And the output should contain:
+      | Forbidden: publicIP is not allowed in Azure disconnected installation |
 

--- a/testdata/cloud/ms-azure/ms_disconnected_env.yaml
+++ b/testdata/cloud/ms-azure/ms_disconnected_env.yaml
@@ -1,0 +1,34 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster:
+    machine.openshift.io/cluster-api-machine-role: worker
+    machine.openshift.io/cluster-api-machine-type: worker
+  name: disconnected-azure-36489
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster:
+      machine.openshift.io/cluster-api-machineset:
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster:
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset:
+    spec:
+      metadata: {}
+      taints:
+      - effect: "NoSchedule"
+        key: "mapi"
+        value: "mapi_test"
+      providerSpec:
+        value:
+          publicIP: false
+          location:
+          osDisk:
+            diskSizeGB: 128
+


### PR DESCRIPTION
Related to -- https://bugzilla.redhat.com/show_bug.cgi?id=1889620
 we can wait for bug to be verified status(with new nightly) before merging , already verified with Danil though ..

Output 
:"mapi","value":"mapi_test"}],"providerSpec":{"value":{"publicIP":true,"location":null,"osDisk":{"diskSizeGB":128}}}}}}}
      [12:42:38] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@23.99.177.119:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@23.99.177.119:3128
      oc create -f - --config=/root/workdir/9fb4c01f2a99-/ocp4_admin.kubeconfig
      
      STDERR:
      Error from server (providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation): error when creating "STDIN": admission webhook "validation.machineset.machine.openshift.io" denied the request: providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation
      
      [12:42:40] INFO> Exit Status: 1
      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %> |
      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | disconnected-azure-36489                    |
      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %> |
      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | disconnected-azure-36489                    |
      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["publicIP"]                         | true                                        |
    And the output should contain:                                                                       # features/step_definitions/common.rb:33
      | Forbidden: publicIP is not allowed in Azure disconnected installation |
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [12:42:40] INFO> === After Scenario: [Azure] Machineset should not be created when publicIP:true in disconnected Azure enviroment ===
      [12:42:40] INFO> Shell Commands: rm -r -f -- /root/workdir/9fb4c01f2a99-
      
      [12:42:40] INFO> Exit Status: 0
      [12:42:40] INFO> === End After Scenario: [Azure] Machineset should not be created when publicIP:true in disconnected Azure enviroment ===

1 scenario (1 passed)
5 steps (5 passed)
