### PR TITLE
Use new YAML file for externalip_pod

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -165,17 +165,17 @@ Feature: Service related networking scenarios
     """
 
     # Create a pod
-    Given I obtain test data file "routing/web-server-1.yaml"
+    Given I obtain test data file "networking/externalip_pod.yaml"
     When I run the :create client command with:
-      | f | web-server-1.yaml |
+      | f | externalip_pod.yaml |
     Then the step should succeed
-    And the pod named "web-server-1" becomes ready
-
+    And the pod named "externalip-pod" becomes ready
+ 
     # Curl externalIP:portnumber should pass
     When I execute on the pod:
       | /usr/bin/curl | --connect-timeout | 10 | <%= cb.hostip %>:27017 |
     Then the output should contain:
-      | Hello-OpenShift |
+      | Hello OpenShift! |
 
   # @author weliang@redhat.com
   # @case_id OCP-24692
@@ -213,17 +213,17 @@ Feature: Service related networking scenarios
     """
 
     # Create a pod
-    Given I obtain test data file "routing/web-server-1.yaml"
+    Given I obtain test data file "networking/externalip_pod.yaml"
     When I run the :create client command with:
-      | f | web-server-1.yaml |
+      | f | externalip_pod.yaml |
     Then the step should succeed
-    And the pod named "web-server-1" becomes ready
+    And the pod named "externalip-pod" becomes ready
 
     # Curl externalIP:portnumber on new pod
     When I execute on the pod:
       | /usr/bin/curl | -k | 22.2.2.130:27017 |
     Then the output should contain:
-      | Hello-OpenShift |
+      | Hello OpenShift! |
 
   # @author weliang@redhat.com
   # @case_id OCP-24670
@@ -324,17 +324,17 @@ Feature: Service related networking scenarios
     """
 
     # Create a pod
-    Given I obtain test data file "routing/web-server-1.yaml"
+    Given I obtain test data file "networking/externalip_pod.yaml"
     When I run the :create client command with:
-      | f | web-server-1.yaml |
+      | f | externalip_pod.yaml |
     Then the step should succeed
-    And the pod named "web-server-1" becomes ready
+    And the pod named "externalip-pod" becomes ready
 
     # Curl externalIP:portnumber from pod
     When I execute on the pod:
       | /usr/bin/curl | --connect-timeout | 10 | <%= cb.host1ip %>:27017 |
     Then the output should contain:
-      | Hello-OpenShift |
+      | Hello OpenShift! |
 
     # Delete created pod and svc
     When I run the :delete client command with:
@@ -352,17 +352,17 @@ Feature: Service related networking scenarios
     """
 
     # Create a pod
-    Given I obtain test data file "routing/web-server-1.yaml"
+   Given I obtain test data file "networking/externalip_pod.yaml"
     When I run the :create client command with:
-      | f | web-server-1.yaml |
+      | f | externalip_pod.yaml |
     Then the step should succeed
-    And the pod named "web-server-1" becomes ready
+    And the pod named "externalip-pod" becomes ready
 
     # Curl externalIP:portnumber on new pod
     When I execute on the pod:
       | /usr/bin/curl | --connect-timeout | 10 | <%= cb.host2ip %>:27017 |
     Then the output should contain:
-      | Hello-OpenShift |
+      | Hello OpenShift! |
 
   # @author anusaxen@redhat.com
   # @case_id OCP-26035

--- a/testdata/networking/externalip_pod.yaml
+++ b/testdata/networking/externalip_pod.yaml
@@ -1,0 +1,14 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: externalip-pod
+  labels:
+    name: externalip-pod
+spec:
+  containers:
+  - name: externalip-container
+    image: "quay.io/openshifttest/hello-sdn@sha256:d5785550cf77b7932b090fcd1a2625472912fb3189d5973f177a5a2c347a1f95"
+    ports:
+    - containerPort: 8080
+    - containerPort: 8443

--- a/testdata/networking/externalip_service1.json
+++ b/testdata/networking/externalip_service1.json
@@ -18,7 +18,7 @@
            "10.5.0.1"
         ],
         "selector": {
-                "name": "caddy-docker"
+                "name": "externalip-pod"
         }
     }
 }


### PR DESCRIPTION
In current service externalIP scripts, pod use testdata/routing/web-server-1.yaml
Other team's PR https://github.com/openshift/verification-tests/pull/1770  caused all service externalIP script cases failed.

The web-server-1.yaml is not must for our service externaip pod, the fix is to create our own pod file saved in testdata/networking dir and not use other team file any more.

Test logs:
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3-smoke/2780/console
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3-smoke/2782/console
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3-smoke/2785/console
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3-smoke/2786/console
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3-smoke/2787/console

@zhaozhanqi @huiran0826 @anuragthehatter @rbbratta  @asood @dbrahane