### PR TITLE
Debug sctp failed cases

### DIFF
--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -5,6 +5,12 @@ Feature: SCTP related scenarios
   @admin
   @destructive
   Scenario: Establish pod to pod SCTP connections
+    # Debug steps: to check the number of worker nodes
+    When I run the :get admin command with:
+      |resource|nodes|
+    Then the step should succeed
+    Then the outputs should contain "Ready"
+    
     Given I store the workers in the :workers clipboard    
     Given I install machineconfigs load-sctp-module
     Given I have a project
@@ -27,6 +33,20 @@ Feature: SCTP related scenarios
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
    
+    # Debug steps: check where are the sctp pods created
+    When I run the :describe admin command with:
+      | resource  | pods                |
+      | namespace | <%= project.name %> |
+      Then the step should succeed
+
+    # Debug steps: check if nc is avaible in sctpserver pod
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I execute on the "sctpserver" pod:
+      | nc | -version |
+    Then the output should contain "Ncat: Version"
+    """
+
     # sctpserver pod start to wait for sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """
@@ -38,6 +58,14 @@ Feature: SCTP related scenarios
       | exec_command_arg | -c                  |
       | exec_command_arg | nc -l 30102 --sctp  |
     Then the step should succeed
+    """
+
+    # Debug steps: check if nc is avaible in sctpclient pod
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I execute on the "sctpclient" pod:
+      | nc | -version |
+    Then the output should contain "Ncat: Version"
     """
 
     # sctpclient pod start to send sctp traffic
@@ -61,6 +89,12 @@ Feature: SCTP related scenarios
   @admin
   @destructive
   Scenario: Expose SCTP ClusterIP Services
+    # Debug steps: to check the number of worker nodes
+    When I run the :get admin command with:
+      |resource|nodes|
+    Then the step should succeed
+    Then the outputs should contain "Ready"
+
     Given I store the workers in the :workers clipboard    
     Given I install machineconfigs load-sctp-module
     Given I have a project
@@ -89,6 +123,20 @@ Feature: SCTP related scenarios
     Given I use the "sctpservice" service
     And evaluation of `service.ip(user: user)` is stored in the :service_ip clipboard
 
+    # Debug steps: check where are the sctp pods created
+    When I run the :describe admin command with:
+      | resource  | pods                |
+      | namespace | <%= project.name %> |
+      Then the step should succeed
+
+    # Debug steps: check if nc is avaible in sctpserver pod
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I execute on the "sctpserver" pod:
+      | nc | -version |
+    Then the output should contain "Ncat: Version"
+    """
+
     # sctpserver pod start to wait for sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """"
@@ -101,6 +149,14 @@ Feature: SCTP related scenarios
       | exec_command_arg | nc -l 30102 --sctp  |
     Then the step should succeed
     """"
+
+     # Debug steps: check if nc is avaible in sctpclient pod
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I execute on the "sctpclient" pod:
+      | nc | -version |
+    Then the output should contain "Ncat: Version"
+    """
 
     # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
@@ -123,6 +179,12 @@ Feature: SCTP related scenarios
   @admin
   @destructive
   Scenario: Expose SCTP NodePort Services
+    # Debug steps: to check the number of worker nodes
+    When I run the :get admin command with:
+      |resource|nodes|
+    Then the step should succeed
+    Then the outputs should contain "Ready"
+
     Given I store the workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ip clipboard  
     Given I install machineconfigs load-sctp-module
@@ -152,6 +214,20 @@ Feature: SCTP related scenarios
     Given I use the "sctpservice" service
     And evaluation of `service(cb.sctpserver).node_port(port:30102)` is stored in the :nodeport clipboard
 
+    # Debug steps: check where are the sctp pods created
+    When I run the :describe admin command with:
+      | resource  | pods                |
+      | namespace | <%= project.name %> |
+      Then the step should succeed
+
+    # Debug steps: check if nc is avaible in sctpserver pod
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I execute on the "sctpserver" pod:
+      | nc | -version |
+    Then the output should contain "Ncat: Version"
+    """
+
     # sctpserver pod start to wait for sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """"
@@ -163,6 +239,14 @@ Feature: SCTP related scenarios
       | exec_command_arg | -c                  |
       | exec_command_arg | nc -l 30102 --sctp  |
     Then the step should succeed
+    """
+
+     # Debug steps: check if nc is avaible in sctpclient pod
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I execute on the "sctpclient" pod:
+      | nc | -version |
+    Then the output should contain "Ncat: Version"
     """
 
     # sctpclient pod start to send sctp traffic on worknode:port
@@ -186,6 +270,12 @@ Feature: SCTP related scenarios
   @admin
   @destructive
   Scenario: Networkpolicy allow SCTP Client
+    # Debug steps: to check the number of worker nodes
+    When I run the :get admin command with:
+      |resource|nodes|
+    Then the step should succeed
+    Then the outputs should contain "Ready"
+
     Given I store the workers in the :workers clipboard    
     Given I install machineconfigs load-sctp-module
     Given I have a project
@@ -221,6 +311,28 @@ Feature: SCTP related scenarios
     Then the step should succeed
     """
 
+    # Debug steps: check where are the sctp pods created
+    When I run the :describe admin command with:
+      | resource  | pods                |
+      | namespace | <%= project.name %> |
+      Then the step should succeed
+
+    # Debug steps: check if nc is avaible in sctpserver pod
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I execute on the "sctpserver" pod:
+      | nc | -version |
+    Then the output should contain "Ncat: Version"
+    """
+
+     # Debug steps: check if nc is avaible in sctpclient pod
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I execute on the "sctpclient" pod:
+      | nc | -version |
+    Then the output should contain "Ncat: Version"
+    """
+    
     # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """"


### PR DESCRIPTION
In e2e CI testing, sctp failed on:
cat: /sys/module/sctp/initstate: No such file or directory

This PR will not fix any failed issue, it is only to add several debug steps to troubleshoot why
the scripts intermittently failed in QE e2e CI testing. 

@pruan-rht @liangxia 
Please help to merge, the debug information will be useful for a real fixing PR.

