### PR TITLE
sctp fix no nc file

### DIFF
--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -21,7 +21,7 @@ Feature: SCTP related scenarios
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "sctpserver" pod:
-      | bash | -c | which nc    |
+      | bash | -c | which nc |
     Then the step should succeed
     """
 
@@ -36,7 +36,7 @@ Feature: SCTP related scenarios
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "sctpclient" pod:
-      | bash | -c | which nc    |
+      | bash | -c | which nc |
     Then the step should succeed
     """
    
@@ -87,7 +87,7 @@ Feature: SCTP related scenarios
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "sctpserver" pod:
-      | bash | -c | which nc    |
+      | bash | -c | which nc |
     Then the step should succeed
     """
 
@@ -100,7 +100,7 @@ Feature: SCTP related scenarios
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "sctpclient" pod:
-      | bash | -c | which nc    |
+      | bash | -c | which nc |
     Then the step should succeed
     """
    
@@ -159,7 +159,7 @@ Feature: SCTP related scenarios
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "sctpserver" pod:
-      | bash | -c | which nc    |
+      | bash | -c | which nc |
     Then the step should succeed
     """
 
@@ -172,7 +172,7 @@ Feature: SCTP related scenarios
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "sctpclient" pod:
-      | bash | -c | which nc    |
+      | bash | -c | which nc |
     Then the step should succeed
     """
    
@@ -230,7 +230,7 @@ Feature: SCTP related scenarios
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "sctpserver" pod:
-      | bash | -c | which nc    |
+      | bash | -c | which nc |
     Then the step should succeed
     """
     Then evaluation of `pod.ip` is stored in the :serverpod_ip clipboard
@@ -244,7 +244,7 @@ Feature: SCTP related scenarios
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "sctpclient" pod:
-      | bash | -c | which nc    |
+      | bash | -c | which nc |
     Then the step should succeed
     """
    

--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -18,13 +18,6 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[0].name %> |
     Then the step should succeed
     And the pod named "sctpserver" becomes ready
-    And I wait up to 20 seconds for the steps to pass:
-    """
-    When I execute on the "sctpserver" pod:
-      | bash | -c | which nc |
-    Then the step should succeed
-    """
-
     Then evaluation of `pod.ip` is stored in the :serverpod_ip clipboard
 
     Given I obtain test data file "networking/sctp/sctpclient.yaml"
@@ -33,32 +26,29 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[1].name %> |
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
-    And I wait up to 20 seconds for the steps to pass:
-    """
-    When I execute on the "sctpclient" pod:
-      | bash | -c | which nc |
-    Then the step should succeed
-    """
    
     # sctpserver pod start to wait for sctp traffic
+    And I wait up to 60 seconds for the steps to pass:
+    """
     When I run the :exec background client command with:
-      | pod              | sctpserver                                |
-      | namespace        | <%= project.name %>                       |
-      | oc_opts_end      |                                           |
-      | exec_command     | sh                                        |
-      | exec_command_arg | -c                                        |
-      | exec_command_arg | nc -l 30102 --sctp -k -m 5 -w 60 |
+      | pod              | sctpserver          |
+      | namespace        | <%= project.name %> |
+      | oc_opts_end      |                     |
+      | exec_command     | bash                |
+      | exec_command_arg | -c                  |
+      | exec_command_arg | nc -l 30102 --sctp  |
     Then the step should succeed
+    """
 
     # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """"
     When I run the :exec client command with:
-      | pod              | sctpclient                                                                |
-      | namespace        | <%= project.name %>                                                       |
-      | oc_opts_end      |                                                                           |
-      | exec_command     | sh                                                                        |
-      | exec_command_arg | -c                                                                        |
+      | pod              | sctpclient                                                       |
+      | namespace        | <%= project.name %>                                              |
+      | oc_opts_end      |                                                                  |
+      | exec_command     | bash                                                             |
+      | exec_command_arg | -c                                                               |
       | exec_command_arg | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp |
     Then the step should succeed
     And the output should contain:
@@ -84,12 +74,6 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[0].name %> |
     Then the step should succeed
     And the pod named "sctpserver" becomes ready
-    And I wait up to 20 seconds for the steps to pass:
-    """
-    When I execute on the "sctpserver" pod:
-      | bash | -c | which nc |
-    Then the step should succeed
-    """
 
     Given I obtain test data file "networking/sctp/sctpclient.yaml"
     When I run oc create as admin over "sctpclient.yaml" replacing paths:
