### PR TITLE
fix ocp-11645

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -405,7 +405,7 @@ Feature: Service related networking scenarios
     # Create loadbalancer service
     When I run the :create_service_loadbalancer client command with:
       | name | hello-pod |
-      | tcp  | 5678:8080 |
+      | tcp  | 5678:8081 |
     Then the step should succeed
 
     # Get the external ip of the loadbaclancer service


### PR DESCRIPTION
Fix OCP-11645, the case failed due to the the image listening port changed, updated it accordingly.

Log: https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/238388/console

@zhaozhanqi @anuragthehatter @weliang1 @rbbratta 