### PR TITLE
enhancce OCP-38812 to support private cluster

### DIFF
--- a/testdata/routing/operator/ingressctl-ns-shards.yaml
+++ b/testdata/routing/operator/ingressctl-ns-shards.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   domain: shards.example.com
   replicas: 1
+  endpointPublishingStrategy:
+    loadBalancer:
+      scope: External
+    type: LoadBalancerService
   namespaceSelector:
     matchLabels:
       namespace: shards


### PR DESCRIPTION
Ensure the "shards" ingresscontroller always use the same LB scope to the default ingresscontroller, so the case can be executed on private cluster as well.

log
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/276980/console

@quarterpin Please help take a look. Thanks

cc @jechen0648 

