### PR TITLE
git rid of URI.open deprecated warning

### DIFF
--- a/tools/find_image.rb
+++ b/tools/find_image.rb
@@ -33,14 +33,14 @@ class QueryPayload
           :url => "https://amd64.ocp.releases.ci.openshift.org/"
         raise "missing query string" if options.query.nil?
         print("Querying #{options.url} against #{options.build_type}\n")
-        doc = Nokogiri::HTML(URI.open(options.url).read)
+        doc = Nokogiri::HTML(URI(options.url).open.read)
         links = doc.xpath("//a[contains(text(), '#{options.build_type}')]")
 
         target_links = links.map { |l|  options.url + l.attributes['href'].value }
         threads = []
         target_links.each do |link|
           threads << Thread.new(link) do |i|
-            doc = Nokogiri::HTML(URI.open(link).read)
+            doc = Nokogiri::HTML(URI(link).open.read)
               if doc.to_s.include? options.query
                 puts "Pattern '#{options.query}' found in payload: #{link}"
               end


### PR DESCRIPTION
like the following...
`./tools/find_image.rb:43: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open`