### PR TITLE
more verbose eval print

### DIFF
--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -133,7 +133,21 @@ end
 Then /^(?:the )?expression should be true> (.+)$/ do |expr|
   res = eval expr
   unless res
-    raise "expression \"#{expr}\" returned non-positive status: #{res}"
+    # try to print out the left and right operand values to help with debugging
+    # please note the order of the operator matters
+    comparison_operators = /===|==|>=|<=|!=|>|<|&&|\|\|&|\|/
+    op = expr.scan(comparison_operators).first
+    if op
+      e1, e2 = expr.split(op)
+      # XXX: we may not catch everything, wrap it around begin/rescue and print
+      # out blank if some complex comparison is in the expression.
+      begin
+        eval_details = "\nleft_operand: #{eval(e1)}, right_operand: #{eval(e2)}\n"
+      rescue
+        eval_details = ""
+      end
+    end
+    raise "expression \"#{expr}\" returned non-positive status: #{res}" + eval_details
   end
 end
 


### PR DESCRIPTION
Added support for more verbose printing when eval is called and the result is false.

Current printout:
```
    Then the expression should be true> cb.tmp.size > 5                       # features/step_definitions/common.rb:133
      expression "cb.tmp.size > 5" returned non-positive status: false
```

New more verbose printout:
```
      expression "cb.tmp.size > 5" returned non-positive status: false
      left_operand: 5, right_operand: 5
```