### PR TITLE
OCP-38751-[Bug 1914284] The namespace networkpolicy for an application is functional post upgrade

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -305,6 +305,15 @@ Given /^the DefaultDeny policy is applied to the "(.+?)" namespace$/ do | projec
   end
 end
 
+Given /^the AllowNamespaceAndPod policy is applied to the "(.+?)" namespace$/ do | project_name |
+  ensure_admin_tagged
+
+    @result = admin.cli_exec(:create, n: project_name , f: "#{BushSlicer::HOME}/testdata/networking/networkpolicy/allow-ns-and-pod.yaml")
+    unless @result[:success]
+      raise "Failed to apply the default deny policy to specified namespace."
+    end
+end
+
 Given /^the cluster network plugin type and version and stored in the clipboard$/ do
   ensure_admin_tagged
   _host = node.host

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -308,10 +308,10 @@ end
 Given /^the AllowNamespaceAndPod policy is applied to the "(.+?)" namespace$/ do | project_name |
   ensure_admin_tagged
 
-    @result = admin.cli_exec(:create, n: project_name , f: "#{BushSlicer::HOME}/testdata/networking/networkpolicy/allow-ns-and-pod.yaml")
-    unless @result[:success]
-      raise "Failed to apply the default deny policy to specified namespace."
-    end
+  @result = admin.cli_exec(:create, n: project_name , f: "#{BushSlicer::HOME}/testdata/networking/networkpolicy/allow-ns-and-pod.yaml")
+  unless @result[:success]
+    raise "Failed to apply the default deny policy to specified namespace."
+  end
 end
 
 Given /^the cluster network plugin type and version and stored in the clipboard$/ do

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -308,10 +308,12 @@ end
 Given /^the AllowNamespaceAndPod policy is applied to the "(.+?)" namespace$/ do | project_name |
   ensure_admin_tagged
 
-  @result = admin.cli_exec(:create, n: project_name , f: "#{BushSlicer::HOME}/testdata/networking/networkpolicy/allow-ns-and-pod.yaml")
-  unless @result[:success]
-    raise "Failed to apply the default deny policy to specified namespace."
-  end
+  step %Q{I obtain test data file "networking/networkpolicy/allow-ns-and-pod.yaml"}
+  step %Q/I run the :create admin command with:/,table(%{
+    | f | allow-ns-and-pod.yaml |
+    | n | #{project_name} |
+  })
+  step %Q{the step should succeed}
 end
 
 Given /^the cluster network plugin type and version and stored in the clipboard$/ do

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -311,7 +311,7 @@ Given /^the AllowNamespaceAndPod policy is applied to the "(.+?)" namespace$/ do
   step %Q{I obtain test data file "networking/networkpolicy/allow-ns-and-pod.yaml"}
   step %Q/I run the :create admin command with:/,table(%{
     | f | allow-ns-and-pod.yaml |
-    | n | #{project_name} |
+    | n | #{project_name}       |
   })
   step %Q{the step should succeed}
 end

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -109,6 +109,7 @@ Feature: SDN compoment upgrade testing
     Given a pod becomes ready with labels:
       | name=hello-idle |
     And evaluation of `pod(2).name` is stored in the :pod3 clipboard
+    And evaluation of `pod(2).ip_url` is stored in the :pod3ip clipboard
 
     When I use the "policy-upgrade2" project
     Given I obtain test data file "networking/list_for_pods.json"
@@ -155,6 +156,10 @@ Feature: SDN compoment upgrade testing
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail 
     And the output should not contain "Hello"
+    When I execute on the "<%= cb.pod5 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod3ip %>:8080 |
+    Then the step should succeed 
+    And the output should contain "Hello"
 
   # @author asood@redhat.com
   # @case_id OCP-38751
@@ -173,6 +178,7 @@ Feature: SDN compoment upgrade testing
     Given a pod becomes ready with labels:
       | name=hello-idle |
     And evaluation of `pod(2).name` is stored in the :pod3 clipboard
