### PR TITLE
Fixed the error associated with OCP-37144 OCP-37143 OCP-35970

### DIFF
--- a/lib/rules/web/ocm_console/cluster_detail.xyaml
+++ b/lib/rules/web/ocm_console/cluster_detail.xyaml
@@ -371,7 +371,7 @@ check_osd_ocp_comman_details_in_detail_page:
         - selector:
             xpath: //article[@class='pf-c-card ocm-c-overview-details__card']//span[text()='Type']
         - selector:
-            xpath: //article[@class='pf-c-card ocm-c-overview-details__card']//span[text()='Location']
+            xpath: //article[@class='pf-c-card ocm-c-overview-details__card']//span[text()='Region']
         - selector:
             xpath: //article[@class='pf-c-card ocm-c-overview-details__card']//span[text()='Provider']
         - selector:

--- a/lib/rules/web/ocm_console/cluster_detail_addons_tab.xyaml
+++ b/lib/rules/web/ocm_console/cluster_detail_addons_tab.xyaml
@@ -4,11 +4,27 @@ click_add_ons_tab_button:
             xpath: //button[contains(.,'Add-ons')]
         op: click
 
+click_addon_article:
+    element:
+        selector:
+            xpath: //div[text()='<addon_name>']
+        op: click
+
 addon_install_button_loaded:
     element: &addon_install_button
         selector:
-            xpath: //div[text()='<addon_name>']/../div/button[@aria-label='Install' and text()='Install']
+            xpath: //button[text()='Install']
+
+wait_for_uninstalling_complete:
+    element:
+        selector:
+            xpath: //span[text()='Uninstalling']
+        missing: true
+        timeout: <timeout>
+
 wait_for_addon_install_button_show:
+    action: wait_for_uninstalling_complete
+    action: click_addon_article
     element:
         <<: *addon_install_button
         timeout: <timeout>
@@ -17,9 +33,13 @@ addon_install_button_missing:
         <<: *addon_install_button
         missing: true
 click_addon_install_button:
-    element:
-        <<: *addon_install_button
-        op: click
+    elements:
+        - selector:
+            xpath: //div[text()='<addon_name>']
+          op: click
+        - selector:
+            xpath: //button[contains(@aria-label,'Install')]
+          op: click
 install_addon:
     action: click_add_ons_tab_button
     action: click_addon_install_button
@@ -51,21 +71,29 @@ click_addon_actions_dropdown:
             xpath: //div[text()='<addon_name>']/..//button[@aria-label='Actions']
         op: click
 
+
 click_delete_addon_button:
-    action: click_addon_actions_dropdown
+    action: click_addon_article
     element:
         selector:
-            xpath: //button[text()='Uninstall add-on']
+            xpath: //button[text()='Uninstall']
         op: click
 check_console_url:
     element:
         selector:
            xpath: //div[text()='<addon_name>']/../div/a/button[text()='View in console']
 
-check_contact_support:
+click_addon_card:
     element:
         selector:
-            xpath: //div[text()='<addon_name>']/..//a[@href='https://access.redhat.com/support/cases/#/case/new' and text()='Contact support']
+            xpath: //div[text()='<addon_name>']
+        op: click
+
+check_contact_support:
+    action: click_addon_card
+    element:
+        selector:
+            xpath: //a[@href='https://access.redhat.com/support/cases/#/case/new']
 check_addons_tab:
     action: click_add_ons_tab_button
     elements:
@@ -81,7 +109,7 @@ delete_addon:
 no_permission_tooltip_display:
     elements:
         - selector:
-            xpath: //div[text()='<addon_name>']/..//button[@aria-label='Actions' and @disabled]
-          op: hover
+            xpath: //div[text()='<addon_name>']
+          op: click
         - selector:
-            xpath: //*[contains(text(), "You do not have permission to make changes to this add-on.")]
+            xpath: //button[@aria-disabled='true' and text()='Uninstall']

