### PR TITLE
added case OCP-41813 and check for qe-app-registry

### DIFF
--- a/features/cluster_configuration/create_index_catalog.feature
+++ b/features/cluster_configuration/create_index_catalog.feature
@@ -1,0 +1,7 @@
+Feature: create index catalog
+  # based on https://gitlab.cee.redhat.com/aosqe/aosqe-tools/-/blob/master/app_registry_tools/create_index_catalogsource.sh
+  @admin
+  @destructive
+  Scenario: create index catalogsource
+    Given I create "qe-app-registry" catalogsource for my cluster
+

--- a/features/cluster_configuration/create_index_catalog.feature
+++ b/features/cluster_configuration/create_index_catalog.feature
@@ -3,5 +3,5 @@ Feature: create index catalog
   @admin
   @destructive
   Scenario: create index catalogsource
-    Given I create "qe-app-registry" catalogsource for my cluster
+    Given I create "qe-app-registry" catalogsource for testing
 

--- a/features/node/kata/install_uninstall.feature
+++ b/features/node/kata/install_uninstall.feature
@@ -35,3 +35,13 @@ Feature: kata related features
   @destructive
   Scenario: kata operator can be installed via CLI with OLM for OCP>=4.8
     Given the kata-operator is installed using OLM CLI
+
+  # @author pruan@redhat.com
+  # @case_id OCP-41813
+  @admin
+  @destructive
+  Scenario: basic smoke test for kata
+    Given the kata-operator is installed using OLM CLI
+    And I verify kata container runtime is installed into a worker node
+    And I ensure "<%= project.name %>" project is deleted
+    And I remove kata operator from the namespace

--- a/features/node/kata/install_uninstall.feature
+++ b/features/node/kata/install_uninstall.feature
@@ -40,7 +40,7 @@ Feature: kata related features
   # @case_id OCP-41813
   @admin
   @destructive
-  Scenario: basic smoke test for kata
+  Scenario: install kata, verify pod has kata runtime followed by uninstall kata from cluster
     Given the kata-operator is installed using OLM CLI
     And I verify kata container runtime is installed into a worker node
     And I ensure "<%= project.name %>" project is deleted

--- a/features/step_definitions/cluster_configuration/cluster_config.rb
+++ b/features/step_definitions/cluster_configuration/cluster_config.rb
@@ -37,7 +37,7 @@ end
 Given /^I create #{QUOTED} catalogsource for my#{OPT_QUOTED} cluster$/ do |catalog_name, ocp_version|
   ensure_admin_tagged
   ensure_destructive_tagged
-  
+
   step %Q/I store master major version in the :master_version clipboard/ unless ocp_version
   ocp_version ||= cb.master_version
   project("openshift-marketplace")

--- a/features/step_definitions/cluster_configuration/cluster_config.rb
+++ b/features/step_definitions/cluster_configuration/cluster_config.rb
@@ -67,7 +67,7 @@ Given /^I create #{QUOTED} catalogsource(?: with index version #{QUOTED})? for#{
   end
   # create policy
   step %Q|I obtain test data file "catalogsource/image_content_soruce_policy.yaml"|
-  admin.cli_exec(:create, f: 'image_content_soruce_policy.yaml')
+  admin.cli_exec(:apply, f: 'image_content_soruce_policy.yaml')
   step %Q(I run oc create as admin over ERB test file: catalogsource/catalog_source.yaml)
   step %Q(all pods in the project are ready)
 end

--- a/features/step_definitions/kata.rb
+++ b/features/step_definitions/kata.rb
@@ -114,7 +114,7 @@ Given /^the kata-operator is installed(?: to #{OPT_QUOTED})? using OLM(?: (CLI|G
   step %Q/I switch to cluster admin pseudo user/
   project('openshift-marketplace')
   unless catalog_source('qe-app-registry').exists?
-    logger.info("Kata installation depends on `qe-app-registry`, which is missing in this cluster, calling step to create it..."
+    logger.info("Kata installation depends on `qe-app-registry`, which is missing in this cluster, calling step to create it...")
     step %Q/I create "qe-app-registry" catalogsource for my cluster/
   end
 

--- a/features/step_definitions/kata.rb
+++ b/features/step_definitions/kata.rb
@@ -22,7 +22,7 @@ Given /^kata container has been installed successfully(?: in the #{QUOTED} proje
 end
 
 Given /^I wait for #{QUOTED} (uninstall|install) to start$/ do | kc_name, mode |
-  timeout = 50
+  timeout = 300
   stats = {}
   success = false
   wait_for(timeout, stats: stats) do
@@ -115,7 +115,7 @@ Given /^the kata-operator is installed(?: to #{OPT_QUOTED})? using OLM(?: (CLI|G
   project('openshift-marketplace')
   unless catalog_source('qe-app-registry').exists?
     logger.info("Kata installation depends on `qe-app-registry`, which is missing in this cluster, calling step to create it...")
-    step %Q/I create "qe-app-registry" catalogsource for my cluster/
+    step %Q/I create "qe-app-registry" catalogsource for testing/
   end
 
   unless kata_config(kata_config_name).exists?

--- a/features/step_definitions/kata.rb
+++ b/features/step_definitions/kata.rb
@@ -110,12 +110,18 @@ Given /^the kata-operator is installed(?: to #{OPT_QUOTED})? using OLM(?: (CLI|G
   step %Q/I store master major version in the :master_version clipboard/
   raise "Kata operator OLM installation only supported for OCP >= 4.8" unless cb.master_version >= "4.8"
   install_method ||= 'CLI'
+  # first check pre-req
+  step %Q/I switch to cluster admin pseudo user/
+  project('openshift-marketplace')
+  unless catalog_source('qe-app-registry').exists?
+    logger.info("Kata installation depends on `qe-app-registry`, which is missing in this cluster, calling step to create it..."
+    step %Q/I create "qe-app-registry" catalogsource for my cluster/
+  end
 
   unless kata_config(kata_config_name).exists?
     if install_method == 'GUI'
       package_name = 'kata-operator'
       catalog_name = 'qe-app-registry'
-
       @result = admin.cli_exec(:create_namespace, name: kata_ns)
       project(kata_ns)
       step %Q/I switch to the first user/

--- a/testdata/catalogsource/catalog_source.yaml
+++ b/testdata/catalogsource/catalog_source.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name:  "<%= cb.catalog_name %>"
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: "<%= cb.iib %>"
+

--- a/testdata/catalogsource/image_content_soruce_policy.yaml
+++ b/testdata/catalogsource/image_content_soruce_policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: brew-registry
+spec:
+  repositoryDigestMirrors:
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry.redhat.io
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry.stage.redhat.io
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry-proxy.engineering.redhat.com
+


### PR DESCRIPTION
1. added smoke test for kata
2. added check for `qe-app-registry` which is needed in order to run the installation
3. added step to create the `qe-app-registry` if it does not exist.

https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3081/console