### PR TITLE
fix string.scan check

### DIFF
--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -135,7 +135,7 @@ Then /^(?:the )?expression should be true> (.+)$/ do |expr|
   eval_details = ""
   unless res
     ruby_special_op = /\?/
-    unless expr.scan(ruby_special_op)
+    unless expr.scan(ruby_special_op).count > 0
       # try to print out the left and right operand values to help with debugging
       # please note the order of the operator matters
       comparison_operators = /===|==|>=|<=|!=|>|<|&&|\|\|&|\|/


### PR DESCRIPTION
currently, this is wrong `unless expr.scan(ruby_special_op)`.  Should be gauged by `.count > 0` instead.  Original PR #2128 introduced the bug of not interpreting the expression correctly.

