### PR TITLE
update multus judgment in case DESIRED multus still not be updated when node remove

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -591,7 +591,7 @@ Given /^the multus is enabled on the cluster$/ do
   available_multus_replicas = daemon_set('multus', project('openshift-multus')).replica_counters(user: admin)[:available]
   #storing desired_multus_replicas value in desired_multus_replicas clipboard variable as well
   cb.desired_multus_replicas = desired_multus_replicas
-  unless desired_multus_replicas == available_multus_replicas && available_multus_replicas != 0
+  unless (desired_multus_replicas == available_multus_replicas || desired_multus_replicas > env.nodes.count) && available_multus_replicas != 0
     daemon_set('multus', project('openshift-multus')).describe(admin, quiet:false)
     BushSlicer::Pod.get_labeled("app=multus", user: admin, project: project("openshift-multus", switch: false)) do |pod|
       pod.describe(admin, quiet: false)


### PR DESCRIPTION
this kind of case will scale up node (eg. OCP-28108).  The nodes will be restore when the case is finished. However the multus DESIRED number will not be updated in short time.  see below logs:  the node number is 6. however multus DESIRED is still 7 in short time

```
NAME                                         STATUS   ROLES    AGE   VERSION
ip-10-0-135-35.us-east-2.compute.internal    Ready    master   62m   v1.20.0+e1bc274
ip-10-0-153-194.us-east-2.compute.internal   Ready    worker   57m   v1.20.0+e1bc274
ip-10-0-164-171.us-east-2.compute.internal   Ready    worker   61m   v1.20.0+e1bc274
ip-10-0-164-252.us-east-2.compute.internal   Ready    master   66m   v1.20.0+e1bc274
ip-10-0-196-233.us-east-2.compute.internal   Ready    master   62m   v1.20.0+e1bc274
ip-10-0-216-25.us-east-2.compute.internal    Ready    worker   61m   v1.20.0+e1bc274
NAME                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
multus                        7         7         6       7            6           kubernetes.io/os=linux            66m
multus-admission-controller   3         3         3       3            3           node-role.kubernetes.io/master=   66m
network-metrics-daemon        7         7         6       7            6           kubernetes.io/os=linux            66m
NAME                                         STATUS   ROLES    AGE   VERSION
ip-10-0-135-35.us-east-2.compute.internal    Ready    master   62m   v1.20.0+e1bc274
ip-10-0-153-194.us-east-2.compute.internal   Ready    worker   57m   v1.20.0+e1bc274
ip-10-0-164-171.us-east-2.compute.internal   Ready    worker   61m   v1.20.0+e1bc274
ip-10-0-164-252.us-east-2.compute.internal   Ready    master   66m   v1.20.0+e1bc274
ip-10-0-196-233.us-east-2.compute.internal   Ready    master   62m   v1.20.0+e1bc274
ip-10-0-216-25.us-east-2.compute.internal    Ready    worker   61m   v1.20.0+e1bc274
NAME                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
multus                        7         7         6       7            6           kubernetes.io/os=linux            66m
multus-admission-controller   3         3         3       3            3           node-role.kubernetes.io/master=   66m
network-metrics-daemon        7         7         6       7            6           kubernetes.io/os=linux            66m
NAME                                         STATUS   ROLES    AGE   VERSION
ip-10-0-135-35.us-east-2.compute.internal    Ready    master   62m   v1.20.0+e1bc274
ip-10-0-153-194.us-east-2.compute.internal   Ready    worker   57m   v1.20.0+e1bc274
ip-10-0-164-171.us-east-2.compute.internal   Ready    worker   61m   v1.20.0+e1bc274
ip-10-0-164-252.us-east-2.compute.internal   Ready    master   66m   v1.20.0+e1bc274
ip-10-0-196-233.us-east-2.compute.internal   Ready    master   62m   v1.20.0+e1bc274
ip-10-0-216-25.us-east-2.compute.internal    Ready    worker   61m   v1.20.0+e1bc274
NAME                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
multus                        7         7         6       7            6           kubernetes.io/os=linux            66m
multus-admission-controller   3         3         3       3            3           node-role.kubernetes.io/master=   66m
network-metrics-daemon        7         7         6       7            6           kubernetes.io/os=linux            66m
NAME                                         STATUS   ROLES    AGE   VERSION
ip-10-0-135-35.us-east-2.compute.internal    Ready    master   62m   v1.20.0+e1bc274
ip-10-0-153-194.us-east-2.compute.internal   Ready    worker   57m   v1.20.0+e1bc274
ip-10-0-164-171.us-east-2.compute.internal   Ready    worker   61m   v1.20.0+e1bc274
ip-10-0-164-252.us-east-2.compute.internal   Ready    master   66m   v1.20.0+e1bc274
ip-10-0-196-233.us-east-2.compute.internal   Ready    master   62m   v1.20.0+e1bc274
ip-10-0-216-25.us-east-2.compute.internal    Ready    worker   61m   v1.20.0+e1bc274
NAME                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
multus                        6         6         6       6            6           kubernetes.io/os=linux            66m
multus-admission-controller   3         3         3       3            3           node-role.kubernetes.io/master=   66m
network-metrics-daemon        6         6         6       6            6           kubernetes.io/os=linux            66m
NAME                                         STATUS   ROLES    AGE   VERSION
ip-10-0-135-35.us-east-2.compute.internal    Ready    master   62m   v1.20.0+e1bc274
ip-10-0-153-194.us-east-2.compute.internal   Ready    worker   57m   v1.20.0+e1bc274
ip-10-0-164-171.us-east-2.compute.internal   Ready    worker   61m   v1.20.0+e1bc274
ip-10-0-164-252.us-east-2.compute.internal   Ready    master   67m   v1.20.0+e1bc274
ip-10-0-196-233.us-east-2.compute.internal   Ready    master   63m   v1.20.0+e1bc274
ip-10-0-216-25.us-east-2.compute.internal    Ready    worker   61m   v1.20.0+e1bc274
NAME                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
multus                        6         6         6       6            6           kubernetes.io/os=linux            66m
multus-admission-controller   3         3         3       3            3           node-role.kubernetes.io/master=   66m
network-metrics-daemon        6         6         6       6            6           kubernetes.io/os=linux            66m
```
So here add one `|| desired_multus_replicas >= env.nodes.count)` to make the case go ahead.
@weliang1 @rbbratta @huiran0826 @kakkoyun @asood-rh @brahaney 

