### PR TITLE
Fix OCP-33058

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -395,7 +395,7 @@ Feature: Machine features testing
     Then the step should succeed
   
     Then I store the last provisioned machine in the :machine_latest clipboard
-    And I wait up to 120 seconds for the steps to pass:
+    And I wait up to 400 seconds for the steps to pass:
     """
     Then the expression should be true> machine(cb.machine_latest).phase(cached: false) == "Running"
     """


### PR DESCRIPTION
increase the time to create the machineset @miyadav @jhou1 please help to take a look.
```
      [04:13:04] INFO> === End After Scenario: Implement defaulting machineset values for azure ===
2 scenarios (2 passed)
30 steps (30 passed)
15m16.543s
```