### PR TITLE
skip installation steps if there's an existing kataconfig

### DIFF
--- a/features/node/kata/install_uninstall.feature
+++ b/features/node/kata/install_uninstall.feature
@@ -4,8 +4,8 @@ Feature: kata related features
   @admin
   @destructive
   Scenario: kata container operator installation
-    Given kata container has been installed successfully in the "sandboxed-containers-operator-system" project
-    And I verify kata container runtime is installed into the a worker node
+    Given kata container has been installed successfully in the "openshift-sandboxed-containers-operator" project
+    And I verify kata container runtime is installed into a worker node
 
   # @author pruan@redhat.com
   # @case_id OCP-36509


### PR DESCRIPTION
1. skip kata installation steps if there's an existing kataconfig
2. fix a typo in a step
3. default kata project is now 'openshift-sandboxed-containers-operator'