### PR TITLE
Space issue fixed by dev a extra space was there earlier

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -361,8 +361,8 @@ Feature: Machine features testing
     When I run the :logs admin command with:
       | resource_name | <%= pod.name %> |
       | c             | #{cb.id}        |
-    Then the output should contain:
-      | attempting to acquire leader lease openshift-machine-api/cluster-api-provider |
+    Then the output should match:
+      | attempting to acquire leader lease (.*)openshift-machine-api/cluster-api-provider |
     """
 
   # @author zhsun@redhat.com

--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -362,7 +362,7 @@ Feature: Machine features testing
       | resource_name | <%= pod.name %> |
       | c             | #{cb.id}        |
     Then the output should contain:
-      | attempting to acquire leader lease  openshift-machine-api/cluster-api-provider |
+      | attempting to acquire leader lease openshift-machine-api/cluster-api-provider |
     """
 
   # @author zhsun@redhat.com


### PR DESCRIPTION
Validated :

```
      
      [10:09:55] INFO> Exit Status: 0
      """
      When I run the :logs admin command with:
        | resource_name | <%= pod.name %> |
        | c             | #{cb.id}        |
      Then the output should contain:
        | attempting to acquire leader lease openshift-machine-api/cluster-api-provider|
      """
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [10:09:55] INFO> === After Scenario: Run machine api Controllers using leader election ===
      [10:09:55] INFO> Shell Commands: rm -r -f -- /root/workdir/ab65b6d5c5b5-
      
      [10:09:55] INFO> Exit Status: 0
      [10:09:55] INFO> === End After Scenario: Run machine api Controllers using leader election ===

1 scenario (1 passed)
6 steps (6 passed)
0m26.875s
[10:09:55] INFO> === At Exit ===
```
It failed in the CI run for 4.7 today ..