### PR TITLE
Introduced FlexyEnvVariable and FlexyEnvFile helper classes

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -109,4 +109,51 @@ module BushSlicer
       return Object.const_get(class_opts[:class]).new(**class_opts[:opts])
     end
   end
+
+  class FlexyEnvVariable
+    attr_reader :var_name
+
+    def initialize(var_name)
+      @var_name=var_name
+    end
+    def ==(other)
+      self.class===other &&
+        @var_name==other.var_name
+    end
+    def to_s
+      ENV[@var_name]
+    end
+    
+    alias :eql? :==
+    alias :to_str :to_s
+    alias :[]= :to_s
+  end
+
+  class FlexyEnvFile
+    @@files = Hash.new
+    attr_reader :var_name
+
+    def initialize(var_name)
+      @var_name=var_name
+    end
+    def ==(other)
+      self.class===other && 
+        @var_name==other.var_name
+    end
+    def to_s
+      path=@@files[@var_name]
+      if path.nil?
+        e = ENV[@var_name]
+        Tempfile.open("env_#{@var_name}_") do |f|
+          f.write("#{e}") if !e.nil?
+          @@files[@var_name]=f.path
+        end
+      end
+      path
+    end
+
+    alias :eql? :==
+    alias :to_str :to_s
+    alias :[]= :to_s
+  end
 end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -153,6 +153,7 @@ module BushSlicer
         Tempfile.open("env_#{@var_name}_") do |f|
           f.write("#{e}") if !e.nil?
           @@files[@var_name]=f
+          file=f
         end
       end
       file.path

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -142,10 +142,13 @@ module BushSlicer
     end
     def to_s
       file=@@files[@var_name]
+
+      # file has been deleted on filesystem
       if !file.nil? && !file.file?
         @@files.except!(@var_name)
         file=nil
       end
+
       if file.nil?
         e = ENV[@var_name]
         Tempfile.open("env_#{@var_name}_") do |f|

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -143,7 +143,7 @@ module BushSlicer
       file=@@files[@var_name]
 
       # file has been deleted on filesystem
-      if !file.nil? && !file.file?
+      if !file.nil? && !File.file?(file.path)
         @@files.except!(@var_name)
         file=nil
       end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -141,15 +141,19 @@ module BushSlicer
         @var_name==other.var_name
     end
     def to_s
-      path=@@files[@var_name]
-      if path.nil?
+      file=@@files[@var_name]
+      if !file.nil? && !file.file?
+        @@files.except!(@var_name)
+        file=nil
+      end
+      if file.nil?
         e = ENV[@var_name]
         Tempfile.open("env_#{@var_name}_") do |f|
           f.write("#{e}") if !e.nil?
-          @@files[@var_name]=f.path
+          @@files[@var_name]=f
         end
       end
-      path
+      file.path
     end
 
     alias :eql? :==

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -126,7 +126,6 @@ module BushSlicer
     
     alias :eql? :==
     alias :to_str :to_s
-    alias :[]= :to_s
   end
 
   class FlexyEnvFile
@@ -161,6 +160,5 @@ module BushSlicer
 
     alias :eql? :==
     alias :to_str :to_s
-    alias :[]= :to_s
   end
 end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -143,7 +143,7 @@ module BushSlicer
       file=@@files[@var_name]
 
       # file has been deleted on filesystem
-      if !file.nil? && !File.file?(file.path)
+      if file && !File.file?(file.path)
         @@files.except!(@var_name)
         file=nil
       end


### PR DESCRIPTION
We can use it in config.yaml for Flexy.

`FlexyEnvFile` class like:

```
services:
  AWS-CI:
    host_opts:
#      ssh_private_key: keys/pjanouse.pem
      ssh_private_key: !ruby/object:BushSlicer::FlexyEnvVariable
        var_name: ENVVAR1
```
where environment variable `ENVVAR1` contains the real (base64 encoded) key.

`FlexyEnvVariable` class like:
```
services:
 openstack_upshift:
#    url: https://<host-name>:1300/v3/auth/tokens
    url: !ruby/object:BushSlicer::FlexyEnvVariable
      var_name: ENVVAR1
```
where environment variable `ENVVAR1` contains the real URL.
