### PR TITLE
[hotfix] skip scenario skipping on conflict

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -32,7 +32,8 @@ end
 ## while we can move everything inside World, lets try to outline here the
 #    basic steps to have world ready to execute scenario
 Before do |_scenario|
-  if _scenario.respond_to?(:test_case_manager_skip?)
+  if manager.skip_scenario? _scenario
+    manager.skip_scenario_done _scenario
     skip_this_scenario "Scenario skipped by Test Case Manager"
     next
   end

--- a/lib/manager.rb
+++ b/lib/manager.rb
@@ -91,6 +91,30 @@ module BushSlicer
       @ast_lookup
     end
 
+    def skip_scenario!(scenario)
+      @skip_scenario = scenario
+    end
+
+    def skip_scenario?(scenario)
+      if @skip_scenario
+        if @skip_scenario == scenario
+          true
+        else
+          raise "instructed to skip scenario #{@skip_scenario} but was asked about #{scenario}"
+        end
+      end
+    end
+
+    def skip_scenario_done(scenario)
+      if @skip_scenario
+        if @skip_scenario != scenario
+          raise "instructed to skip scenario #{@skip_scenario} but was notified about skipping #{scenario}"
+        end
+      else
+        raise "no scenario to skip but was notified about skipping #{scenario}"
+      end
+    end
+
     def init_test_case_manager(cucumber_config)
       tc_mngr = ENV['BUSHSLICER_TEST_CASE_MANAGER'] || conf[:test_case_manager]
       tc_mngr = tc_mngr ? tc_mngr + '_tc_manager' : false

--- a/lib/polarshift/test_suite.rb
+++ b/lib/polarshift/test_suite.rb
@@ -121,10 +121,13 @@ module BushSlicer
 
       # @param test_case [Cucumber::Events::TestRunFinished]
       def test_case_execute_finish!(event, attach:)
+        unless current_test_record
+          raise "Bug in test case management - current test record is not set but we finished scenario '#{event.test_case.name}'"
+        end
         test_case_expected?(event.test_case)
         current_test_record.finished!(event, attach: attach)
       ensure
-        if current_test_record.finished?
+        if current_test_record&.finished?
           self.current_test_record = nil
         end
       end

--- a/lib/test_case_manager_filter.rb
+++ b/lib/test_case_manager_filter.rb
@@ -27,17 +27,15 @@ module BushSlicer
     # called at end of the list to print summary
     def done
       # note that registering events in #initialize results in dup registration
-      config = Manager.instance.cucumber_config
+      manager = Manager.instance
+      config = manager.cucumber_config
 
       config.on_event :test_case_started do |event|
         if tc_manager.commit!(event.test_case)
           tc_manager.signal(:start_case, event.test_case)
         else
           # ugly but I don't see another way to mark this test case for skipping
-          test_case = event.test_case
-          def test_case.test_case_manager_skip?
-            true
-          end
+          manager.skip_scenario! event.test_case
         end
       end
 


### PR DESCRIPTION
conflict here means that another executor has taken this scenario already
so we need to skip it to avoid double execution