### PR TITLE
remove flack and destructive cases

### DIFF
--- a/features/logging/logging_acceptance.feature
+++ b/features/logging/logging_acceptance.feature
@@ -3,8 +3,6 @@ Feature: Logging smoke test case
   # @author gkarager@redhat.com
   # @case_id OCP-37508
   @admin
-  @destructive
-  @flaky
   Scenario: One logging acceptance case for all cluster
 # Deploy cluster-logging operator via web console
     Given logging channel name is stored in the :logging_channel clipboard	

--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -196,7 +196,6 @@ end
 
 # to cleanup OLM installed clusterlogging
 Given /^logging service is removed successfully$/ do
-  ensure_destructive_tagged
   ensure_admin_tagged
   # remove namespace
   clo_proj_name = "openshift-logging"


### PR DESCRIPTION
For some design limitation, all logging cases are belong to destructive cases. thus logging cases may be skipped in some testing.
For some known issues(resource limitation, unstable mirror registry in disconnect cluster,  no mirror images in some cluster), some critical logging cases are tagged as flaky and won't be executed in our automated framework. 

To minimal the risk  in openshift and openshift-logging testing.  We want to make this acceptance case to be the only one non-destructive case and can be running one any platform. As this is the only one case in no-destructive bucket.  I suggest we didn't  flaky it unless it block the other cases.  Logging QE will treat this case failure as high priority.  We will continue to enhance it and  integrate more feature into it.

@QiaolingTang  @gkarager  @wsun1  @jhou1  @liangxia   Looking forward to your idea.

