### PR TITLE
URI.escape is deprecated, replace with encode_www_form_component instead

### DIFF
--- a/features/support/cucu_formatter.rb
+++ b/features/support/cucu_formatter.rb
@@ -255,7 +255,7 @@ class CucuFormatter
     url << "/" << file
     # need to escape file path above because encode/escape method is deprecated
     # see https://bugs.ruby-lang.org/issues/4167
-    url = URI.encode(url)
+    url = URI.encode_www_form_component(url)
     url << '#L' << line
     return url
   end


### PR DESCRIPTION
### Currently
`/home/jenkins/ws/workspace/Runner-v3/features/support/cucu_formatter.rb:258: warning: URI.escape is obsolete
`https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/279366/console

### With fix
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/279368/console

