### PR TITLE
fix OCP-21482 and OCP-18998

### DIFF
--- a/features/step_definitions/registry.rb
+++ b/features/step_definitions/registry.rb
@@ -384,6 +384,7 @@ Given /^I enable image-registry default route$/ do
       | type          | merge                                                       |
   })
   step %Q/the step should succeed/
+  step %Q/admin waits for the "image-registry" service to become ready in the "openshift-image-registry" project/
   step %Q/admin waits for the "default-route" route to appear in the "openshift-image-registry" project up to 120 seconds/
   project(org_proj_name) if org_proj_name
 end

--- a/features/step_definitions/registry.rb
+++ b/features/step_definitions/registry.rb
@@ -378,10 +378,10 @@ Given /^I enable image-registry default route$/ do
   org_proj_name = project(generate: false).name rescue nil
 
   step 'I run the :patch admin command with:', table(%{
-      | resource      | configs.imageregistry.operator.openshift.io |
-      | resource_name | cluster                                     |
-      | p             | {"spec":{"defaultRoute":true}}              |
-      | type          | merge                                       |
+      | resource      | configs.imageregistry.operator.openshift.io                 |
+      | resource_name | cluster                                                     |
+      | p             | {"spec":{"defaultRoute":true,"managementState": "Managed"}} |
+      | type          | merge                                                       |
   })
   step %Q/the step should succeed/
   step %Q/admin waits for the "default-route" route to appear in the "openshift-image-registry" project up to 120 seconds/


### PR DESCRIPTION
On openstack, intergrated registry is default setting to Removed.
We add post action to change registry to Managed, but not ipv6 and ipv4 in edge team. Since set registry here in case registry are setting to Removed scenarios.

@openshift/devexp-qe Please help review, thanks