### PR TITLE
update case OCP-25933

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -366,8 +366,6 @@ Feature: SDN related networking scenarios
     | nmcli |
   Then the output should contain:
     | br-int: unmanaged                    |
-    | br-local: unmanaged                  |
-    | ovn-k8s-gw0: unmanaged               |
     | genev_sys_6081: unmanaged            |
     | <%= cb.tunnel_inf_name %>: unmanaged |
   # And veths ovs interfaces also needs to be unmanaged


### PR DESCRIPTION
Found this issue in daily failed cases https://polarion.engineering.redhat.com/polarion/#/project/OSE/wiki/Networking/Networking%20failed%20cases
and the failed logs http://ci-qe-openshift.usersys.redhat.com/userContent/cucushift/v3/2021/04/18/04:21:11/NetworkManager_should_consider_OVS_interfaces_as_unmanaged/console.html
some OVN cluster may not contain `br-local` and `ovn-k8s-gw0` when using 'nmcli`. I did not research more for it. if you know please help comment it.  thanks