@@ -97,12 +81,6 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[1].name %> |
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
-    And I wait up to 20 seconds for the steps to pass:
-    """
-    When I execute on the "sctpclient" pod:
-      | bash | -c | which nc |
-    Then the step should succeed
-    """
    
     Given I obtain test data file "networking/sctp/sctpservice.yaml"
     When I run oc create as admin over "sctpservice.yaml" replacing paths:
@@ -112,24 +90,27 @@ Feature: SCTP related scenarios
     And evaluation of `service.ip(user: user)` is stored in the :service_ip clipboard
 
     # sctpserver pod start to wait for sctp traffic
+    And I wait up to 60 seconds for the steps to pass:
+    """"
     When I run the :exec background client command with:
-      | pod              | sctpserver                                |
-      | namespace        | <%= project.name %>                       |
-      | oc_opts_end      |                                           |
-      | exec_command     | sh                                        |
-      | exec_command_arg | -c                                        |
-      | exec_command_arg | nc -l 30102 --sctp -k -m 5 -w 60 |
+      | pod              | sctpserver          |
+      | namespace        | <%= project.name %> |
+      | oc_opts_end      |                     |
+      | exec_command     | bash                |
+      | exec_command_arg | -c                  |
+      | exec_command_arg | nc -l 30102 --sctp  |
     Then the step should succeed
+    """"
 
     # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """"
     When I run the :exec client command with:
-      | pod              | sctpclient                                                              |
-      | namespace        | <%= project.name %>                                                     |
-      | oc_opts_end      |                                                                         |
-      | exec_command     | sh                                                                      |
-      | exec_command_arg | -c                                                                      |
+      | pod              | sctpclient                                                     |
+      | namespace        | <%= project.name %>                                            |
+      | oc_opts_end      |                                                                |
+      | exec_command     | bash                                                           |
+      | exec_command_arg | -c                                                             |
       | exec_command_arg | echo test-openshift \| nc -v <%= cb.service_ip %> 30102 --sctp |
     Then the step should succeed
     And the output should contain:
@@ -156,12 +137,6 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[0].name %> |
     Then the step should succeed
     And the pod named "sctpserver" becomes ready
-    And I wait up to 20 seconds for the steps to pass:
-    """
-    When I execute on the "sctpserver" pod:
-      | bash | -c | which nc |
-    Then the step should succeed
-    """
 
     Given I obtain test data file "networking/sctp/sctpclient.yaml"
     When I run oc create as admin over "sctpclient.yaml" replacing paths:
@@ -169,12 +144,6 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[1].name %> |
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
-    And I wait up to 20 seconds for the steps to pass:
-    """
-    When I execute on the "sctpclient" pod:
-      | bash | -c | which nc |
-    Then the step should succeed
-    """
    
     Given I obtain test data file "networking/sctp/sctpservice.yaml"
     When I run oc create as admin over "sctpservice.yaml" replacing paths:
@@ -184,24 +153,27 @@ Feature: SCTP related scenarios
     And evaluation of `service(cb.sctpserver).node_port(port:30102)` is stored in the :nodeport clipboard
 
     # sctpserver pod start to wait for sctp traffic
+    And I wait up to 60 seconds for the steps to pass:
+    """"
     When I run the :exec background client command with:
-      | pod              | sctpserver                                |
-      | namespace        | <%= project.name %>                       |
-      | oc_opts_end      |                                           |
-      | exec_command     | sh                                        |
-      | exec_command_arg | -c                                        |
-      | exec_command_arg | nc -l 30102 --sctp -k -m 5 -w 60 |
+      | pod              | sctpserver          |
+      | namespace        | <%= project.name %> |
+      | oc_opts_end      |                     |
+      | exec_command     | bash                |
+      | exec_command_arg | -c                  |
+      | exec_command_arg | nc -l 30102 --sctp  |
     Then the step should succeed
+    """
 
     # sctpclient pod start to send sctp traffic on worknode:port
     And I wait up to 60 seconds for the steps to pass:
     """"
     When I run the :exec client command with:
-      | pod              | sctpclient                                                                            |
-      | namespace        | <%= project.name %>                                                                   |
-      | oc_opts_end      |                                                                                       |
-      | exec_command     | sh                                                                                    |
-      | exec_command_arg | -c                                                                                    |
+      | pod              | sctpclient                                                                   |
+      | namespace        | <%= project.name %>                                                          |
+      | oc_opts_end      |                                                                              |
+      | exec_command     | bash                                                                         |
+      | exec_command_arg | -c                                                                           |
       | exec_command_arg | echo test-openshift \| nc -v <%= cb.worker1_ip %> <%= cb.nodeport %>  --sctp |
     Then the step should succeed
     And the output should contain:
@@ -227,12 +199,6 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[0].name %> |
     Then the step should succeed
     And the pod named "sctpserver" becomes ready
-    And I wait up to 20 seconds for the steps to pass:
-    """
-    When I execute on the "sctpserver" pod:
-      | bash | -c | which nc |
-    Then the step should succeed
-    """
     Then evaluation of `pod.ip` is stored in the :serverpod_ip clipboard
 
     Given I obtain test data file "networking/sctp/sctpclient.yaml"
@@ -241,32 +207,29 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[1].name %> |
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
-    And I wait up to 20 seconds for the steps to pass:
-    """
-    When I execute on the "sctpclient" pod:
-      | bash | -c | which nc |
-    Then the step should succeed
-    """
    
     # sctpserver pod start to wait for sctp traffic
+    And I wait up to 60 seconds for the steps to pass:
+    """"
      When I run the :exec background client command with:
