### PR TITLE
Fix OCP-11695

### DIFF
--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -86,6 +86,12 @@ Feature: deployment related features
     When I get project dc named "hooks"
     Then the output should match:
       | hooks.*|
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I get project dc named "hooks" as JSON
+    Then the output should contain:
+      | "latestVersion": 2 |
+    """
     When I run the :rollback client command with:
       | deployment_name         | hooks-1 |
       | output                  | json    |


### PR DESCRIPTION
Sometimes script proceeds when the latestVersion is 0 due to which the test script is failing with run time error, so fixing the issue. One example is as below
http://virt-openshift-05.lab.eng.nay.redhat.com/buildcorp/Runner-v3/198456/console