### PR TITLE
update nginx-alpine image to support IPv6

### DIFF
--- a/testdata/routing/abrouting/abtest-websrv1.yaml
+++ b/testdata/routing/abrouting/abtest-websrv1.yaml
@@ -15,7 +15,7 @@ items:
           name: abtest-websrv1
       spec:
         containers:
-        - image: quay.io/openshifttest/nginx-alpine@sha256:0bda74bd61ffdc5b7d876fd30f44567afdb211439c0ad4c8dbb86f30c0617cdf
+        - image: quay.io/openshifttest/nginx-alpine@sha256:7b888a83dc936934b7bb49b103df41b53d28fa58795ceb86b50ee280dca4257c
           name: nginx
 - apiVersion: v1
   kind: Service

--- a/testdata/routing/abrouting/abtest-websrv2.yaml
+++ b/testdata/routing/abrouting/abtest-websrv2.yaml
@@ -15,7 +15,7 @@ items:
           name: abtest-websrv2
       spec:
         containers:
-        - image: quay.io/openshifttest/nginx-alpine@sha256:0bda74bd61ffdc5b7d876fd30f44567afdb211439c0ad4c8dbb86f30c0617cdf
+        - image: quay.io/openshifttest/nginx-alpine@sha256:7b888a83dc936934b7bb49b103df41b53d28fa58795ceb86b50ee280dca4257c
           name: nginx
 - apiVersion: v1
   kind: Service

--- a/testdata/routing/abrouting/abtest-websrv3.yaml
+++ b/testdata/routing/abrouting/abtest-websrv3.yaml
@@ -15,7 +15,7 @@ items:
           name: abtest-websrv3
       spec:
         containers:
-        - image: quay.io/openshifttest/nginx-alpine@sha256:0bda74bd61ffdc5b7d876fd30f44567afdb211439c0ad4c8dbb86f30c0617cdf
+        - image: quay.io/openshifttest/nginx-alpine@sha256:7b888a83dc936934b7bb49b103df41b53d28fa58795ceb86b50ee280dca4257c
           name: nginx
 - apiVersion: v1
   kind: Service

--- a/testdata/routing/abrouting/abtest-websrv4.yaml
+++ b/testdata/routing/abrouting/abtest-websrv4.yaml
@@ -15,7 +15,7 @@ items:
           name: abtest-websrv4
       spec:
         containers:
-        - image: quay.io/openshifttest/nginx-alpine@sha256:0bda74bd61ffdc5b7d876fd30f44567afdb211439c0ad4c8dbb86f30c0617cdf
+        - image: quay.io/openshifttest/nginx-alpine@sha256:7b888a83dc936934b7bb49b103df41b53d28fa58795ceb86b50ee280dca4257c
           name: nginx
 - apiVersion: v1
   kind: Service

--- a/testdata/routing/web-server-1.yaml
+++ b/testdata/routing/web-server-1.yaml
@@ -6,7 +6,7 @@ metadata:
   name: web-server-1
 spec:
   containers:
-  - image: quay.io/openshifttest/nginx-alpine@sha256:0bda74bd61ffdc5b7d876fd30f44567afdb211439c0ad4c8dbb86f30c0617cdf
+  - image: quay.io/openshifttest/nginx-alpine@sha256:7b888a83dc936934b7bb49b103df41b53d28fa58795ceb86b50ee280dca4257c
     name: nginx
     ports:
     - containerPort: 8080

--- a/testdata/routing/web-server-rc.yaml
+++ b/testdata/routing/web-server-rc.yaml
@@ -15,7 +15,7 @@ items:
           name: web-server-rc
       spec:
         containers:
-        - image: quay.io/openshifttest/nginx-alpine@sha256:0bda74bd61ffdc5b7d876fd30f44567afdb211439c0ad4c8dbb86f30c0617cdf
+        - image: quay.io/openshifttest/nginx-alpine@sha256:7b888a83dc936934b7bb49b103df41b53d28fa58795ceb86b50ee280dca4257c
           name: nginx
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
enable nginx server to listen on both IPv4 and IPv6 address.

```
# oc -n hongli rsh web-server-rc-5wd86
~ $ netstat -anlp
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN      1/nginx: master pro
tcp        0      0 0.0.0.0:8443            0.0.0.0:*               LISTEN      1/nginx: master pro
tcp        0      0 :::8080                 :::*                    LISTEN      1/nginx: master pro
tcp        0      0 :::8443                 :::*                    LISTEN      1/nginx: master pro
```

@quarterpin please take a look. thanks
