### PR TITLE
update apiVersion for the routes

### DIFF
--- a/testdata/routing/edge/route_edge.json
+++ b/testdata/routing/edge/route_edge.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": "v1",
+	"apiVersion": "route.openshift.io/v1",
 		"kind": "Route",
 		"metadata": {
 			"name": "secured-edge-route"

--- a/testdata/routing/reencrypt/reencrypt-without-all-cert.yaml
+++ b/testdata/routing/reencrypt/reencrypt-without-all-cert.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 items:
 - kind: Route
-  apiVersion: v1
+  apiVersion: route.openshift.io/v1
   metadata:
     name: route-reencrypt
   spec:

--- a/testdata/routing/reencrypt/route_reencrypt.json
+++ b/testdata/routing/reencrypt/route_reencrypt.json
@@ -1,6 +1,6 @@
 {
         "kind": "Route",
-        "apiVersion": "v1",
+        "apiVersion": "route.openshift.io/v1",
         "metadata": {
                 "name": "route-reencrypt"
         },

--- a/testdata/routing/route_withouthost1.json
+++ b/testdata/routing/route_withouthost1.json
@@ -1,6 +1,6 @@
 {
     "kind": "Route",
-    "apiVersion": "v1",
+    "apiVersion": "route.openshift.io/v1",
     "metadata": {
         "name": "service-unsecure1"
     },

--- a/testdata/routing/unsecure/route_unsecure.json
+++ b/testdata/routing/unsecure/route_unsecure.json
@@ -1,6 +1,6 @@
 {
     "kind": "Route",
-    "apiVersion": "v1",
+    "apiVersion": "route.openshift.io/v1",
     "metadata": {
         "name": "route"
     },

--- a/testdata/routing/wildcard_route/route_edge.json
+++ b/testdata/routing/wildcard_route/route_edge.json
@@ -1,5 +1,5 @@
 {
-        "apiVersion": "v1",
+        "apiVersion": "route.openshift.io/v1",
         "kind": "Route",
         "metadata": {
                 "name": "wildcard-edge-route"

--- a/testdata/routing/wildcard_route/route_pass.json
+++ b/testdata/routing/wildcard_route/route_pass.json
@@ -1,6 +1,6 @@
 {
     "kind": "Route",
-    "apiVersion": "v1",
+    "apiVersion": "route.openshift.io/v1",
     "metadata": {
         "name": "route-passthrough"
     },

--- a/testdata/routing/wildcard_route/route_reencrypt.json
+++ b/testdata/routing/wildcard_route/route_reencrypt.json
@@ -1,6 +1,6 @@
 {
         "kind": "Route",
-        "apiVersion": "v1",
+        "apiVersion": "route.openshift.io/v1",
         "metadata": {
                 "name": "wildcard-reencrypt-route"
         },


### PR DESCRIPTION
see below warning message if using old apiVersion, so update related routes in testdata to use `route.openshift.io/v1`.

```
W0317 11:12:03.889137    6752 shim_kubectl.go:55] Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "route.openshift.io/v1" for your resource
route.route.openshift.io/secured-edge-route created
```

@quarterpin @jechen0648 please help take a look. thanks.