### PR TITLE
OCP-40620 - allow from router and allow from host network policy in upgrade scenario

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -233,3 +233,121 @@ Feature: SDN compoment upgrade testing
     Then the step should succeed
     And the output should contain "Hello"
     """
+
+  # @author asood@redhat.com
+  @admin
+  @upgrade-prepare
+  Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade - prepare
+    Given I switch to cluster admin pseudo user
+    When I run the :new_project client command with:
+      | project_name | policy-upgrade3 |
+    Then the step should succeed
+    When I run the :new_project client command with:
+      | project_name | policy-upgrade4 |
+    Then the step should succeed
+    When I run the :new_project client command with:
+      | project_name | policy-upgrade5 |
+    Then the step should succeed
+
+    #Setup
+    When I use the "policy-upgrade3" project
+    Given I obtain test data file "networking/list_for_pods.json"
+    When I run oc create over "list_for_pods.json" replacing paths:
+      | ["items"][0]["spec"]["replicas"]  | 1    |
+    Then the step should succeed
+    Given a pod becomes ready with labels:
+      | name=test-pods |
+    When I expose the "test-service" service
+    And I wait up to 60 seconds for a web server to become available via the "test-service" route
+    Then the step should succeed
+    Given the DefaultDeny policy is applied to the "policy-upgrade3" namespace
+    Then the step should succeed
+    Given I obtain test data file "networking/networkpolicy/allow-from-router-ingress.yaml"
+    When I run the :create admin command with:
+      | f | allow-from-router-ingress.yaml     |
+    Then the step should succeed
+
+    When I use the "policy-upgrade4" project
+    Given I obtain test data file "networking/list_for_pods.json"
+    When I run oc create over "list_for_pods.json" replacing paths:
+      | ["items"][0]["spec"]["replicas"]  | 1    |
+    Then the step should succeed
+    Given a pod becomes ready with labels:
+      | name=test-pods |
+    When I expose the "test-service" service
+    And I wait up to 60 seconds for a web server to become available via the "test-service" route
+    Then the step should succeed
+    Given the DefaultDeny policy is applied to the "policy-upgrade4" namespace
+    Then the step should succeed
+    Given I obtain test data file "networking/networkpolicy/allow-from-router.yaml"
+    When I run the :create admin command with:
+      | f | allow-from-router.yaml     |
+    Then the step should succeed
+
+    When I use the "policy-upgrade5" project
+    Given I obtain test data file "networking/list_for_pods.json"
+    When I run oc create over "list_for_pods.json" replacing paths:
+      | ["items"][0]["spec"]["replicas"]  | 1    |
+    Then the step should succeed
+    Given a pod becomes ready with labels:
+      | name=test-pods |
+    Then the step should succeed
+    And evaluation of `pod(2).ip_url` is stored in the :p5pod1ip clipboard
+    Given I save multus pod on master node to the :multuspod clipboard
+    Given the DefaultDeny policy is applied to the "policy-upgrade5" namespace
+    Then the step should succeed
+    Given I obtain test data file "networking/networkpolicy/allow-from-hostnetwork.yaml"
+    When I run the :create admin command with:
+      | f | allow-from-hostnetwork.yaml     |
+    Then the step should succeed
+
+    #Validation
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    When I use the "policy-upgrade3" project
+    When I open web server via the "test-service" route
+    Then the step should succeed
+
+    When I use the "policy-upgrade4" project
+    When I open web server via the "test-service" route
+    Then the step should succeed
+
+    Given I switch to cluster admin pseudo user
+    Given I use the "openshift-multus" project
+    When I execute on the "<%= cb.multuspod %>" pod:
+      | curl | -I | <%= cb.p5pod1ip %>:8080 |
+    Then the step should succeed
+    And the output should contain "200 OK"
+    """
+
+  # @author asood@redhat.com
+  # @case_id OCP-40620
+  @admin
+  @upgrade-check
+  Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade 
+    Given I switch to cluster admin pseudo user
+    When I use the "policy-upgrade3" project
+    Given a pod becomes ready with labels:
+      | name=test-pods |
+    And I wait up to 60 seconds for a web server to become available via the "test-service" route
+    Then the step should succeed
+
+    When I use the "policy-upgrade4" project
+    Given a pod becomes ready with labels:
+      | name=test-pods |
+    And I wait up to 60 seconds for a web server to become available via the "test-service" route
+    Then the step should succeed
+
+    When I use the "policy-upgrade5" project
+    Given a pod becomes ready with labels:
+      | name=test-pods |
+    And evaluation of `pod(2).ip_url` is stored in the :p5pod1ip clipboard
+    Given I save multus pod on master node to the :multuspod clipboard
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    Given I switch to cluster admin pseudo user
+    Given I use the "openshift-multus" project
+    When I execute on the "<%= cb.multuspod %>" pod:
+      | curl | -I | <%= cb.p5pod1ip %>:8080 |
+    Then the step should succeed
+    """

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -259,7 +259,6 @@ Feature: SDN compoment upgrade testing
       | name=test-pods |
     When I expose the "test-service" service
     And I wait up to 60 seconds for a web server to become available via the "test-service" route
-    Then the step should succeed
     Given the DefaultDeny policy is applied to the "policy-upgrade3" namespace
     Then the step should succeed
     Given I obtain test data file "networking/networkpolicy/allow-from-router-ingress.yaml"
@@ -276,7 +275,6 @@ Feature: SDN compoment upgrade testing
       | name=test-pods |
     When I expose the "test-service" service
     And I wait up to 60 seconds for a web server to become available via the "test-service" route
-    Then the step should succeed
     Given the DefaultDeny policy is applied to the "policy-upgrade4" namespace
     Then the step should succeed
     Given I obtain test data file "networking/networkpolicy/allow-from-router.yaml"
@@ -330,13 +328,11 @@ Feature: SDN compoment upgrade testing
     Given a pod becomes ready with labels:
       | name=test-pods |
     And I wait up to 60 seconds for a web server to become available via the "test-service" route
-    Then the step should succeed
 
     When I use the "policy-upgrade4" project
     Given a pod becomes ready with labels:
       | name=test-pods |
     And I wait up to 60 seconds for a web server to become available via the "test-service" route
-    Then the step should succeed
 
     When I use the "policy-upgrade5" project
     Given a pod becomes ready with labels:


### PR DESCRIPTION
All three policies (allow from router- new label, allow from router -old label and allow from hostnetork )are applied respectively to three projects.
The test case ensures the policies do what they are supposed (postive path).
Default deny policies are also applied but no validation around it, just assuming the policies do deny traffic to the project.

Testing:-
vSphere (Hostnetwork)
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3266/console (pre upgrade)
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3267/console (post upgrade)

AWS (LoadBalancer Service)
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3268/console (pre upgrade)
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3269/console

/cc @openshift/team-sdn-qe
