### PR TITLE
Revert "Add update_caseruns_smart"

### DIFF
--- a/lib/polarshift/request.rb
+++ b/lib/polarshift/request.rb
@@ -209,6 +209,7 @@ module BushSlicer
           end
         }
 
+
         Http.request(
           method: :post,
           url: "#{base_url}project/#{project_id}/test-cases/query",
@@ -217,6 +218,7 @@ module BushSlicer
           **common_opts
         )
       end
+
 
       def query_test_cases_smart(timeout: 360, **opts)
         res = query_test_cases(**opts)
@@ -303,22 +305,6 @@ module BushSlicer
           raise_on_error: false,
           **common_opts
         )
-      end
-
-      def update_caseruns_smart(project_id, run_id, updates, timeout: 360)
-        res = nil
-        success = wait_for(timeout, interval: 30) {
-          res = update_caseruns(project_id, run_id, updates)
-          if res[:success]
-            return res
-          else
-            logger.info %Q{got status "#{res[:exitstatus]}" updating test run "#{run_id}" in project "#{project_id}":\n#{res[:response]}}
-            false
-          end
-        }
-        unless success
-          raise %Q{timeout ("#{timeout}" seconds) updating run "#{run_id}" in project "#{project_id}":\n#{res[:response]}}
-        end
       end
 
       # @param project_id [String]

--- a/lib/polarshift/test_record.rb
+++ b/lib/polarshift/test_record.rb
@@ -119,7 +119,7 @@ module BushSlicer
       def update_to!(new_state)
         raise "cannot update virtual test record" if virtual?
         logger.info "Updating PolarShift test case #{test_case_id} with #{new_state["result"]} status and duration of #{new_state["duration"]} seconds"
-        res = request.update_caseruns_smart(project_id, run_id, {
+        res = request.update_caseruns(project_id, run_id, {
           "id" => test_case_id,
           "current" => {
             "comment" => comment,


### PR DESCRIPTION
Reverts openshift/verification-tests#1701 due to:
```
timeout ("360" seconds) updating run "20201215-0157" in project "OSE":
{"error":"no test case results updated","description":"Most probably due to concurrent modification these cases' state is not what you expected: [\"OCP-10181\"]"} (RuntimeError)
/home/jenkins/ws/workspace/Runner-v3/lib/polarshift/request.rb:320:in `update_caseruns_smart'
/home/jenkins/ws/workspace/Runner-v3/lib/polarshift/test_record.rb:122:in `update_to!'
/home/jenkins/ws/workspace/Runner-v3/lib/polarshift/test_record.rb:94:in `reserve!'
/home/jenkins/ws/workspace/Runner-v3/lib/polarshift/test_suite.rb:76:in `block in test_case_next!'
/home/jenkins/ws/workspace/Runner-v3/lib/polarshift/test_suite.rb:76:in `each'
/home/jenkins/ws/workspace/Runner-v3/lib/polarshift/test_suite.rb:76:in `find'
/home/jenkins/ws/workspace/Runner-v3/lib/polarshift/test_suite.rb:76:in `test_case_next!'
/home/jenkins/ws/workspace/Runner-v3/lib/test_case_manager.rb:113:in `next'
/home/jenkins/ws/workspace/Runner-v3/lib/test_case_manager_filter.rb:15:in `test_case'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-1.5.0/lib/cucumber/core/test/case.rb:23:in `describe_to'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-2.4.0/lib/cucumber/filters/activate_steps.rb:11:in `test_case'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-1.5.0/lib/cucumber/core/test/case.rb:23:in `describe_to'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-2.4.0/lib/cucumber/filters/quit.rb:11:in `test_case'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-1.5.0/lib/cucumber/core/test/case.rb:23:in `describe_to'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-2.4.0/lib/cucumber/filters/randomizer.rb:21:in `block in done'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-2.4.0/lib/cucumber/filters/randomizer.rb:20:in `each'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-2.4.0/lib/cucumber/filters/randomizer.rb:20:in `done'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-1.5.0/lib/cucumber/core/test/filters/locations_filter.rb:19:in `done'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-1.5.0/lib/cucumber/core/filter.rb:61:in `done'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-1.5.0/lib/cucumber/core/test/filters/tag_filter.rb:18:in `done'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-1.5.0/lib/cucumber/core/compiler.rb:23:in `done'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-1.5.0/lib/cucumber/core/gherkin/parser.rb:35:in `done'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-1.5.0/lib/cucumber/core.rb:29:in `parse'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-1.5.0/lib/cucumber/core.rb:18:in `compile'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-2.4.0/lib/cucumber/runtime.rb:67:in `run!'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-2.4.0/lib/cucumber/cli/main.rb:32:in `execute!'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-2.4.0/bin/cucumber:8:in `<top (required)>'
/home/jenkins/.gem/bundler/ruby/2.7.0/bin/cucumber:23:in `load'
/home/jenkins/.gem/bundler/ruby/2.7.0/bin/cucumber:23:in `<top (required)>'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/libexec/bundle:46:in `block in <top (required)>'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.1.4/libexec/bundle:34:in `<top (required)>'
/opt/rh/rh-ruby27/root/usr/bin/bundle:23:in `load'
/opt/rh/rh-ruby27/root/usr/bin/bundle:23:in `<main>'
```