### PR TITLE
fix for web rules

### DIFF
--- a/lib/rules/web/admin_console/4.8/check_links.xyaml
+++ b/lib/rules/web/admin_console/4.8/check_links.xyaml
@@ -57,11 +57,7 @@ click_alert_manager_menu:
     text: Alerting
     link_url: /monitoring/alerts
   action: click_link_with_text
-check_alert_manager_url:
-  params:
-    text: Alertmanager UI
-    link_url: https://<alert_ui_route>/#/alerts
-  action: check_link_and_text
+check_alert_manager_url: {}
 click_metrics_prometheus_menu:
   params:
     text: Metrics

--- a/lib/rules/web/admin_console/4.8/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.8/common_ui_elements.xyaml
@@ -380,7 +380,7 @@ check_containerdetails_text_in_breadcrumb:
 check_imagestreamtagdetails_text_in_breadcrumb:
   params:
     layer_number: 3
-    text: Image Stream Tag Details
+    text: ImageStreamTag details
   action: check_text_in_breadcrumb
 check_text_in_breadcrumb:
   element:

--- a/lib/rules/web/admin_console/4.8/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.8/operator_hub.xyaml
@@ -59,12 +59,12 @@ set_pod_count:
 increase_pod_count:
   element:
     selector:
-      xpath: //button[contains(@class,'co-m-number-spinner__button') and @aria-label='Increment']
+      xpath: //button[@aria-label='Increment']
     op: click
 decrease_pod_count:
   element:
     selector:
-      xpath: //button[contains(@class,'co-m-number-spinner__button') and @aria-label='Decrement']
+      xpath: //button[@aria-label='Decrement']
     op: click
 toggle_boolean_switch:
   params:

--- a/lib/rules/web/admin_console/4.8/search.xyaml
+++ b/lib/rules/web/admin_console/4.8/search.xyaml
@@ -17,20 +17,26 @@ click_resource_type_dropdown:
 send_type_filter:
   elements:
   - selector:
-      xpath: //input[@data-test-id='dropdown-text-filter']
+      xpath: //input[@placeholder='Select Resource']
     op: send_keys <resource_kind>
 search_resource_kind_only:
-  element:
-    selector:
-      xpath: //li//span[text()='<resource_kind>']
+  elements:
+  - selector:
+      xpath: //label//span[text()='<resource_kind>']
     op: click
     timeout: 15
+  - selector:
+      xpath: //span[@class='pf-c-dropdown__toggle']
+    op: click
 search_resource_kind_and_api_group:
-  element:
-    selector:
-      xpath: //li//span[text()='<resource_kind>']/following-sibling::span[contains(., '<resource_group>')]
+  elements:
+  - selector:
+      xpath: //span[text()='<resource_kind>']/following-sibling::span[contains(., '<resource_group>')]
     op: click
     timeout: 15
+  - selector:
+      xpath: //span[@class='pf-c-dropdown__toggle']
+    op: click
 clear_one_search_item:
   elements:
   - selector:

--- a/lib/rules/web/admin_console/4.8/storage.xyaml
+++ b/lib/rules/web/admin_console/4.8/storage.xyaml
@@ -135,7 +135,7 @@ remove_volume_from_container_but_cancel:
   action: remove_volume_from_container_base
 remove_volume_from_container:
   params:
-    button_text: Remove Volume
+    button_text: Remove volume
   action: remove_volume_from_container_base
 set_storageclass_name:
   params:


### PR DESCRIPTION
OCP-27601		Multiple resources could be selected on event page    
OCP-27550		Allow users to search for more than one resource type on search page        
OCP-24415		Select container when attach/remove volume        
 OCP-24106		[admin] Check breadcrumb on resource detail page      
OCP-19532             Check resource events      
OCP-21461		[admin] check monitoring routes on web console        
OCP-28832		[admin] Basic sync of YAML and Form for creating operator instance    
Fix rules for cases above, will paste log jobs when available.