### PR TITLE
fix the node-upgrade project not deleted issue

### DIFF
--- a/features/upgrade/node/hpa/upgrade.feature
+++ b/features/upgrade/node/hpa/upgrade.feature
@@ -4,6 +4,7 @@ Feature: basic verification for upgrade testing
   @admin
   Scenario: Upgrade - Make sure multiple resources work well after upgrade - prepare
     Given I switch to cluster admin pseudo user
+    Given I ensure "node-upgrade" project is deleted
     When I run the :new_project client command with:
       | project_name | node-upgrade |
     And I use the "node-upgrade" project


### PR DESCRIPTION
@sunilcio @lyman9966 @rhpmali ,could you help take a look?
Adding a step to ensure the `node-upgrade` project is deleted before execution

```
And the pod named "dapi-test-pod-1" status becomes :succeeded                    # features/step_definitions/pod.rb:77
      [07:59:10] INFO>
      [07:59:12] INFO> After 2 iterations and 3 seconds:
      matched status for pods dapi-test-pod-1: 'succeeded' while expecting '[:succeeded]'
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [07:59:12] INFO> === After Scenario: Upgrade - Make sure multiple resources work well after upgrade - prepare ===
      [07:59:12] INFO> Shell Commands: rm -r -f -- /home/weinliu/workdir/rhel8-weinliu

      [07:59:13] INFO> Exit Status: 0
      [07:59:14] INFO> === End After Scenario: Upgrade - Make sure multiple resources work well after upgrade - prepare ===
# @author weinliu@redhat.com
# @case_id OCP-13016

1 scenario (1 passed)
22 steps (22 passed)
1m10.918s
[07:59:14] INFO> === At Exit ===
```