### PR TITLE
deploy external log stores in different projects and other fixes

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -81,6 +81,12 @@ Given /^logging operators are installed successfully$/ do
       end
     end
   end
+  # check csv existense
+  success = wait_for(300, interval: 10) {
+    csv = subscription('elasticsearch-operator').current_csv
+    cluster_service_version(csv).exists?
+  }
+  raise "CSV #{csv} isn't created" unless success
   step %Q/elasticsearch operator is ready/
 
   # Create namespace
@@ -124,6 +130,12 @@ Given /^logging operators are installed successfully$/ do
       end
     end
   end
+  # check csv existense
+  success = wait_for(300, interval: 10) {
+    csv = subscription('cluster-logging').current_csv
+    cluster_service_version(csv).exists?
+  }
+  raise "CSV #{csv} isn't created" unless success
   step %Q/cluster logging operator is ready/
 end
 
@@ -406,7 +418,7 @@ Given /^I create pipelinesecret(?: named#{OPT_QUOTED})?(?: with sharedkey#{OPT_Q
   secret_name ||= "pipelinesecret"
   step %Q/admin ensures "#{secret_name}" secret is deleted from the "openshift-logging" project after scenario/
   if shared_key != nil
-    step %Q/I run the :create_secret client command with:/, table(%{
+    step %Q/I run the :create_secret admin command with:/, table(%{
       | name         | #{secret_name}           |
       | secret_type  | generic                  |
       | from_file    | tls.key=logging-es.key   |
@@ -417,7 +429,7 @@ Given /^I create pipelinesecret(?: named#{OPT_QUOTED})?(?: with sharedkey#{OPT_Q
       | n            | openshift-logging        |
     })
   else
-    step %Q/I run the :create_secret client command with:/, table(%{
+    step %Q/I run the :create_secret admin command with:/, table(%{
       | name         | #{secret_name}           |
       | secret_type  | generic                  |
       | from_file    | tls.key=logging-es.key   |

--- a/testdata/logging/clusterlogforwarder/elasticsearch/insecure/clusterlogforwarder.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/insecure/clusterlogforwarder.yaml
@@ -1,21 +1,29 @@
-apiVersion: logging.openshift.io/v1
-kind: ClusterLogForwarder
+kind: Template
+apiVersion: v1
 metadata:
-  name: instance
-  namespace: openshift-logging
-spec:
-  outputs:
-  - name: es-created-by-user
-    type: elasticsearch
-    url: 'http://elasticsearch-server.openshift-logging.svc:9200'
-    insecure: true
-  pipelines:
-  - name: forward-to-external-es
-    inputRefs:
-    - infrastructure
-    - application
-    - audit
-    labels:
-      forward-with-labels: test-labels
-    outputRefs:
-    - es-created-by-user
+  name: clusterlogforwarder-template
+objects:
+- apiVersion: logging.openshift.io/v1
+  kind: ClusterLogForwarder
+  metadata:
+    name: instance
+    namespace: openshift-logging
+  spec:
+    outputs:
+    - name: insecure-es
+      type: elasticsearch
+      url: "${URL}"
+      insecure: true
+    pipelines:
+    - name: forward-to-external-es
+      inputRefs:
+      - infrastructure
+      - application
+      - audit
+      labels:
+        forward-with-labels: forward-to-insecure-es
+      outputRefs:
+      - insecure-es
+parameters:
+- name: URL
+  value: "http://elasticsearch-server.openshift-logging.svc:9200"

--- a/testdata/logging/clusterlogforwarder/elasticsearch/secure/clusterlogforwarder.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/secure/clusterlogforwarder.yaml
@@ -1,34 +1,44 @@
-apiVersion: logging.openshift.io/v1
-kind: ClusterLogForwarder
+kind: Template
+apiVersion: v1
 metadata:
-  name: instance
-  namespace: openshift-logging
-spec:
-  outputs:
-  - name: es-created-by-user
-    type: elasticsearch
-    url: 'https://elasticsearch-server.openshift-logging.svc:9200'
-    secret:
-       name: 'pipelinesecret'
-  pipelines:
-  - name: forward-app-logs
-    inputRefs:
-    - application
-    labels:
-      logging: app-logs
-    outputRefs:
-    - es-created-by-user
-  - name: forward-infra-logs
-    inputRefs:
-    - infrastructure
-    labels:
-      logging: infra-logs
-    outputRefs:
-    - es-created-by-user
-  - name: forward-audit-logs
-    inputRefs:
-    - audit
-    labels:
-      logging: audit-logs
-    outputRefs:
-    - es-created-by-user
+  name: clusterlogforwarder-template
+objects:
+- apiVersion: logging.openshift.io/v1
+  kind: ClusterLogForwarder
+  metadata:
+    name: instance
+    namespace: openshift-logging
+  spec:
+    outputs:
+    - name: secure-es
+      type: elasticsearch
+      url: ${URL}
+      secret:
+        name: ${PIPELINE_SECRET_NAME}
+    pipelines:
+    - name: forward-app-logs
+      inputRefs:
+      - application
+      labels:
+        logging: app-logs
+      outputRefs:
+      - secure-es
+    - name: forward-infra-logs
+      inputRefs:
+      - infrastructure
+      labels:
+        logging: infra-logs
+      outputRefs:
+      - secure-es
+    - name: forward-audit-logs
+      inputRefs:
+      - audit
+      labels:
+        logging: audit-logs
+      outputRefs:
+      - secure-es
+parameters:
+- name: URL
+  value: "https://elasticsearch-server.openshift-logging.svc:9200"
+- name: PIPELINE_SECRET_NAME
+  value: "pipelinesecret"

--- a/testdata/logging/clusterlogforwarder/fluentd/insecure/clusterlogforwarder.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/insecure/clusterlogforwarder.yaml
@@ -1,21 +1,29 @@
-apiVersion: logging.openshift.io/v1
-kind: ClusterLogForwarder
+kind: Template
+apiVersion: v1
 metadata:
-  name: instance
-  namespace: openshift-logging
-spec:
-  outputs:
-  - name: fluentd-created-by-user
-    type: fluentdForward
-    url: 'tcp://fluentdserver.openshift-logging.svc:24224'
-    insecure: true
-  pipelines:
-  - name: forward-to-fluentd-server
-    inputRefs:
-    - infrastructure
-    - application
-    - audit
-    labels:
-      forward-with-labels: test-labels
-    outputRefs:
-    - fluentd-created-by-user
+  name: clusterlogforwarder-template
+objects:
+- apiVersion: logging.openshift.io/v1
+  kind: ClusterLogForwarder
+  metadata:
+    name: instance
+    namespace: openshift-logging
+  spec:
+    outputs:
+    - name: fluentd-insecure
+      type: fluentdForward
+      url: "${URL}"
+      insecure: true
+    pipelines:
+    - name: forward-to-fluentd-server
+      inputRefs:
+      - infrastructure
+      - application
+      - audit
+      labels:
+        forward-with-labels: fluentd-insecure-forward
+      outputRefs:
+      - fluentd-insecure
+parameters:
+- name: URL
+  value: 'tcp://fluentdserver.openshift-logging.svc:24224'

--- a/testdata/logging/clusterlogforwarder/fluentd/secure/clusterlogforwarder.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/secure/clusterlogforwarder.yaml
@@ -1,22 +1,32 @@
-apiVersion: logging.openshift.io/v1
-kind: ClusterLogForwarder
+kind: Template
+apiVersion: v1
 metadata:
-  name: instance
-  namespace: openshift-logging
-spec:
-  outputs:
-  - name: fluentd-created-by-user
-    type: fluentdForward
-    url: 'tls://fluentdserver.openshift-logging.svc:24224'
-    secret:
-       name: 'fluentdserver'
-  pipelines:
-  - name: forward-to-fluentd-server
-    inputRefs:
-    - infrastructure
-    - application
-    - audit
-    labels:
-      forward-with-labels: test-labels
-    outputRefs:
-    - fluentd-created-by-user
+  name: clusterlogforwarder-template
+objects:
+- apiVersion: logging.openshift.io/v1
+  kind: ClusterLogForwarder
+  metadata:
+    name: instance
+    namespace: openshift-logging
+  spec:
+    outputs:
+    - name: fluentd-secure
+      type: fluentdForward
+      url: "${URL}"
+      secret:
+        name: ${PIPELINE_SECRET_NAME}
+    pipelines:
+    - name: forward-to-fluentd-server
+      inputRefs:
+      - infrastructure
+      - application
+      - audit
+      labels:
+        forward-with-labels: fluentd-secure-forward
+      outputRefs:
+      - fluentd-secure
+parameters:
+- name: URL
+  value: "tls://fluentdserver.openshift-logging.svc:24224"
+- name: PIPELINE_SECRET_NAME
+  value: "fluentdserver"

--- a/testdata/logging/clusterlogforwarder/rsyslog/rsys_clf_RFC3164.yaml
+++ b/testdata/logging/clusterlogforwarder/rsyslog/rsys_clf_RFC3164.yaml
@@ -1,22 +1,34 @@
-apiVersion: logging.openshift.io/v1      
-kind: ClusterLogForwarder      
-metadata:      
-  name: instance      
-  namespace: openshift-logging      
-spec:      
-  outputs:      
-    - name: rsyslog-created-by-user
-      type: syslog      
-      syslog:      
-        facility: local0
-        rfc: RFC3164    
-        severity: informational     
-      url: 'tls://rsyslogserver.openshift-logging.svc:514'      
-  pipelines:      
-    - name: forward-to-external-syslog      
-      inputRefs:      
-        - infrastructure      
-        - application      
-        - audit      
-      outputRefs:      
-        - rsyslog-created-by-user
+kind: Template
+apiVersion: v1
+metadata:
+  name: clusterlogforwarder-template
+objects:
+- apiVersion: logging.openshift.io/v1
+  kind: ClusterLogForwarder
+  metadata:
+    name: instance
+    namespace: openshift-logging
+  spec:
+    outputs:
+    - name: rsyslog-rfc3164
+      type: syslog
+      syslog:
+        rfc: RFC3164
+        facility: ${FACILITY}
+        severity: ${SEVERITY}
+      url: ${URL}
+    pipelines:
+    - name: forward-to-external-syslog
+      inputRefs:
+      - infrastructure
+      - application
+      - audit
+      outputRefs:
+      - rsyslog-rfc3164
+parameters:
+- name: URL
+  value: "tls://rsyslogserver.openshift-logging.svc:514"
+- name: FACILITY
+  value: "local0"
+- name: SEVERITY
+  value: "informational"

--- a/testdata/logging/clusterlogforwarder/rsyslog/rsys_clf_RFC5424.yaml
+++ b/testdata/logging/clusterlogforwarder/rsyslog/rsys_clf_RFC5424.yaml
@@ -1,22 +1,34 @@
-apiVersion: logging.openshift.io/v1      
-kind: ClusterLogForwarder      
-metadata:      
-  name: instance      
-  namespace: openshift-logging      
-spec:      
-  outputs:      
-    - name: rsyslog-created-by-user
-      type: syslog      
-      syslog:      
-        facility: local0
-        rfc: RFC5424    
-        severity: informational     
-      url: 'tcp://rsyslogserver.openshift-logging.svc:514'      
-  pipelines:      
-    - name: forward-to-external-syslog      
-      inputRefs:      
-        - infrastructure      
-        - application      
-        - audit      
-      outputRefs:      
-        - rsyslog-created-by-user
+kind: Template
+apiVersion: v1
+metadata:
+  name: clusterlogforwarder-template
+objects:
+- apiVersion: logging.openshift.io/v1
+  kind: ClusterLogForwarder
+  metadata:
+    name: instance
+    namespace: openshift-logging
+  spec:
+    outputs:
+    - name: rsyslog-rfc5424
+      type: syslog
+      syslog:
+        rfc: RFC5424
+        facility: ${FACILITY}
+        severity: ${SEVERITY}
+      url: ${URL}
+    pipelines:
+    - name: forward-to-external-syslog
+      inputRefs:
+      - infrastructure
+      - application
+      - audit
+      outputRefs:
+      - rsyslog-rfc5424
+parameters:
+- name: URL
+  value: "tcp://rsyslogserver.openshift-logging.svc:514"
+- name: FACILITY
+  value: "local0"
+- name: SEVERITY
+  value: "informational"

--- a/testdata/logging/clusterlogforwarder/rsyslog/rsys_clf_default.yaml
+++ b/testdata/logging/clusterlogforwarder/rsyslog/rsys_clf_default.yaml
@@ -1,21 +1,33 @@
-apiVersion: logging.openshift.io/v1      
-kind: ClusterLogForwarder      
-metadata:      
-  name: instance      
-  namespace: openshift-logging      
-spec:      
-  outputs:      
-    - name: rsyslog-created-by-user 
-      type: syslog      
-      syslog:      
-        facility: local0
-        severity: informational     
-      url: 'udp://rsyslogserver.openshift-logging.svc:514'      
-  pipelines:      
-    - name: forward-to-external-syslog      
-      inputRefs:      
-        - infrastructure      
-        - application      
-        - audit      
-      outputRefs:      
-        - rsyslog-created-by-user
+kind: Template
+apiVersion: v1
+metadata:
+  name: clusterlogforwarder-template
+objects:
+- apiVersion: logging.openshift.io/v1
+  kind: ClusterLogForwarder
+  metadata:
+    name: instance
+    namespace: openshift-logging
+  spec:
+    outputs:
+    - name: rsyslog-default
+      type: syslog
+      syslog:
+        facility: ${FACILITY}
+        severity: ${SEVERITY}
+      url: ${URL}
+    pipelines:
+    - name: forward-to-external-syslog
+      inputRefs:
+      - infrastructure
+      - application
+      - audit
+      outputRefs:
+      - rsyslog-default
+parameters:
+- name: URL
+  value: "udp://rsyslogserver.openshift-logging.svc:514"
+- name: FACILITY
+  value: "local0"
+- name: SEVERITY
+  value: "informational"


### PR DESCRIPTION
Fixes:
1. check CSV status when subscribing operators
2. deploy external log stores in different projects 