### PR TITLE
 test machine with spec securityProfile encryption at rest as "true"

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -393,16 +393,12 @@ Feature: Machine features testing
       | ["metadata"]["name"]                                                                      | <name>                                      |
     Then the step should succeed
   
+    Then I store the last provisioned machine in the :machine_latest clipboard
     And I wait up to 120 seconds for the steps to pass:
     """
-    When I run the :get admin command with:
-      | resource | machine |
-    Then the step should succeed
-    And the output should contain:
-      | Running |
+    Then the expression should be true> machine(cb.machine_latest).phase(cached: false) == "Running"
     """
-
-    Then I store the last provisioned machine in the :machine_latest clipboard
+   
     When I run the :describe admin command with:
       | resource | machine                  |
       | name     | <%= cb.machine_latest %> |

--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -370,10 +370,9 @@ Feature: Machine features testing
     Then the machineset should have expected number of running machines
 
   # @author miyadav@redhat.com
-  # @case_id OCP-33058
   @admin
   @destructive
-  Scenario: Implement defaulting machineset values for azure
+  Scenario Outline: Implement defaulting machineset values for azure
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -381,17 +380,40 @@ Feature: Machine features testing
 
     Given I store the last provisioned machine in the :machine clipboard
     Then evaluation of `machine(cb.machine).azure_location` is stored in the :default_location clipboard
-    And admin ensures "default-valued-33058" machineset is deleted after scenario
+    And admin ensures "<name>" machineset is deleted after scenario
 
-    Given I obtain test data file "cloud/ms-azure/ms_default_values.yaml"
-    When I run oc create over "ms_default_values.yaml" replacing paths:
-      | n                                                                                         | openshift-machine-api                           |
-      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %>     |
-      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | default-valued-33058                            |
-      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %>     |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["location"]                         | <%= cb.default_location %>                      |
-      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | default-valued-33058                            |
+    Given I obtain test data file "cloud/ms-azure/<file_name>"
+    When I run oc create over "<file_name>" replacing paths:
+      | n                                                                                         | openshift-machine-api                       |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %> |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | <name>                                      |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %> |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["location"]                         | <%= cb.default_location %>                  |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | <name>                                      |
+      | ["metadata"]["name"]                                                                      | <name>                                      |
     Then the step should succeed
+  
+    And I wait up to 120 seconds for the steps to pass:
+    """
+    When I run the :get admin command with:
+      | resource | machine |
+    Then the step should succeed
+    And the output should contain:
+      | Running |
+    """
+
+    Then I store the last provisioned machine in the :machine_latest clipboard
+    When I run the :describe admin command with:
+      | resource | machine                  |
+      | name     | <%= cb.machine_latest %> |
+    Then the step should succeed
+    And the output should contain:
+      | <Validation> |
+
+    Examples:
+      | name                    | file_name               | Validation                |
+      | default-valued-33058    | ms_default_values.yaml  | Public IP                 |# @case_id OCP-33058
+      | encrypt-at-rest-39639   | ms_encrypt_at_rest.yaml | Encryption At Host:  true |# @case_id OCP-39639
 
   # @author miyadav@redhat.com
   # @case_id OCP-33455

--- a/testdata/cloud/ms-azure/ms_encrypt_at_rest.yaml
+++ b/testdata/cloud/ms-azure/ms_encrypt_at_rest.yaml
@@ -1,0 +1,34 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster:
+    machine.openshift.io/cluster-api-machine-role: worker
+    machine.openshift.io/cluster-api-machine-type: worker
+  name: default-valued-33058
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster:
+      machine.openshift.io/cluster-api-machineset:
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster:
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset:
+    spec:
+      metadata: {}
+      taints:
+      - effect: "NoSchedule"
+        key: "mapi"
+        value: "mapi_test"
+      providerSpec:
+        value:
+          location:
+          osDisk:
+            diskSizeGB: 128
+          securityProfile:
+                  encryptionAtHost: true

--- a/testdata/cloud/ms-azure/ms_encrypt_at_rest.yaml
+++ b/testdata/cloud/ms-azure/ms_encrypt_at_rest.yaml
@@ -31,4 +31,4 @@ spec:
           osDisk:
             diskSizeGB: 128
           securityProfile:
-                  encryptionAtHost: true
+            encryptionAtHost: true


### PR DESCRIPTION
@jhou1 @sunzhaohua2 PTAL , whenever you get time
Auto test to validate changes by - https://bugzilla.redhat.com/show_bug.cgi?id=1900454

```
.
.
.
    
    [11:23:46] INFO> Exit Status: 0
    [11:23:46] INFO> Shell Commands: oc delete machines encrypt-at-rest-39639-6bq5t --wait=false --config=/root/workdir/d97593744bfd-/ocp4_admin.kubeconfig --namespace=openshift-machine-api
    machine.machine.openshift.io "encrypt-at-rest-39639-6bq5t" deleted
    
    [11:23:48] INFO> Exit Status: 0
    [11:23:50] INFO> oc get machines encrypt-at-rest-39639-6bq5t --output=yaml --config=/root/workdir/d97593744bfd-/ocp4_admin.kubeconfig --namespace=openshift-machine-api
    [11:25:49] INFO> After 45 iterations and 121 seconds:
    
    STDERR:
    Error from server (NotFound): machines.machine.openshift.io "encrypt-at-rest-39639-6bq5t" not found
    
    [11:25:49] INFO> Shell Commands: oc get machines encrypt-at-rest-39639-6bq5t --output=yaml --config=/root/workdir/d97593744bfd-/ocp4_admin.kubeconfig --namespace=openshift-machine-api
    
    STDERR:
    Error from server (NotFound): machines.machine.openshift.io "encrypt-at-rest-39639-6bq5t" not found
    
    [11:25:51] INFO> Exit Status: 1
    [11:25:51] INFO> Shell Commands: rm -r -f -- /root/workdir/d97593744bfd-
    
    [11:25:52] INFO> Exit Status: 0
    [11:25:53] INFO> === End After Scenario: Implement defaulting machineset values for azure, Examples (#2) ===

2 scenarios (2 passed)
30 steps (30 passed)
5m27.997s
[11:25:53] INFO> === At Exit ===
```


