### PR TITLE
fix OCP-28875

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -463,8 +463,7 @@ Feature: Machine features testing
       | resource | pv |
     Then the step should succeed
     And the output should contain:
-      | failure-domain.beta.kubernetes.io/zone in [<%= cb.default_zone %>]     |
-      | failure-domain.beta.kubernetes.io/region in [<%= cb.default_region %>] |
+      | region in [<%= cb.default_region %>] |
 
   # @author miyadav@redhat.com
   @admin


### PR DESCRIPTION
Update the output message to fit all versions. @jhou1 @miyadav please help to take a look.
```
    [02:37:32] INFO> === End After Scenario: Machineset should have relevant annotations to support scale from/to zero, Examples (#1) ===

1 scenario (1 passed)
23 steps (2
```