### PR TITLE
fix OCP-41179

### DIFF
--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -582,6 +582,8 @@ Feature: Egress-ingress related networking scenarios
       | ["metadata"]["namespace"]    | <%= project.name %> |
     Then the step should succeed
 
+    And I wait up to 60 seconds for the steps to pass:
+    """
     When I run the :get admin command with:
       | resource      | egressfirewall                 |
       | resource_name | default                        |
@@ -590,6 +592,7 @@ Feature: Egress-ingress related networking scenarios
     Then the step should succeed
     And the output should contain:
       | EgressFirewall Rules applied |
+    """
 
     #Check the last dns name in yaml file should be allowed
     When I execute on the pod:


### PR DESCRIPTION
When creating the EgressFirewall, it may takes some time to generate the rule, but in auto run, the step is fast, so add timeout here to wait for the rule generated and status updated.

And run it multiple times for the fix and it passed.
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3067/console

@zhaozhanqi @anuragthehatter @rbbratta @weliang1 