+    And evaluation of `pod(2).ip_url` is stored in the :pod3ip clipboard
     When I execute on the "<%= cb.pod3 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail
@@ -190,3 +196,7 @@ Feature: SDN compoment upgrade testing
     When I execute on the "<%= cb.pod5 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail 
+    When I execute on the "<%= cb.pod5 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod3ip %>:8080 |
+    Then the step should succeed 
+    And the output should contain "Hello"

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -78,3 +78,116 @@ Feature: SDN compoment upgrade testing
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail
     And the output should not contain "Hello"
+
+
+  # @author asood@redhat.com
+  @admin
+  @upgrade-prepare
+  Scenario: Check the namespace networkpolicy for an application works well after upgrade - prepare
+    Given I switch to cluster admin pseudo user
+    When I run the :new_project client command with:
+      | project_name | test1 |
+    Then the step should succeed
+    When I run the :new_project client command with:
+      | project_name | test2 |
+    Then the step should succeed
+
+    When I use the "test1" project
+    Given I obtain test data file "networking/list_for_pods.json"
+    And I run the :create client command with:
+      | f | list_for_pods.json |
+    Then the step should succeed
+    Given 2 pods become ready with labels:
+      | name=test-pods |
+    And evaluation of `pod(1).ip` is stored in the :pod2ip clipboard
+    And evaluation of `pod(0).name` is stored in the :pod1 clipboard
+
+    Given I obtain test data file "rc/idle-rc-1.yaml"
+    And I run the :create client command with:
+      | f | idle-rc-1.yaml |
+    Then the step should succeed
+    Given 2 pods become ready with labels:
+      | name=hello-idle |
+    And evaluation of `pod(2).name` is stored in the :pod3 clipboard
+
+    When I use the "test2" project
+    Given I obtain test data file "networking/list_for_pods.json"
+    And I run the :create client command with:
+      | f | list_for_pods.json |
+    Then the step should succeed
+    Given 2 pods become ready with labels:
+      | name=test-pods |
+    And evaluation of `pod(4).name` is stored in the :pod5 clipboard
+
+    Given I obtain test data file "rc/idle-rc-1.yaml"
+    And I run the :create client command with:
+      | f | idle-rc-1.yaml |
+    Then the step should succeed
+    Given 2 pods become ready with labels:
+      | name=hello-idle |
+    And evaluation of `pod(6).name` is stored in the :pod7 clipboard
+
+    Given I have a project
+    When I run the :label admin command with:
+      | resource | namespace                |
+      | name     | test2                    |
+      | key_val  | team=operations          |
+    Then the step should succeed
+
+    Given the AllowNamespaceAndPod policy is applied to the "test1" namespace
+    Then the step should succeed
+
+    When I use the "test1" project
+    When I execute on the "<%= cb.pod1 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should fail 
+    And the output should not contain "Hello"
+    When I execute on the "<%= cb.pod3 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should fail
+    And the output should not contain "Hello"
+
+    When I use the "test2" project
+    When I execute on the "<%= cb.pod5 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should succeed
+    And the output should contain "Hello"
+    When I execute on the "<%= cb.pod7 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should fail 
+    And the output should not contain "Hello"
+
+  # @author asood@redhat.com
+  # @case_id OCP-38751
+  @admin
+  @upgrade-check
+  Scenario: Check the networkpolicy works well after upgrade
+    Given I switch to cluster admin pseudo user
+    When I use the "test1" project
+    Given status becomes :running of 2 pods labeled:
+      | name=test-pods |
+    And evaluation of `pod(1).ip` is stored in the :pod2ip clipboard
+    And evaluation of `pod(0).name` is stored in the :pod1 clipboard
+    When I execute on the "<%= cb.pod1 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should fail
+    Given status becomes :running of 2 pods labeled:
+      | name=hello-idle |
+    And evaluation of `pod(2).name` is stored in the :pod3 clipboard
+    When I execute on the "<%= cb.pod3 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should fail
+
+    When I use the "test2" project
+    Given status becomes :running of 2 pods labeled:
+      | name=test-pods |
+    And evaluation of `pod(4).name` is stored in the :pod5 clipboard
+    When I execute on the "<%= cb.pod5 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should succeed
+    Given status becomes :running of 2 pods labeled:
+      | name=hello-idle |
+    And evaluation of `pod(6).name` is stored in the :pod7 clipboard
+    When I execute on the "<%= cb.pod7 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should fail 

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -86,58 +86,57 @@ Feature: SDN compoment upgrade testing
   Scenario: Check the namespace networkpolicy for an application works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
