### PR TITLE
Fix and add multi OCM ui cases

### DIFF
--- a/lib/rules/web/ocm_console/cluster_detail.xyaml
+++ b/lib/rules/web/ocm_console/cluster_detail.xyaml
@@ -336,15 +336,13 @@ check_osd_details_in_detail_page:
         - selector:
             xpath: //dl[1]/dt[text()='Persistent storage']
         - selector:
-            xpath: //dl[1]/dt[text()='Desired nodes']
+            xpath: //dl[1]/dt[text()='Nodes']
         - selector:
             xpath: //dl[1]/dt[text()='Master:']
         - selector:
             xpath: //dl[2]/dt[text()='Infra:']
         - selector:
             xpath: //dl[3]/dt[text()='Compute:']
-        - selector:
-            xpath: //dl[1]/dt[text()='Actual nodes']
         - selector:
             xpath: //dl[1]/dt[text()='Network']
 check_osd_ocp_comman_details_in_detail_page:
@@ -384,12 +382,16 @@ check_ocp_actions_behind_open_console_button:
             xpath: //button[text()='Archive cluster']
         - selector:
             xpath: //button[text()='Edit subscription settings']
+        - selector:
+            xpath: //button[text()='Transfer cluster ownership']
 check_osd_actions_behind_open_console_button:
     elements:
         - selector:
             xpath: //button[text()='Edit display name']
         - selector:
-            xpath: //button[text()='Scale cluster']
+            xpath: //button[text()='Edit load balancers and persistent storage']
+        - selector:
+            xpath: //button[text()='Edit node count']
         - selector:
             xpath: //button[text()='Delete cluster']
 close_actions_behind_open_console_button:
@@ -452,7 +454,7 @@ check_cluster_history_section_common_part:
 check_default_osd_cluster_history:
     elements:
         - selector:
-            xpath: //td[@data-label='Description' and text()='Cluster installed and registered successfully']
+            xpath: //td[@data-label='Description' and text()='Cluster registered successfully']
         - selector:
             xpath: //td[@data-label='Severity' and text()='Info']
 input_description_for_cluster_history:
@@ -497,3 +499,52 @@ select_cluster_history_by_severity:
           op: click
         - selector:
             xpath: //td[text()='<result_keyword>']
+transfer_cluster_ownership:
+    action: expand_actions_on_cluster_detail_page
+    action: click_transfer_cluster_ownership_button
+    action: check_transfer_cluster_ownership_dialog
+    action: click_initiate_transfer_button
+    action: check_transfer_cluster_ownership_notification
+click_transfer_cluster_ownership_button:
+    element:
+        selector:
+            xpath: //button[@class='pf-c-dropdown__menu-item' and text()='Transfer cluster ownership']
+        op: click
+check_transfer_cluster_ownership_dialog:
+    elements:
+        - selector:
+            xpath: //h1[text()='Transfer cluster ownership']
+        - selector:
+            xpath: //p[text()='Transferring cluster ownership will allow another individual to manage this cluster. The steps for transferring cluster ownership are:']
+        - selector:
+            xpath: //a[@href='https://access.redhat.com/solutions/4902871' and contains(., 'pull secret')]
+        - selector:
+            xpath: //p[text()='The transfer is complete when OpenShift Cluster Manager receives telemetry data from the cluster with the new pull secret.']
+        - selector:
+            xpath: //h4[text()='If the transfer is not completed within 5 days, the procedure must be restarted.']
+click_initiate_transfer_button:
+    element:
+        selector:
+            xpath: //button[text()='Initiate transfer']            
+        op: click
+check_transfer_cluster_ownership_notification:
+    elements:
+        - selector:
+            xpath: //h4[text()='Cluster ownership transfer initiated']
+        - selector:
+            xpath: //div[text()='The transfer process will complete once the pull secret has been changed in the cluster. See']
+        - selector:
+            xpath: //a[@href='https://access.redhat.com/solutions/4902871' and contains(., 'this knowledgebase article')]
+cancel_transfer_cluster_ownership:
+    action: expand_actions_on_cluster_detail_page
+    action: click_cancel_transfer_cluster_ownership_button
+    action: check_cancel_transfer_cluster_ownership_notification
+click_cancel_transfer_cluster_ownership_button:
+    element:
+        selector:
+            xpath: //button[text()='Cancel ownership transfer']            
+        op: click
+check_cancel_transfer_cluster_ownership_notification:
+    element:
+        selector:
+            xpath: //h4[text()='Cluster ownership transfer canceled']

