### PR TITLE
Modifying bridge deletion procedure via network pods

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -729,13 +729,8 @@ end
 
 Given /^the bridge interface named "([^"]*)" is deleted from the "([^"]*)" node$/ do |bridge_name, node_name|
   ensure_admin_tagged
-  check_and_delete_inf= %Q(if ip addr show  #{bridge_name};
-                           then
-                              ip link delete #{bridge_name};
-                           fi)
   node = node(node_name)
-  host = node.host
-  @result = host.exec_admin(check_and_delete_inf)
+  @result=step "I run command on the node's sdn pod:", table("| bash | -c | if ip addr show #{bridge_name};then ip link delete #{bridge_name};fi |")
   raise "Failed to delete bridge interface" unless @result[:success]
 end
 


### PR DESCRIPTION
As per analysis done here
https://issues.redhat.com/browse/OCPQE-2793?focusedCommentId=15506276&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15506276

It was observed that deletion of bridge interfaces via ```oc debug node``` takes some time as cucushift create projects to execute commands like ```oc debug``` under project name like ```tests-psiv45-cucushift-oc44-standard-slave-zcgh9-0``` and if the project stuck in deletion state causes upcoming test to exit as premature as upcoming test also try to create project with same naming convention (as observed in http://ci-qe-openshift.usersys.redhat.com/userContent/cucushift/v3/2020/11/24/10:45:46/Pods_cannot_communicate_each_other_with_different_vlan_tag/console.html) This is not getting repro'ed on local env but keep happening in CI. So to avoid such failures in CI, I am proposing to delete interfaces via network pods instead of ```oc debug node```. Small change. This change will detect corresponding network pod and execute bridge deletion inside there so we can save extra projects creation by cucushift. If its repro'ed in local env by anyone, we should file a bug on why sometime project deletion takes time. Meanwhile this seems a good approach to keep network regression testing unblocked for such cases. 

This change is being utilized in 3-4 cases

Test Logs:  https://privatebin-it-iso.int.open.paas.redhat.com/?189df181e63b3b63#CeaHDm3RucSGHb9sfiMGTznAZxkf266XzBe2EZSgGjqo

@zhaozhanqi @rbbratta @weliang1 @huiran0826 