### PR TITLE
Fix restore logic of scheduler

### DIFF
--- a/features/step_definitions/scheduler.rb
+++ b/features/step_definitions/scheduler.rb
@@ -32,7 +32,7 @@ Given /^the CR #{QUOTED} named #{QUOTED} is restored after scenario$/ do |crd, n
     @result = _admin.cli_exec(:patch, **opts)
     raise "Cannot restore crd: #{name}" unless @result[:success]
     timeout = 300
-    if crd == 'kubescheduler'
+    if crd == 'kubescheduler' or crd == 'Scheduler'
        crd = 'kube-scheduler'
     end
     wait_for(timeout) do


### PR DESCRIPTION
When the crd is Scheduler restore logic  tries Scheduler instead of kubescheduler so it fails, fixing the same.