### PR TITLE
Move this case to be a '@destructive' case

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1108,6 +1108,7 @@ Feature: Multus-CNI related scenarios
   # @author weliang@redhat.com
   # @case_id OCP-25917
   @admin
+  @destructive
   Scenario: Multus Telemetry Adds capability to track usage of network attachment definitions
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster


### PR DESCRIPTION
PR is to fix https://issues.redhat.com/browse/OCPQE-3372

Any parallel running  multus cases can cause this case fail in checking the number of network_attachment_definition_instances{networks="any"} 

Simple solution is move this case to be a '@destructive' case

@zhaozhanqi @anuragthehatter @huiran0826 @rbbratta @asood @brahaney @kedark3