-      | project_name | test1 |
+      | project_name | policy-upgrade1 |
     Then the step should succeed
     When I run the :new_project client command with:
-      | project_name | test2 |
+      | project_name | policy-upgrade2 |
     Then the step should succeed
 
-    When I use the "test1" project
+    When I use the "policy-upgrade1" project
     Given I obtain test data file "networking/list_for_pods.json"
     And I run the :create client command with:
       | f | list_for_pods.json |
     Then the step should succeed
     Given 2 pods become ready with labels:
       | name=test-pods |
-    And evaluation of `pod(1).ip` is stored in the :pod2ip clipboard
+    And evaluation of `pod(1).ip_url` is stored in the :pod2ip clipboard
     And evaluation of `pod(0).name` is stored in the :pod1 clipboard
 
     Given I obtain test data file "rc/idle-rc-1.yaml"
-    And I run the :create client command with:
-      | f | idle-rc-1.yaml |
+    When I run oc create over "idle-rc-1.yaml" replacing paths:
+      | ["items"][0]["spec"]["replicas"]  | 1    |
     Then the step should succeed
-    Given 2 pods become ready with labels:
+    Given a pod becomes ready with labels:
       | name=hello-idle |
     And evaluation of `pod(2).name` is stored in the :pod3 clipboard
 
-    When I use the "test2" project
+    When I use the "policy-upgrade2" project
     Given I obtain test data file "networking/list_for_pods.json"
-    And I run the :create client command with:
-      | f | list_for_pods.json |
+    When I run oc create over "list_for_pods.json" replacing paths:
+      | ["items"][0]["spec"]["replicas"]  | 1    |
     Then the step should succeed
-    Given 2 pods become ready with labels:
+    Given a pod becomes ready with labels:
       | name=test-pods |
-    And evaluation of `pod(4).name` is stored in the :pod5 clipboard
+    And evaluation of `pod(3).name` is stored in the :pod4 clipboard
 
     Given I obtain test data file "rc/idle-rc-1.yaml"
-    And I run the :create client command with:
-      | f | idle-rc-1.yaml |
+    When I run oc create over "idle-rc-1.yaml" replacing paths:
+      | ["items"][0]["spec"]["replicas"]  | 1    |
     Then the step should succeed
-    Given 2 pods become ready with labels:
+    Given a pod becomes ready with labels:
       | name=hello-idle |
-    And evaluation of `pod(6).name` is stored in the :pod7 clipboard
+    And evaluation of `pod(4).name` is stored in the :pod5 clipboard
 
-    Given I have a project
     When I run the :label admin command with:
       | resource | namespace                |
-      | name     | test2                    |
+      | name     | policy-upgrade2          |
       | key_val  | team=operations          |
     Then the step should succeed
 
-    Given the AllowNamespaceAndPod policy is applied to the "test1" namespace
+    Given the AllowNamespaceAndPod policy is applied to the "policy-upgrade1" namespace
     Then the step should succeed
 
-    When I use the "test1" project
+    When I use the "policy-upgrade1" project
     When I execute on the "<%= cb.pod1 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail 
@@ -147,12 +146,12 @@ Feature: SDN compoment upgrade testing
     Then the step should fail
     And the output should not contain "Hello"
 
-    When I use the "test2" project
-    When I execute on the "<%= cb.pod5 %>" pod:
+    When I use the "policy-upgrade2" project
+    When I execute on the "<%= cb.pod4 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should succeed
     And the output should contain "Hello"
