### PR TITLE
Change storage v3-testfile to verification-tests/testdata

### DIFF
--- a/features/storage/aws.feature
+++ b/features/storage/aws.feature
@@ -15,7 +15,7 @@ Feature: AWS specific scenarios
       | ["metadata"]["annotations"]["volume.beta.kubernetes.io/storage-class"] | sc-<%= project.name %>     |
     Then the step should succeed
     And the "efspvc-<%= project.name %>" PVC becomes :bound within 60 seconds
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/ebs/pod.yaml" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/ebs/pod.yaml" replacing paths:
       | ["metadata"]["name"]                                         | pod1-<%= project.name %>   |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | efspvc-<%= project.name %> |
     Then the step should succeed
@@ -24,7 +24,7 @@ Feature: AWS specific scenarios
       | touch | /tmp/file_pod1 |
     Then the step should succeed
 
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/ebs/pod.yaml" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/ebs/pod.yaml" replacing paths:
       | ["metadata"]["name"]                                         | pod2-<%= project.name %>   |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | efspvc-<%= project.name %> |
     Then the step should succeed

--- a/features/storage/cinder.feature
+++ b/features/storage/cinder.feature
@@ -10,7 +10,7 @@ Feature: Cinder Persistent Volume
     #create test pod
     And I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/cinder/cinder-pod.yaml" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/cinder/cinder-pod.yaml" replacing paths:
       | ['spec']['volumes'][0]['cinder']['volumeID'] | <%= cb.vid %> |
     Then the step should succeed
     And the pod named "cinder" becomes ready

--- a/features/storage/cloud_provider.feature
+++ b/features/storage/cloud_provider.feature
@@ -18,7 +18,7 @@ Feature: kubelet restart and node restart
       | resource | pv |
     Then the output should contain:
       | dynamic-pvc-#{cb.i} |
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pod.yaml" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/misc/pod.yaml" replacing paths:
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | dynamic-pvc-#{cb.i} |
       | ["metadata"]["name"]                                         | mypod#{cb.i}        |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/<platform>     |

--- a/features/storage/dynamic_provisioning.feature
+++ b/features/storage/dynamic_provisioning.feature
@@ -23,7 +23,7 @@ Feature: Dynamic provisioning
 
     And I save volume id from PV named "<%= pvc.volume_name %>" in the :volumeID clipboard
 
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pod.yaml" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/misc/pod.yaml" replacing paths:
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | <%= pvc.name %>       |
       | ["metadata"]["name"]                                         | mypod1                |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/<cloud_provider> |

--- a/features/storage/glusterfs.feature
+++ b/features/storage/glusterfs.feature
@@ -23,7 +23,7 @@ Feature: Storage of GlusterFS plugin testing
       | ["subsets"][0]["ports"][0]["port"]   | 24007                         |
     Then the step should succeed
 
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/security/gluster_pod_sg.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/gluster/security/gluster_pod_sg.json" replacing paths:
       | ["metadata"]["name"] | glusterpd-<%= project.name %> |
     Then the step should succeed
 
@@ -45,7 +45,7 @@ Feature: Storage of GlusterFS plugin testing
     And the output should contain:
       | Hello OpenShift Storage |
 
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/security/gluster_pod_sg.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/gluster/security/gluster_pod_sg.json" replacing paths:
       | ["metadata"]["name"]                              | glusterpd-negative-<%= project.name %> |
       | ["spec"]["securityContext"]["supplementalGroups"] | [123460]                               |
     Then the step should succeed
@@ -79,7 +79,7 @@ Feature: Storage of GlusterFS plugin testing
     # Switch to admin so as to create privileged pod
     Given I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/pod.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/gluster/dynamic-provisioning/pod.json" replacing paths:
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc1 |
     Then the step should succeed
     And the pod named "gluster" status becomes :running
@@ -143,7 +143,7 @@ Feature: Storage of GlusterFS plugin testing
     # Switch to admin so as to create privileged pod
     Given I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/pod.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/gluster/dynamic-provisioning/pod.json" replacing paths:
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc1 |
     Then the step should succeed
     And the pod named "gluster" status becomes :running
@@ -177,7 +177,7 @@ Feature: Storage of GlusterFS plugin testing
       | pv.beta.kubernetes.io/gid: "3333" |
 
     # Verify Pod is assigned gid 3333
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/pod_gid.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/gluster/dynamic-provisioning/pod_gid.json" replacing paths:
       | ["metadata"]["name"]                                         | pod-<%= project.name %> |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc1                    |
     Then the step should succeed
@@ -195,7 +195,7 @@ Feature: Storage of GlusterFS plugin testing
 
     # Pod should work as well having its supplementalGroups set to 3333 explicitly
     Given I ensure "pod-<%= project.name %>" pod is deleted
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/pod_gid.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/gluster/dynamic-provisioning/pod_gid.json" replacing paths:
       | ["metadata"]["name"]                                         | pod1-<%= project.name %> |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc1                     |
       | ["spec"]["securityContext"]["supplementalGroups"]            | [3333]                   |

