### PR TITLE
Replace image from docker to quay

### DIFF
--- a/testdata/downwardapi/ocp10707/pod-downwardapi-env.yaml
+++ b/testdata/downwardapi/ocp10707/pod-downwardapi-env.yaml
@@ -6,7 +6,7 @@ metadata:
     name: downwardapi-env
 spec:
   containers:
-    - image: docker.io/ocpqe/hello-pod:latest
+    - image: quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7
       name: downwardapi-env
       env:
         - name: MYSQL_ROOT_PASSWORD

--- a/testdata/pods/allinone-volume/allinone-normal-pod.yaml
+++ b/testdata/pods/allinone-volume/allinone-normal-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: allinone-normal
-    image: docker.io/ocpqe/hello-pod:latest
+    image: quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7
     resources:
       limits:
         cpu: "500m"

--- a/testdata/pods/initContainers/init-containers-deadline.yaml
+++ b/testdata/pods/initContainers/init-containers-deadline.yaml
@@ -14,7 +14,7 @@ metadata:
     ]'
 spec:
   containers:
-    - image: "docker.io/deshuai/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:

--- a/testdata/pods/initContainers/init-containers-fail.yaml
+++ b/testdata/pods/initContainers/init-containers-fail.yaml
@@ -19,7 +19,7 @@ metadata:
     ]'
 spec:
   containers:
-    - image: "docker.io/deshuai/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:

--- a/testdata/pods/initContainers/init-containers-privilege.yaml
+++ b/testdata/pods/initContainers/init-containers-privilege.yaml
@@ -15,7 +15,7 @@ metadata:
     }]'
 spec:
   containers:
-    - image: "docker.io/deshuai/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:

--- a/testdata/pods/initContainers/init-containers-quota-1.yaml
+++ b/testdata/pods/initContainers/init-containers-quota-1.yaml
@@ -37,7 +37,7 @@ metadata:
     }]'
 spec:
   containers:
-    - image: "docker.io/deshuai/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:
@@ -57,7 +57,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: tmp
-    - image: "docker.io/deshuai/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod-1
       env:

--- a/testdata/pods/initContainers/init-containers-quota-2.yaml
+++ b/testdata/pods/initContainers/init-containers-quota-2.yaml
@@ -37,7 +37,7 @@ metadata:
     }]'
 spec:
   containers:
-    - image: "docker.io/deshuai/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:
@@ -57,7 +57,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: tmp
-    - image: "docker.io/deshuai/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod-1
       env:

--- a/testdata/pods/initContainers/init-containers-readiness.yaml
+++ b/testdata/pods/initContainers/init-containers-readiness.yaml
@@ -17,7 +17,7 @@ metadata:
     }]'
 spec:
   containers:
-    - image: "docker.io/deshuai/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:

--- a/testdata/pods/initContainers/init-containers-sleep.yaml
+++ b/testdata/pods/initContainers/init-containers-sleep.yaml
@@ -14,7 +14,7 @@ metadata:
     ]'
 spec:
   containers:
-    - image: "docker.io/deshuai/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:

--- a/testdata/pods/initContainers/init-containers-success.yaml
+++ b/testdata/pods/initContainers/init-containers-success.yaml
@@ -14,7 +14,7 @@ metadata:
     ]'
 spec:
   containers:
-    - image: "docker.io/deshuai/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:

--- a/testdata/pods/initContainers/volume-init-containers.yaml
+++ b/testdata/pods/initContainers/volume-init-containers.yaml
@@ -6,7 +6,7 @@ metadata:
     pod.alpha.kubernetes.io/init-containers: '[
         {
             "name": "install",
-            "image": "docker.io/ocpqe/hello-pod:latest",
+            "image": "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7",
             "command": ["/bin/sh", "-c","echo hello init-containers > /work-dir/hello.txt"],
             "volumeMounts": [
                 {
@@ -18,7 +18,7 @@ metadata:
     ]'
 spec:
   containers:
-    - image: "docker.io/ocpqe/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       command: ["/bin/sh", "-c", "while true; do cat /tmp/hello.txt; sleep 5; done"]

--- a/testdata/pods/securityContext/both-level.yaml
+++ b/testdata/pods/securityContext/both-level.yaml
@@ -6,7 +6,7 @@ metadata:
   name: both-level-pod
 spec:
   containers:
-    - image: "docker.io/ocpqe/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:

--- a/testdata/pods/securityContext/container-selinux.yaml
+++ b/testdata/pods/securityContext/container-selinux.yaml
@@ -6,7 +6,7 @@ metadata:
   name: selinux-container
 spec:
   containers:
-    - image: "docker.io/ocpqe/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:

--- a/testdata/pods/securityContext/pod-selinux.yaml
+++ b/testdata/pods/securityContext/pod-selinux.yaml
@@ -6,7 +6,7 @@ metadata:
   name: selinux-pod
 spec:
   containers:
-    - image: "docker.io/ocpqe/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: hello-pod
       ports:

--- a/testdata/pods/tolerations/defaultTolerationSeconds-override.yaml
+++ b/testdata/pods/tolerations/defaultTolerationSeconds-override.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mytoleration
 spec:
   containers:
-    - image: "docker.io/ocpqe/hello-pod:latest"
+    - image: "quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7"
       imagePullPolicy: IfNotPresent
       name: mytoleration
       ports:

--- a/testdata/secrets/mapping-secret-volume-pod.yaml
+++ b/testdata/secrets/mapping-secret-volume-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: mapping-secret-volume-pod
-      image: docker.io/ocpqe/hello-pod:latest
+      image: quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7
       env:
       - name: MYSQL_USER
         value: userSUM

--- a/testdata/secrets/pod-secret-datastring-image-volume.yaml
+++ b/testdata/secrets/pod-secret-datastring-image-volume.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: pod-secret-datastring-image-volume
-    image: docker.io/ocpqe/hello-pod:latest
+    image: quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7
     env:
     - name: MYSQL_USER
       value: userSUM

--- a/testdata/secrets/secret-pod-1.yaml
+++ b/testdata/secrets/secret-pod-1.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: secret-pod-1
-    image: docker.io/ocpqe/hello-pod:latest
+    image: quay.io/openshifttest/hello-pod@sha256:04b6af86b03c1836211be2589db870dba09b7811c197c47c07fbbe33c7f80ef7
     env:
     - name: MYSQL_USER
       value: userSUM


### PR DESCRIPTION
/cc @jhou1 @xiuwang @pruan-rht 
Action item from automation bi-weekly meeting on Dec 2nd.

Why we switch from docker to quay ?
1. There are rate limit added recently on docker, which will result pulling image to fail as we reach the threshold.
2. We have mirror the image from quay to internal registry for disconnect testing.