### PR TITLE
remove the registered 'clean up' from ocm

### DIFF
--- a/lib/rules/web/ocm_console/archived_cluster_detail.xyaml
+++ b/lib/rules/web/ocm_console/archived_cluster_detail.xyaml
@@ -9,9 +9,7 @@ archived_cluster_detail_page_loaded:
         - selector:
             xpath: //button[@aria-controls='overviewTabContent' and contains(.,'Overview')]
         - selector:
-            xpath: //h2[text()='Resource usage']
-        - selector:
-            xpath: //p[text()='The cluster has been archived and does not have any metrics data.']
+            xpath: //button[@aria-controls='supportTabContent' and contains(.,'Support')]
         - selector:
             xpath: //h2[text()='Details']
         - selector:

--- a/lib/rules/web/ocm_console/archived_clusters.xyaml
+++ b/lib/rules/web/ocm_console/archived_clusters.xyaml
@@ -1,3 +1,5 @@
+go_to_archived_cluster_list_page:
+    url: /openshift/archived
 archived_page_loaded:
     elements:
         - selector:

--- a/lib/rules/web/ocm_console/cluster_detail.xyaml
+++ b/lib/rules/web/ocm_console/cluster_detail.xyaml
@@ -99,7 +99,7 @@ check_new_name_in_cluster_detail:
 wait_cluster_status_on_detail_page:
     element:
         selector:
-            xpath: //div[@class='pf-l-grid']//span[text()='Status']/../../dd/div[text()='<cluster_status>']
+            xpath: //dt/span[text()='Status']/../../dd/div[text()='<cluster_status>']
         timeout: <wait_time>
 go_to_edit_node_count_dialog_on_cluster_detail_page:
   action: expand_actions_on_cluster_detail_page

--- a/lib/rules/web/ocm_console/dialogs_and_sidebar.xyaml
+++ b/lib/rules/web/ocm_console/dialogs_and_sidebar.xyaml
@@ -53,17 +53,17 @@ click_archive_button:
         selector:
             xpath: //button[@class='pf-c-button pf-m-primary' and text()='Archive cluster']
         op: click
-archive_succ_promt_message_displayed:
-    element: &archive_succ_promt_message
+archive_succ_prompt_message_displayed:
+    element: &archive_succ_prompt_message
         selector:
             xpath: //h4[contains(text(),'Cluster <cluster_name> has been archived')]
         timeout: 5
     action:
         if_param: wait_missing
-        ref: archive_succ_promt_message_missing
-archive_succ_promt_message_missing:
+        ref: archive_succ_prompt_message_missing
+archive_succ_prompt_message_missing:
     element:
-        <<: *archive_succ_promt_message
+        <<: *archive_succ_prompt_message
         missing: true
         timeout: 20
         
@@ -101,9 +101,9 @@ hover_unarchive_succ_prompt_message:
         <<: *unarchive_succ_prompt_message
         op: hover
 
-hover_archive_succ_promt_message:
+hover_archive_succ_prompt_message:
     element:
-        <<: *archive_succ_promt_message
+        <<: *archive_succ_prompt_message
         op: hover
 uninstall_succ_prompt_message_displayed:
     element: &uninstall_succ_prompt_message
@@ -264,7 +264,7 @@ close_customer_cloud_subscription_prompt_message:
 go_to_cluster_list_page:
     element:
         selector:
-            xpath: //a[contains(@href, '/openshift/') and text()='Clusters']
+            xpath: //a[contains(@href, '/openshift') and text()='Clusters']
         op: click
     action: cluster_list_page_loaded
 open_cluster_registration_dialog_from_cluster_list_page:
@@ -770,3 +770,10 @@ click_install_button_on_parameter_dialog:
         selector:
             xpath: //button[@type='submit' and text()="Install"]
         op: click
+wait_for_dialog_disappear:
+    element:
+        selector:
+            xpath: //div[@role='dialog']
+        missing: true
+        timeout: 5
+        

--- a/lib/rules/web/ocm_console/ocm_workflow.xyaml
+++ b/lib/rules/web/ocm_console/ocm_workflow.xyaml
@@ -58,19 +58,19 @@ archive_cluster_from_cluster_list_page:
     action: click_archive_button_on_cluster_list_page
     action: archive_dialog_loaded
     action: click_archive_button
-    action: archive_succ_promt_message_displayed
     action: cluster_list_page_loaded
+    action: wait_for_dialog_disappear
     
 unarchive_cluster_from_cluster_list_page:
     params:
         filter_keyword: <cluster_name>
-    action: go_to_archived_cluster_page
+    action: go_to_archived_cluster_list_page
     action: archived_page_loaded
     action: filter_name_or_id
     action: click_unarchive_cluster_button_on_archived_cluster_list_page
     action: unarchive_dialog_loaded
     action: click_unarchive_button
-    action: unarchive_succ_prompt_message_displayed
+    action: wait_for_dialog_disappear
 archive_cluster_from_cluster_detail_page:
     action: cluster_list_page_loaded
     action: go_to_cluster_detail_page
@@ -79,7 +79,6 @@ archive_cluster_from_cluster_detail_page:
     action: click_archive_button_on_cluster_detail_page
     action: archive_dialog_loaded
     action: click_archive_button
-    action: archive_succ_promt_message_displayed
     action: archived_cluster_detail_page_loaded
 unarchive_cluster_from_cluster_detail_page:
     action: archived_page_loaded
@@ -87,7 +86,6 @@ unarchive_cluster_from_cluster_detail_page:
     action: click_detail_page_unarchive_cluster_button
     action: unarchive_dialog_loaded
     action: click_unarchive_button
-    action: unarchive_succ_prompt_message_displayed
     action: cluster_detail_page_loaded
 go_to_cluster_list_page_by_navigator_link:
     element:

--- a/lib/rules/web/ocm_console/subscription_page.xyaml
+++ b/lib/rules/web/ocm_console/subscription_page.xyaml
@@ -3,11 +3,6 @@ go_to_subscription_quota_annual_page:
     url: /openshift/quota
 go_to_subscription_quota_limit_page:
     url: /openshift/quota/resource-limits
-switch_subscriptions_page:
-    element:
-        selector:
-            xpath: //a[text()='Subscriptions' and contains(@href, '/openshift/subscriptions')]
-        op: click
 check_quota_page_title:
     scripts:
     - command: return document.title=='Quota | Red Hat OpenShift Cluster Manager'


### PR DESCRIPTION
@xueli181114 When I do removing the registered 'clean up', I found that the rules for the cases(related to archived cluster) are out-of-date or dirty, just do a simple changes. Assume in future, we need to reorganize the steps/rules for these cases. Please help review.

The related cucushift PR: https://github.com/openshift/cucushift/pull/8636