### PR TITLE
OVN: error if no leader

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1043,7 +1043,7 @@ Given /^I store the ovnkube-master#{OPT_QUOTED} leader pod in the#{OPT_SYM} clip
   raise "Failed to execute network command!" unless cluster_state != nil
   # for some reason "oc rsh" output contains CR, so we have to remove them
   leader_id = cluster_state.match(/Leader:\s+(\S+)/)
-  if leader_id[1] == "unknown"
+  if leader_id.nil? || leader_id[1] == "unknown"
     raise "Unknown leader"
   end
   servers = cluster_state.match(/Servers:\n(.*)/m)


### PR DESCRIPTION
On Single Node OpenShift there is no OVN leader, `leader_id` is nil.

Instead of

```
NoMethodError: undefined method `[]' for nil:NilClass
```
use the regular error message