### PR TITLE
fix rule for console upgrade case

### DIFF
--- a/lib/rules/web/admin_console/4.1/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.1/common_ui_elements.xyaml
@@ -227,6 +227,7 @@ check_resource_link:
   element:
     selector:
       css: a[href$='<resource_link>']
+check_resource_item_name: {}
 check_page_contains:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.2/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.2/common_ui_elements.xyaml
@@ -888,3 +888,4 @@ click_workload_details:
   params:
     button_text: Overview
   action: click_button_text
+check_resource_item_name: {}


### PR DESCRIPTION
check_resource_item_name is used in console upgrade case. In upgrade ci, there are still 4.1/4.2 original version, console case would fail in these runs.