### PR TITLE
Update iscsi prepare step

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -502,7 +502,8 @@ Given /^I have a iSCSI setup in the environment$/ do
   end
 
   if !_service.exists?(user:admin, quiet: true)
-    @result = admin.cli_exec(:create, n: _project.name, f: "#{BushSlicer::HOME}/testdata/storage/iscsi/service.json")
+    step %Q{I obtain test data file "storage/iscsi/service.json"}
+    @result = admin.cli_exec(:create, n: _project.name, f: "service.json")
     raise "could not create iSCSI service" unless @result[:success]
   end
 

--- a/testdata/storage/iscsi/iscsi-target.json
+++ b/testdata/storage/iscsi/iscsi-target.json
@@ -14,14 +14,14 @@
         "selector": {
             "role": "iscsi-target"
         },
-	"tolerations": [
+        "tolerations": [
             {
                 "effect": "NoSchedule",
                 "key": "node-role.kubernetes.io/master",
                 "operator": "Exists"
             }
-	],
-	"nodeSelector": {
+        ],
+        "nodeSelector": {
             "node-role.kubernetes.io/master": ""
         },
         "containers": [

--- a/testdata/storage/iscsi/iscsi-target.json
+++ b/testdata/storage/iscsi/iscsi-target.json
@@ -14,6 +14,16 @@
         "selector": {
             "role": "iscsi-target"
         },
+	"tolerations": [
+            {
+                "effect": "NoSchedule",
+                "key": "node-role.kubernetes.io/master",
+                "operator": "Exists"
+            }
+	],
+	"nodeSelector": {
+            "node-role.kubernetes.io/master": ""
+        },
         "containers": [
             {
                 "name": "iscsi-target",

--- a/testdata/storage/iscsi/service.json
+++ b/testdata/storage/iscsi/service.json
@@ -1,0 +1,20 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "iscsi-target"
+    },
+    "spec": {
+	"selector": {
+	    "storage": "iscsi-target"
+	},
+	"ports": [
+	    {
+		"name": "3260",
+		"protocol": "TCP",
+		"port": 3260,
+		"targetPort": 3260
+	    }
+	]	
+    }
+}

--- a/testdata/storage/iscsi/service.json
+++ b/testdata/storage/iscsi/service.json
@@ -5,16 +5,16 @@
         "name": "iscsi-target"
     },
     "spec": {
-	"selector": {
-	    "storage": "iscsi-target"
-	},
-	"ports": [
-	    {
-		"name": "3260",
-		"protocol": "TCP",
-		"port": 3260,
-		"targetPort": 3260
-	    }
-	]	
+        "selector": {
+                "storage": "iscsi-target"
+        },
+        "ports": [
+            {   
+                "name": "3260",
+                "protocol": "TCP",
+                "port": 3260,
+                "targetPort": 3260
+            }
+        ]	
     }
 }


### PR DESCRIPTION
In our daily test, we found the worker node might be in "NotReady" status for the OOM, if the iscsi target pod is scheduled to the woker node and the node status is "NotReady", then the test cases for the iscsi will be blocked.

@duanwei33 @chao007 Please help review.