--- a/lib/rules/web/ocm_console/cluster_detail_networking_tab.xyaml
+++ b/lib/rules/web/ocm_console/cluster_detail_networking_tab.xyaml
@@ -9,7 +9,7 @@ click_networking_tab:
 networking_tab_loaded:
     elements:
         - selector:
-            xpath: //h1[text()='Master API endpoint']
+            xpath: //h1[text()='Control Plane API endpoint']
         - selector:
             xpath: //label[text()='Make API private']
         - selector:

--- a/lib/rules/web/ocm_console/dialogs_and_sidebar.xyaml
+++ b/lib/rules/web/ocm_console/dialogs_and_sidebar.xyaml
@@ -179,20 +179,20 @@ click_delete_button_on_deletion_dialog:
 osd_creation_error_dialog_loaded:
     elements:
         - selector:
-            xpath: //h2[text()='Error creating cluster']
-            timeout: 30
+            xpath: //h2[@class='pf-c-title pf-m-2xl']
+          timeout: 60
         - selector:
             xpath: //h2/*[name()='svg']
-            timeout: 30
+          timeout: 60
         - selector:
             xpath: //p[contains(text(),"<error_reason>")]
-            timeout: 30
+          timeout: 30
         - selector:
             xpath: //p[contains(text(), 'Operation ID')]
-            timeout: 30
+          timeout: 30
         - selector:
             xpath: //button[text()='Close']
-            timeout: 30
+          timeout: 30
 close_error_message_dialog:
     element:
         selector:
@@ -499,7 +499,7 @@ click_change_settings_button_on_dialog:
 check_change_cluster_privacy_settings_dialog:
     elements:
         - selector:
-            xpath: //h1[text()='Change cluster privacy settings?']
+            xpath: //span[text()='Change cluster privacy settings?']
         - selector:
             xpath: //div[contains(.,'Changes may be required in AWS to maintain access.')]
         - selector:
@@ -624,7 +624,7 @@ click_delete_node_label_button:
 select_node_count:
     elements:
         - selector:
-            xpath: //select[@aria-label='Compute nodes']
+            xpath: //select[@aria-label='Worker nodes']
           op: click
         - selector:
             xpath: //option[@value='<compute_node>']
@@ -761,7 +761,7 @@ set_addon_cidr_default_parameter:
 input_addon_install_parameter:
     element:
         selector:
-            xpath: //input[@id='parameters.<parameter_key>']
+            xpath: //input[@name='parameters.<parameter_key>']
         op: send_keys <parameter_value>
 
 click_install_button_on_parameter_dialog:

--- a/lib/rules/web/ocm_console/login.xyaml
+++ b/lib/rules/web/ocm_console/login.xyaml
@@ -7,7 +7,7 @@ login_ocm_page_loaded:
   element:
     selector:
       css: "#kc-form-login, #username, #login-show-step2"
-    timeout: 60
+    timeout: 600
 login_ocm_portal:
   elements:
     - selector:

--- a/lib/rules/web/ocm_console/osd_creation_page.xyaml
+++ b/lib/rules/web/ocm_console/osd_creation_page.xyaml
@@ -56,15 +56,20 @@ select_compute_node_count_on_creation_page:
           op: click
         - selector:
             xpath: //option[text()='<node_number>']
+          op: click
 
 specified_machine_type_loaded:
     element: &machine_type_locator
         selector:
             xpath: //button[contains(@id,"<machine_type>")]
 select_machine_type:
-    element:
-        <<: *machine_type_locator
-        op: click
+    elements: 
+        - selector:
+            xpath: //*[text()='Worker node instance type']/../../..//button
+          op: click
+        - selector:
+            xpath: //span[text()='<machine_type>']
+          op: click
 
 hover_machine_type:
     element:


### PR DESCRIPTION

Debug cases OCP-37144 OCP-37143 OCP-35970

Updated June 24.

The errors mainly are associated with the add-on installation page. The new UI will have to require the user to first click on the article of a specific add-on, and then do operations on it. I modified the automation script to accommodate for this change.

The successful automation log can be found here http://pastebin.test.redhat.com/974134