### PR TITLE
Add wait before validating to ensure the policy has been applied

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -137,6 +137,8 @@ Feature: SDN compoment upgrade testing
     Given the AllowNamespaceAndPod policy is applied to the "policy-upgrade1" namespace
     Then the step should succeed
 
+    And I wait up to 10 seconds for the steps to pass:
+    """
     When I use the "policy-upgrade1" project
     When I execute on the "<%= cb.pod1 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
@@ -160,6 +162,7 @@ Feature: SDN compoment upgrade testing
       | curl | -s | --connect-timeout | 5 | <%= cb.pod3ip %>:8080 |
     Then the step should succeed 
     And the output should contain "Hello"
+    """
 
   # @author asood@redhat.com
   # @case_id OCP-38751
@@ -172,27 +175,32 @@ Feature: SDN compoment upgrade testing
       | name=test-pods |
     And evaluation of `pod(1).ip_url` is stored in the :pod2ip clipboard
     And evaluation of `pod(0).name` is stored in the :pod1 clipboard
-    When I execute on the "<%= cb.pod1 %>" pod:
-      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
-    Then the step should fail
     Given a pod becomes ready with labels:
       | name=hello-idle |
     And evaluation of `pod(2).name` is stored in the :pod3 clipboard
     And evaluation of `pod(2).ip_url` is stored in the :pod3ip clipboard
+    And I wait up to 10 seconds for the steps to pass:
+    """
+    When I execute on the "<%= cb.pod1 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should fail
     When I execute on the "<%= cb.pod3 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail
+    """
 
     When I use the "policy-upgrade2" project
     Given a pod becomes ready with labels:
       | name=test-pods |
     And evaluation of `pod(3).name` is stored in the :pod4 clipboard
-    When I execute on the "<%= cb.pod4 %>" pod:
-      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
-    Then the step should succeed
     Given a pod becomes ready with labels:
       | name=hello-idle |
     And evaluation of `pod(4).name` is stored in the :pod5 clipboard
+    And I wait up to 10 seconds for the steps to pass:
+    """
+    When I execute on the "<%= cb.pod4 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should succeed
     When I execute on the "<%= cb.pod5 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
     Then the step should fail 
@@ -200,3 +208,4 @@ Feature: SDN compoment upgrade testing
       | curl | -s | --connect-timeout | 5 | <%= cb.pod3ip %>:8080 |
     Then the step should succeed 
     And the output should contain "Hello"
+    """


### PR DESCRIPTION
Fix for issue https://issues.redhat.com/browse/OCPQE-3886 

First validation done immediately after applying policy to namespace fails.
The fix is to add wait of 10 second in both the runs before running validation checks.

Local run
Pre upgrade
1 scenario (1 passed)
34 steps (34 passed)
1m22.300s


Post upgrade 
1 scenario (1 passed)
15 steps (15 passed)
0m36.182s
[14:15:37] INFO> === At Exit ===
