### PR TITLE
add get ipv6 address for pod and service

### DIFF
--- a/features/networking/ipv6_dualstack.feature
+++ b/features/networking/ipv6_dualstack.feature
@@ -1,0 +1,78 @@
+Feature: ipv6 dual stack cluster test scenarios
+
+  # @author zzhao@redhat.com
+  # @case_id OCP-40581
+  @admin
+  Scenario: Project should be in isolation when using multitenant policy for ipv6 dual stack
+    # create project and pods
+    Given I have a project
+    And evaluation of `project.name` is stored in the :proj1 clipboard
+    Given I obtain test data file "networking/list_for_pods_ipv6.json"
+    When I run the :create client command with:
+      | f | list_for_pods_ipv6.json |
+    Then the step should succeed
+    Given a pod becomes ready with labels:
+      | name=test-pods |
+    And evaluation of `pod(0).ip_v4` is stored in the :p1pod1ipv4 clipboard
+    And evaluation of `pod(0).ip_v6_url` is stored in the :p1pod1ipv6_url clipboard
+    Given I use the "test-service" service
+    And evaluation of `service.ip_v4_url` is stored in the :service_ipv4_url clipboard
+    And evaluation of `service.ip_v6_url` is stored in the :service_ipv6_url clipboard
+
+    # create another project and pods
+    Given I create a new project
+    And evaluation of `project.name` is stored in the :proj2 clipboard
+    Given I obtain test data file "networking/list_for_pods_ipv6.json"
+    When I run the :create client command with:
+      | f | list_for_pods_ipv6.json |
+    Then the step should succeed
+    Given a pod becomes ready with labels:
+      | name=test-pods |
+    And evaluation of `pod(1).name` is stored in the :p2pod1 clipboard
+
+    When I execute on the "<%= cb.p2pod1 %>" pod:
+      | curl | --connect-timeout | 10 | <%= cb.p1pod1ipv4 %>:<%= service.ports[0]["targetPort"] %> |
+    Then the step should succeed
+    And the output should contain "Hello"
+    When I execute on the "<%= cb.p2pod1 %>" pod:
+      | curl | --connect-timeout | 10 | <%= cb.p1pod1ipv6_url %>:<%= service.ports[0]["targetPort"] %> |
+    Then the step should succeed
+    And the output should contain "Hello"
+
+    #access pod by service ipv4 and ipv6 address
+    When I execute on the "<%= cb.p2pod1 %>" pod:
+      | curl | --connect-timeout | 10 | <%= cb.service_ipv4_url %> |
+    Then the step should succeed
+    And the output should contain "Hello"
+
+    When I execute on the "<%= cb.p2pod1 %>" pod:
+      | curl | --connect-timeout | 10 | <%= cb.service_ipv6_url %> |
+    Then the step should succeed
+    And the output should contain "Hello"
+
+
+    #create multitetant policy in project 1
+    Given I obtain test data file "networking/networkpolicy/multitenant_policy.yaml"
+    When I run the :create admin command with:
+      | f | multitenant_policy.yaml |
+      | n | <%= cb.proj1 %>         |
+    Then the step should succeed
+
+
+    When I execute on the "<%= cb.p2pod1 %>" pod:
+      | curl | --connect-timeout | 5 | <%= cb.p1pod1ipv4 %>:<%= service.ports[0]["targetPort"] %> |
+    Then the step should fail
+    When I execute on the "<%= cb.p2pod1 %>" pod:
+      | curl | --connect-timeout | 5 | <%= cb.p1pod1ipv6_url %>:<%= service.ports[0]["targetPort"] %> |
+    Then the step should fail
+
+    #access pod by service ipv4 and ipv6 address
+    When I execute on the "<%= cb.p2pod1 %>" pod:
+      | curl | --connect-timeout | 5 | <%= cb.service_ipv4_url %> |
+    Then the step should fail
+
+    When I execute on the "<%= cb.p2pod1 %>" pod:
+      | curl | --connect-timeout | 5 | <%= cb.service_ipv6_url %> |
+    Then the step should fail
+
+

--- a/lib/openshift/pod.rb
+++ b/lib/openshift/pod.rb
@@ -50,6 +50,7 @@ module BushSlicer
       props[:volumes] = spec["volumes"]
       s = pod_hash["status"]
       props[:ip] = s["podIP"]
+      props[:ips] = s["podIPs"]
       # status should be retrieved on demand but we cache it for the brave
       props[:status] = s
 
@@ -111,6 +112,23 @@ module BushSlicer
     # @note call without parameters only when props are loaded
     def ip(user: nil, cached: true, quiet: false)
       return get_cached_prop(prop: :ip, user: user, cached: cached, quiet: quiet)