--- a/lib/rules/web/ocm_console/cluster_detail_support_tab.xyaml
+++ b/lib/rules/web/ocm_console/cluster_detail_support_tab.xyaml
@@ -1,0 +1,41 @@
+click_support_tab:
+    element:
+        selector:
+            xpath: //button[contains(.,'Support')]
+        op: click
+check_support_tab_first_section:
+    action: check_add_notification_contact_button
+    elements:
+        - selector:
+            xpath: //h2[text()='Notification contacts']
+        - selector:
+            xpath: //div[text()='Add users to be contacted in the event of notifications about this cluster.']
+        - selector:
+            xpath: //div[text()='The cluster owner will always receive notifications, at email address <']
+        - selector:
+            xpath: //div[contains(., '<owner_email>')]
+check_add_notification_contact_button:
+    element:
+        selector:
+            xpath: //button[text()='Add notification contact']
+        timeout: 10
+check_add_notification_contact_button_disabled:
+    element:
+        selector:
+            xpath: //button[text()='Add notification contact' and @aria-disabled='true']
+        timeout: 10
+check_support_tab_second_section:
+    action: check_open_support_case_button
+    elements:
+        - selector:
+            xpath: //h2[text()='Support cases']
+        - selector:
+            xpath: //table[@aria-label='Support Cases']
+check_open_support_case_button:
+    element:
+        selector:
+            xpath: //button[text()='Open support case']
+check_support_tab:
+    action: click_support_tab
+    action: check_support_tab_first_section
+    action: check_support_tab_second_section

--- a/lib/rules/web/ocm_console/cluster_list_page.xyaml
+++ b/lib/rules/web/ocm_console/cluster_list_page.xyaml
@@ -129,6 +129,7 @@ check_filter_cluster_existed:
     element:
         selector:
             xpath: //tbody/tr[<coloumn_number>]/td/a[contains(text(),'<filter_keyword>')]
+        timeout: 10
 check_filter_no_result_message:
     element:
         selector:

--- a/lib/rules/web/ocm_console/dialogs_and_sidebar.xyaml
+++ b/lib/rules/web/ocm_console/dialogs_and_sidebar.xyaml
@@ -241,10 +241,6 @@ customer_cloud_subscription_prompt_message_loaded:
         - selector:
             text: "In order for the cluster provisioning to succeed, you must ensure the following:"
         - selector:
-            xpath: //*[contains(text(),"Your AWS account has no services deployed in it.")]
-        - selector:
-            text: "Your AWS account has no services deployed in it."
-        - selector:
             xpath: //*[contains(text(),"Your AWS account has the necessary limits to support the desired cluster size.")]
         - selector:
             xpath: //a[@href='https://www.openshift.com/dedicated/ccs' and text()=' See resource requirements.']

--- a/lib/rules/web/ocm_console/install_page.xyaml
+++ b/lib/rules/web/ocm_console/install_page.xyaml
@@ -15,7 +15,9 @@ go_to_gcp_upi_install_page:
     url: /openshift/install/gcp/user-provisioned
 go_to_vsphere_install_page:
     url: /openshift/install/vsphere/user-provisioned
-go_to_bare_metal_install_page:
+go_to_bare_metal_ipi_install_page:
+    url: /openshift/install/metal/installer-provisioned
+go_to_bare_metal_upi_install_page:
     url: /openshift/install/metal/user-provisioned
 go_to_ibm_z_install_page:
     url: /openshift/install/ibmz/user-provisioned
