### PR TITLE
Change the pod image to a valid image

### DIFF
--- a/testdata/pods/ocp10031/pod.json
+++ b/testdata/pods/ocp10031/pod.json
@@ -10,7 +10,7 @@
   "spec": {
       "containers": [{
         "name": "hello-pod",
-        "image": "quay.io/openshifttest/hello-openshift-getent"
+        "image": "quay.io/openshifttest/hello-sdn@sha256:d5785550cf77b7932b090fcd1a2625472912fb3189d5973f177a5a2c347a1f95"
       }]
   }
 }


### PR DESCRIPTION
Updating the image for the testcase as the previous image was missing/invalid causing `ImagePullBackOff`

Test could be: `bundle exec cucumber features/networking/pod.feature:24`