### PR TITLE
fix proxy test in ci agents

### DIFF
--- a/features/node/proxy.feature
+++ b/features/node/proxy.feature
@@ -3,6 +3,7 @@ Feature: Node proxy configuration tests
   # @author jhou@redhat.com
   @admin
   Scenario Outline: Proxy config should be applied to kubelet and crio
+    Given I use the "default" project
     Given I switch to cluster admin pseudo user
     When I run the :get client command with:
       | resource      | proxy   |


### PR DESCRIPTION
More contexts are in OCPQE-3579, the real issue is: `oc get proxy` is issued against the ci agent's ocp cluster, rather than the cluster under test, which keeps returning an empty proxy and making the test fail. Adding step `And I use the "xxx" project'` as a workaround.

Issue example: http://ci-qe-openshift.usersys.redhat.com/userContent/cucushift/v3/2021/03/08/09:30:29/Proxy_config_should_be_applied_to_kubelet_and_crio-etc_systemd_system_kubelet_service_d_1_1751551161/console.html

@sunilcio pls review