### PR TITLE
fix failure when deploy operators

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -10,6 +10,7 @@ Given /^logging service has been installed successfully$/ do
   else
     example_cr = "<%= BushSlicer::HOME %>/testdata/logging/clusterlogging/example_indexmanagement.yaml"
   end
+  step %Q/logging operators are installed successfully/
   step %Q/I create clusterlogging instance with:/, table(%{
     | remove_logging_pods | false         |
     | crd_yaml            | #{example_cr} |
@@ -84,7 +85,7 @@ Given /^logging operators are installed successfully$/ do
   # check csv existense
   success = wait_for(300, interval: 10) {
     csv = subscription('elasticsearch-operator').current_csv
-    cluster_service_version(csv).exists?
+    !(csv.nil?) && cluster_service_version(csv).exists?
   }
   raise "CSV #{csv} isn't created" unless success
   step %Q/elasticsearch operator is ready/
@@ -133,7 +134,7 @@ Given /^logging operators are installed successfully$/ do
   # check csv existense
   success = wait_for(300, interval: 10) {
     csv = subscription('cluster-logging').current_csv
-    cluster_service_version(csv).exists?
+    !(csv.nil?) && cluster_service_version(csv).exists?
   }
   raise "CSV #{csv} isn't created" unless success
   step %Q/cluster logging operator is ready/


### PR DESCRIPTION
Fix failure:
```
      [01:38:29] INFO> Exit Status: 0
      what ClusterServiceVersion are you talking about? (RuntimeError)
      /home/jenkins/ws/workspace/Runner-v3/lib/world.rb:313:in `project_resource'
      /home/jenkins/ws/workspace/Runner-v3/lib/world.rb:141:in `cluster_service_version'
      /home/jenkins/ws/workspace/Runner-v3/features/step_definitions/logging.rb:87:in `block (2 levels) in <top (required)>'
      /home/jenkins/ws/workspace/Runner-v3/lib/base_helper.rb:153:in `wait_for'
      /home/jenkins/ws/workspace/Runner-v3/features/step_definitions/logging.rb:85:in `/^logging operators are installed successfully$/'
      /opt/rh/rh-ruby27/root/usr/share/ruby/forwardable.rb:235:in `invoke_dynamic_step'
      /home/jenkins/ws/workspace/Runner-v3/features/support/clusterlogging_env.rb:3:in `Before'
```