### PR TITLE
Adding wait for log acceptance feature on webconsole validation

### DIFF
--- a/features/logging/logging_acceptance.feature
+++ b/features/logging/logging_acceptance.feature
@@ -51,8 +51,13 @@ Feature: Logging smoke test case
     # Console Dashboard
     When I run the :goto_monitoring_db_cluster_logging web action
     Then the step should succeed
-    Given 60 seconds have passed
-    Given evaluation of `["Elastic Cluster Status", "Elastic Nodes", "Elastic Shards", "Elastic Documents", "Total Index Size on Disk", "Elastic Pending Tasks", "Elastic JVM GC time", "Elastic JVM GC Rate", "Elastic Query/Fetch Latency | Sum", "Elastic Query Rate | Top 5", "CPU", "Elastic JVM Heap Used", "Elasticsearch Disk Usage", "File Descriptors In Use", "FluentD emit count", "FluentD Buffer Availability", "Elastic rx bytes", "Elastic Index Failure Rate", "FluentD Output Error Rate"]` is stored in the :cards clipboard
+    Given evaluation of `["Elastic Nodes", "Elastic Shards", "Elastic Documents", "Total Index Size on Disk", "Elastic Pending Tasks", "Elastic JVM GC time", "Elastic JVM GC Rate", "Elastic Query/Fetch Latency | Sum", "Elastic Query Rate | Top 5", "CPU", "Elastic JVM Heap Used", "Elasticsearch Disk Usage", "File Descriptors In Use", "FluentD emit count", "FluentD Buffer Availability", "Elastic rx bytes", "Elastic Index Failure Rate", "FluentD Output Error Rate"]` is stored in the :cards clipboard
+    Given I wait up to 360 seconds for the steps to pass:
+    """
+    When I perform the :check_monitoring_dashboard_card web action with:
+      | card_name | Elastic Cluster Status |
+    Then the step should succeed
+    """
     And I repeat the following steps for each :card in cb.cards:
     """
     When I perform the :check_monitoring_dashboard_card web action with:

--- a/features/logging/logging_acceptance.feature
+++ b/features/logging/logging_acceptance.feature
@@ -51,6 +51,7 @@ Feature: Logging smoke test case
     # Console Dashboard
     When I run the :goto_monitoring_db_cluster_logging web action
     Then the step should succeed
+    Given 60 seconds have passed
     Given evaluation of `["Elastic Cluster Status", "Elastic Nodes", "Elastic Shards", "Elastic Documents", "Total Index Size on Disk", "Elastic Pending Tasks", "Elastic JVM GC time", "Elastic JVM GC Rate", "Elastic Query/Fetch Latency | Sum", "Elastic Query Rate | Top 5", "CPU", "Elastic JVM Heap Used", "Elasticsearch Disk Usage", "File Descriptors In Use", "FluentD emit count", "FluentD Buffer Availability", "Elastic rx bytes", "Elastic Index Failure Rate", "FluentD Output Error Rate"]` is stored in the :cards clipboard
     And I repeat the following steps for each :card in cb.cards:
     """


### PR DESCRIPTION
This is a PR to add wait before Web Console validation for log acceptance scenario.

Previous Runner job was failing due to the Elastic Cluster Status not appearing on web console validation. 
(Sample Failed Job: https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/79818/console)

New Runner smoke job success after adding wait.
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3179/console

Please review and approve @anpingli @QiaolingTang @gkarager 