### PR TITLE
Provide AWS credentials as envvar

### DIFF
--- a/lib/launchers/amz.rb
+++ b/lib/launchers/amz.rb
@@ -23,6 +23,16 @@ module BushSlicer
       @config = conf[:services, service_name]
       @can_terminate = true
 
+aws_env=ENV["AWS_CREDENTIALS"]
+logger.info("AWS_CREDENTIALS: '#{aws_env}")
+logger.info("access_key: '#{access_key}', secret_key: '#{secret_key}'")
+      idx = ENV["AWS_CREDENTIALS"]&.index(':')
+      if idx
+        access_key = ENV["AWS_CREDENTIALS"][0..idx-1]
+        secret_key = ENV["AWS_CREDENTIALS"][idx+1..-1]
+      end
+logger.info("access_key: '#{access_key}', secret_key: '#{secret_key}'")
+
       if access_key && secret_key
         awscred = {
           "aws_access_key_id" => access_key,

--- a/lib/launchers/amz.rb
+++ b/lib/launchers/amz.rb
@@ -23,15 +23,12 @@ module BushSlicer
       @config = conf[:services, service_name]
       @can_terminate = true
 
-aws_env=ENV["AWS_CREDENTIALS"]
-logger.info("AWS_CREDENTIALS: '#{aws_env}")
-logger.info("access_key: '#{access_key}', secret_key: '#{secret_key}'")
       idx = ENV["AWS_CREDENTIALS"]&.index(':')
       if idx
+        logger.info("Using envvar AWS_CREDENTIALS.")
         access_key = ENV["AWS_CREDENTIALS"][0..idx-1]
         secret_key = ENV["AWS_CREDENTIALS"][idx+1..-1]
       end
-logger.info("access_key: '#{access_key}', secret_key: '#{secret_key}'")
 
       if access_key && secret_key
         awscred = {


### PR DESCRIPTION
The precedence (try envvars if fails then consult configuration) is aligned to common handling used in Dynect or OSP.