### PR TITLE
Change location of policy files to public repo and use multus pod from naster node

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1322,7 +1322,7 @@ end
 
 Given /^I save multus pod on master node to the#{OPT_SYM} clipboard$/ do | cb_name |
   ensure_admin_tagged
-  cb_name = "multus_pod" unless cb_name
+  cb_name ||= :multuspod
   master_nodes = env.nodes.select { |n| n.schedulable? && n.is_master? }
   master_node_names = master_nodes.collect { |n| n.name }
   cb[cb_name] = BushSlicer::Pod.get_labeled("app=multus", project: project("openshift-multus", switch: false), user: admin) { |pod, hash|

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1322,6 +1322,7 @@ end
 
 Given /^I save multus pod on master node to the#{OPT_SYM} clipboard$/ do | cb_name |
   ensure_admin_tagged
+  cb_name = "multus_pod" unless cb_name
   master_nodes = env.nodes.select { |n| n.schedulable? && n.is_master? }
   master_node_names = master_nodes.collect { |n| n.name }
   cb[cb_name] = BushSlicer::Pod.get_labeled("app=multus", project: project("openshift-multus", switch: false), user: admin) { |pod, hash|

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1319,3 +1319,13 @@ Given /^the node's active nmcli connection is stored in the#{OPT_SYM} clipboard$
   cb[cb_name] = @result[:response].split("\n").first
   logger.info "Node's active nmcli connection uuid is stored in the #{cb_name} clipboard as #{cb[cb_name]}"
 end
+
+Given /^I save multus pod on master node to the#{OPT_SYM} clipboard$/ do | cb_name |
+  ensure_admin_tagged
+  master_nodes = env.nodes.select { |n| n.schedulable? && n.is_master? }
+  master_node_names = master_nodes.collect { |n| n.name }
+  cb[cb_name] = BushSlicer::Pod.get_labeled("app=multus", project: project("openshift-multus", switch: false), user: admin) { |pod, hash|
+     master_node_names.include?(pod.node_name)
+  }.first.name
+  logger.info "The multus pod is stored to the #{cb[cb_name]} clipboard."
+end

--- a/testdata/networking/networkpolicy/allow-from-hostnetwork.yaml
+++ b/testdata/networking/networkpolicy/allow-from-hostnetwork.yaml
@@ -1,0 +1,16 @@
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-hostnetwork
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/host-network: ""
+  podSelector: {}
+  policyTypes:
+  - Ingress
+
+

--- a/testdata/networking/networkpolicy/allow-from-router-ingress.yaml
+++ b/testdata/networking/networkpolicy/allow-from-router-ingress.yaml
@@ -1,0 +1,16 @@
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-router
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+  podSelector: {}
+  policyTypes:
+  - Ingress
+
+

--- a/testdata/networking/networkpolicy/allow-from-router.yaml
+++ b/testdata/networking/networkpolicy/allow-from-router.yaml
@@ -1,0 +1,16 @@
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-router
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/ingress: ""
+  podSelector: {}
+  policyTypes:
+  - Ingress
+
+


### PR DESCRIPTION
The network policies moved from private repo to public repo as these are going to be used for upgrade scripts.
Added a step to obtain multus pod on master nodes to ensure allow from hostnetwork policy is actually tested.
If the test pod end up on same node from where multus pod is scheduled then the network policy does not have anything to do so it is not really tested. This step makes sure multus pod used for testing is running on one of master node.

Test logs can be found here:-
vSphere
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3223/console OCP-41944
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3224/console (OCP-40898 and OCP-40899)

https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3225/console (OCP-40898 and OCP-40899)
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3228/console  OCP-40908

/cc @openshift/team-sdn-qe
