### PR TITLE
 vpshere version gets changed, ex- as now it is 7.0.1

### DIFF
--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -157,5 +157,4 @@ Feature: Machine misc features testing
       | path  | /api/v1/query?                         |
       | query | cloudprovider_vsphere_vcenter_versions |
     Then the step should succeed
-    And the expression should be true> @result[:parsed]["data"]["result"][0]["metric"]["version"] == "7.0.0"
-
+    And the expression should be true> @result[:parsed]["data"]["result"][0]["metric"]["version"] =~ /7.0/


### PR DESCRIPTION
@jhou1 @sunzhaohua2 , Please have a look whenever possible 
Modified to make sure it doesnt fail till the time vsphere version changes are minor releases :) 

```
.
.
.

      [07:10:19] INFO> HTTP GET https://prometheus-k8s-openshift-monitoring.apps.miyadav-31.qe.devcluster.openshift.com/api/v1/query?query=cloudprovider_vsphere_vcenter_versions
      [07:10:20] INFO> HTTP GET took 1.261 sec: 200 OK | application/json 511 bytes
      
      | path  | /api/v1/query?                         |
      | query | cloudprovider_vsphere_vcenter_versions |
    And evaluation of `@result[:parsed]["data"]["result"][0]["metric"]["version"]` is stored in the :vsphere_version clipboard # features/step_definitions/common.rb:128
    Then the output should contain:                                                                                            # features/step_definitions/common.rb:33
      | 7.0. |
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [07:10:20] INFO> === After Scenario: Report vCenter version to telemetry ===
      [07:10:20] INFO> Shell Commands: rm -r -f -- /root/workdir/dc757a505ece-
      
      [07:10:21] INFO> Exit Status: 0
      [07:10:22] INFO> === End After Scenario: Report vCenter version to telemetry ===

1 scenario (1 passed)
4 steps (4 passed)
0m21.400s
[07:10:22] INFO> === At Exit ===

```