### PR TITLE
Fix small mtu test

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -434,7 +434,7 @@ Feature: Service related networking scenarios
     And the output should contain "Hello OpenShift"
     """
 
-  # @author anusaxen@redhat.com, kkulkarni@redhat.com
+  # @author anusaxen@redhat.com
   # @case_id OCP-24694
   @admin
   @destructive
@@ -469,8 +469,8 @@ Feature: Service related networking scenarios
     #Reset the MTU using nmcli
     Given I use the "<%= cb.subject_node %>" node
     And I run commands on the host:
-    | nmcli con modify "<%= cb.nmcli_active_con_uuid %>" ethernet.mtu <%= cb.mtu_actual %> |
-    | nmcli dev reapply  <%= cb.default_interface %> |
+      | nmcli con modify "<%= cb.nmcli_active_con_uuid %>" ethernet.mtu <%= cb.mtu_actual %> |
+      | nmcli dev reapply  <%= cb.default_interface %> |
     Then the step should succeed
     And the node's MTU value is stored in the :mtu_actual_redeployed clipboard
     And the expression should be true> cb.mtu_actual == cb.mtu_actual_redeployed

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -434,23 +434,25 @@ Feature: Service related networking scenarios
     And the output should contain "Hello OpenShift"
     """
 
-  # @author anusaxen@redhat.com
+  # @author anusaxen@redhat.com, kkulkarni@redhat.com
   # @case_id OCP-24694
   @admin
   @destructive
   Scenario: Taint node with too small MTU value
     Given the default interface on nodes is stored in the :default_interface clipboard
     And the node's MTU value is stored in the :mtu_actual clipboard
+    And the node's active nmcli connection is stored in the :nmcli_active_con_uuid clipboard
     And evaluation of `node.name` is stored in the :subject_node clipboard
     And I run commands on the host:
-      | systemctl stop NetworkManager                        |
-      | ip link set mtu 1300 dev <%= cb.default_interface %> |
+      | nmcli con modify  "<%= cb.nmcli_active_con_uuid %>"  ethernet.mtu  1300  |
+      | nmcli dev reapply <%= cb.default_interface %> |
     Then the step should succeed
     Given I register clean-up steps:
     """
     Given I use the "<%= cb.subject_node %>" node
     And I run commands on the host:
-      | systemctl start NetworkManager |
+      | nmcli con modify "<%= cb.nmcli_active_con_uuid %>" ethernet.mtu <%= cb.mtu_actual %> |
+      | nmcli dev reapply  <%= cb.default_interface %> |
     Then the step should succeed
     """
     #This def will also store network project name in network_project_name variable
@@ -464,10 +466,11 @@ Feature: Service related networking scenarios
     Then the step should succeed
     And the output should contain "mtu-too-small"
     """
-    #Starting NetworkManager to roll out original system MTU
+    #Reset the MTU using nmcli
     Given I use the "<%= cb.subject_node %>" node
     And I run commands on the host:
-      | systemctl start NetworkManager |
+    | nmcli con modify "<%= cb.nmcli_active_con_uuid %>" ethernet.mtu <%= cb.mtu_actual %> |
+    | nmcli dev reapply  <%= cb.default_interface %> |
     Then the step should succeed
     And the node's MTU value is stored in the :mtu_actual_redeployed clipboard
     And the expression should be true> cb.mtu_actual == cb.mtu_actual_redeployed

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1000,7 +1000,7 @@ Given /^I store "([^"]*)" node's corresponding default networkType pod name in t
   cb[cb_pod_name] = BushSlicer::Pod.get_labeled(app, project: project(project_name, switch: false), user: admin) { |pod, hash|
     pod.node_name == node_name
   }.first.name
-  logger.info "node's corresponding networkType pod name is stored in the #{cb_pod_name} clipboard."
+  logger.info "node's corresponding networkType pod name is stored in the #{cb_pod_name} clipboard as #{cb[cb_pod_name]}."
 end
 
 Given /^I store the ovnkube-master#{OPT_QUOTED} leader pod in the#{OPT_SYM} clipboard(?: using node #{QUOTED})?$/ do |ovndb, cb_leader_name, node_name|

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1306,7 +1306,7 @@ end
 
 Given /^the node's active nmcli connection is stored in the#{OPT_SYM} clipboard$/ do |cb_name|
   ensure_admin_tagged
-  cb_name = "nmcli_active_con_uuid" unless cb_name
+  cb_name = "active_con_uuid" unless cb_name
   @result = host.exec_admin("nmcli -t -f UUID c show --active")
   # run command and store first line of output as the response
   cb[cb_name] = @result[:response].split("\n").first

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -716,7 +716,7 @@ Given /^the default interface on nodes is stored in the#{OPT_SYM} clipboard$/ do
   end
   # OVN uses `br-ex` and `-` is not a word char, so we have to split on whitespace
   cb[cb_name] = @result[:response].split("\n").first.split[4]
-  logger.info "The node's default interface is stored in the #{cb_name} clipboard."
+  logger.info "The node's default interface is stored in the #{cb_name} clipboard as #{cb[cb_name]}."
 end
 
 Given /^CNI vlan info is obtained on the#{OPT_QUOTED} node$/ do | node_name |
@@ -1233,7 +1233,7 @@ Given /^the node's MTU value is stored in the#{OPT_SYM} clipboard$/ do |cb_node_
   inf_name = @result[:response].split("\n").first.split[4]
   @result = host.exec_admin("ip a show #{inf_name}")
   cb[cb_node_mtu] = @result[:response].split(/mtu /)[1][0,4]
-  logger.info "Node's MTU value is stored in the #{cb_node_mtu} clipboard."
+  logger.info "Node's MTU value is stored in the #{cb_node_mtu} clipboard as #{cb[cb_node_mtu]}."
 end
 
 Given /^the mtu value "([^"]*)" is patched in CNO config according to the networkType$/ do | mtu_value |
@@ -1302,4 +1302,13 @@ Given /^the IPsec is enabled on the cluster$/ do
   network_operator = BushSlicer::NetworkOperator.new(name: "cluster", env: env)
   default_network = network_operator.default_network(user: admin)
   raise "env doesn't have IPSec enabled" unless default_network["ipsecConfig"]
+end
+
+Given /^the node's active nmcli connection is stored in the#{OPT_SYM} clipboard$/ do |cb_name|
+  ensure_admin_tagged
+  cb_name = "nmcli_active_con_uuid" unless cb_name
+  @result = host.exec_admin("nmcli -t -f UUID c show --active")
+  # run command and store first line of output as the response
+  cb[cb_name] = @result[:response].split("\n").first
+  logger.info "Node's active nmcli connection uuid is stored in the #{cb_name} clipboard as #{cb[cb_name]}"
 end


### PR DESCRIPTION
# Purpose

Developers pointed out in the bz https://bugzilla.redhat.com/show_bug.cgi?id=1930446 that we should not need to use NetworkManager during modification of MTU. In order to align with that, I updated the test case.

# Current state

The Test works as expected, it is able to modify the MTU successfully on a new cluster. But as soon as we modify the MTU, the cluster breaks and starts acting weird(sometimes, more likely in the case where your test picks master node to modify mtu). What that means is we cannot actually reliably execute the test successfully. The bug associated with the test is open and awaiting fix. https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/28355/console

cc @rbbratta @weliang1 @asood-rh @zhaozhanqi @huiran0826  @brahaney @pruan-rht 