### PR TITLE
auto OCP-34697

### DIFF
--- a/features/machine/upi_gcp.feature
+++ b/features/machine/upi_gcp.feature
@@ -1,6 +1,13 @@
 Feature: UPI GCP Tests
 
   # @author zhsun@redhat.com
+  # @case_id OCP-34697
+  @admin
+  @destructive
+  Scenario: MachineSets in GCP should create Machines in a Shared (XPN) VPC environment
+    Given I have an UPI deployment and machinesets are enabled
+
+  # @author zhsun@redhat.com
   # @case_id OCP-25034
   @admin
   @destructive


### PR DESCRIPTION
Auto OCP-34697: MachineSets in GCP should create Machines in a Shared (XPN) VPC environment @jhou1 @miyadav please help to take a look
```
      [05:30:18] INFO> === End After Scenario: MachineSets in GCP should create Machines in a Shared (XPN) VPC environment ===

1 scenario (1 passed)
1 step (1 passed)
0m14.550s
```
Enable upi xpn gcp machinesets pr: https://gitlab.cee.redhat.com/aosqe/flexy-templates/-/merge_requests/526