### PR TITLE
Fixing for BZ-1879241

### DIFF
--- a/features/networking/multicast.feature
+++ b/features/networking/multicast.feature
@@ -212,7 +212,7 @@ Feature: testing multicast scenarios
     Then the step should succeed
     And the output should match:
       | eth0\s+1\s+239.255.254.24 |
-    And I wait up to 10 seconds for the steps to pass:
+    And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.proj1pod3 %>" pod:
       | cat | /tmp/proj1pod3.log |
@@ -220,8 +220,9 @@ Feature: testing multicast scenarios
     And the output should match:
       | <%= cb.proj1pod1ip %>.*joined \(S,G\) = \(\*, 239.255.254.24\), pinging |
       | <%= cb.proj1pod2ip %>.*joined \(S,G\) = \(\*, 239.255.254.24\), pinging |
-      | <%= cb.proj1pod1ip %>.*multicast, xmt/rcv/%loss = 5/5/0%                |
-      | <%= cb.proj1pod2ip %>.*multicast, xmt/rcv/%loss = 5/5/0%                |
+    And the output should not contain:
+      | <%= cb.proj1pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/0%                |
+      | <%= cb.proj1pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0%                |
     """
 
     # Check multicast group 239.255.254.24 stream in proj2
@@ -257,7 +258,7 @@ Feature: testing multicast scenarios
     Then the step should succeed
     And the output should match:
       | eth0\s+1\s+239.255.254.24 |
-    And I wait up to 10 seconds for the steps to pass:
+    And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.proj2pod3 %>" pod:
       | cat | /tmp/proj2pod3.log |
@@ -265,6 +266,8 @@ Feature: testing multicast scenarios
     And the output should match:
       | <%= cb.proj2pod1ip %>.*joined \(S,G\) = \(\*, 239.255.254.24\), pinging |
       | <%= cb.proj2pod2ip %>.*joined \(S,G\) = \(\*, 239.255.254.24\), pinging |
-      | <%= cb.proj2pod1ip %>.*multicast, xmt/rcv/%loss = 5/5/0%                |
-      | <%= cb.proj2pod2ip %>.*multicast, xmt/rcv/%loss = 5/5/0%                |
+    And the output should not contain:
+      | <%= cb.proj2pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/0%                |
+      | <%= cb.proj2pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0%                |
     """
+

--- a/features/networking/multicast.feature
+++ b/features/networking/multicast.feature
@@ -220,7 +220,7 @@ Feature: testing multicast scenarios
     And the output should match:
       | <%= cb.proj1pod1ip %>.*joined \(S,G\) = \(\*, 239.255.254.24\), pinging |
       | <%= cb.proj1pod2ip %>.*joined \(S,G\) = \(\*, 239.255.254.24\), pinging |
-    And the output should not contain:
+    And the output should not match:
       | <%= cb.proj1pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/0%                |
       | <%= cb.proj1pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0%                |
     """
@@ -266,7 +266,7 @@ Feature: testing multicast scenarios
     And the output should match:
       | <%= cb.proj2pod1ip %>.*joined \(S,G\) = \(\*, 239.255.254.24\), pinging |
       | <%= cb.proj2pod2ip %>.*joined \(S,G\) = \(\*, 239.255.254.24\), pinging |
-    And the output should not contain:
+    And the output should not match:
       | <%= cb.proj2pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/0%                |
       | <%= cb.proj2pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0%                |
     """


### PR DESCRIPTION
This case will test multicast in both SDN and OVN cluster.

Testing always failed in OVN cluster due to Bug 1879241 - [OVN] Pods always lose one multicast packets
Testing randomly failed in SDN and OVN due to 10 seconds is not enough for pod to collect multicast traffic log

Fixing:
1. In old code, the server send 5 multicast packets, and client expect to receive 5, new code is updated to check not all 5 packets lost in the client side.
2. Increase 10 to 20 seconds to wait pod to collect multicast log

Testing log:
http://file.rdu.redhat.com/~weliang/log-OVN
http://file.rdu.redhat.com/~weliang/log-SDN

/cc @openshift/team-sdn-qe