### PR TITLE
Fix image name

### DIFF
--- a/testdata/quota/pod-completed.yaml
+++ b/testdata/quota/pod-completed.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: pi
-    image: perl
+    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
     command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
     resources:
       requests:


### PR DESCRIPTION
With the previous image the test case was hitting docker pull limit, so changing the image so that it can be pulled from quay.io