### PR TITLE
Add supports if the default scheduler is set

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -486,7 +486,15 @@ end
 Given /^I have a iSCSI setup in the environment$/ do
   ensure_admin_tagged
 
-  _project = project("default", switch: false)
+  _project = project("iscsi-target", switch: false)
+  if !_project.exists?(user:admin, quiet: true)
+    step %Q{admin creates a project with:}, table(%{
+      | project_name  | iscsi-target |
+      | node_selector |              |
+    })
+    step %Q{the step should succeed}
+  end
+
   _pod = cb.iscsi_pod = pod("iscsi-target", _project)
   _service = cb.iscsi_service = service("iscsi-target", _project)
 
@@ -519,7 +527,7 @@ end
 Given /^I create a second iSCSI path$/ do
   ensure_admin_tagged
 
-  _project = project("default", switch: false)
+  _project = project("iscsi-target", switch: false)
   _pod = cb.iscsi_pod = pod("iscsi-target", _project)
   step %Q{I download a file from "https://raw.githubusercontent.com/openshift-qe/docker-iscsi/master/service.json"}
   service_content = JSON.load(@result[:response])
@@ -547,7 +555,7 @@ end
 Given /^I disable the second iSCSI path$/ do
   ensure_destructive_tagged
 
-  _project = project("default", switch: false)
+  _project = project("iscsi-target", switch: false)
   _service_2 = service('iscsi-target-2', _project)
   _service_2.ensure_deleted(user: admin)
 end

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -438,7 +438,10 @@ module BushSlicer
     #   support purposes (e.g. host a debug pod for running node commands)
     def service_project
       unless @service_project
-        project = Project.new(name: "tests-" + EXECUTOR_NAME.downcase, env: self)
+        # if the cluster set the default scheduler, set the project running debug pod node-selector=''
+        # to overwrite the default scheduler, or the pod can not be run successfully
+        project_name = "tests-" + EXECUTOR_NAME.downcase
+        project = Project.new(name: project_name, env: self)
         unless project.active?
           # 30 seconds is no longer enough
           project.wait_to_disappear(admin, 60)
@@ -446,6 +449,7 @@ module BushSlicer
           unless res[:success]
             raise "failed to create service project #{project.name}, see log"
           end
+          admin.cli_exec(:annotate, resource: "namespace", resourcename: project_name, keyval: 'openshift.io/node-selector=', overwrite: true)
           # we must update the cache, since we just waited for the previously active project to disappear
           project.reload
         end


### PR DESCRIPTION
@duanwei33 @chao007 @liangxia @pruan-rht Please help review this PR.

This PR is for there is default scheduler is set in the cluster, such as:
```
$ oc get scheduler cluster -ojson|jq .spec
{
  "defaultNodeSelector": "node-role.kubernetes.io/worker=",
  "mastersSchedulable": false,
  "policy": {
    "name": ""
  }
}
```
The update in `helper_services.rb` file is for the iscsi test, our iscsi target pod is scheduled to the master node, so if we still use the `default` ns, then there will be some conflict in the node selector config.
The update in `enviorment.rb` file is for the cmd `oc debug node`, if we created a namespace without overwrite the cluster wide scheduler, then the `oc debug node` cmd will fail.