### PR TITLE
Disable all repos by default

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.rhel7
+++ b/tools/jenkins/slaves/Dockerfile.rhel7
@@ -9,7 +9,7 @@ ENV USER_PATHS="$HOME /etc/machine-id /etc/passwd /etc/pki"
 
 RUN set -x && \
     yum repolist all && \
-    yum-config-manager --disable rhel-7-server-htb-rpms && \
+    yum-config-manager --disable \* && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-extras-rpms && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \


### PR DESCRIPTION
Another repo `rhel-7-for-power-le-rpms` enabled unexpectedly in redhat.repo. So disable all repos by default to prevent such issue from happen again.