### PR TITLE
Fixed the error associated with OCP-21100

### DIFF
--- a/lib/rules/web/ocm_console/cluster_detail.xyaml
+++ b/lib/rules/web/ocm_console/cluster_detail.xyaml
@@ -371,7 +371,7 @@ check_osd_ocp_comman_details_in_detail_page:
         - selector:
             xpath: //article[@class='pf-c-card ocm-c-overview-details__card']//span[text()='Type']
         - selector:
-            xpath: //article[@class='pf-c-card ocm-c-overview-details__card']//span[text()='Location']
+            xpath: //article[@class='pf-c-card ocm-c-overview-details__card']//span[text()='Region']
         - selector:
             xpath: //article[@class='pf-c-card ocm-c-overview-details__card']//span[text()='Provider']
         - selector:

--- a/lib/rules/web/ocm_console/cluster_detail_addons_tab.xyaml
+++ b/lib/rules/web/ocm_console/cluster_detail_addons_tab.xyaml
@@ -17,9 +17,13 @@ addon_install_button_missing:
         <<: *addon_install_button
         missing: true
 click_addon_install_button:
-    element:
-        <<: *addon_install_button
-        op: click
+    elements:
+        - selector:
+            xpath: //div[text()='<addon_name>']
+          op: click
+        - selector:
+            xpath: //button[contains(@aria-label,'Install')]
+          op: click
 install_addon:
     action: click_add_ons_tab_button
     action: click_addon_install_button
@@ -62,10 +66,17 @@ check_console_url:
         selector:
            xpath: //div[text()='<addon_name>']/../div/a/button[text()='View in console']
 
-check_contact_support:
+click_addon_card:
     element:
         selector:
-            xpath: //div[text()='<addon_name>']/..//a[@href='https://access.redhat.com/support/cases/#/case/new' and text()='Contact support']
+            xpath: //div[text()='<addon_name>']
+        op: click
+
+check_contact_support:
+    action: click_addon_card
+    element:
+        selector:
+            xpath: //a[@href='https://access.redhat.com/support/cases/#/case/new']
 check_addons_tab:
     action: click_add_ons_tab_button
     elements:

--- a/lib/rules/web/ocm_console/cluster_detail_networking_tab.xyaml
+++ b/lib/rules/web/ocm_console/cluster_detail_networking_tab.xyaml
@@ -9,7 +9,7 @@ click_networking_tab:
 networking_tab_loaded:
     elements:
         - selector:
-            xpath: //h1[text()='Master API endpoint']
+            xpath: //h1[text()='Control Plane API endpoint']
         - selector:
             xpath: //label[text()='Make API private']
         - selector:

--- a/lib/rules/web/ocm_console/dialogs_and_sidebar.xyaml
+++ b/lib/rules/web/ocm_console/dialogs_and_sidebar.xyaml
@@ -499,7 +499,7 @@ click_change_settings_button_on_dialog:
 check_change_cluster_privacy_settings_dialog:
     elements:
         - selector:
-            xpath: //h1[text()='Change cluster privacy settings?']
+            xpath: //span[text()='Change cluster privacy settings?']
         - selector:
             xpath: //div[contains(.,'Changes may be required in AWS to maintain access.')]
         - selector:

--- a/lib/rules/web/ocm_console/login.xyaml
+++ b/lib/rules/web/ocm_console/login.xyaml
@@ -7,7 +7,7 @@ login_ocm_page_loaded:
   element:
     selector:
       css: "#kc-form-login, #username, #login-show-step2"
-    timeout: 60
+    timeout: 600
 login_ocm_portal:
   elements:
     - selector:

--- a/lib/rules/web/ocm_console/osd_creation_page.xyaml
+++ b/lib/rules/web/ocm_console/osd_creation_page.xyaml
@@ -56,15 +56,20 @@ select_compute_node_count_on_creation_page:
           op: click
         - selector:
             xpath: //option[text()='<node_number>']
+          op: click
 
 specified_machine_type_loaded:
     element: &machine_type_locator
         selector:
             xpath: //button[contains(@id,"<machine_type>")]
 select_machine_type:
-    element:
-        <<: *machine_type_locator
-        op: click
+    elements: 
+        - selector:
+            xpath: //*[text()='Worker node instance type']/../../..//button
+          op: click
+        - selector:
+            xpath: //span[text()='<machine_type>']
+          op: click
 
 hover_machine_type:
     element:


### PR DESCRIPTION
As for OCP-21100, the script for the automation test creating an advanced OSD cluster, there quite a few errors that prevent the automation from successfully running, I fixed those. The first things I fixed are some small errors where the name is not up-to-date, such as I fixed the outdated name "Location" to the new name "Region".

The next thing is I fixed the automation go to the add-on tab in the cluster overview page and select the appropriate add-on and install it. The script works only for the old UI and now it needs updates.

I also fixed the place where the add-on failed and we need to check whether there is a "Contact Support". Again, the script only works for the old UI, it needs updates

Next, the automation can't successfully selected the correct button for selecting the Machine Type when creating a OSD cluster, I also fixed this.

I also fixed the waiting time while trying to log in. Sometimes the automation cannot log in when the waiting time is short.