### PR TITLE
helper step to check for number of replicas for a cluster resource

### DIFF
--- a/features/step_definitions/replicas.rb
+++ b/features/step_definitions/replicas.rb
@@ -1,0 +1,20 @@
+# replicas related steps
+#
+
+## example usage Given there are 6 "daemon_set" replicas in the "openshift-monitoring" project
+Given /^there are #{NUMBER} #{QUOTED} replicas in the #{QUOTED} project$/ do |expected, resource_type, namespace|
+  ensure_admin_tagged
+  expected = expected.to_i
+  clazz = resource_class(resource_type)
+  if BushSlicer::ProjectResource > clazz
+    list = clazz.list(user: user, project: project(namespace))
+  else
+    list = clazz.list(user: user)
+  end
+  list.each do | cl |
+    desired_count = cl.replica_counters(cached: false)[:desired]
+    if desired_count != expected.to_i
+      raise "#{resource_type} count is #{desired_count}, but is expected to be #{expected} instead"
+    end
+  end
+end

--- a/features/step_definitions/replicas.rb
+++ b/features/step_definitions/replicas.rb
@@ -2,7 +2,7 @@
 #
 
 ## example usage Given there are 6 "daemon_set" replicas in the "openshift-monitoring" project
-Given /^there are #{NUMBER} #{QUOTED} replicas in the #{QUOTED} project$/ do |expected, resource_type, namespace|
+Given /^there (is|are) #{NUMBER} #{QUOTED} replicas? in the #{QUOTED} project$/ do |pronoun, expected, resource_type, namespace|
   ensure_admin_tagged
   expected = expected.to_i
   clazz = resource_class(resource_type)
@@ -14,7 +14,7 @@ Given /^there are #{NUMBER} #{QUOTED} replicas in the #{QUOTED} project$/ do |ex
   list.each do | cl |
     desired_count = cl.replica_counters(cached: false)[:desired]
     if desired_count != expected.to_i
-      raise "#{resource_type} count is #{desired_count}, but is expected to be #{expected} instead"
+      raise "#{resource_type} #{cl.name} count is #{desired_count}, but is expected to be #{expected} instead"
     end
   end
 end


### PR DESCRIPTION
example usage `Given there are 6 "daemon_set" replicas in the "openshift-monitoring" project`.  Should help with PR #2029

@lihongyan1 this should help with your PR