### PR TITLE
Add steps to modify the policy post upgrade to verify it works well

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -209,3 +209,29 @@ Feature: SDN compoment upgrade testing
     Then the step should succeed 
     And the output should contain "Hello"
     """
+    #Steps to modify policy post upgrade for bug 1973679
+    When I obtain test data file "networking/networkpolicy/allow-ns-and-pod.yaml"
+    And I replace lines in "allow-ns-and-pod.yaml":
+      | test-pods | hello-idle |
+    And I run the :replace admin command with:
+      | f | allow-ns-and-pod.yaml |
+      | n | policy-upgrade1       |
+    Then the step should succeed
+
+    And I wait up to 10 seconds for the steps to pass:
+    """
+    When I execute on the "<%= cb.pod4 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod3ip %>:8080 |
+    Then the step should fail
+    And the output should not contain "Hello"
+    When I execute on the "<%= cb.pod5 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
+    Then the step should succeed
+    And the output should contain "Hello"
+    When I execute on the "<%= cb.pod5 %>" pod:
+      | curl | -s | --connect-timeout | 5 | <%= cb.pod3ip %>:8080 |
+    Then the step should succeed
+    And the output should contain "Hello"
+    """
+
+

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -233,5 +233,3 @@ Feature: SDN compoment upgrade testing
     Then the step should succeed
     And the output should contain "Hello"
     """
-
-


### PR DESCRIPTION
The network policy is tweaked to change the pod labels to ensure ACLs are recreated if the policy is modified.
Pod label controlled by policy is hello-idle instead of test-pods.
pod4->pod3ip passed prior to modification but fails as expected
pod5->pod2ip failed but succeeds post modification.
pod5->pod3ip (positive test case step)
Testing:-
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3206/console (Upgrade prepare)
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3206/console (Post upgrade)

/cc @openshift/team-sdn-qe