### PR TITLE
added support to remove all kata pods in a cluster

### DIFF
--- a/features/test/kata.feature
+++ b/features/test/kata.feature
@@ -1,19 +1,22 @@
 Feature: example kata container scenarios
-  @admin
-  @destructive
-  @upgrade-prepare
-  Scenario: kata container operator installation
-    Given the master version >= "4.6"
-    Given kata container has been installed successfully in the "kata-operator" project
-    And I verify kata container runtime is installed into the a worker node
-
-  @admin
-  @destructive
-  @upgrade-prepare
-  Scenario: test delete kata installation
-    Given the master version >= "4.6"
-    Given I switch to cluster admin pseudo user
-    And I remove kata operator from "kata-operator" namespace
-
   Scenario: test get channel
     Given I extract the channel information from subscription and save it to the :channel clipboard
+
+  @admin
+  Scenario: test kata_step
+    Given I have a project
+    And I obtain test data file "kata/example-fedora-kata.yaml"
+    When I run the :create client command with:
+      | f | example-fedora-kata.yaml |
+    Then the step should succeed
+    And a pod becomes ready with labels:
+      | app=example-fedora-kata-app |
+    Given I create a new project
+    And I obtain test data file "templates/ui/httpd-example.yaml"
+    Then I run the :new_app client command with:
+      | file | httpd-example.yaml |
+    And a pod becomes ready with labels:
+      | name=httpd-example |
+    Given I switch to cluster admin pseudo user
+    Given I find all pods running with kata as runtime in the cluster and store them to the clipboard
+    And I remove all kata pods in the cluster stored in the clipboard


### PR DESCRIPTION
1. optimized pods in all namespace for kata. It was printing out all of the pods in all namespaces which resulted in a massive print so the run log is over 4Meg as a result.  Now we filter out using jsonpath, using two `oc` calls.  Not sure if it's possible to get multiple values in one `oc` call
2. added methods for getting `metadata.ownerReferences` for project resource objects.  This is needed to determine the proper resource to remove in order to delete a pod.  For example, pods that are generated via `Deployment` or `DeploymentConfig`, we'll need to delete that resource instead of the kata pod to prevent it from regenerated

3. Added extra duty during the remove kataconfig step to remove all existing kata-pods in the cluster instead of raising an exception and exit.

runlog: job/Runner/91382/console