+    end
+
+    def ip_v6(user: nil, cached: true, quiet: false)
+      ips = get_cached_prop(prop: :ips, user: user, cached: cached, quiet: quiet)
+      ipv6 = ips.find { |ip| ip["ip"].include? ":" }
+      return ipv6["ip"]
+    end
+
+    # return pod ipv6 address as URL for dualstack cluster
+    def ip_v6_url(user: nil, cached: true, quiet: false)
+      return "[#{ip_v6(user: user, cached: cached, quiet: quiet)}]"
+    end
+
+    def ip_v4(user: nil, cached: true, quiet: false)
+      ips = get_cached_prop(prop: :ips, user: user, cached: cached, quiet: quiet)
+      ipv4 = ips.find { |ip| ip["ip"].include? "." }
+      return ipv4["ip"]
     end
 
     # @return [String] string IP if IPv4 or [IP] if IPv6

--- a/lib/openshift/service.rb
+++ b/lib/openshift/service.rb
@@ -80,6 +80,35 @@ module BushSlicer
       spec = raw_resource(user: user, cached: cached, quiet: quiet).dig('spec')
       return (spec.dig('portalIP') || spec.dig('clusterIP'))
     end
+    
+    # return service ipv6 address for dualstack cluster
+    def ip_v6(user: nil, cached: true, quiet: false)
+      spec = raw_resource(user: user, cached: cached, quiet: quiet).dig('spec')
+      ipv6 = spec['clusterIPs'].find { |ip| ip.include? ":" }
+      return ipv6
+    end
+
+    # return service ipv6 address as URL for dualstack cluster
+    def ip_v6_url(user: nil, cached: true, quiet: false)
+      ipv6 = self.ip_v6(user: user, cached: cached, quiet: quiet)
+      port = self.ports(user: user, cached: true, quiet: quiet)[0]["port"]
+      "[#{ipv6}]:#{port}"
+    end
+
+    # return service ipv4 address for dualstack cluster
+    def ip_v4(user: nil, cached: true, quiet: false)
+      spec = raw_resource(user: user, cached: cached, quiet: quiet).dig('spec')
+      ipv4 = spec['clusterIPs'].find { |ip| ip.include? "." }
+      return ipv4
+    end
+
+    # return service ipv4 address as URL for dualstack cluster
+    def ip_v4_url(user: nil, cached: true, quiet: false)
+      ipv4 = self.ip_v4(user: user, cached: cached, quiet: quiet)
+      port = self.ports(user: user, cached: true, quiet: quiet)[0]["port"]
+      "#{ipv4}:#{port}"
+    end
+
     # @note call without parameters only when props are loaded
     # return @Array of ports
     def ports(user: nil, cached: true, quiet: false)

--- a/testdata/networking/list_for_pods_ipv6.json
+++ b/testdata/networking/list_for_pods_ipv6.json
@@ -1,0 +1,65 @@
+{
+    "apiVersion": "v1",
+    "kind": "List",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "ReplicationController",
+            "metadata": {
+                "labels": {
+                    "name": "test-rc"
+                },
+                "name": "test-rc"
+            },
+            "spec": {
+                "replicas": 1,
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "name": "test-pods"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "quay.io/openshifttest/hello-sdn@sha256:d5785550cf77b7932b090fcd1a2625472912fb3189d5973f177a5a2c347a1f95",
+                                "name": "test-pod",
+                                "imagePullPolicy": "IfNotPresent",
+                                "resources":{
+                                  "limits":{
+                                    "memory":"340Mi"
+                                  }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "labels": {
+                    "name": "test-service"
+                },
+                "name": "test-service"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": 27017,
+                        "protocol": "TCP",
+                        "targetPort": 8080
+                    }
+                ],
+                "ipFamilyPolicy": "RequireDualStack",
+                "selector": {
+                    "name": "test-pods"
+                }
+            }
+        }
+    ]
+}
+

--- a/testdata/networking/networkpolicy/multitenant_policy.yaml
+++ b/testdata/networking/networkpolicy/multitenant_policy.yaml
@@ -1,0 +1,55 @@
+---
+
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: deny-by-default
+spec:
+  podSelector:
+  ingress: []
+
+--- 
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-ingress
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+  podSelector: {}
+  policyTypes:
+  - Ingress
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-monitoring
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+  podSelector: {}
+  policyTypes:
+  - Ingress
+
+---
+
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-same-namespace
+spec:
+  podSelector:
+  ingress:
+  - from:
+    - podSelector: {}
+
+---


### PR DESCRIPTION
for dual stack cluster .we have ipv4 and ipv6 ip for pod and service, see 

pod:
```
              f:ip: {}
    hostIP: 192.168.123.71
    podIP: 10.130.0.94
    podIPs:
    - ip: 10.130.0.94
    - ip: fd01:0:0:3::5e
```
service:
```
spec:
  clusterIP: 172.30.133.189
  clusterIPs:
   - 172.30.133.189
   - fd02::1cd8
  ipFamilies:
```
@akostadinov @pruan-rht @liangxia  could you help take a look?
 
cc @rbbratta @weliang1 @huiran0826 @asood-rh @kakkoyun @brahaney 