### PR TITLE
Update OCM rules because of the new changes

### DIFF
--- a/lib/rules/web/ocm_console/archived_cluster_detail.xyaml
+++ b/lib/rules/web/ocm_console/archived_cluster_detail.xyaml
@@ -3,7 +3,7 @@ archived_cluster_detail_page_loaded:
         - selector:
             xpath: //a[@class='pf-c-breadcrumb__link' and text()='Clusters']
         - selector:
-            xpath: //a[@class='pf-c-breadcrumb__link' and text()='Archived clusters']
+            xpath: //a[@class='pf-c-breadcrumb__link' and text()='Cluster Archives']
         - selector:
             xpath: //button[text()='Unarchive']
         - selector:
@@ -15,7 +15,7 @@ archived_cluster_detail_page_loaded:
         - selector:
             xpath: //h2[text()='Details']
         - selector:
-            xpath: //dt/span[text()='Status']/../../dd/div[text()='Archived']
+            xpath: //dt/span[text()='Status']/../../dd/div[text()='archived']
 click_detail_page_unarchive_cluster_button:
     element:
         selector:

--- a/lib/rules/web/ocm_console/cluster_list_page.xyaml
+++ b/lib/rules/web/ocm_console/cluster_list_page.xyaml
@@ -31,14 +31,14 @@ check_cluster_list_page:
         - selector:
             css: input.pf-c-form-control.cluster-list-filter
         - selector:
-            xpath: //span[text()='Filter']
+            xpath: //span[text()='Cluster type']
         - selector:
             xpath: //button[text()='Create cluster']/../../..//button[@aria-label='Actions']
           op: click
         - selector:
             xpath: //a[text()='Register cluster' and contains(@href, '/openshift/register')]
         - selector:
-            xpath: //a[text()='Show archived clusters' and contains(@href, '/openshift/archived')]
+            xpath: //a[text()='View cluster archives' and contains(@href, '/openshift/archived')]
         - selector:
             xpath: //button[text()='Create cluster']/../../..//button[@aria-label='Actions']
           op: click

--- a/lib/rules/web/ocm_console/install_page.xyaml
+++ b/lib/rules/web/ocm_console/install_page.xyaml
@@ -274,8 +274,6 @@ check_breadcrumbs_include_infrastructure_in_install_page:
         - selector:
             xpath: //a[contains(@href, '/openshift/create') and text()='Create']
         - selector:
-            xpath: //a[contains(@href, '/openshift/install') and text()='OpenShift Container Platform']
-        - selector:
             xpath: //a[contains(@href, '/openshift/install/<provider_link>') and text()='<provider_name>']
         - selector:
             xpath: //li[@class='pf-c-breadcrumb__item' and text()='<infrastructure>']
@@ -285,8 +283,6 @@ check_breadcrumbs_exclude_infrastructure_in_install_page:
             xpath: //li[contains(@href, '/openshift/')]/a[text()='Clusters']
         - selector:
             xpath: //a[contains(@href, '/openshift/create') and text()='Create']
-        - selector:
-            xpath: //a[contains(@href, '/openshift/install') and text()='OpenShift Container Platform']
         - selector:
             xpath: //li[@class='pf-c-breadcrumb__item' and text()='<provider_name>']
 check_developer_preview_bar_in_install_page:
@@ -527,7 +523,7 @@ check_bare_metal_upi_install_page:
         - selector:
             xpath: //a[contains(@href, 'installing_bare_metal/installing-bare-metal.html#creating-machines-bare-metal') and text()='Learn more']
         - selector:
-            xpath: //a[contains(@href, '/rhcos/latest/latest/rhcos-installer.x86_64.iso') and text()='Download RHCOS ISO']
+            xpath: //a[contains(@href, '/rhcos/latest/latest/rhcos-live.x86_64.iso') and text()='Download RHCOS ISO']
         - selector:
             xpath: //a[contains(@href, '/rhcos/latest/latest/rhcos-metal.x86_64.raw.gz') and text()='Download RHCOS RAW']
 check_bare_metal_upi_page_title:


### PR DESCRIPTION
1.Update breadcrumbs because of the new changes about creation page, this update related with all of the install page cases: OCP-24068,OCP-24069,OCP-24070,OCP-24071,OCP-24072,OCP-25174,OCP-25176,OCP-26297,OCP-26380,OCP-27839,OCP-28794,OCP-28795,OCP-28796,OCP-30121,OCP-36001,OCP-36034
2.Update archive button and title because of the new changes about archive page, this update related with: OCP-28142,OCP-21339. 
3.Update the link of bare metal RHCOS in OCP-24070, this change comes from new story.

Here is the Jenkins result: https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/Runner-v3/280033/console (OCP-21339 failed because of the known bug)
@yasun1 @xueli181114 @yuwang-RH Please help review cases.

