### PR TITLE
fix ocp-33704 ocp-34938

### DIFF
--- a/features/networking/egress-ip.feature
+++ b/features/networking/egress-ip.feature
@@ -121,12 +121,11 @@ Feature: Egress IP related features
   @destructive
   Scenario: Should remove the egressIP from the array if it was not being used
     Given I store a random unused IP address from the reserved range to the clipboard
-    And evaluation of `IPAddr.new("<%= cb.valid_ip %>").to_i + 1 ` is stored in the :newipint clipboard
-    And evaluation of `IPAddr.new(<%= cb.newipint %>, Socket::AF_INET).to_s` is stored in the :newip clipboard
+    And evaluation of `IPAddr.new("<%= cb.subnet_range %>").to_s+"/"+IPAddr.new("<%= cb.subnet_range %>").prefix.to_s` is stored in the :valid_subnet clipboard
 
     #Patch egress cidr to the node
     Given as admin I successfully merge patch resource "hostsubnet/<%= node.name %>" with:
-      | {"egressCIDRs": ["<%= cb.subnet_range %>"] }   |
+      | {"egressCIDRs": ["<%= cb.valid_subnet %>"] }   |
     And I register clean-up steps:
     """
     as admin I successfully merge patch resource "hostsubnet/<%= node.name %>" with:
@@ -136,18 +135,30 @@ Feature: Egress IP related features
     # Patch egress IP to the project twice
     Given I have a project
     And as admin I successfully merge patch resource "netnamespace/<%= project.name %>" with:
-      | {"egressIPs": ["<%= cb.newip %>"]} |
-    And as admin I successfully merge patch resource "netnamespace/<%= project.name %>" with:
-      | {"egressIPs": ["<%= cb.valid_ip %>"]} |
+      | {"egressIPs": ["<%= cb.valid_ips[0]%>"]} |
+
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    When I run command on the "<%= node.name%>" node's sdn pod:
+      | bash | -c | ip address show label <%= cb.interface %>:eip |
+    Then the step should succeed
+    And evaluation of `@result[:response].chomp.match(/inet.*eip/)[0].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :egress_ip clipboard
+    Then the expression should be true> cb.egress_ip == cb.valid_ips[0]
+    Then the expression should be true> cb.egress_ip != cb.valid_ips[1]
+    """
+
+    Given as admin I successfully merge patch resource "netnamespace/<%= project.name %>" with:
+      | {"egressIPs": ["<%= cb.valid_ips[1] %>"]} |
 
     # Check the egress ip is the last one applied
     And I wait up to 30 seconds for the steps to pass:
     """
     When I run command on the "<%= node.name%>" node's sdn pod:
-      | bash | -c | ip address show <%= cb.interface %> |
+      | bash | -c | ip address show label <%= cb.interface %>:eip |
     Then the step should succeed
-    And the output should contain "<%= cb.valid_ip %>"
-    And the output should not contain "<%= cb.newip %>"
+    And evaluation of `@result[:response].chomp.match(/inet.*eip/)[0].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :egress_new_ip clipboard
+    Then the expression should be true> cb.egress_new_ip == cb.valid_ips[1]
+    Then the expression should be true> cb.egress_new_ip != cb.valid_ips[0]
     """
 
   # @author huirwang@redhat.com

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -528,7 +528,7 @@ Given /^I store a random unused IP address from the reserved range to the#{OPT_S
   cb_name = "valid_ip" unless cb_name
   step "the subnet for primary interface on node is stored in the clipboard"
 
-  reserved_range = "#{cb.subnet_range}"
+  reserved_range = cb.subnet_range
 
   unused_ips=[]
   #Save four unused ip in the clipboard
@@ -827,7 +827,7 @@ Given /^the subnet for primary interface on node is stored in the#{OPT_SYM} clip
     "| bash | -c | ip -4 -brief a show \"<%= cb.interface %>\" \\| awk '{print $3}' |"
   )
   raise "Failed to get the subnet range for the primary interface on the node" unless @result[:success]
-  cb[cb_name] = @result[:response].chomp
+  cb[cb_name] = @result[:stdout].chomp
   logger.info "Subnet range for the primary interface on the node is stored in the #{cb_name} clipboard."
 end
 


### PR DESCRIPTION
ocp-33704 sometimes failed as the hello-pod may located on same node as reboot node which will cause the pod killed after reboot, fix it by explicitly specifying  the node for the pod .
ocp-34938 failed as it get the event from project aos-qe-ci namespace which is incorrect,  fix it by explicitly using the default project to get event.

Logs:
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3-smoke/2622/console
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3-smoke/2621/console

@zhaozhanqi @anuragthehatter @weliang1 @rbbratta 