-      | pod              | sctpserver                                |
-      | namespace        | <%= project.name %>                       |
-      | oc_opts_end      |                                           |
-      | exec_command     | sh                                        |
-      | exec_command_arg | -c                                        |
-      | exec_command_arg | nc -l 30102 --sctp -k -m 5 -w 90 |
+      | pod              | sctpserver          |
+      | namespace        | <%= project.name %> |
+      | oc_opts_end      |                     |
+      | exec_command     | bash                |
+      | exec_command_arg | -c                  |
+      | exec_command_arg | nc -l 30102 --sctp  |
     Then the step should succeed
+    """
 
     # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """"
     When I run the :exec client command with:
-      | pod              | sctpclient                                                                |
-      | namespace        | <%= project.name %>                                                       |
-      | oc_opts_end      |                                                                           |
-      | exec_command     | sh                                                                        |
-      | exec_command_arg | -c                                                                        |
+      | pod              | sctpclient                                                       |
+      | namespace        | <%= project.name %>                                              |
+      | oc_opts_end      |                                                                  |
+      | exec_command     | bash                                                             |
+      | exec_command_arg | -c                                                               |
       | exec_command_arg | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp | 
     Then the step should succeed
     And the output should contain:
@@ -283,11 +246,11 @@ Feature: SCTP related scenarios
 
     # sctpclient pod start to send sctp traffic
     When I run the :exec client command with:
-      | pod              | sctpclient                                                                |
-      | namespace        | <%= project.name %>                                                       |
-      | oc_opts_end      |                                                                           |
-      | exec_command     | sh                                                                        |
-      | exec_command_arg | -c                                                                        |
+      | pod              | sctpclient                                                       |
+      | namespace        | <%= project.name %>                                              |
+      | oc_opts_end      |                                                                  |
+      | exec_command     | bash                                                             |
+      | exec_command_arg | -c                                                               |
       | exec_command_arg | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp |
     Then the step should fail
    
@@ -299,24 +262,27 @@ Feature: SCTP related scenarios
     Then the step should succeed
 
     # sctpserver pod start to wait for sctp traffic
+    And I wait up to 60 seconds for the steps to pass:
+    """"
     When I run the :exec background client command with:
-      | pod              | sctpserver                                |
-      | namespace        | <%= project.name %>                       |
-      | oc_opts_end      |                                           |
-      | exec_command     | sh                                        |
-      | exec_command_arg | -c                                        |
-      | exec_command_arg | nc -l 30102 --sctp -k -m 5 -w 60 |
+      | pod              | sctpserver          |
+      | namespace        | <%= project.name %> |
+      | oc_opts_end      |                     |
+      | exec_command     | bash                |
+      | exec_command_arg | -c                  |
+      | exec_command_arg | nc -l 30102 --sctp  |
     Then the step should succeed
+    """
 
     # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """"
     When I run the :exec client command with:
-      | pod              | sctpclient                                                                |
-      | namespace        | <%= project.name %>                                                       |
-      | oc_opts_end      |                                                                           |
-      | exec_command     | sh                                                                        |
-      | exec_command_arg | -c                                                                        |
+      | pod              | sctpclient                                                       |
+      | namespace        | <%= project.name %>                                              |
+      | oc_opts_end      |                                                                  |
+      | exec_command     | bash                                                             |
+      | exec_command_arg | -c                                                               |
       | exec_command_arg | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp |
     Then the step should succeed
     And the output should contain:

