### PR TITLE
Window container case for Loadbalancer svc

### DIFF
--- a/features/networking/ovn_winc.feature
+++ b/features/networking/ovn_winc.feature
@@ -70,7 +70,7 @@ Feature: OVNKubernetes Windows Container related networking scenarios
       | name | win-webserver |
       | tcp  | 80            |
     Then the step should succeed
-    And I pry
+    
     # Get the external ip of the loadbalancer service
     And I wait up to 60 seconds for the steps to pass:
     """

--- a/features/networking/ovn_winc.feature
+++ b/features/networking/ovn_winc.feature
@@ -49,3 +49,41 @@ Feature: OVNKubernetes Windows Container related networking scenarios
       | curl | -s | --connect-timeout | 2 | <%= cb.linux_pod.ip %>:8080 |
     Then the step should succeed
     And the output should contain "Hello OpenShift" 
+
+  # @author anusaxen@redhat.com
+  # @case_id OCP-37519
+  @admin	
+  Scenario: Create Loadbalancer service for a window container
+    Given the env has hybridOverlayConfig enabled
+    And the env is using windows nodes
+    Given I have a project
+    And I have a pod-for-ping in the project
+    Given I obtain test data file "networking/windows_pod_and_service.yaml"
+    When I run the :create client command with:
+      | f | windows_pod_and_service.yaml |
+    Then the step should succeed
+    And a pod becomes ready with labels:
+      | app=win-webserver |
+      
+    # Create loadbalancer service
+    When I run the :create_service_loadbalancer client command with:
+      | name | win-webserver |
+      | tcp  | 80            |
+    Then the step should succeed
+    And I pry
+    # Get the external ip of the loadbalancer service
+    And I wait up to 60 seconds for the steps to pass:
+    """
+    When I run the :get client command with:
+      | resource      | svc                                        |
+      | resource_name | win-webserver                              |
+      | template      | {{(index .status.loadBalancer.ingress 0)}} |
+    Then the step should succeed
+    """
+    And evaluation of `@result[:response].match(/:(.*)]/)[1]` is stored in the :service_external_ip clipboard
+
+    # check the external:ip of loadbalancer can be accessed
+    When I execute on the "hello-pod" pod:
+      | curl | -s | --connect-timeout | 10 | <%= cb.service_external_ip %> |
+    Then the step should succeed
+    And the output should contain "Windows Container Web Server"


### PR DESCRIPTION
We Should have a quick LB svc check for window container as well like we do for linux 
Logs: https://privatebin-it-iso.int.open.paas.redhat.com/?4513f4efce5d3048#9nJ1G2onaUnGxqU3RjjMMGrkbtHwNy6CgKGKd4c6jocZ

@rbbratta @zhaozhanqi @huiran0826 @weliang1 @brahaney @asood-rh 