### PR TITLE
extend timeout for kataconfig deletion

### DIFF
--- a/features/step_definitions/kata.rb
+++ b/features/step_definitions/kata.rb
@@ -68,7 +68,7 @@ Given /^I remove kata operator from the#{OPT_QUOTED} namespace$/ do | kata_ns |
   end
 
   kataconfig_name = BushSlicer::KataConfig.list(user: admin).first.name
-  step %Q/I ensure "#{kataconfig_name}" kata_config is deleted within 1200 seconds/
+  step %Q/I ensure "#{kataconfig_name}" kata_config is deleted within 1500 seconds/
   # 2. remove namespace
   step %Q/I ensure "#{kata_ns}" project is deleted/
 end


### PR DESCRIPTION
A recent run failed due to only 2/3 worker-nodes were removed within the timeout 1200 seconds, extend it 5 more minutes.
```
07-08 22:22:57.735          unInstallationStatus:
07-08 22:22:57.735            completed:
07-08 22:22:57.735              completedNodesCount: 2
07-08 22:22:57.735              completedNodesList:
07-08 22:22:57.735              - qeci-49-6tl5h-worker-a-lh6s5.c.openshift-qe.internal
07-08 22:22:57.735              - qeci-49-6tl5h-worker-b-7g4fc.c.openshift-qe.internal
07-08 22:22:57.735            errorMessage: Existing pods using Kata Runtime found. Please delete the pods manually
07-08 22:22:57.735              for KataConfig deletion to proceed
07-08 22:22:57.735            failed: {}
07-08 22:22:57.735            inProgress:
07-08 22:22:57.735              status: "True"
07-08 22:22:57.735          upgradeStatus: {}
07-08 22:22:57.735        
07-08 22:22:57.735        BushSlicer::KataConfig example-kataconfig did not disappear within 1200 sec (RuntimeError)
```