### PR TITLE
allow setting stdin in flexy launcher commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 junit-report/
 vendor/
 .byebug_history
+.tool-versions
 /tmp
 *.iml

--- a/tools/launch_instance.rb
+++ b/tools/launch_instance.rb
@@ -603,7 +603,7 @@ module BushSlicer
       when "shell_command"
         exec_opts = {
           single: true,
-          stderr: :stdout, stdout: STDOUT,
+          stderr: :stdout, stdout: STDOUT, stdin: task[:stdin],
           timeout: 36000
         }
         if task[:env]


### PR DESCRIPTION
needs testing to allow setting stdin to `shell_commands`

This can workaround `gcloud` issue where it crashes if
`stdin` is closed with

```
ERROR: gcloud crashed (AttributeError): 'NoneType' object has no attribute 'isatty'

If you would like to report this issue, please run the following command:
  gcloud feedback

To check gcloud for common problems, please run the following command:
  gcloud info --run-diagnostics
```

So a tast to workaround this would look like
```
install_sequence:
- type: shell_command
  stdin: :empty
  cmd:
  - bash
  - "-c"
  - |
    gcloud auth activate-service-account "some-serviceaccount@whatever.iam.gserviceaccount.com" --key-file /tmp/openshift-qe-gce_v4.json
```

FYI the `gcloud` reproducer
```
ssh -T installer3@hostname 'exec 0<&- ; gcloud auth activate-service-account "some-serviceaccount@whatever.iam.gserviceaccount.com" --key-file /tmp/openshift-qe-gce_v4.json'
```

I filed upstream issue https://issuetracker.google.com/issues/190540255