@@ -23,8 +25,10 @@ go_to_openstack_ipi_install_page:
     url: /openshift/install/openstack/installer-provisioned
 go_to_openstack_upi_install_page:
     url: /openshift/install/openstack/user-provisioned
-go_to_rhv_install_page:
+go_to_rhv_ipi_install_page:
     url: /openshift/install/rhv/installer-provisioned
+go_to_rhv_upi_install_page:
+    url: /openshift/install/rhv/user-provisioned
 go_to_power_upi_install_page:
     url: /openshift/install/power/user-provisioned
 go_to_codeready_install_page:
@@ -470,9 +474,43 @@ check_vsphere_page_title:
     - command: return document.title=='Install OpenShift 4 | Red Hat OpenShift Cluster Manager | vSphere'
       expect_result: true
 
-check_bare_metal_install_page:
+check_linux_cli_download_button_in_install_page:
+    params:
+        os_name: Linux
+        os_link: linux.tar.gz
+    action: check_download_cli_button_in_install_page
+check_macos_cli_download_button_in_install_page:
+    params:
+        os_name: MacOS
+        os_link: mac.tar.gz
+    action: check_download_cli_button_in_install_page
+check_bare_metal_download_cli_button:
+    params:
+        installer_type: clients/ocp/latest
+    action: check_linux_cli_download_button_in_install_page
+    action: check_macos_cli_download_button_in_install_page
+    action: check_windows_download_button_in_install_page
+
+check_bare_metal_ipi_install_page:
     action: required_specific_provider_install_items_loaded 
-    action: check_bare_metal_page_title
+    action: check_bare_metal_ipi_page_title
+    action: check_bare_metal_download_cli_button
+    action: check_pull_secret_part_in_install_page
+    action: check_data_collection_message_in_install_page
+    action: check_install_page_part_three
+    elements:
+        - selector:
+            xpath: //h2[text()='Follow the instructions to configure your environment and install your cluster']
+        - selector:
+            xpath: //a[contains(@href, 'installing_bare_metal_ipi/ipi-install-installation-workflow.html') and text()='Get started']
+check_bare_metal_ipi_page_title:
+    scripts:
+    - command: return document.title=='Install OpenShift 4 | Red Hat OpenShift Cluster Manager | Bare Metal Installer-Provisioned Infrastructure'
+      expect_result: true
+
+check_bare_metal_upi_install_page:
+    action: required_specific_provider_install_items_loaded 
+    action: check_bare_metal_upi_page_title
     action: check_download_part_in_normal_install_page
     action: check_pull_secret_part_in_install_page
     action: check_install_page_common_part_two
@@ -492,7 +530,7 @@ check_bare_metal_install_page:
             xpath: //a[contains(@href, '/rhcos/latest/latest/rhcos-installer.x86_64.iso') and text()='Download RHCOS ISO']
         - selector:
             xpath: //a[contains(@href, '/rhcos/latest/latest/rhcos-metal.x86_64.raw.gz') and text()='Download RHCOS RAW']
-check_bare_metal_page_title:
+check_bare_metal_upi_page_title:
     scripts:
     - command: return document.title=='Install OpenShift 4 | Red Hat OpenShift Cluster Manager | Bare Metal User-Provisioned Infrastructure'
       expect_result: true
@@ -573,9 +611,9 @@ check_openstack_upi_page_title:
     - command: return document.title=='Install OpenShift 4 | Red Hat OpenShift Cluster Manager | OpenStack User-Provisioned Infrastructure'
       expect_result: true
 
-check_rhv_install_page:
+check_rhv_ipi_install_page:
     action: required_specific_provider_install_items_loaded 
-    action: check_rhv_page_title
+    action: check_rhv_ipi_page_title
     action: check_download_part_in_normal_install_page
     action: check_pull_secret_part_in_install_page
     action: check_install_page_common_part_two
