### PR TITLE
Kernel#open is deprecated, use URI.open instead...also update the rel…

### DIFF
--- a/tools/find_image.rb
+++ b/tools/find_image.rb
@@ -30,17 +30,17 @@ class QueryPayload
       c.action do |args, options|
         options.default \
           :build_type => "nightly-",
-          :url => "https://openshift-release.svc.ci.openshift.org/"
+          :url => "https://amd64.ocp.releases.ci.openshift.org/"
         raise "missing query string" if options.query.nil?
         print("Querying #{options.url} against #{options.build_type}\n")
-        doc = Nokogiri::HTML(open(options.url).read)
+        doc = Nokogiri::HTML(URI.open(options.url).read)
         links = doc.xpath("//a[contains(text(), '#{options.build_type}')]")
 
         target_links = links.map { |l|  options.url + l.attributes['href'].value }
         threads = []
         target_links.each do |link|
           threads << Thread.new(link) do |i|
-            doc = Nokogiri::HTML(open(link).read)
+            doc = Nokogiri::HTML(URI.open(link).read)
               if doc.to_s.include? options.query
                 puts "Pattern '#{options.query}' found in payload: #{link}"
               end


### PR DESCRIPTION
…ease page URL.  

### Before:
```
$./tools/find_image.rb --query "1921274"
./tools/find_image.rb:43: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
./tools/find_image.rb:43: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
./tools/find_image.rb:43: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
...
Pattern '1921274' found in payload: https://openshift-release.svc.ci.openshift.org//releasestream/4.6.0-0.nightly/release/4.6.0-0.nightly-2021-02-04-091446
```
### After:
```
$ ./tools/find_image.rb --query "1921274"
Querying https://amd64.ocp.releases.ci.openshift.org/ against nightly-
Pattern '1921274' found in payload: https://amd64.ocp.releases.ci.openshift.org//releasestream/4.6.0-0.nightly/release/4.6.0-0.nightly-2021-02-04-091446
```