### PR TITLE
fix OCP-34718

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -463,8 +463,7 @@ Feature: Machine features testing
       | resource | pv |
     Then the step should succeed
     And the output should contain:
-      | failure-domain.beta.kubernetes.io/zone in [<%= cb.default_zone %>]     |
-      | failure-domain.beta.kubernetes.io/region in [<%= cb.default_region %>] |
+      | region in [<%= cb.default_region %>] |
 
   # @author miyadav@redhat.com
   @admin


### PR DESCRIPTION
Fix  OCP-34718, @miyadav @jhou1 please take a look. From 4.8 this changed from `failure-domain.beta.kubernetes.io/region` to `topology.kubernetes.io/region`.

And on azure,zone has no value, so removed the verification of the zone.
```
Node Affinity:
  Required Terms:
    Term 0:        failure-domain.beta.kubernetes.io/region in [northcentralus]
 ✘ oc get machine
NAME                                               PHASE     TYPE              REGION           ZONE   AGE
wduan-0615c-az-jfkrj-master-0                      Running   Standard_D8s_v3   northcentralus          3h2m
wduan-0615c-az-jfkrj-master-1                      Running   Standard_D8s_v3   northcentralus          3h2m
wduan-0615c-az-jfkrj-master-2                      Running   Standard_D8s_v3   northcentralus          3h2m
wduan-0615c-az-jfkrj-worker-northcentralus-dcb7c   Running   Standard_D2s_v3   northcentralus          179m
wduan-0615c-az-jfkrj-worker-northcentralus-rptld   Running   Standard_D2s_v3   northcentralus          179m
wduan-0615c-az-jfkrj-worker-northcentralus-x7z2g   Running   Standard_D2s_v3   northcentralus          179m
```