### PR TITLE
Fix scheduler

### DIFF
--- a/features/step_definitions/scheduler.rb
+++ b/features/step_definitions/scheduler.rb
@@ -21,7 +21,14 @@ Given /^the CR #{QUOTED} named #{QUOTED} is restored after scenario$/ do |crd, n
   patch_json = org_scheduler.to_json
   _admin = admin
   teardown_add {
-    opts = {resource: 'scheduler', resource_name: name, p: patch_json, type: 'merge' }
+    # Added code to support removal of tlsSecurityProfile while restoring
+    @result = admin.cli_exec(:get, resource: crd, resource_name: name, o: 'yaml')
+    if @result[:success] and @result[:parsed]['spec']['tlsSecurityProfile']
+      patch_json = [{"op": "remove","path": "/spec/tlsSecurityProfile"}].to_json
+      opts = {resource: crd, resource_name: name, p: patch_json, type: 'json' }
+    else
+      opts = {resource: 'scheduler', resource_name: name, p: patch_json, type: 'merge' }
+    end
     @result = _admin.cli_exec(:patch, **opts)
     raise "Cannot restore scheduler: #{name}" unless @result[:success]
     timeout = 300

--- a/features/upgrade/workloads/scheduler-upgrade.feature
+++ b/features/upgrade/workloads/scheduler-upgrade.feature
@@ -39,7 +39,6 @@ Feature: scheduler with custom policy upgrade check
     And the output should contain:
       | map[CheckNodeUnschedulable:{} CheckVolumeBinding:{} GeneralPredicates:{} MatchInterPodAffinity:{} MaxAzureDiskVolumeCount:{} MaxCSIVolumeCountPred:{} MaxEBSVolumeCount:{} MaxGCEPDVolumeCount:{} NoDiskConflict:{} NoVolumeZoneConflict:{} PodToleratesNodeTaints:{}] |
 
-
   # @author knarra@redhat.com
   # @case_id OCP-34164
   @upgrade-check


### PR DESCRIPTION
With the existing code, cannot restore the cluster object to the right state if any additional child elements like tlsSecurityProfile is added to the spec, so modified the code a little to handle the same.