### PR TITLE
for older OCP version, the label doesn't have  take it out

### DIFF
--- a/features/step_definitions/metering.rb
+++ b/features/step_definitions/metering.rb
@@ -527,7 +527,7 @@ Given /^I set up environment for metering sharedPVC$/ do
   step %Q(I run oc create as admin over ERB test file: metering/configs/pv_metering.yaml)
   step %Q(the step should succeed)
   step %Q/a pod becomes ready with labels:/, table(%{
-    | app=metering-operator,name=metering-operator |
+    | app=metering-operator |
   })
 end
 


### PR DESCRIPTION
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/213077/console