### PR TITLE
add auto case 41666

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -383,6 +383,7 @@ Feature: Service related networking scenarios
     Then the step should succeed
     And the output should contain:
       | The service "<%= project.name %>/test-service" has been marked as idled |
+    And I wait until number of replicas match "0" for replicationController "test-rc"
     Given I have a pod-for-ping in the project
     And I wait up to 30 seconds for the steps to pass:
     """

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -383,7 +383,6 @@ Feature: Service related networking scenarios
     Then the step should succeed
     And the output should contain:
       | The service "<%= project.name %>/test-service" has been marked as idled |
-    And I wait until number of replicas match "0" for replicationController "test-rc"
     Given I have a pod-for-ping in the project
     And I wait up to 30 seconds for the steps to pass:
     """

--- a/testdata/networking/custom_kubelet.yaml
+++ b/testdata/networking/custom_kubelet.yaml
@@ -1,0 +1,10 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: set-max-pods
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      custom-kubelet: large-pods
+  kubeletConfig:
+    maxPods: 520

--- a/testdata/networking/max-pods-without-consume-memory.yaml
+++ b/testdata/networking/max-pods-without-consume-memory.yaml
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "v1",
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "ReplicationController",
+      "metadata": {
+        "labels": {
+          "name": "max-pods"
+        },
+        "name": "max-pods"
+      },
+      "spec": {
+        "replicas": 500,
+        "template": {
+          "metadata": {
+            "labels":  {
+              "name": "max-pods"
+            }
+          },
+          "spec": {
+            "containers": [
+              {  
+              "name": "max-pod",
+                "image": "quay.io/openshifttest/nonexist"
+              }
+            ],
+          "nodeName": "node-name"
+          }
+        }
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
@weliang1  could you help check the steps are correct here. 

I tested the script locally on IPI aws with `vm_type_workers: 'm5.xlarge'`, using normal cluster in our CI often caused the worker become not ready. 
and this case may cost 30 Mins to run it. 

@mffiedler this is the case we talked about in watch list docs need to run on large cluster.  Could you help review it and How to choose this case and run on perf cluster. 