### PR TITLE
Add code to remove forcedeploymentreason

### DIFF
--- a/features/step_definitions/scheduler.rb
+++ b/features/step_definitions/scheduler.rb
@@ -29,6 +29,9 @@ Given /^the CR #{QUOTED} named #{QUOTED} is restored after scenario$/ do |crd, n
     elsif @result[:success] and @result[:parsed]['spec']['profile']
       patch_json = [{"op": "remove","path": "/spec/profile"}].to_json
       opts = {resource: crd, resource_name: name, p: patch_json, type: 'json' }
+    elsif @result[:success] and @result[:parsed]['spec']['forceRedeploymentReason']
+      patch_json = [{"op": "remove","path":  "/spec/forceRedeploymentReason"}].to_json
+      opts = {resource: crd, resource_name: name, p: patch_json, type: 'json' }
     else
       opts = {resource: crd, resource_name: name, p: patch_json, type: 'merge' }
     end


### PR DESCRIPTION
currently when etcd cluster is patched to redeploy openshift-etcd pods there is no way to restore the etcd cluster back after the test, adjusting the function here to do the same.