--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -18,6 +18,13 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[0].name %> |
     Then the step should succeed
     And the pod named "sctpserver" becomes ready
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "sctpserver" pod:
+      | bash | -c | which nc    |
+    Then the output should contain "/usr/bin/nc"
+    """
+
     Then evaluation of `pod.ip` is stored in the :serverpod_ip clipboard
 
     Given I obtain test data file "networking/sctp/sctpclient.yaml"
@@ -26,6 +33,12 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[1].name %> |
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "sctpclient" pod:
+      | bash | -c | which nc    |
+    Then the output should contain "/usr/bin/nc"
+    """
    
     # sctpserver pod start to wait for sctp traffic
     When I run the :exec background client command with:
@@ -71,6 +84,12 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[0].name %> |
     Then the step should succeed
     And the pod named "sctpserver" becomes ready
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "sctpserver" pod:
+      | bash | -c | which nc    |
+    Then the output should contain "/usr/bin/nc"
+    """
 
     Given I obtain test data file "networking/sctp/sctpclient.yaml"
     When I run oc create as admin over "sctpclient.yaml" replacing paths:
@@ -78,6 +97,12 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[1].name %> |
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "sctpclient" pod:
+      | bash | -c | which nc    |
+    Then the output should contain "/usr/bin/nc"
+    """
    
     Given I obtain test data file "networking/sctp/sctpservice.yaml"
     When I run oc create as admin over "sctpservice.yaml" replacing paths:
@@ -131,6 +156,12 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[0].name %> |
     Then the step should succeed
     And the pod named "sctpserver" becomes ready
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "sctpserver" pod:
+      | bash | -c | which nc    |
+    Then the output should contain "/usr/bin/nc"
+    """
 
     Given I obtain test data file "networking/sctp/sctpclient.yaml"
     When I run oc create as admin over "sctpclient.yaml" replacing paths:
@@ -138,6 +169,12 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[1].name %> |
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "sctpclient" pod:
+      | bash | -c | which nc    |
+    Then the output should contain "/usr/bin/nc"
+    """
    
     Given I obtain test data file "networking/sctp/sctpservice.yaml"
     When I run oc create as admin over "sctpservice.yaml" replacing paths:
@@ -190,6 +227,12 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[0].name %> |
     Then the step should succeed
     And the pod named "sctpserver" becomes ready
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "sctpserver" pod:
+      | bash | -c | which nc    |
+    Then the output should contain "/usr/bin/nc"
+    """
     Then evaluation of `pod.ip` is stored in the :serverpod_ip clipboard
 
     Given I obtain test data file "networking/sctp/sctpclient.yaml"
@@ -198,6 +241,12 @@ Feature: SCTP related scenarios
       | ["spec"]["nodeName"]      | <%= cb.workers[1].name %> |
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "sctpclient" pod:
+      | bash | -c | which nc    |
+    Then the output should contain "/usr/bin/nc"
+    """
    
     # sctpserver pod start to wait for sctp traffic
      When I run the :exec background client command with:

--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -22,7 +22,7 @@ Feature: SCTP related scenarios
     """
     When I execute on the "sctpserver" pod:
       | bash | -c | which nc    |
-    Then the output should contain "/usr/bin/nc"
+    Then the step should succeed
     """
 
     Then evaluation of `pod.ip` is stored in the :serverpod_ip clipboard
@@ -37,7 +37,7 @@ Feature: SCTP related scenarios
     """
     When I execute on the "sctpclient" pod:
       | bash | -c | which nc    |
-    Then the output should contain "/usr/bin/nc"
+    Then the step should succeed
     """
    
     # sctpserver pod start to wait for sctp traffic
@@ -47,7 +47,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                           |
       | exec_command     | sh                                        |
       | exec_command_arg | -c                                        |
-      | exec_command_arg | /usr/bin/nc -l 30102 --sctp -k -m 5 -w 60 |
+      | exec_command_arg | nc -l 30102 --sctp -k -m 5 -w 60 |
     Then the step should succeed
 
     # sctpclient pod start to send sctp traffic
@@ -59,7 +59,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                                                           |
       | exec_command     | sh                                                                        |
       | exec_command_arg | -c                                                                        |
