### PR TITLE
workaround for OCPQE-4052

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 # source 'https://gems.ruby-china.com/'
 
 gem 'json'
-gem 'psych'
+# temp workaround for https://issues.redhat.com/browse/OCPQE-4052
+gem 'psych', '~> 3.3', '>= 3.3.1'
 # gem 'rest-client', '2.0.0.rc2'
 gem 'rest-client', '>=2.0'
 # gem 'httpclient', '>=2.4'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 # source 'https://gems.ruby-china.com/'
 
 gem 'json'
-# temp workaround for https://issues.redhat.com/browse/OCPQE-4052
+# temp workaround for OCPQE-4052 in which Psych 4.x is not compatible with
+# cucumber 5.x
 gem 'psych', '~> 3.3', '>= 3.3.1'
 # gem 'rest-client', '2.0.0.rc2'
 gem 'rest-client', '>=2.0'


### PR DESCRIPTION
Psych 4.x and our cuke5 migration doesn't seem to play well as described in JIRA [OCPQE-4052](https://issues.redhat.com/browse/OCPQE-4052).  To unblock folks, specify the Psych (ruby YAML lib) to 3.x