### PR TITLE
Using digest for disconnected

### DIFF
--- a/testdata/pods/pod_with_special_fsGroup.json
+++ b/testdata/pods/pod_with_special_fsGroup.json
@@ -12,7 +12,7 @@
         "containers": [
             {
                 "name": "hello-openshift",
-                "image": "openshift/hello-openshift",
+                "image": "quay.io/openshifttest/hello-openshift@sha256:aaea76ff622d2f8bcb32e538e7b3cd0ef6d291953f3e7c9f556c1ba5baf47e2e",
                 "ports": [
                     {
                         "containerPort": 8080,


### PR DESCRIPTION
Fixes:
```
cucumber -p polarshift features/cli/create.feature:6 # Scenario: Process with special FSGroup id can be ran when using RunAsAny as the RunAsGroupStrategy 
# Back-off pulling image "openshift/hello-openshift"
```

When run in disconnected setup, this image `openshift/hello-openshift` can not be pulled see [log](https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/212762/consoleFull). Now update the image reference so that in disconnected it works as well. Image picked from https://gitlab.cee.redhat.com/aosqe/flexy-templates/-/blob/master/functionality-testing/aos-4_6/hosts/image-list-digest.txt

@zhouying7780 @kasturinarra PTAL.