### PR TITLE
Fix ImagePullBackOff for "I have LDAP service in my project" cases

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -161,8 +161,8 @@ Given /^I have LDAP service in my project$/ do
     # So take the second one since this one can be implemented currently
     ###
     step %Q/I run the :run client command with:/, table(%{
-      | name  |ldapserver                             |
-      | image |openshift/openldap-2441-centos7:latest |
+      | name  | ldapserver                                       |
+      | image | quay.io/openshifttest/ldap:openldap-2441-centos7 |
       })
     step %Q/the step should succeed/
     step %Q/a pod becomes ready with labels:/, table(%{


### PR DESCRIPTION
In today auto run 20210116-2057 (connected env), cases failed like https://url.corp.redhat.com/Sync-ldap-group-to-openshift-group-with-paging-from-ldap-server and so on ...
The cause should be docker.io limits pull. Thus fix with quay.io. Pass log: Runner-v3/254308/console
@rhpmali @barleyer please review, thx