### PR TITLE
[WIP] added kata-webhook support

### DIFF
--- a/features/step_definitions/cli.rb
+++ b/features/step_definitions/cli.rb
@@ -110,8 +110,8 @@ end
 # instead of writing multiple steps, this step does this in one go:
 # 1. download file from URL
 # 2. load it as an ERB file with the cucumber scenario variables binding
-# 3. runs `oc create` command over the resulting file
-When /^I run oc create( as admin)? over ERB test file: (.*)$/ do |admin, file_path|
+# 3. runs `oc create|apply` command over the resulting file
+When /^I run oc (create|apply)( as admin)? over ERB test file: (.*)$/ do |action, admin, file_path|
   step %Q|I obtain test data file "#{file_path}"|
   file_path = cb.test_file
   # overwrite with ERB loaded content
@@ -119,9 +119,9 @@ When /^I run oc create( as admin)? over ERB test file: (.*)$/ do |admin, file_pa
   File.write(file_path, loaded)
   if admin
     ensure_admin_tagged
-    @result = self.admin.cli_exec(:create, {f: file_path})
+    @result = self.admin.cli_exec(action.to_sym, {f: file_path})
   else
-    @result = user.cli_exec(:create, {f: file_path})
+    @result = user.cli_exec(action.to_sym, {f: file_path})
   end
 end
 

--- a/features/step_definitions/project.rb
+++ b/features/step_definitions/project.rb
@@ -49,6 +49,11 @@ When /^I create a new project(?: via (.*?))?$/ do |via|
       step %Q/I use the "#{@projects.last.name}" project/
     end
   end
+  ## special case for enable kata webhook automatically when user sets the
+  # env variable USE_KATA_RUNTIME
+  if ENV.has_key? 'USE_KATA_RUNTIME' and ENV['USE_KATA_RUNTIME']
+    step %Q/I install kata-webhook for the namespace/
+  end
 end
 
 # create a new project w/o leading digit to get around this java bug.
@@ -64,6 +69,11 @@ Given /^I create a project with non-leading digit name$/ do
       logger.warn("Project #{@projects.last.name} not visible on server after create")
     end
   end
+  ## special case for enable kata webhook automatically when user sets the
+  # env variable USE_KATA_RUNTIME
+  if ENV.has_key? 'USE_KATA_RUNTIME' and ENV['USE_KATA_RUNTIME']
+    step %Q/I install kata-webhook for the namespace/
+  end
 end
 
 # create a new project w/ a leading digit to test OVS quoting
@@ -76,6 +86,11 @@ Given /^I create a project with leading digit name$/ do
     unless @result[:success]
       logger.warn("Project #{@projects.last.name} not visible on server after create")
     end
+  end
+  ## special case for enable kata webhook automatically when user sets the
+  # env variable USE_KATA_RUNTIME
+  if ENV.has_key? 'USE_KATA_RUNTIME' and ENV['USE_KATA_RUNTIME']
+    step %Q/I install kata-webhook for the namespace/
   end
 end
 

--- a/features/test/kata.feature
+++ b/features/test/kata.feature
@@ -14,3 +14,11 @@ Feature: example kata container scenarios
     Given the master version >= "4.6"
     Given I switch to cluster admin pseudo user
     And I remove kata operator from "kata-operator" namespace
+
+
+  Scenario: test install kata-webhook
+    Given I have a project
+    And evaluation of `project.name` is stored in the :test_project_name clipboard
+    And I run oc create over ERB test file: kata/webhook/example-fedora.yaml
+    And the pod named "example-fedora" becomes ready
+    Then the expression should be true> pod.runtime_class_name == 'kata'

--- a/lib/openshift/pod.rb
+++ b/lib/openshift/pod.rb
@@ -48,6 +48,7 @@ module BushSlicer
       props[:service_account_name] = spec["serviceAccountName"]
       props[:termination_grace_period_seconds] = spec['terminationGracePeriodSeconds']
       props[:volumes] = spec["volumes"]
+      props[:runtime_class_name] = spec["runtimeClassName"]
       s = pod_hash["status"]
       props[:ip] = s["podIP"]
       # status should be retrieved on demand but we cache it for the brave
@@ -325,6 +326,10 @@ module BushSlicer
 
     def tolerations(user: nil, cached: true, quiet: false)
       raw_resource(user: user, cached: cached, quiet: quiet).dig('spec', 'tolerations')
+    end
+
+    def runtime_class_name(user: nil, cached: true, quiet: false)
+      return get_cached_prop(prop: :runtime_class_name, user: user, cached: cached, quiet: quiet)
     end
 
   end

--- a/testdata/kata/webhook/example-fedora.yaml
+++ b/testdata/kata/webhook/example-fedora.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-fedora
+  labels:
+    app: example-fedora-app
+spec:
+  containers:
+    - name: example-fedora
+      image: fedora:30
+      ports:
+        - containerPort: 8080
+      command: ["python3"]
+      args: [ "-m", "http.server", "8080"]
+

--- a/testdata/kata/webhook/webhook-certs.yaml
+++ b/testdata/kata/webhook/webhook-certs.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pod-annotate-webhook-certs
+  namespace: <%= project.name %>
+data:
+  cert.pem: <%= cb.webhook_cert_pem %>
+  key.pem: <%= cb.webhook_key_pem %>

--- a/testdata/kata/webhook/webhook-registration.yaml
+++ b/testdata/kata/webhook/webhook-registration.yaml
@@ -1,0 +1,23 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: pod-annotate-webhook
+  labels:
+    app: pod-annotate-webhook
+    kind: mutator
+webhooks:
+  - name: pod-annotate-webhook.kata.xyz
+    admissionReviewVersions:
+    - v1beta1
+    sideEffects: None
+    clientConfig:
+      service:
+        name: pod-annotate-webhook
+        namespace: <%= project.name %>
+        path: "/mutate"
+      caBundle: <%= cb.ca_bundle %>
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]

--- a/testdata/kata/webhook/webhook.yaml
+++ b/testdata/kata/webhook/webhook.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-annotate-webhook
+  labels:
+    app: pod-annotate-webhook
+spec:
+  selector:
+    matchLabels:
+      app: pod-annotate-webhook
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: pod-annotate-webhook
+    spec:
+      containers:
+        - name: pod-annotate-webhook
+          image: quay.io/fidencio/kata-webhook-example:latest
+          imagePullPolicy: Always
+          args:
+            - -tls-cert-file=/etc/webhook/certs/cert.pem
+            - -tls-key-file=/etc/webhook/certs/key.pem
+            - -exclude-namespaces=rook-ceph-system,rook-ceph
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: pod-annotate-webhook-certs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pod-annotate-webhook
+  labels:
+    app: pod-annotate-webhook
+spec:
+  ports:
+  - port: 443
+    targetPort: 8080
+  selector:
+    app: pod-annotate-webhook


### PR DESCRIPTION
kata-webhook support using admission controller, which requires admin privileges.  In an effort to run existing tests w/o modification, this PR will leverage off environment variable `USE_KATA_RUNTIME` to install the admission controller for kata when an new project is created.