### PR TITLE
fix failure when finding the index patterns in kibana

### DIFF
--- a/features/logging/kibana.feature
+++ b/features/logging/kibana.feature
@@ -76,7 +76,7 @@ Feature: Kibana related features
     When I login to kibana logging web console
     Then the step should succeed
     When I perform the :create_index_pattern_in_kibana web action with:
-      | index_pattern_name | app |
+      | index_pattern_name | "*app" |
     Then the step should succeed
     Given I wait up to 300 seconds for the steps to pass:
     """
@@ -85,7 +85,7 @@ Feature: Kibana related features
     """
     # check the log count, wait for the Kibana console to be loaded
     When I perform the :kibana_find_index_pattern web action with:
-      | index_pattern_name | app* |
+      | index_pattern_name | *app |
     Then the step should succeed
     Given I wait up to 300 seconds for the steps to pass:
     """
@@ -113,14 +113,14 @@ Feature: Kibana related features
     And I use the "openshift-logging" project
     Given I wait for the "app" index to appear in the ES pod with labels "es-node-master=true"
     Given I wait for the "infra" index to appear in the ES pod with labels "es-node-master=true"
-    And I wait for the project "<%= cb.proj.name %>" logs to appear in the ES pod 
+    And I wait for the project "<%= cb.proj.name %>" logs to appear in the ES pod
     When I login to kibana logging web console
     Then the step should succeed
     When I perform the :create_index_pattern_in_kibana web action with:
-      | index_pattern_name | app |
+      | index_pattern_name | "*app" |
     Then the step should succeed
     When I perform the :create_index_pattern_in_kibana web action with:
-      | index_pattern_name | infra |
+      | index_pattern_name | "*infra" |
     Then the step should succeed
     Given I wait up to 180 seconds for the steps to pass:
     """
@@ -129,7 +129,7 @@ Feature: Kibana related features
     """
 
     When I perform the :kibana_find_index_pattern web action with:
-      | index_pattern_name | app* |
+      | index_pattern_name | *app |
     Then the step should succeed
     Given I wait up to 180 seconds for the steps to pass:
     """
@@ -139,10 +139,10 @@ Feature: Kibana related features
     And I run the :kibana_expand_index_patterns web action
     Then the step should succeed
     When I perform the :kibana_click_index web action with:
-      | index_pattern_name | infra* |
+      | index_pattern_name | *infra |
     Then the step should succeed
     When I perform the :kibana_find_index_pattern web action with:
-      | index_pattern_name | infra* |
+      | index_pattern_name | *infra |
     Then the step should succeed
     Given I wait up to 180 seconds for the steps to pass:
     """
@@ -186,7 +186,7 @@ Feature: Kibana related features
       | idp        | <%= env.idp %>               |
     Then the step should succeed
     # click `Log in with OpenShift` button and login again
-    When I run the :logout_kibana web action 
+    When I run the :logout_kibana web action
     Then the step should succeed
     When I perform the :login_kibana web action with:
       | username   | <%= user.name %>             |

--- a/lib/rules/web/admin_console/4.7/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.7/logging_kibana.xyaml
@@ -45,7 +45,7 @@ check_kibana_status:
       xpath: //div[@id="createStatusPageReact"]
     missing: true
     timeout: 30
-  
+
 create_index_pattern_in_kibana:
   action:
     if_element:
@@ -60,7 +60,7 @@ create_index_pattern:
       selector:
         xpath: //a[@data-test-subj="indexPatternLink"]
       timeout: 30
-    ref: click_create_index_pattern_button   
+    ref: click_create_index_pattern_button
   action: set_index_patter_name
   action: click_create_index_pattern_go_to_step2_button
   action: create_index_pattern_time_field_select
@@ -98,7 +98,7 @@ click_kibana_index_patterns:
     selector:
       xpath: //span[@class="euiSideNavItemButton__label" and contains(., "Index Patterns")]
     timeout: 30
-    op: click 
+    op: click
 
 click_create_index_pattern_button:
   element:
@@ -108,7 +108,7 @@ click_create_index_pattern_button:
     op: click
 
 set_index_patter_name:
-  elements: 
+  elements:
   - selector:
       xpath: //input[@type="text" and @name="indexPattern"]
     timeout: 30
@@ -168,7 +168,7 @@ check_log_count:
     selector:
       xpath: //span[@data-test-subj="discoverQueryHits" and @class="kuiLocalBreadcrumb__emphasis"]
   scripts:
-  - command: | 
+  - command: |
       var x = document.querySelector("#kui_local_breadcrumb > span:nth-child(2)").textContent;
       var replaced_x = x.replace(/\,/g,'')
       var doc_count = false;


### PR DESCRIPTION
Fix failure:
```
      [05:35:09] INFO> found 0 element elements with selector: {:xpath=>"//h2[@class=\"index-pattern-label\" and @id=\"index_pattern_id\" and contains(., \"app*\")] | //span[contains(., \"app*\")]"}
      [05:35:09] INFO> embedding "2021-01-05T05:35:09+00:00-screenshot.png"
      [05:35:09] INFO> embedding "2021-01-05T05:35:09+00:00.html"
      | index_pattern_name | app* |/home/jenkins/ws/workspace/Runner-v3/features/support/cucu_formatter.rb:258: warning: URI.escape is obsolete

    Then the step should succeed                                                               # features/step_definitions/common.rb:4
      the step failed (RuntimeError)
      /home/jenkins/ws/workspace/Runner-v3/features/step_definitions/common.rb:6:in `/^the step should( not)? (succeed|fail)$/'
      features/logging/kibana.feature:89:in `Then the step should succeed'
```
When using `send_keys` option, it sends the characters one-by-one,  but the kibana will add `*` automatically after the first character is sent. 
According to https://github.com/elastic/kibana/blob/master/test/functional/page_objects/settings_page.ts#L388-L414, change the index pattern name to `*app` and `*infra`.
