### PR TITLE
Fix OCP-11207

### DIFF
--- a/testdata/authorization/scc/ocp11207/pod2.json
+++ b/testdata/authorization/scc/ocp11207/pod2.json
@@ -12,6 +12,7 @@
         "containers": [{
             "name": "hello-openshift",
             "image": "aosqe/client-cert",
+
             "ports": [{
                 "containerPort": 9443,
                 "protocol": "TCP"
@@ -27,7 +28,7 @@
             "securityContext": {
                 "capabilities": {},
                 "privileged": false,
-                "runAsUser": <%= cb.scc_uid %>
+                "runAsNonRoot": true
             }
         }],
         "volumes": [{
@@ -38,7 +39,7 @@
         "dnsPolicy": "ClusterFirst",
         "serviceAccount": "",
         "securityContext":{
-            "runAsUser": <%= cb.proj_scc_uid %>
+            "runAsNonRoot": false
         }
     },
     "status": {}


### PR DESCRIPTION
We map test case ID 511602 in TCMS (obsoleted test case manage system), to ID 11207 in Polarion (Currently in use test case manage system), via https://github.com/openshift/cucushift/pull/8255/files#diff-439c289cb76ddf7ad0f35ed591aaa8a100e9d819aa8f118c29329a721b4fd000L460

Then we update the test data path in verification-tests to reflect the change, via https://github.com/openshift/verification-tests/pull/1687/files#diff-26928b8ac649356f4cdb0045068eb79ce9c37cafdd2c66860b363fce5e33879a
And we found the test data also exist in cucushift, so we remove that via https://github.com/openshift/cucushift/pull/8255/files#diff-1a2c1833135545e38afdfd5bca283a70b21b0cd5aee7e7eb318c473d145c7166
Unfortunately, only test data `pod1.json` was check (it's the same in verification-tests and in cucushift), and `pod2.json` was missed.
The PR add `pod2.json` back to fix above issue.

```
    When I run oc create over ERB test file: authorization/scc/ocp11207/pod2.json                                                                                                   # features/step_definitions/cli.rb:114
      could not find test file in '["/home/jenkins/workspace/Runner-v3/testdata/authorization/scc/ocp11207/pod2.json", "/home/jenkins/workspace/Runner-v3/features/tierN/testdata/authorization/scc/ocp11207/pod2.json"]' (RuntimeError)
```

/cc @pruan-rht @barleyer @xingxingxia 