### PR TITLE
fix: Error from server (NotFound): namespaces "aos-qe-ci" not found

### DIFF
--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -6,7 +6,6 @@ Feature: cluster-logging-operator related test
   @admin
   @destructive
   @commonlogging
-  @flaky
   Scenario: ServiceMonitor Object for collector is deployed along with cluster logging
     Given I wait for the "fluentd" service_monitor to appear
     Given the expression should be true> service_monitor('fluentd').service_monitor_endpoint_spec(server_name: "fluentd.openshift-logging.svc").port == "metrics"
@@ -24,7 +23,6 @@ Feature: cluster-logging-operator related test
   # @case_id OCP-21907
   @admin
   @destructive
-  @flaky
   Scenario: Deploy elasticsearch-operator via OLM using CLI
     Given logging operators are installed successfully
 


### PR DESCRIPTION
Fix issue when deploy logging operators:
```
[2021-07-02T00:47:57.737Z] [36m[33m[00:47:56] INFO> Shell Commands: oc get packagemanifests cluster-logging --output=yaml --config=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_admin.kubeconfig[0m[0m
[2021-07-02T00:47:57.737Z] [36m[0m
[2021-07-02T00:47:57.737Z] [36mSTDERR:[0m
[2021-07-02T00:47:57.737Z] [36mError from server (NotFound): namespaces "aos-qe-ci" not found[0m
```