### PR TITLE
fix failure 'You are not a member of project openshift-marketplace.'

### DIFF
--- a/features/logging/logging_acceptance.feature
+++ b/features/logging/logging_acceptance.feature
@@ -5,9 +5,9 @@ Feature: Logging smoke test case
   @admin
   Scenario: One logging acceptance case for all cluster
     # Deploy cluster-logging operator via web console
+    Given logging service is removed successfully
     Given cluster-logging channel name is stored in the :clo_channel clipboard
     And elasticsearch-operator channel name is stored in the :eo_channel clipboard
-    Given logging service is removed successfully
     Given elasticsearch-operator catalog source name is stored in the :eo_catsrc clipboard
     Given cluster-logging catalog source name is stored in the :clo_catsrc clipboard
     Given I switch to the first user


### PR DESCRIPTION
Fix failure:
```
07-06 16:07:12.242        Logged into "https://api.xxxxxxxxx.com:6443" as "testuser-36" using the token provided.
07-06 16:07:12.242        
07-06 16:07:12.242        You don't have any projects. You can try to create a new project, by running
07-06 16:07:12.242        
07-06 16:07:12.242            oc new-project <projectname>
07-06 16:07:12.242        
07-06 16:07:12.242        
07-06 16:07:12.242        [08:07:09] INFO> Exit Status: 0
07-06 16:07:12.242        [08:07:10] INFO> Shell Commands: oc project openshift-marketplace --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_testuser-36.kubeconfig
07-06 16:07:12.242        
07-06 16:07:12.242        STDERR:
07-06 16:07:12.242        error: You are not a member of project "openshift-marketplace".
07-06 16:07:12.242        You are not a member of any projects. You can request a project to be created with the 'new-project' command.
07-06 16:07:12.242        
07-06 16:07:12.242        [08:07:11] INFO> Exit Status: 1
07-06 16:07:12.242        can not switch to project openshift-marketplace (RuntimeError)
07-06 16:07:12.242        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/project.rb:118:in `/^I use the "(.+?)" project$/'
07-06 16:07:12.242        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/transform.rb:33:in `call'
07-06 16:07:12.242        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/transform.rb:33:in `block in singleton class'
07-06 16:07:12.242        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/logging.rb:370:in `/^(cluster-logging|elasticsearch-operator) channel name is stored in the(?: :(\S+))? clipboard$/'
07-06 16:07:12.242        features/logging/logging_acceptance.feature:8:in `cluster-logging channel name is stored in the :clo_channel clipboard'
```
The issue is imported by https://github.com/openshift/verification-tests/pull/2142 
/cc @anpingli 