### PR TITLE
Remove trailing whitespace

### DIFF
--- a/features/registry/registry.feature
+++ b/features/registry/registry.feature
@@ -175,7 +175,7 @@ Feature: Testing registry
     And the "myimage" image stream becomes ready
 
   # @author xiuwang@redhat.com
-  # @case_id OCP-29696 
+  # @case_id OCP-29696
   Scenario: Use node credentials in imagestream import
     Given I have a project
     When I run the :tag client command with:
@@ -232,7 +232,7 @@ Feature: Testing registry
     Then the step should succeed
 
   # @author xiuwang@redhat.com
-  # @case_id OCP-29706 
+  # @case_id OCP-29706
   @admin
   Scenario: Node secret takes effect when common secret is removed
     Given I have a project


### PR DESCRIPTION
Fix the issue,
```
$ tools/polarshift.rb update-automation OCP-29696 OCP-29706
Traceback (most recent call last):
	8: from tools/polarshift.rb:488:in `<main>'
	7: from tools/polarshift.rb:262:in `run'
	6: from /home/lxia/.rvm/gems/ruby-2.7.0/gems/commander-4.5.2/lib/commander/delegates.rb:15:in `run!'
	5: from /home/lxia/.rvm/gems/ruby-2.7.0/gems/commander-4.5.2/lib/commander/runner.rb:68:in `run!'
	4: from /home/lxia/.rvm/gems/ruby-2.7.0/gems/commander-4.5.2/lib/commander/runner.rb:452:in `run_active_command'
	3: from /home/lxia/.rvm/gems/ruby-2.7.0/gems/commander-4.5.2/lib/commander/command.rb:155:in `run'
	2: from /home/lxia/.rvm/gems/ruby-2.7.0/gems/commander-4.5.2/lib/commander/command.rb:184:in `call'
	1: from tools/polarshift.rb:64:in `block (2 levels) in run'
/home/lxia/github.com/verification-tests/lib/gherkin_parse.rb:118:in `locations_for': could not find locations for case IDs: OCP-29696,OCP-29706 (RuntimeError)
```

/cc @xiuwang @wzheng1 