### PR TITLE
update case OCP-22202 to use admin user

### DIFF
--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -127,8 +127,12 @@ Feature: Operator related networking scenarios
   @destructive
   Scenario: The clusteroperator should be able to reflect the realtime status of the network when a new node added
     Given I have an IPI deployment
-    # Check that the operator is not progressing
-    Given the expression should be true> cluster_operator('network').condition(type: 'Progressing')['status'] == "False"
+    And I switch to cluster admin pseudo user
+    # Check that the operator is not progressing at the beginning to make sure the network operator is normal
+    Given I wait up to 160 seconds for the steps to pass:
+    """
+    Given the status of condition "Progressing" for network operator is :False
+    """
 
     # Record the original machine replica and scale it up to number +1
     Given I pick a random machineset to scale


### PR DESCRIPTION
this cases failed due to normal user cannot get machines in `clean up` steps
```
^[[36mError from server (Forbidden): machines.machine.openshift.io "qeci-11104-qkwcq-worker-us-east-2c-mclf6" is forbidden: User "testuser-40" cannot get resource "machines" in API group "machine.openshift.io" in the namespace "aos-qe-ci"^[[0m
```
Add one step to make use 'admin' user

logs: http://pastebin.test.redhat.com/921515
@anuragthehatter @huiran0826 @rbbratta @weliang1 ^^
@liangxia @pruan-rht  No big changes 