### PR TITLE
error msg changed to providing invalid value instead of only key , bu…

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -271,14 +271,14 @@ Feature: MachineHealthCheck Test Scenarios
     Given I obtain test data file "cloud/mhc/mhc_validations.yaml"
     When I run oc create over "mhc_validations.yaml" replacing paths:
       | ["spec"]["maxUnhealthy"] | <maxUnhealthy> |
-    Then the output should contain:
-      | maxUnhealthy: Invalid value: "": spec.maxUnhealthy |
+    Then the output should match:
+      | maxUnhealthy: Invalid value: ".*": spec.maxUnhealthy |
 
    Examples:
       | maxUnhealthy |
       |  -2a         |
-      | "10t%"       |
-      | "-2%"        |
+      |  10t%        |
+      |  -2%         |
       |  -2%         |
 
   # @author miyadav@redhat.com


### PR DESCRIPTION
…t not to 4.6 , so using pattern match

Here are validation result : 
      STDERR:
      The MachineHealthCheck "mhc-malformed" is invalid: spec.maxUnhealthy: Invalid value: "-2%": spec.maxUnhealthy in body should match '^((100|[0-9]{1,2})%|[0-9]+)$'
      
      [04:41:58] INFO> Exit Status: 1
      | ["spec"]["maxUnhealthy"] | -2% |
        Then the output should match:                                     # features/step_definitions/common.rb:33
      | maxUnhealthy: Invalid value: ".*": spec.maxUnhealthy |
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    [04:41:58] INFO> === After Scenario: Leverage OpenAPI validation within MHC, Examples (#4) ===
    [04:41:58] INFO> Shell Commands: rm -r -f -- /root/workdir/a085541df561-
    
    [04:41:58] INFO> Exit Status: 0
    [04:41:58] INFO> === End After Scenario: Leverage OpenAPI validation within MHC, Examples (#4) ===

4 scenarios (4 passed)
24 steps (24 passed)
0m30.034s
[04:41:58] INFO> === At Exit ===

I can use "maxUnhealthy: Invalid value: "<maxUnhealthy>": spec.maxUnhealthy" , but that will break it for 4.6 
@jhou1 @sunzhaohua2  PTAL ...