--- a/features/storage/hostpath.feature
+++ b/features/storage/hostpath.feature
@@ -40,7 +40,7 @@ Feature: Storage of Hostpath plugin testing
     Then the step should succeed
     And the "localc-<%= cb.proj_name %>" PVC becomes bound to the "local-<%= cb.proj_name %>" PV
 
-    Then I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/hostpath/pod.yaml" replacing paths:
+    Then I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/hostpath/pod.yaml" replacing paths:
       | ["metadata"]["name"]                                         | localpd-<%= cb.proj_name %> |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | localc-<%= cb.proj_name %>  |
     Then the step should succeed

--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -72,7 +72,7 @@ Feature: NFS Persistent Volume
 
     Given I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/security/pod-supplementalgroup.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/nfs/security/pod-supplementalgroup.json" replacing paths:
       | ["metadata"]["name"]                                         | nfspd-<%= project.name %> |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | nfsc-<%= project.name %>  |
     Then the step should succeed
@@ -128,7 +128,7 @@ Feature: NFS Persistent Volume
 
     Given I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/security/pod-supplementalgroup.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/nfs/security/pod-supplementalgroup.json" replacing paths:
       | ["metadata"]["name"]                                         | nfspd-<%= project.name %> |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | nfsc-<%= project.name %>  |
     Then the step should succeed

--- a/features/storage/rbd.feature
+++ b/features/storage/rbd.feature
@@ -27,7 +27,7 @@ Feature: Storage of Ceph plugin testing
     And I use the "<%= project.name %>" project
     And I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/rbd/dynamic-provisioning/user_secret.yaml" replacing paths:
       | ["data"]["key"] | <%= cb.secret_key %> |
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/rbd/dynamic-provisioning/pod.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/rbd/dynamic-provisioning/pod.json" replacing paths:
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
     Then the step should succeed
     And the pod named "rbdpd" becomes ready

--- a/features/storage/reclaim_policy.feature
+++ b/features/storage/reclaim_policy.feature
@@ -22,7 +22,7 @@ Feature: Persistent Volume reclaim policy tests
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes bound to the "pv-<%= project.name %>" PV
 
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gce/pod.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/gce/pod.json" replacing paths:
       | ["metadata"]["name"]                                         | pod-<%= project.name %> |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt                    |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
@@ -64,7 +64,7 @@ Feature: Persistent Volume reclaim policy tests
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes bound to the "pv-<%= project.name %>" PV
 
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gce/pod.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/gce/pod.json" replacing paths:
       | ["metadata"]["name"]                                         | pod-<%= project.name %> |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt                    |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |

--- a/features/storage/security.feature
+++ b/features/storage/security.feature
@@ -110,7 +110,7 @@ Feature: storage security check
     Given I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
     When I run the :create client command with:
-      | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/secret/secret-pod-test.json |
+      | filename | https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/secret/secret-pod-test.json |
     Then the step should succeed
 
     Given the pod named "secretpd" becomes ready

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -101,7 +101,7 @@ Feature: storageClass related feature
     # check storage zone info
     # gcloud compute disks describe --zone <zone> diskNameViaPvInfo
 
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pod.yaml" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/misc/pod.yaml" replacing paths:
       | ["metadata"]["name"]                                         | pod-<%= project.name %> |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/iaas               |
@@ -200,7 +200,7 @@ Feature: storageClass related feature
     And the expression should be true> pvc.access_modes[0] == "ReadWriteOnce"
     And the expression should be true> pv(pvc.volume_name).reclaim_policy == "Delete"
 
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pod.yaml" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/misc/pod.yaml" replacing paths:
       | ["metadata"]["name"]                                         | pod-<%= project.name %> |
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/iaas               |

--- a/features/storage/storage_object_in_use_protection.feature
+++ b/features/storage/storage_object_in_use_protection.feature
@@ -19,7 +19,7 @@ Feature: Storage object in use protection
       | ["metadata"]["name"] | pvc-<%= project.name %> |
     Then the step should succeed
     And the "pvc-<%= project.name %>" PVC becomes :bound
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pod.yaml" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/misc/pod.yaml" replacing paths:
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
       | ["metadata"]["name"]                                         | mypod                   |
     Then the step should succeed

--- a/features/storage/vsphere.feature
+++ b/features/storage/vsphere.feature
@@ -17,7 +17,7 @@ Feature: vSphere test scenarios
     # Testing volume mount and read/write
     Given I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/vsphere/pod.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/storage/vsphere/pod.json" replacing paths:
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
       | ["metadata"]["name"]                                         | mypod                   |
     Then the step should succeed


### PR DESCRIPTION
Change the pod yaml file from v3-testfile to verification-tests/testdata as openshift-qe/v3-testfiles is deprecated now.
See discussion here: https://coreos.slack.com/archives/CPJQCSN49/p1612767945263600

@qinpingli @liangxia PTAL
