### PR TITLE
extend timeout for install and uninstall

### DIFF
--- a/features/step_definitions/kata.rb
+++ b/features/step_definitions/kata.rb
@@ -41,7 +41,7 @@ Given /^I wait for #{QUOTED} (uninstall|install) to start$/ do | kc_name, mode |
 end
 
 Given /^I wait until number of completed kata runtime nodes match#{OPT_QUOTED} for #{QUOTED}$/ do |number, kc_name|
-  ready_timeout = 900
+  ready_timeout = 1000
   matched = kata_config(kc_name).wait_till_installed_counter_match(
     user: user, seconds: ready_timeout)
   unless matched[:success]
@@ -59,7 +59,7 @@ Given /^I remove kata operator from the#{OPT_QUOTED} namespace$/ do | kata_ns |
   # 1. remove kataconfig first
   project(kata_ns)
   kataconfig_name = BushSlicer::KataConfig.list(user: admin).first.name
-  step %Q/I ensure "#{kataconfig_name}" kata_config is deleted within 900 seconds/
+  step %Q/I ensure "#{kataconfig_name}" kata_config is deleted within 1000 seconds/
   # 2. remove namespace
   step %Q/I ensure "#{kata_ns}" project is deleted/
 end
@@ -155,7 +155,7 @@ Given /^the kata-operator is installed(?: to #{OPT_QUOTED})? using OLM(?: (CLI|G
     end
 
     # make sure kata-operator is running first before installing the kataconfig
-    step %Q/a pod is present with labels:/, table(%{
+    step %Q/a pod becomes ready with labels:/, table(%{
       | control-plane=controller-manager |
     })
     step %Q|I obtain test data file "kata/release-#{cb.master_version}/kataconfiguration_v1_kataconfig.yaml"|
@@ -166,7 +166,12 @@ Given /^the kata-operator is installed(?: to #{OPT_QUOTED})? using OLM(?: (CLI|G
     logger.info("There's already an existing 'kataconfig' resuing it...")
     project(kata_ns)
     step %Q/I switch to cluster admin pseudo user/
+    # make sure kata-operator is running first before installing the kataconfig
+    step %Q/a pod becomes ready with labels:/, table(%{
+      | control-plane=controller-manager |
+    })
   end
+  logger.info("Using kata image: #{pod.container_specs.first.image}")
   step %Q/I wait until number of completed kata runtime nodes match for "#{kata_config_name}"/
 end
 


### PR DESCRIPTION
Extend the timeout value to 1000 seconds instead of 900.  Also print the kata operator image information