### PR TITLE
Fix scheduler restore logic

### DIFF
--- a/features/step_definitions/scheduler.rb
+++ b/features/step_definitions/scheduler.rb
@@ -26,6 +26,9 @@ Given /^the CR #{QUOTED} named #{QUOTED} is restored after scenario$/ do |crd, n
     if @result[:success] and @result[:parsed]['spec']['tlsSecurityProfile']
       patch_json = [{"op": "remove","path": "/spec/tlsSecurityProfile"}].to_json
       opts = {resource: crd, resource_name: name, p: patch_json, type: 'json' }
+    elsif @result[:success] and @result[:parsed]['spec']['profile']
+      patch_json = [{"op": "remove","path": "/spec/profile"}].to_json
+      opts = {resource: crd, resource_name: name, p: patch_json, type: 'json' }
     else
       opts = {resource: crd, resource_name: name, p: patch_json, type: 'merge' }
     end


### PR DESCRIPTION
Currently when the scheduler cluster has profile in the spec, restore logic does not handle it the right way, so fixing the same.