@@ -587,10 +625,34 @@ check_rhv_install_page:
         - selector:
             xpath: //p[text()='The installer will take about 45 minutes to run.']
         - selector:
-            xpath: //a[contains(@href, 'installing_rhv/installing-rhv-customizations.html') and text()='Get started']
-check_rhv_page_title:
+            xpath: //a[contains(@href, '/installing_rhv/installing-rhv-default.html') and text()='Get started']
+        - selector:
+            xpath: //a[contains(@href, '/installing_rhv/installing-rhv-customizations.html') and text()='install with customizations']
+check_rhv_ipi_page_title:
     scripts:
-    - command: return document.title=='Install OpenShift 4 | Red Hat OpenShift Cluster Manager | Red Hat Virtualization'
+    - command: return document.title=='Install OpenShift 4 | Red Hat OpenShift Cluster Manager | RHV Installer-Provisioned Infrastructure'
+      expect_result: true
+
+check_rhv_upi_install_page:
+    action: required_specific_provider_install_items_loaded 
+    action: check_rhv_upi_page_title
+    action: check_download_part_in_normal_install_page
+    action: check_pull_secret_part_in_install_page
+    action: check_install_page_common_part_two
+    action: check_data_collection_message_in_install_page
+    action: check_install_page_part_three
+    elements:
+        - selector:
+            xpath: //h2[text()='Follow the instructions to configure your environment and install your cluster']
+        - selector:
+            xpath: //p[text()='The installer will take about 45 minutes to run.']
+        - selector:
+            xpath: //a[contains(@href, '/installing_rhv/installing-rhv-user-infra.html') and text()='Get started']
+        - selector:
+            xpath: //a[contains(@href, '/installing_rhv/installing-rhv-customizations.html') and text()='install with customizations']
+check_rhv_upi_page_title:
+    scripts:
+    - command: return document.title=='Install OpenShift 4 | Red Hat OpenShift Cluster Manager | RHV User-Provisioned Infrastructure'
       expect_result: true
 
 check_power_upi_install_page:
@@ -629,6 +691,8 @@ check_codeready_install_page:
         - selector:
             xpath: //h3[text()='CodeReady Containers archive']
         - selector:
+            xpath: //p[text()='Download and extract the CodeReady Containers archive for your operating system and place the executable in your']
+        - selector:
             xpath: //h2[text()='Follow the documentation to install CodeReady containers']
         - selector:
             xpath: //a[contains(@href, 'https://access.redhat.com/documentation/en-us/red_hat_codeready_containers') and text()='Get started']
@@ -654,10 +718,6 @@ check_pre_release_page:
             xpath: //a[contains(@href, '/latest/support/remote_health_monitoring/about-remote-health-monitoring.html') and contains(., 'Learn more')]
         - selector:
             xpath: //h3[text()='Feature Completion in Nightly Builds']
-        - selector:
-            xpath: //p[contains(., 'the latest pre-release nightly builds')]
-        - selector:
-            xpath: //a[contains(@href, 'query_based_on=OCP4-4-blocker&query_format=advanced&target_release=4.5.0') and text()='test blocker bug list']
         - selector:
             xpath: //a[@href='https://github.com/openshift/installer/tree/master/docs/user' and text()='latest installer documentation']
         - selector:


### PR DESCRIPTION
Update OCP-28797 cluster log, OCP-26380 pre-release page, OCP-25175 crc page, OCP-21339 cluster list, OCP-21090 action list of detail page, OCP-29659 byoc creation page, OCP-27839 rhv ipi, OCP-24070 baremetal upi.
Add OCP-36001 rhv upi, OCP-36034 baremetal ipi, OCP-28135 permission of subscription settings, OCP-33436 transfer ui, OCP-36294 permission of support tab, OCP-35651 support tab ui.

Here is Jenkins log: https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/208015/console.

Please help review cases, thanks. @yasun1 @xueli181114 @yuwang-RH 