### PR TITLE
fix some automation issues

### DIFF
--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -147,7 +147,13 @@ Feature: cluster-logging-operator related test
     And I open admin console in a browser
     When I run the :goto_monitoring_db_cluster_logging web action
     Then the step should succeed
-    Given evaluation of `["Elastic Cluster Status", "Elastic Nodes", "Elastic Shards", "Elastic Documents", "Total Index Size on Disk", "Elastic Pending Tasks", "Elastic JVM GC time", "Elastic JVM GC Rate", "Elastic Query/Fetch Latency | Sum", "Elastic Query Rate | Top 5", "CPU", "Elastic JVM Heap Used", "Elasticsearch Disk Usage", "File Descriptors In Use", "FluentD emit count", "FluentD Buffer Availability", "Elastic rx bytes", "Elastic Index Failure Rate", "FluentD Output Error Rate"]` is stored in the :cards clipboard
+    And I wait up to 300 seconds for the steps to pass:
+    """
+    When I perform the :check_monitoring_dashboard_card web action with:
+      | card_name | Elastic Cluster Status |
+    Then the step should succeed
+    """
+    Given evaluation of `["Elastic Nodes", "Elastic Shards", "Elastic Documents", "Total Index Size on Disk", "Elastic Pending Tasks", "Elastic JVM GC time", "Elastic JVM GC Rate", "Elastic Query/Fetch Latency | Sum", "Elastic Query Rate | Top 5", "CPU", "Elastic JVM Heap Used", "Elasticsearch Disk Usage", "File Descriptors In Use", "FluentD emit count", "FluentD Buffer Availability", "Elastic rx bytes", "Elastic Index Failure Rate", "FluentD Output Error Rate"]` is stored in the :cards clipboard
     And I repeat the following steps for each :card in cb.cards:
     """
     When I perform the :check_monitoring_dashboard_card web action with:

--- a/features/logging/elasticsearch.feature
+++ b/features/logging/elasticsearch.feature
@@ -125,6 +125,6 @@ Feature: Elasticsearch related tests
     And evaluation of `@result[:parsed].select {|e| e['index'].start_with? "infra"}.map {|x| x["index"]}` is stored in the :new_infra_indices clipboard
     And evaluation of `@result[:parsed].select {|e| e['index'].start_with? "audit"}.map {|x| x["index"]}` is stored in the :new_audit_indices clipboard
     Then the expression should be true> !(cb.new_app_indices - cb.app_indices).empty? && !(cb.app_indices - cb.new_app_indices).empty?
-    And the expression should be true> !(cb.new_infra_indices - cb.infra_indices).empty? && !(cb.app_indices - cb.new_app_indices).empty?
-    And the expression should be true> !(cb.new_audit_indices - cb.audit_indices).empty? && !(cb.app_indices - cb.new_app_indices).empty?
+    And the expression should be true> !(cb.new_infra_indices - cb.infra_indices).empty? && !(cb.infra_indices - cb.new_infra_indices).empty?
+    And the expression should be true> !(cb.new_audit_indices - cb.audit_indices).empty? && !(cb.audit_indices - cb.new_audit_indices).empty?
     """

--- a/features/logging/elasticsearch_operator.feature
+++ b/features/logging/elasticsearch_operator.feature
@@ -80,7 +80,13 @@ Feature: elasticsearch-operator related tests
     And I open admin console in a browser
     When I run the :goto_monitoring_db_elasticsearch web action
     Then the step should succeed
-    Given evaluation of `["Cluster status", "Cluster nodes", "Cluster data nodes", "Cluster pending tasks", "Cluster active shards", "Cluster non-active shards", "Number of segments", "Memory used by segments", "ThreadPool tasks", "CPU % usage", "Memory usage", "Disk space % used", "Documents indexing rate", "Indexing latency", "Search rate", "Search latency", "Documents count (with replicas)", "Documents deleting rate", "Documents merging rate", "Field data memory size", "Field data evictions", "Query cache size", "Query cache evictions", "Query cache hits", "Query cache misses", "Indexing throttling", "Merging throttling", "Heap used", "GC count", "GC time"]` is stored in the :cards clipboard
+    And I wait up to 300 seconds for the steps to pass:
+    """
+    When I perform the :check_monitoring_dashboard_card web action with:
+      | card_name | Cluster status |
+    Then the step should succeed
+    """
+    Given evaluation of `["Cluster nodes", "Cluster data nodes", "Cluster pending tasks", "Cluster active shards", "Cluster non-active shards", "Number of segments", "Memory used by segments", "ThreadPool tasks", "CPU % usage", "Memory usage", "Disk space % used", "Documents indexing rate", "Indexing latency", "Search rate", "Search latency", "Documents count (with replicas)", "Documents deleting rate", "Documents merging rate", "Field data memory size", "Field data evictions", "Query cache size", "Query cache evictions", "Query cache hits", "Query cache misses", "Indexing throttling", "Merging throttling", "Heap used", "GC count", "GC time"]` is stored in the :cards clipboard
     And I repeat the following steps for each :card in cb.cards:
     """
     When I perform the :check_monitoring_dashboard_card web action with:

--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -529,7 +529,7 @@ Given /^I create a pipeline secret with:$/ do | table |
   ]
 
   if transport_ssl_enabled == "true" || auth_type == "mTLS" || auth_type == "mTLS_share"
-    secret_keys << ["from_file", "tls.key=logging-es.key"] << ["from_file", "tls.crt=logging-es.crt"] << ["from_file", "ca-bundle.crt=ca.crt"] << ["from_file", "ca.key=ca.key"]
+    secret_keys << ["from_file", "tls.key=logging-es.key"] << ["from_file", "tls.crt=logging-es.crt"] << ["from_file", "ca-bundle.crt=ca.crt"]
   end
 
   if user_auth_enabled == "true"
@@ -537,7 +537,7 @@ Given /^I create a pipeline secret with:$/ do | table |
   end
 
   if http_ssl_enabled == "true" || auth_type == "server_auth" || auth_type == "server_auth_share"
-    secret_keys << ["from_file", "ca-bundle.crt=ca.crt"] << ["from_file", "ca.key=ca.key"]
+    secret_keys << ["from_file", "ca-bundle.crt=ca.crt"]
   end
 
   if auth_type == "mTLS_share" || auth_type == "server_auth_share"


### PR DESCRIPTION
Fix following issues:
1. remove unused key `ca.key` when creating pipeline secret
2. add a wait block when checking logging dashboards to wait for the web page to be fully loaded
3. fix typo when testing index management scripts

/cc @anpingli @kabirbhartiRH 