-      | exec_command_arg | echo test-openshift \| /usr/bin/nc -v <%= cb.serverpod_ip %> 30102 --sctp |
+      | exec_command_arg | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp |
     Then the step should succeed
     And the output should contain:
       | Connected to <%= cb.serverpod_ip %>:30102 |
@@ -88,7 +88,7 @@ Feature: SCTP related scenarios
     """
     When I execute on the "sctpserver" pod:
       | bash | -c | which nc    |
-    Then the output should contain "/usr/bin/nc"
+    Then the step should succeed
     """
 
     Given I obtain test data file "networking/sctp/sctpclient.yaml"
@@ -101,7 +101,7 @@ Feature: SCTP related scenarios
     """
     When I execute on the "sctpclient" pod:
       | bash | -c | which nc    |
-    Then the output should contain "/usr/bin/nc"
+    Then the step should succeed
     """
    
     Given I obtain test data file "networking/sctp/sctpservice.yaml"
@@ -118,7 +118,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                           |
       | exec_command     | sh                                        |
       | exec_command_arg | -c                                        |
-      | exec_command_arg | /usr/bin/nc -l 30102 --sctp -k -m 5 -w 60 |
+      | exec_command_arg | nc -l 30102 --sctp -k -m 5 -w 60 |
     Then the step should succeed
 
     # sctpclient pod start to send sctp traffic
@@ -130,7 +130,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                                                         |
       | exec_command     | sh                                                                      |
       | exec_command_arg | -c                                                                      |
-      | exec_command_arg | echo test-openshift \| /usr/bin/nc -v <%= cb.service_ip %> 30102 --sctp |
+      | exec_command_arg | echo test-openshift \| nc -v <%= cb.service_ip %> 30102 --sctp |
     Then the step should succeed
     And the output should contain:
       | Connected to <%= cb.service_ip %>:30102 |
@@ -160,7 +160,7 @@ Feature: SCTP related scenarios
     """
     When I execute on the "sctpserver" pod:
       | bash | -c | which nc    |
-    Then the output should contain "/usr/bin/nc"
+    Then the step should succeed
     """
 
     Given I obtain test data file "networking/sctp/sctpclient.yaml"
@@ -173,7 +173,7 @@ Feature: SCTP related scenarios
     """
     When I execute on the "sctpclient" pod:
       | bash | -c | which nc    |
-    Then the output should contain "/usr/bin/nc"
+    Then the step should succeed
     """
    
     Given I obtain test data file "networking/sctp/sctpservice.yaml"
@@ -190,7 +190,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                           |
       | exec_command     | sh                                        |
       | exec_command_arg | -c                                        |
-      | exec_command_arg | /usr/bin/nc -l 30102 --sctp -k -m 5 -w 60 |
+      | exec_command_arg | nc -l 30102 --sctp -k -m 5 -w 60 |
     Then the step should succeed
 
     # sctpclient pod start to send sctp traffic on worknode:port
@@ -202,7 +202,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                                                                       |
       | exec_command     | sh                                                                                    |
       | exec_command_arg | -c                                                                                    |
-      | exec_command_arg | echo test-openshift \| /usr/bin/nc -v <%= cb.worker1_ip %> <%= cb.nodeport %>  --sctp |
+      | exec_command_arg | echo test-openshift \| nc -v <%= cb.worker1_ip %> <%= cb.nodeport %>  --sctp |
     Then the step should succeed
     And the output should contain:
       | Connected to <%= cb.worker1_ip %>:<%= cb.nodeport %> |
@@ -231,7 +231,7 @@ Feature: SCTP related scenarios
     """
     When I execute on the "sctpserver" pod:
       | bash | -c | which nc    |
-    Then the output should contain "/usr/bin/nc"
+    Then the step should succeed
     """
     Then evaluation of `pod.ip` is stored in the :serverpod_ip clipboard
 
@@ -245,7 +245,7 @@ Feature: SCTP related scenarios
     """
     When I execute on the "sctpclient" pod:
       | bash | -c | which nc    |
-    Then the output should contain "/usr/bin/nc"
+    Then the step should succeed
     """
    
     # sctpserver pod start to wait for sctp traffic
@@ -255,7 +255,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                           |
       | exec_command     | sh                                        |
       | exec_command_arg | -c                                        |
