### PR TITLE
method `query_test_cases_smart` only accepts 4 parameters `[:project_…

### DIFF
--- a/lib/polarshift/request.rb
+++ b/lib/polarshift/request.rb
@@ -221,6 +221,10 @@ module BushSlicer
 
 
       def query_test_cases_smart(timeout: 360, **opts)
+        valid_params =[:project_id, :case_query, :template_id, :custom_fields]
+        invalids = opts.keys - valid_params
+        # need to remove extra Hash keys that is not part of the valid parameters for method query_test_cases
+        invalids.each { |i| opts.delete(i) }
         res = query_test_cases(**opts)
         if res[:exitstatus] == 202
           op_url = JSON.load(res[:response])["operation_result_url"]


### PR DESCRIPTION
…id, :case_query, :template_id, :custom_fields]`, need to delete the other keys from the input hash when doing the query.  @eurijon this should fix the issue you mentioned so you don't need to modify the input YAML to remove the un-supported keys.