### PR TITLE
fix kibana cases

### DIFF
--- a/features/logging/kibana.feature
+++ b/features/logging/kibana.feature
@@ -92,14 +92,17 @@ Feature: Kibana related features
     When I run the :check_log_count web action
     Then the step should succeed
     """
-    # Verify the token are encrypted in kibana logs 
-    Given the first user is cluster-admin
+    # Verify the token are encrypted in kibana logs
+    Given I switch to cluster admin pseudo user
+    And I use the "openshift-logging" project
     Given a pod becomes ready with labels:
       | logging-infra=kibana |
     When I run the :logs client command with:
       | resource_name | <%= pod.name %> |
-      | c | kibana |
-    Then the output should not contain "XXXXXXXXXXXXXXXXXXXXXXXX"
+      | c             | kibana          |
+    Then the output should contain:
+      | "x-forwarded-access-token":"XXXXXXXXXXXXXX |
+      | "x-forwarded-email":"XXXXXXXXXXXXXX        |
 
   # @author qitang@redhat.com
   # @case_id OCP-30361
@@ -149,11 +152,11 @@ Feature: Kibana related features
     When I perform the :kibana_click_index web action with:
       | index_pattern_name | *infra |
     Then the step should succeed
+    Given I wait up to 180 seconds for the steps to pass:
+    """
     When I perform the :kibana_find_index_pattern web action with:
       | index_pattern_name | *infra |
     Then the step should succeed
-    Given I wait up to 180 seconds for the steps to pass:
-    """
     When I run the :check_log_count web action
     Then the step should succeed
     """


### PR DESCRIPTION
Fix failure:
```
    When I perform the :kibana_find_index_pattern web action with:                               # features/step_definitions/web.rb:1
      [00:54:13] INFO> running web action kibana_find_index_pattern ... 
      [00:54:13] INFO> elements..
      | index_pattern_name | *infra |
      Unable to locate element collection from {:xpath=>"//h2[@class=\"index-pattern-label\" and @id=\"index_pattern_id\" and contains(., \"*infra\")] | //span[contains(., \"*infra\")]"} due to changing page (Watir::Exception::LocatorException)
```
and
```
    When I run the :logs client command with:                                                  # features/step_definitions/cli.rb:13
      [01:15:56] INFO> Shell Commands: oc logs kibana-78447cb644-lkj44 -c kibana --kubeconfig=/home/qitang/workdir/localhost-qitang/ocp4_testuser-43.kubeconfig
      
      STDERR:
      Error from server (NotFound): pods "kibana-78447cb644-lkj44" not found
      
      [01:15:58] INFO> Exit Status: 1
      | resource_name | <%= pod.name %> |
      | c             | kibana          |
    Then the output should not contain "XXXXXXXXXXXXXXXXXXXXXXXX"                              # features/step_definitions/common.rb:113
```

/cc @anpingli @gkarager 