### PR TITLE
get vCenter version to telemetry

### DIFF
--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -131,3 +131,14 @@ Feature: Machine misc features testing
       | kube-rbac-proxy                 | openshift-machine-api              | k8s-app=machine-api-operator        |
       | kube-rbac-proxy                 | openshift-machine-api              | k8s-app=cluster-autoscaler-operator |
 
+  # @author miyadav@redhat.com
+  # @case_id OCP-37180
+  @admin
+  Scenario: Report vCenter version to telemetry
+    Given I switch to cluster admin pseudo user
+    When I perform the GET prometheus rest client with:
+      | path  | /api/v1/query?                         |
+      | query | cloudprovider_vsphere_vcenter_versions |
+    Then the step should succeed
+    And the expression should be true> @result[:parsed]["data"]["result"][0]["metric"]["version"] == "7.0.0"
+


### PR DESCRIPTION
This is to automate OCP- 37180 , below is validation :

.
```
.
      [03:45:04] INFO> Exit Status: 0
      [03:45:04] INFO> HTTP GET https://prometheus-k8s-openshift-monitoring.apps.jima011401.qe.devcluster.openshift.com/api/v1/query?query=cloudprovider_vsphere_vcenter_versions
      [03:45:05] INFO> HTTP GET took 1.293 sec: 200 OK | application/json 501 bytes
      
      | path  | /api/v1/query?                         |
      | query | cloudprovider_vsphere_vcenter_versions |
    Then the step should succeed                                                                             # features/step_definitions/common.rb:4
    And the expression should be true> @result[:parsed]["data"]["result"][0]["metric"]["version"] == "7.0.0" # features/step_definitions/common.rb:133
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [03:45:05] INFO> === After Scenario: Report vCenter version to telemetry ===
      [03:45:05] INFO> Shell Commands: rm -r -f -- /root/workdir/51004ea96c79-
      
      [03:45:05] INFO> Exit Status: 0
      [03:45:05] INFO> === End After Scenario: Report vCenter version to telemetry ===

1 scenario (1 passed)
4 steps (4 passed)
0m14.267s
[03:45:05] INFO> === At Exit ===
```

@sunzhaohua2 @jhou1  PTAL 