-    When I execute on the "<%= cb.pod7 %>" pod:
+    When I execute on the "<%= cb.pod5 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail 
     And the output should not contain "Hello"
@@ -163,31 +162,31 @@ Feature: SDN compoment upgrade testing
   @upgrade-check
   Scenario: Check the networkpolicy works well after upgrade
     Given I switch to cluster admin pseudo user
-    When I use the "test1" project
+    When I use the "policy-upgrade1" project
     Given status becomes :running of 2 pods labeled:
       | name=test-pods |
-    And evaluation of `pod(1).ip` is stored in the :pod2ip clipboard
+    And evaluation of `pod(1).ip_url` is stored in the :pod2ip clipboard
     And evaluation of `pod(0).name` is stored in the :pod1 clipboard
     When I execute on the "<%= cb.pod1 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail
-    Given status becomes :running of 2 pods labeled:
+    Given a pod becomes ready with labels:
       | name=hello-idle |
     And evaluation of `pod(2).name` is stored in the :pod3 clipboard
     When I execute on the "<%= cb.pod3 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail
 
-    When I use the "test2" project
-    Given status becomes :running of 2 pods labeled:
+    When I use the "policy-upgrade2" project
+    Given a pod becomes ready with labels:
       | name=test-pods |
-    And evaluation of `pod(4).name` is stored in the :pod5 clipboard
-    When I execute on the "<%= cb.pod5 %>" pod:
+    And evaluation of `pod(3).name` is stored in the :pod4 clipboard
+    When I execute on the "<%= cb.pod4 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should succeed
-    Given status becomes :running of 2 pods labeled:
+    Given a pod becomes ready with labels:
       | name=hello-idle |
-    And evaluation of `pod(6).name` is stored in the :pod7 clipboard
-    When I execute on the "<%= cb.pod7 %>" pod:
+    And evaluation of `pod(4).name` is stored in the :pod5 clipboard
+    When I execute on the "<%= cb.pod5 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail 

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -156,7 +156,7 @@ Feature: SDN compoment upgrade testing
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail 
     And the output should not contain "Hello"
-    When I execute on the "<%= cb.pod5 %>" pod:
+    When I execute on the "<%= cb.pod4 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod3ip %>:8080 |
     Then the step should succeed 
     And the output should contain "Hello"
@@ -196,7 +196,7 @@ Feature: SDN compoment upgrade testing
     When I execute on the "<%= cb.pod5 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail 
-    When I execute on the "<%= cb.pod5 %>" pod:
+    When I execute on the "<%= cb.pod4 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod3ip %>:8080 |
     Then the step should succeed 
     And the output should contain "Hello"

--- a/testdata/networking/networkpolicy/allow-ns-and-pod.yaml
+++ b/testdata/networking/networkpolicy/allow-ns-and-pod.yaml
@@ -14,6 +14,3 @@ spec:
         podSelector:
           matchLabels:
             name: test-pods
-  podSelector:
-     matchLabels:
-       name: test-pods

--- a/testdata/networking/networkpolicy/allow-ns-and-pod.yaml
+++ b/testdata/networking/networkpolicy/allow-ns-and-pod.yaml
@@ -1,0 +1,19 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ns-and-pod
+spec:
+  podSelector:
+    matchLabels:
+      name: test-pods
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            team: operations
+        podSelector:
+          matchLabels:
+            name: test-pods
+  podSelector:
+     matchLabels:
+       name: test-pods


### PR DESCRIPTION
The PR automates the network policy managing access to the application ensuring it is functional post upgrade.
The network policy allows access to application only from a specific namespace.

Testing:-
Pre upgrade:-
 bundle exec cucumber features/upgrade/sdn/policy-upgrade.feature:86
1 scenario (1 passed)
47 steps (47 passed)
1m6.249

Post upgrade:-
bundle exec cucumber features/upgrade/sdn/policy-upgrade.feature:164
1 scenario (1 passed)
20 steps (20 passed)
0m36.166s