### PR TITLE
SA warning prevents , node creation , adding that to default machineset

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -350,17 +350,19 @@ Feature: Machine features testing
     Given I store the last provisioned machine in the :machine clipboard
     When evaluation of `machine(cb.machine).gcp_region` is stored in the :default_region clipboard
     And evaluation of `machine(cb.machine).gcp_zone` is stored in the :default_zone clipboard
+    And evaluation of `machine(cb.machine).gcp_service_account` is stored in the :default_service_account clipboard
     Then admin ensures "default-valued-33056" machineset is deleted after scenario
 
     Given I obtain test data file "cloud/ms-gcp/ms_default_values.yaml"
     When I run oc create over "ms_default_values.yaml" replacing paths:
-      | n                                                                                         | openshift-machine-api                           |
-      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %>     |
-      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | default-valued-33056                            |
-      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %>     |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["region"]                           | <%= cb.default_region %>                        |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["zone"]                             | <%= cb.default_zone %>                          |
-      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | default-valued-33056                            |
+      | n                                                                                         | openshift-machine-api                                |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %>          |
+      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | default-valued-33056                                 |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %>          |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["region"]                           | <%= cb.default_region %>                             |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["serviceAccounts"][0]["email"]      | <%=  cb.default_service_account[0].fetch("email") %> | 
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["zone"]                             | <%= cb.default_zone %>                               |
+      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | default-valued-33056                                 |
     Then the step should succeed
 
     # Verify machine could be created successful

--- a/lib/openshift/machine.rb
+++ b/lib/openshift/machine.rb
@@ -57,6 +57,11 @@ module BushSlicer
        raw_resource(user: user, cached: cached ,quiet: quiet).
          dig('spec', 'providerSpec', 'value', 'zone')
     end
+     
+    def gcp_service_account(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'serviceAccounts')
+    end
 
     def aws_ami_id(user: nil, cached: true, quiet: false)
        raw_resource(user: user, cached: cached ,quiet: quiet).

--- a/testdata/cloud/ms-gcp/ms_default_values.yaml
+++ b/testdata/cloud/ms-gcp/ms_default_values.yaml
@@ -3,7 +3,7 @@ kind: MachineSet
 metadata:
   labels:
     machine.openshift.io/cluster-api-cluster:
-  name: default-valued-33056           
+  name: default-valued-33056
 spec:
   replicas: 1
   selector:
@@ -25,6 +25,10 @@ spec:
         value: "mapi_test"
       providerSpec:
         value:
-          region: 
-          zone: 
+          region:
+          zone:
+          serviceAccounts:
+          - email:
+            scopes:
+            - https://www.googleapis.com/auth/cloud-platform
 


### PR DESCRIPTION
This is to make sure machine doesnt get stuck in provisioned state as that can cause , machine to be in deletion phase indefinitely
which might result in Premature failures and other tests from running , leaving it to be a machine without node condition .

@sunzhaohua2 @jhou1  PTAL 

Results : https://url.corp.redhat.com/ocp33056 