-      | exec_command_arg | /usr/bin/nc -l 30102 --sctp -k -m 5 -w 90 |
+      | exec_command_arg | nc -l 30102 --sctp -k -m 5 -w 90 |
     Then the step should succeed
 
     # sctpclient pod start to send sctp traffic
@@ -267,7 +267,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                                                           |
       | exec_command     | sh                                                                        |
       | exec_command_arg | -c                                                                        |
-      | exec_command_arg | echo test-openshift \| /usr/bin/nc -v <%= cb.serverpod_ip %> 30102 --sctp | 
+      | exec_command_arg | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp | 
     Then the step should succeed
     And the output should contain:
       | Connected to <%= cb.serverpod_ip %> |
@@ -288,7 +288,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                                                           |
       | exec_command     | sh                                                                        |
       | exec_command_arg | -c                                                                        |
-      | exec_command_arg | echo test-openshift \| /usr/bin/nc -v <%= cb.serverpod_ip %> 30102 --sctp |
+      | exec_command_arg | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp |
     Then the step should fail
    
     # Define a networkpolicy to allow sctpclient to sctpserver
@@ -305,7 +305,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                           |
       | exec_command     | sh                                        |
       | exec_command_arg | -c                                        |
-      | exec_command_arg | /usr/bin/nc -l 30102 --sctp -k -m 5 -w 60 |
+      | exec_command_arg | nc -l 30102 --sctp -k -m 5 -w 60 |
     Then the step should succeed
 
     # sctpclient pod start to send sctp traffic
@@ -317,7 +317,7 @@ Feature: SCTP related scenarios
       | oc_opts_end      |                                                                           |
       | exec_command     | sh                                                                        |
       | exec_command_arg | -c                                                                        |
-      | exec_command_arg | echo test-openshift \| /usr/bin/nc -v <%= cb.serverpod_ip %> 30102 --sctp |
+      | exec_command_arg | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp |
     Then the step should succeed
     And the output should contain:
       | Connected to <%= cb.serverpod_ip %> |


### PR DESCRIPTION
Existing script failed on:
Shell Commands: oc exec sctpclient  --kubeconfig=/home/jenkins/workspace/Runner-v3/workdir/ocp4_testuser-40.kubeconfig --namespace=j8x39  -- sh -c echo\ test-openshift\ \|\ /usr/bin/nc\ -v\ 10.131.2.8\ 30102\ --sctp

STDERR:
sh: /usr/bin/nc: No such file or directory
command terminated with exit code 127

Seems like script try to use nc just after pod is ready and get failed, add the steps of "which nc" after pod ready, then start to us nc for sctp testing

Here is the new testing log:
 And I wait up to 20 seconds for the steps to pass:                    # features/step_definitions/meta_steps.rb:33
      [20:29:44] INFO> Shell Commands: oc exec sctpclient  --kubeconfig=/home/weliang/workdir/weliang-weliang/ocp4_testuser-0.kubeconfig -n z5fs1  -i -- bash -c which\ nc
      
      STDERR:
      which: no nc in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
      E1116 15:29:45.188828    5684 v2.go:105] write tcp 10.10.116.251:58840->10.0.102.163:6443: use of closed network connection
      command terminated with exit code 1
      
      [20:29:45] INFO> Exit Status: 1
      [20:29:46] INFO> Shell Commands: oc exec sctpclient  --kubeconfig=/home/weliang/workdir/weliang-weliang/ocp4_testuser-0.kubeconfig -n z5fs1  -i -- bash -c which\ nc
      
      STDERR:
      which: no nc in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
      E1116 15:29:46.893460    5699 v2.go:105] write tcp 10.10.116.251:58846->10.0.102.163:6443: use of closed network connection
      command terminated with exit code 1
      
      [20:29:46] INFO> Exit Status: 1
      [20:29:47] INFO> Shell Commands: oc exec sctpclient  --kubeconfig=/home/weliang/workdir/weliang-weliang/ocp4_testuser-0.kubeconfig -n z5fs1  -i -- bash -c which\ nc
      /usr/bin/nc
      
      STDERR:
      E1116 15:29:48.591794    5725 v2.go:105] write tcp 10.10.116.251:58850->10.0.102.163:6443: use of closed network connection
      
      [20:29:48] INFO> Exit Status: 0
      """
      When I execute on the "sctpclient" pod:
        | bash | -c | which nc    |
      Then the output should contain "/usr/bin/nc"
      """
anusaxen@redhat.com, rbrattai@redhat.com,zzhao@redhat.com, huirwang@redhat.com
