### PR TITLE
OCP-22504 quick fix

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1188,7 +1188,7 @@ Feature: Multus-CNI related scenarios
       | name     | <%= cb.pod_name %> |
     Then the step should succeed
     And the output should contain:
-      | cannot find get a network-attachment-definition |
+      | cannot find a network-attachment-definition |
       | ContainerCreating                               |
     """
 

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1189,7 +1189,7 @@ Feature: Multus-CNI related scenarios
     Then the step should succeed
     And the output should contain:
       | cannot find a network-attachment-definition |
-      | ContainerCreating                               |
+      | ContainerCreating                           |
     """
 
   # @author anusaxen@redhat.com


### PR DESCRIPTION
Seems like the upstream/downtream multus has finally corrected this minor english mistake and backported to earlier releases. Hence test case needs to be adjusted accordingly to avoid CI failures
Re-ran to make sure : http://pastebin.test.redhat.com/964530

@openshift/team-sdn-qe 