### PR TITLE
Fix the v3 script to use the same args with 4.x

### DIFF
--- a/features/step_definitions/pv.rb
+++ b/features/step_definitions/pv.rb
@@ -47,6 +47,7 @@ Given /^I have a(?: (\d+) GB)? volume and save volume id in the#{OPT_SYM} clipbo
   step %Q/the step should succeed/
   step %Q/the "<%= project.name %>-<%= cb.dynamic_pvc_name %>" PVC becomes :bound within #{timeout} seconds/
   step %Q/admin ensures "<%= pvc.volume_name %>" pv is deleted after scenario/
+  step %Q/I ensure "<%= project.name %>-<%= cb.dynamic_pvc_name %>" pvc is deleted after scenario/
   step %Q/I save volume id from PV named "<%= pvc.volume_name %>" in the :#{cbname} clipboard/
 end
 

--- a/features/storage/fsType.feature
+++ b/features/storage/fsType.feature
@@ -36,7 +36,39 @@ Feature: testing for parameter fsType
       | ext3   | awsElasticBlockStore | volumeID    | ebs    | # @case_id OCP-10048
       | ext4   | awsElasticBlockStore | volumeID    | ebs    | # @case_id OCP-9612
       | xfs    | awsElasticBlockStore | volumeID    | ebs    | # @case_id OCP-10049
-      | ext3   | cinder               | volumeID    | cinder | # @case_id OCP-10097
-      | ext4   | cinder               | volumeID    | cinder | # @case_id OCP-10098
-      | xfs    | cinder               | volumeID    | cinder | # @case_id OCP-10099
 
+
+  # @author wduan@redhat.com
+  @admin
+  Scenario Outline: persistent volume formated with fsType
+    Given I have a project
+    And I have a 1 GB volume and save volume id in the :vid clipboard
+    And I switch to cluster admin pseudo user
+    And I use the "<%= project.name %>" project
+    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/cinder/security/cinder-selinux-fsgroup-test.json" replacing paths:
+      | ["metadata"]["name"]                                      | pod-<%= project.name %>                                                                               |
+      | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"] | /mnt                                                                                                  |
+      | ["spec"]["containers"][0]["image"]                        | quay.io/openshifttest/storage@sha256:a05b96d373be86f46e76817487027a7f5b8b5f87c0ac18a246b018df11529b40 |
+      | ["spec"]["securityContext"]["fsGroup"]                    | 24680                                                                                                 |
+      | ["spec"]["volumes"][0]["cinder"]["volumeID"]              | <%= cb.vid %>                                                                                         |
+      | ["spec"]["volumes"][0]["cinder"]["fsType"]                | <fsType>                                                                                              |
+    Then the step should succeed
+    And the pod named "pod-<%= project.name %>" becomes ready
+    When I execute on the pod:
+      | mount |
+    Then the step should succeed
+    And the output should contain:
+      | /mnt type <fsType> |
+    When I execute on the pod:
+      | touch | /mnt/testfile |
+    Then the step should succeed
+    When I execute on the pod:
+      | ls | /mnt/testfile |
+    Then the step should succeed
+    Given I ensure "pod-<%= project.name %>" pod is deleted
+
+    Examples:
+      | fsType | type   |
+      | ext3   | cinder | # @case_id OCP-10097
+      | ext4   | cinder | # @case_id OCP-10098
+      | xfs    | cinder | # @case_id OCP-10099


### PR DESCRIPTION
1. Update the fsType.feature to make sure the args are as same as in the polarion
2. Update the cleanup step, in previous code, only deleting pv (which is bound to pvc) doesn't work. It always hung for the timeout.

[pass log](https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3-smoke/3282/console)

@chao007 @jhou1 PTAL