### PR TITLE
Fix nc connection refused issue

### DIFF
--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -207,10 +207,10 @@ Feature: SCTP related scenarios
     """
 
     # Define a networkpolicy to deny sctpclient to sctpserver
-    Given I obtain test data file "networking/sctp/default-deny.yaml"
+    Given I obtain test data file "networking/networkpolicy/defaultdeny-v1-semantic.yaml"
     When I run the :create admin command with:
-      | f | default-deny.yaml   |
-      | n | <%= project.name %> |
+      | f | defaultdeny-v1-semantic.yaml   |
+      | n | <%= project.name %>            |
     Then the step should succeed
 
     # sctpclient pod start to send sctp traffic

--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -28,21 +28,20 @@ Feature: SCTP related scenarios
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
    
-    # sctpserver pod start to wait for sctp traffic
-    When I run the :exec background client command with:
-      | pod              | sctpserver                                |
-      | namespace        | <%= project.name %>                       |
-      | oc_opts_end      |                                           |
-      | exec_command     | bash                                      |
-      | exec_command_arg | -c                                        |
-      | exec_command_arg | /usr/bin/nc -k -l 30102 --sctp            |
-    Then the step should succeed
-
-    # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """
+    # sctpserver pod start to wait for sctp traffic
+    When I run the :exec background client command with:
+      | pod              | sctpserver                  |
+      | namespace        | <%= project.name %>         |
+      | oc_opts_end      |                             |
+      | exec_command     | bash                        |
+      | exec_command_arg | -c                          |
+      | exec_command_arg | /usr/bin/nc -l 30102 --sctp |
+    Then the step should succeed
+    # sctpclient pod start to send sctp traffic   
     When I execute on the "sctpclient" pod:
-      | bash | -c | echo test-openshift \| nc -w 5 -v <%= cb.serverpod_ip %> 30102 --sctp |
+      | bash | -c | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp |
     Then the step should succeed
     And the output should contain:
       | Connected to <%= cb.serverpod_ip %>:30102 |
@@ -83,21 +82,20 @@ Feature: SCTP related scenarios
     Given I use the "sctpservice" service
     And evaluation of `service.ip(user: user)` is stored in the :service_ip clipboard
 
-    # sctpserver pod start to wait for sctp traffic
-    When I run the :exec background client command with:
-      | pod              | sctpserver                                |
-      | namespace        | <%= project.name %>                       |
-      | oc_opts_end      |                                           |
-      | exec_command     | bash                                      |
-      | exec_command_arg | -c                                        |
-      | exec_command_arg | /usr/bin/nc -k -l 30102 --sctp            |
-    Then the step should succeed
-
-    # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """
+    # sctpserver pod start to wait for sctp traffic
+    When I run the :exec background client command with:
+      | pod              | sctpserver                  |
+      | namespace        | <%= project.name %>         |
+      | oc_opts_end      |                             |
+      | exec_command     | bash                        |
+      | exec_command_arg | -c                          |
+      | exec_command_arg | /usr/bin/nc -l 30102 --sctp |
+    Then the step should succeed
+    # sctpclient pod start to send sctp traffic   
     When I execute on the "sctpclient" pod:
-      | bash | -c | echo test-openshift \| nc -w 5 -v <%= cb.service_ip %> 30102 --sctp |
+      | bash | -c | echo test-openshift \| nc -v <%= cb.service_ip %> 30102 --sctp |
     Then the step should succeed
     And the output should contain:
       | Connected to <%= cb.service_ip %>:30102 |
@@ -139,25 +137,25 @@ Feature: SCTP related scenarios
     Given I use the "sctpservice" service
     And evaluation of `service(cb.sctpserver).node_port(port:30102)` is stored in the :nodeport clipboard
 
-    # sctpserver pod start to wait for sctp traffic
-    When I run the :exec background client command with:
-      | pod              | sctpserver                                |
-      | namespace        | <%= project.name %>                       |
-      | oc_opts_end      |                                           |
-      | exec_command     | bash                                      |
-      | exec_command_arg | -c                                        |
-      | exec_command_arg | /usr/bin/nc -k -l 30102 --sctp            |
-    Then the step should succeed
-
-    # sctpclient pod start to send sctp traffic on worknode:port
     And I wait up to 60 seconds for the steps to pass:
     """
+    # sctpserver pod start to wait for sctp traffic
+    When I run the :exec background client command with:
+      | pod              | sctpserver                  |
+      | namespace        | <%= project.name %>         |
+      | oc_opts_end      |                             |
+      | exec_command     | bash                        |
+      | exec_command_arg | -c                          |
+      | exec_command_arg | /usr/bin/nc -l 30102 --sctp |
+    Then the step should succeed
+    # sctpclient pod start to send sctp traffic on worknode:port
     When I execute on the "sctpclient" pod:
-      | bash | -c | echo test-openshift \| nc -w 5 -v <%= cb.worker1_ip %> <%= cb.nodeport %>  --sctp |
+      | bash | -c | echo test-openshift \| nc -v <%= cb.worker1_ip %> <%= cb.nodeport %>  --sctp |
     Then the step should succeed
     And the output should contain:
       | Connected to <%= cb.worker1_ip %>:<%= cb.nodeport %> |
       | 15 bytes sent                                        |
+    Given 5 seconds have passed
     """
 
   # @author weliang@redhat.com
