### PR TITLE
add env vars for logging to set catsrc and channel

### DIFF
--- a/features/test/logging_metrics.feature
+++ b/features/test/logging_metrics.feature
@@ -11,4 +11,4 @@ Feature: test logging and metrics related steps
     Given I obtain test data file "logging/clusterlogging/example.yaml"
     Given I create clusterlogging instance with:
       | crd_yaml            | example.yaml |
-      | remove_logging_pods | true                                                                 |
+      | remove_logging_pods | true         |

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -224,6 +224,28 @@ module BushSlicer
       return @authentication_url
     end
 
+    def logging_channel_name
+      unless @logging_channel_name
+        if opts[:logging_channel_name]
+          @logging_channel_name = opts[:logging_channel_name]
+        else
+          @logging_channel_name = ''
+        end
+      end
+      return @logging_channel_name
+    end
+
+    def logging_catsrc
+      unless @logging_catsrc
+        if opts[:logging_catsrc]
+          @logging_catsrc = opts[:logging_catsrc]
+        else
+          @logging_catsrc = ''
+        end
+      end
+      return @logging_catsrc
+    end
+
     # naming scheme is https://logs.<cluster_id>.openshift.com for Online
     # for OCP it's https://logs.<subdomain>.openshift.com
     def logging_console_url


### PR DESCRIPTION
Start from logging 5.0, there have several different channels, to testing different channels, it's hard to determine the channel name in scenarios. To match logging testing requirements, adding two env vars `logging_catsrc` and `logging_channel_name`.

An example about how to set them:
```
export BUSHSLICER_CONFIG='
  global:
    browser: chrome
  environments:
    ocp4:
      admin_creds_spec: "https://example.com/auth/kubeconfig/*view*/"
      version: "4.8"
      logging_catsrc: "example-registry"
      logging_channel_name: "5.0"
      idp: "example-idp"
      admin_console_url: "https://console-openshift-console.apps.example.com"
'
```
/cc @anpingli 