### PR TITLE
update rule to make checkbox for monitoring optional 

### DIFF
--- a/lib/rules/web/admin_console/4.5/catalog.xyaml
+++ b/lib/rules/web/admin_console/4.5/catalog.xyaml
@@ -141,7 +141,11 @@ subscribe_using_default_params:
 set_custom_channel_and_subscribe:
   action: wait_box_loaded
   action: choose_update_channel
-  action: enable_cluster_monitoring
+  action:
+    if_element:
+      selector:
+        xpath: //input[contains(@type,'checkbox') and contains(@id,'enable-monitoring-checkbox')]
+    ref: enable_cluster_monitoring
   action: click_subscribe_button
 click_image_tag_dropdown:
   params:

--- a/lib/rules/web/admin_console/4.6/catalog.xyaml
+++ b/lib/rules/web/admin_console/4.6/catalog.xyaml
@@ -141,7 +141,11 @@ subscribe_using_default_params:
 set_custom_channel_and_subscribe:
   action: wait_box_loaded
   action: choose_update_channel
-  action: enable_cluster_monitoring
+  action:
+    if_element:
+      selector:
+        xpath: //input[contains(@type,'checkbox') and contains(@id,'enable-monitoring-checkbox')]
+    ref: enable_cluster_monitoring
   action: click_subscribe_button
 click_image_tag_dropdown:
   params:

--- a/lib/rules/web/admin_console/4.7/catalog.xyaml
+++ b/lib/rules/web/admin_console/4.7/catalog.xyaml
@@ -142,7 +142,11 @@ subscribe_using_default_params:
 set_custom_channel_and_subscribe:
   action: wait_box_loaded
   action: choose_update_channel
-  action: enable_cluster_monitoring
+  action:
+    if_element:
+      selector:
+        xpath: //input[contains(@type,'checkbox') and contains(@id,'enable-monitoring-checkbox')]
+    ref: enable_cluster_monitoring
   action: click_subscribe_button
 click_image_tag_dropdown:
   params:


### PR DESCRIPTION
Some operators, NFD, for example, don't have the `monitor` checkbox in the Subscribe/Install page in the OperatorHub page

4.6 https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/269817/console
4.7 https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3-smoke/2850/console