@@ -188,21 +186,20 @@ Feature: SCTP related scenarios
     Then the step should succeed
     And the pod named "sctpclient" becomes ready
 
-    # sctpserver pod start to wait for sctp traffic
-    When I run the :exec background client command with:
-      | pod              | sctpserver                                |
-      | namespace        | <%= project.name %>                       |
-      | oc_opts_end      |                                           |
-      | exec_command     | bash                                      |
-      | exec_command_arg | -c                                        |
-      | exec_command_arg | /usr/bin/nc -k -l 30102 --sctp            |
-    Then the step should succeed
-
-    # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """
+    # sctpserver pod start to wait for sctp traffic
+    When I run the :exec background client command with:
+      | pod              | sctpserver                  |
+      | namespace        | <%= project.name %>         |
+      | oc_opts_end      |                             |
+      | exec_command     | bash                        |
+      | exec_command_arg | -c                          |
+      | exec_command_arg | /usr/bin/nc -l 30102 --sctp |
+    Then the step should succeed
+    # sctpclient pod start to send sctp traffic 
     When I execute on the "sctpclient" pod:
-      | bash | -c | echo test-openshift \| nc -w 5 -v <%= cb.serverpod_ip %> 30102 --sctp |
+      | bash | -c | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp |
     Then the step should succeed
     And the output should contain:
       | Connected to <%= cb.serverpod_ip %> |
@@ -219,8 +216,17 @@ Feature: SCTP related scenarios
     # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """
+    # sctpserver pod start to wait for sctp traffic
+    When I run the :exec background client command with:
+      | pod              | sctpserver                  |
+      | namespace        | <%= project.name %>         |
+      | oc_opts_end      |                             |
+      | exec_command     | bash                        |
+      | exec_command_arg | -c                          |
+      | exec_command_arg | /usr/bin/nc -l 30102 --sctp |
+    Then the step should succeed
     When I execute on the "sctpclient" pod:
-      | bash | -c | echo test-openshift \| nc -w 5 -v <%= cb.serverpod_ip %> 30102 --sctp |
+      | bash | -c | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp |
     Then the step should fail
     """
 
@@ -231,21 +237,20 @@ Feature: SCTP related scenarios
       | n | <%= project.name %>   |
     Then the step should succeed
 
-    # sctpserver pod start to wait for sctp traffic
-    When I run the :exec background client command with:
-      | pod              | sctpserver                                |
-      | namespace        | <%= project.name %>                       |
-      | oc_opts_end      |                                           |
-      | exec_command     | bash                                      |
-      | exec_command_arg | -c                                        |
-      | exec_command_arg | /usr/bin/nc -k -l 30102 --sctp            |
-    Then the step should succeed
-
-    # sctpclient pod start to send sctp traffic
     And I wait up to 60 seconds for the steps to pass:
     """
+    # sctpserver pod start to wait for sctp traffic
+    When I run the :exec background client command with:
+      | pod              | sctpserver                  |
+      | namespace        | <%= project.name %>         |
+      | oc_opts_end      |                             |
+      | exec_command     | bash                        |
+      | exec_command_arg | -c                          |
+      | exec_command_arg | /usr/bin/nc -l 30102 --sctp |
+    Then the step should succeed
+    # sctpclient pod start to send sctp traffic  
     When I execute on the "sctpclient" pod:
-      | bash | -c | echo test-openshift \| nc -w 5 -v <%= cb.serverpod_ip %> 30102 --sctp |
+      | bash | -c | echo test-openshift \| nc -v <%= cb.serverpod_ip %> 30102 --sctp |
     Then the step should succeed
     And the output should contain:
       | Connected to <%= cb.serverpod_ip %> |


### PR DESCRIPTION
Fix nc connection refused issue in https://issues.redhat.com/browse/OCPQE-2668

Current script sometimes cause nc connection refused due to nc -k option is used in the sctp server and nc -w option is used in sctp client.
New update delete both nc options and will continue trying open nc connection in both sctp server and client sides at the same time for 60 seconds to avoid randomly nc connection refused.

Continue testing new script in both ovn and sdn clusters for more than 1 hours, no connection failure happen, the script is more reliable now. 

Testing logs:
OVN: http://file.rdu.redhat.com/~weliang/ovn-log
SDN: http://file.rdu.redhat.com/~weliang/sdn-log

/cc @openshift/team-sdn-qe
