### PR TITLE
removing flay tag from logging cases as they're not really flaky

### DIFF
--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -6,7 +6,6 @@ Feature: cluster-logging-operator related test
   @admin
   @destructive
   @commonlogging
-  @flaky
   Scenario: ServiceMonitor Object for collector is deployed along with cluster logging
     Given I wait for the "fluentd" service_monitor to appear
     Given the expression should be true> service_monitor('fluentd').service_monitor_endpoint_spec(server_name: "fluentd.openshift-logging.svc").port == "metrics"
@@ -24,7 +23,6 @@ Feature: cluster-logging-operator related test
   # @case_id OCP-21907
   @admin
   @destructive
-  @flaky
   Scenario: Deploy elasticsearch-operator via OLM using CLI
     Given logging operators are installed successfully
 


### PR DESCRIPTION
For logging cases, most of the time, they fail due to the packagemanifests are not ready or the limited resources in the cluster. These issues can't be resolved in scenario level. I remove the tag `@flaky` from these cases to make sure we can cover these cases in errata testing and logging CI pipeline.

/cc @anpingli @jhou1 