### PR TITLE
Opt out the time consuming steps in base image's dockerfile

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.rhel7
+++ b/tools/jenkins/slaves/Dockerfile.rhel7
@@ -8,11 +8,13 @@ LABEL maintainer="AOS QE Team"
 ENV USER_PATHS="$HOME /etc/machine-id /etc/passwd /etc/pki"
 
 RUN set -x && \
-    yum repolist all && \
-    yum-config-manager --disable \* && \
-    ENABLE_REPOS="rhel-7-server-rpms rhel-7-server-optional-rpms rhel-7-server-extras-rpms rhel-7-server-ansible-2-rpms rhel-server-rhscl-7-rpms" && \
-    yum-config-manager --enable $ENABLE_REPOS && \
-    yum-config-manager --save --setopt=\*.skip_if_unavailable=1 $ENABLE_REPOS && \
+    yum repolist enabled && \
+    OLD_REPOS=$(yum repolist enabled -q | sed 1d | cut -d'/' -f1) && \
+    ([ -n "$OLD_REPOS" ] && yum-config-manager --disable $OLD_REPOS || :) && \
+    NEW_REPOS="rhel-7-server-rpms rhel-7-server-optional-rpms rhel-7-server-extras-rpms rhel-7-server-ansible-2-rpms rhel-server-rhscl-7-rpms" && \
+    yum-config-manager --enable $NEW_REPOS && \
+    yum-config-manager --save --setopt=\*.skip_if_unavailable=1 $NEW_REPOS && \
+    yum repolist enabled && \
     yum -y update && \
     SCL_BASE_PKGS="scl-utils-build" && \
     INSTALL_PKGS="rh-ruby27 rh-ruby27-ruby-devel rh-ruby27-rubygem-bundler rh-git218 bsdtar" && \


### PR DESCRIPTION
Both steps `yum repolist all` and `yum-config-manager --disable \*` are really time consuming as there are many repositories.

1. Use `yum repolist enabled` to replace `yum repolist all`, as generally we only cares about the enabled repos.
2. Use `yum-config-manager --disable $OLD_REPOS` to replace `yum-config-manager --disable \*`, as there are no need to iterate those disabled repos.

/cc @pruan-rht @jhou1 @JianLi-RH 