### PR TITLE
Clean-up script which test case is removed in Polarion

### DIFF
--- a/features/admin/pod.feature
+++ b/features/admin/pod.feature
@@ -42,25 +42,6 @@ Feature: pod related features
       | Hello OpenShift |
 
   # @author chezhang@redhat.com
-  # @case_id OCP-10345
-  @admin
-  @destructive
-  Scenario: pod node label selector must be consistent with its project node label selector
-    Given I have a project
-    Given a 5 characters random string of type :dns is stored into the :proj_name clipboard
-    When I run the :oadm_new_project admin command with:
-      | project_name  | <%= cb.proj_name %> |
-      | node_selector | os=rhel             |
-      | admin         | <%= user.name %>    |
-    Then the step should succeed
-    Given I obtain test data file "pods/pod-with-nodeselector.yaml"
-    When I run the :create admin command with:
-      | f | pod-with-nodeselector.yaml |
-      | n | <%= cb.proj_name %>                                                                                |
-    Then the step should fail
-    And the output should contain "pod node label selector conflicts with its project node label selector"
-
-  # @author chezhang@redhat.com
   # @case_id OCP-11116
   @admin
   @destructive


### PR DESCRIPTION
Those test cases have been removed in Polarion, clean-up related script so it will not interrupt batch synchronizing tags between code and Polarion using polarshift.rb

/cc @jhou1 @chengzhang1016 @chao007 