### PR TITLE
auto OCP-37139

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -135,6 +135,10 @@ Feature: MachineHealthCheck Test Scenarios
       | mhc-<%= machine_set.name %>-1: total targets: 1,  maxUnhealthy: 0, unhealthy: 1. Short-circuiting remediation   |
       | mhc-<%= machine_set.name %>-2: total targets: 1,  maxUnhealthy: 90%, unhealthy: 1. Short-circuiting remediation |
     """
+    When I run the :describe admin command with:
+      | resource | machinehealthcheck/mhc-<%= machine_set.name %>-2 |
+    Then the output should match:
+      | Type.*RemediationAllowed |
 
   # @author miyadav@redhat.com
   # @case_id OCP-28718


### PR DESCRIPTION
Auto OCP-37139: Check the remediationsAllowed is visible in the MHC status @jhou1 @miyadav please help to take a look.

```
      [04:29:43] INFO> === End After Scenario: Use "maxUnhealthy" to prevent automated remediation ===

1 scenario (1 passed)
18 steps (18 passed)
7m5.779s
```
 