### PR TITLE
[v3] update some critical routing cases to use images from quay

### DIFF
--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -18,10 +18,10 @@ Feature: Testing haproxy router
     #create route and service which has two endpoints
     Given I have a project
     When I run the :create client command with:
-      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/caddy-docker.json |
+      | f | https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/routing/caddy-docker.json |
     Then the step should succeed
     When I run the :create client command with:
-      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/caddy-docker-2.json |
+      | f | https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/routing/caddy-docker-2.json |
     Then the step should succeed
     And all pods in the project are ready
     When I run the :create client command with:
@@ -736,10 +736,10 @@ Feature: Testing haproxy router
     Given the master version >= "3.7"
     Given I have a project
     When I run the :create client command with:
-      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/caddy-docker.json |
+      | f | https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/routing/caddy-docker.json |
     Then the step should succeed
     When I run the :create client command with:
-      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/caddy-docker-2.json |
+      | f | https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/routing/caddy-docker-2.json |
     Then the step should succeed
     And all pods in the project are ready
     When I run the :create client command with:

--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -6,7 +6,7 @@ Feature: Testing route
   Scenario: Alias will be invalid after removing it
     Given I have a project
     When I run the :create client command with:
-      | f  |   https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/header-test/dc.json  |
+      | f | https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/routing/header-test/dc.json |
     Then the step should succeed
     When I run the :create client command with:
       | f  |   https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/header-test/insecure-service.json |
@@ -29,7 +29,7 @@ Feature: Testing route
   @smoke
   Scenario: Service endpoint can be work well if the mapping pod ip is updated
     Given I have a project
-    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/list_for_pods.json" replacing paths:
+    When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/networking/list_for_pods.json" replacing paths:
       | ["items"][0]["spec"]["replicas"] | 1 |
     Then the step should succeed
     Given a pod becomes ready with labels:
@@ -92,7 +92,7 @@ Feature: Testing route
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
-      | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/caddy-docker.json |
+      | f | https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/routing/caddy-docker.json |
     Then the step should succeed
     And a pod becomes ready with labels:
       | name=caddy-docker |


### PR DESCRIPTION
We found some v3 test cases were failed due to image pull rate limit issue of docker.io, since the old  `openshift-qe/v3-testfiles` repo is deprecated, so update the test cases to use the testdata (master branch) that already consumed the images from `quay.io/openshifttest`.

@quarterpin @jechen0648 Please help take a look. Thanks.