### PR TITLE
Fix update-automation of polarshift.rb

### DIFF
--- a/lib/gherkin_parse.rb
+++ b/lib/gherkin_parse.rb
@@ -252,16 +252,16 @@ module BushSlicer
         file_rel = relative_path(file, root)
         res = {}
         scenarios_raw(file).each do |scenario|
-          if scenario[:location][:line] == line
+          if scenario[:scenario][:location][:line] == line
             res["file"] = file_rel
-            res["scenario"] = scenario[:name]
-            res["tags"] = scenario[:tags].map{|s| s[:name][1..-1]}
-          elsif scenario[:type] == :ScenarioOutline
+            res["scenario"] = scenario[:scenario][:name]
+            res["tags"] = scenario[:scenario][:tags].map{|s| s[:name][1..-1]}
+          elsif scenario[:scenario][:keyword] == :ScenarioOutline
             scenario[:examples].each do |examples_table|
               if examples_table[:location][:line] == line
                 res["file"] = file_rel
-                res["scenario"] = scenario[:name]
-                res["tags"] = scenario[:tags].map{|s| s[:name][1..-1]}
+                res["scenario"] = scenario[:scenario][:name]
+                res["tags"] = scenario[:scenario][:tags].map{|s| s[:name][1..-1]}
                 res["tags"].concat examples_table[:tags].map { |ex_tag|
                   ex_tag[:name][1..-1]
                 }
@@ -271,8 +271,8 @@ module BushSlicer
                 examples_table[:tableBody].each do |example|
                   if example[:location][:line] == line
                     res["file"] = file_rel
-                    res["scenario"] = scenario[:name]
-                    res["tags"] = scenario[:tags].map{|s| s[:name][1..-1]}
+                    res["scenario"] = scenario[:scenario][:name]
+                    res["tags"] = scenario[:scenario][:tags].map{|s| s[:name][1..-1]}
                     res["tags"].concat examples_table[:tags].map { |ex_tag|
                       ex_tag[:name][1..-1]
                     }


### PR DESCRIPTION
Might be a side effect of migration to cucumber 5.x

/cc @jhou1 @pruan-rht @kasturinarra @JianLi-RH 

Failure message,
```
$ tools/polarshift.rb update-automation OCP-41580
Traceback (most recent call last):
	13: from tools/polarshift.rb:492:in `<main>'
	12: from tools/polarshift.rb:262:in `run'
	11: from /usr/share/gems/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
	10: from /usr/share/gems/gems/commander-4.6.0/lib/commander/runner.rb:58:in `run!'
	 9: from /usr/share/gems/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
	 8: from /usr/share/gems/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
	 7: from /usr/share/gems/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
	 6: from tools/polarshift.rb:65:in `block (2 levels) in run'
	 5: from /home/lxia/code-bases/github.com/verification-tests/lib/gherkin_parse.rb:251:in `spec_for'
	 4: from /home/lxia/code-bases/github.com/verification-tests/lib/gherkin_parse.rb:251:in `each'
	 3: from /home/lxia/code-bases/github.com/verification-tests/lib/gherkin_parse.rb:254:in `block in spec_for'
	 2: from /home/lxia/code-bases/github.com/verification-tests/lib/gherkin_parse.rb:254:in `each'
	 1: from /home/lxia/code-bases/github.com/verification-tests/lib/gherkin_parse.rb:255:in `block (2 levels) in spec_for'
/usr/share/gems/gems/protobuf-cucumber-3.10.8/lib/protobuf/message.rb:202:in `[]': undefined method `value_from_values' for nil:NilClass (NoMethodError)
	14: from tools/polarshift.rb:492:in `<main>'
	13: from tools/polarshift.rb:262:in `run'
	12: from /usr/share/gems/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
	11: from /usr/share/gems/gems/commander-4.6.0/lib/commander/runner.rb:58:in `run!'
	10: from /usr/share/gems/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
	 9: from /usr/share/gems/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
	 8: from /usr/share/gems/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
	 7: from tools/polarshift.rb:65:in `block (2 levels) in run'
	 6: from /home/lxia/code-bases/github.com/verification-tests/lib/gherkin_parse.rb:251:in `spec_for'
	 5: from /home/lxia/code-bases/github.com/verification-tests/lib/gherkin_parse.rb:251:in `each'
	 4: from /home/lxia/code-bases/github.com/verification-tests/lib/gherkin_parse.rb:254:in `block in spec_for'
	 3: from /home/lxia/code-bases/github.com/verification-tests/lib/gherkin_parse.rb:254:in `each'
	 2: from /home/lxia/code-bases/github.com/verification-tests/lib/gherkin_parse.rb:255:in `block (2 levels) in spec_for'
	 1: from /usr/share/gems/gems/protobuf-cucumber-3.10.8/lib/protobuf/message.rb:200:in `[]'
/usr/share/gems/gems/protobuf-cucumber-3.10.8/lib/protobuf/message.rb:205:in `rescue in []': invalid field name=:location (ArgumentError)

```