### PR TITLE
Execute all multicast cases in verification-tests

### DIFF
--- a/features/networking/multicast.feature
+++ b/features/networking/multicast.feature
@@ -52,10 +52,10 @@ Feature: testing multicast scenarios
 
     # check the omping result on third pod
     When I run the :exec background client command with:
-      | pod              | <%= cb.pod3 %> |
-      | oc_opts_end      |                |
-      | exec_command     | sh             |
-      | exec_command_arg | -c             |
+      | pod              | <%= cb.pod3 %>                                                                     |
+      | oc_opts_end      |                                                                                    |
+      | exec_command     | sh                                                                                 |
+      | exec_command_arg | -c                                                                                 |
       | exec_command_arg | omping -c 5 -T 10 <%= cb.pod1ip %> <%= cb.pod2ip %> <%= cb.pod3ip %> > /tmp/p3.log |
     Then the step should succeed
 
@@ -116,10 +116,10 @@ Feature: testing multicast scenarios
     Then the step should succeed
 
     When I run the :exec background client command with:
-      | pod              | <%= cb.pod2 %> |
-      | oc_opts_end      |                |
-      | exec_command     | sh             |
-      | exec_command_arg | -c             |
+      | pod              | <%= cb.pod2 %>                                                            |
+      | oc_opts_end      |                                                                           |
+      | exec_command     | sh                                                                        |
+      | exec_command_arg | -c                                                                        |
       | exec_command_arg | omping -c 5 -T 10 <%= cb.pod1ip %> <%= cb.pod2ip %> > /tmp/p2-disable.log |
     Then the step should succeed
 
@@ -141,7 +141,7 @@ Feature: testing multicast scenarios
     And the output should contain:
       | <%= cb.pod1ip %> : joined (S,G) = (*, 232.43.211.234), pinging |
     And the output should not match:
-      | <%= cb.pod1ip %> : multicast, xmt/rcv/%loss = 5/0/100%         |
+      | <%= cb.pod1ip %> : multicast, xmt/rcv/%loss = 5/0/100% |
     """
 
   # @author weliang@redhat.com
@@ -203,10 +203,10 @@ Feature: testing multicast scenarios
     Then the step should succeed
     # Enable multicast group 239.255.254.24 stream proj1pod3
     When I run the :exec background client command with:
-      | pod              | <%= cb.proj1pod3 %>  |
-      | oc_opts_end      |                      |
-      | exec_command     | sh                   |
-      | exec_command_arg | -c                   |
+      | pod              | <%= cb.proj1pod3 %>                                                                                                        |
+      | oc_opts_end      |                                                                                                                            |
+      | exec_command     | sh                                                                                                                         |         
+      | exec_command_arg | -c                                                                                                                         |
       | exec_command_arg | omping -m 239.255.254.24 -c 5 -T 10 <%= cb.proj1pod1ip %> <%= cb.proj1pod2ip %> <%= cb.proj1pod3ip %> > /tmp/proj1pod3.log |
     Then the step should succeed
 
@@ -252,10 +252,10 @@ Feature: testing multicast scenarios
     Then the step should succeed
     # Enable multicast group 239.255.254.24 stream proj2pod3
     When I run the :exec background client command with:
-      | pod              | <%= cb.proj2pod3 %> |
-      | oc_opts_end      |                     |
-      | exec_command     | sh                  |
-      | exec_command_arg | -c                  |
+      | pod              | <%= cb.proj2pod3 %>                                                                                                        |
+      | oc_opts_end      |                                                                                                                            |
+      | exec_command     | sh                                                                                                                         |
+      | exec_command_arg | -c                                                                                                                         |
       | exec_command_arg | omping -m 239.255.254.24 -c 5 -T 10 <%= cb.proj2pod1ip %> <%= cb.proj2pod2ip %> <%= cb.proj2pod3ip %> > /tmp/proj2pod3.log |
     Then the step should succeed
 
@@ -281,3 +281,334 @@ Feature: testing multicast scenarios
       | <%= cb.proj2pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0%                |
     """
 
+  # @author hongli@redhat.com
+  # @case_id OCP-12931
+  @admin
+  @destructive
+  Scenario: pods in default project should not be able to receive multicast traffic from other tenants
+    # create multicast testing pod in one project
+    Given I have a project
+    And evaluation of `project.name` is stored in the :proj1 clipboard
+    Given I obtain test data file "networking/multicast-rc.json"
+    When I run oc create over "multicast-rc.json" replacing paths:
+      | ["spec"]["replicas"] | 1 |
+    Then the step should succeed
+    Given 1 pod becomes ready with labels:
+      | name=mcast-pods |
+    And evaluation of `pod.ip` is stored in the :proj1_podip clipboard
+    And evaluation of `pod.name` is stored in the :proj1_pod clipboard
+
+    # enable multicast for the netnamespace
+    Given I enable multicast for the "<%= cb.proj1 %>" namespace
+
+    # enable multicast and create testing pods in default project
+    Given I switch to cluster admin pseudo user
+    And I use the "default" project
+    Given I enable multicast for the "default" namespace
+
+    Given admin ensures "mcast-rc" rc is deleted after scenario
+    Given I obtain test data file "networking/multicast-rc.json"
+    When I run oc create over "multicast-rc.json" replacing paths:
+      | ["spec"]["replicas"] | 1 |
+    Then the step should succeed
+    Given 1 pod becomes ready with labels:
+      | name=mcast-pods |
+    And evaluation of `pod.ip` is stored in the :proj2_podip clipboard
+    And evaluation of `pod.name` is stored in the :proj2_pod clipboard
+
+    # run omping on the pod in first project
+    Given I use the "<%= cb.proj1 %>" project
+    When I run the :exec background client command with:
+      | pod              | <%= cb.proj1_pod %>                                                         |
+      | oc_opts_end      |                                                                             |
+      | exec_command     | sh                                                                          |
+      | exec_command_arg | -c                                                                          |
+      | exec_command_arg | omping -c 5 -T 15 <%= cb.proj1_podip %> <%= cb.proj2_podip %> > /tmp/p1.log |
+    Then the step should succeed
+
+    # run omping on the pod in default project
+    Given I use the "default" project
+    When I run the :exec background client command with:
+      | pod              | <%= cb.proj2_pod %>                                                         |
+      | oc_opts_end      |                                                                             |
+      | exec_command     | sh                                                                          |
+      | exec_command_arg | -c                                                                          |
+      | exec_command_arg | omping -c 5 -T 10 <%= cb.proj1_podip %> <%= cb.proj2_podip %> > /tmp/p2.log |
+    Then the step should succeed
+
+    # check the result and should receive 0 multicast packet
+    Given I use the "<%= cb.proj1 %>" project
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "<%= cb.proj1_pod %>" pod:
+      | cat | /tmp/p1.log |
+    Then the step should succeed
+    And the output should contain:
+      | joined (S,G) = (*, 232.43.211.234), pinging |
+      | multicast, xmt/rcv/%loss = 5/0/100%         |
+    """
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    Given I use the "default" project
+    When I execute on the "<%= cb.proj2_pod %>" pod:
+      | cat | /tmp/p2.log |
+    Then the step should succeed
+    And the output should contain:
+      | joined (S,G) = (*, 232.43.211.234), pinging |
+      | multicast, xmt/rcv/%loss = 5/0/100%         |
+    """  
+    Given I disable multicast for the "default" namespace
+    
+  # @author hongli@redhat.com
+  # @case_id OCP-12928
+  @admin
+  Scenario: pods should be able to join multiple multicast groups at same time  
+    # create some multicast testing pods in the project
+    Given I have a project
+    And evaluation of `project.name` is stored in the :proj1 clipboard
+    Given I obtain test data file "networking/multicast-rc.json"
+    When I run oc create over "multicast-rc.json" replacing paths:
+      | ["spec"]["replicas"] | 2 |
+    Then the step should succeed
+    Given 2 pods become ready with labels:
+      | name=mcast-pods |
+    And evaluation of `pod(0).ip` is stored in the :pod1ip clipboard
+    And evaluation of `pod(0).name` is stored in the :pod1 clipboard
+    And evaluation of `pod(1).ip` is stored in the :pod2ip clipboard
+    And evaluation of `pod(1).name` is stored in the :pod2 clipboard
+
+    # enable multicast for the netnamespace
+    Given I enable multicast for the "<%= cb.proj1 %>" namespace
+
+    # run omping with default group (232.43.211.234) on first pod
+    When I run the :exec background client command with:
+      | pod              | <%= cb.pod1 %>   |
+      | oc_opts_end      |                  |
+      | exec_command     | omping           |
+      | exec_command_arg | -c               |
+      | exec_command_arg | 5                |
+      | exec_command_arg | -T               |
+      | exec_command_arg | 15               |
+      | exec_command_arg | <%= cb.pod1ip %> |
+      | exec_command_arg | <%= cb.pod2ip %> |
+    Then the step should succeed
+
+    # run omping with another group 232.43.211.235 on first pod
+    When I run the :exec background client command with:
+      | pod              | <%= cb.pod1 %>   |
+      | oc_opts_end      |                  |
+      | exec_command     | omping           |
+      | exec_command_arg | -c               |
+      | exec_command_arg | 5                |
+      | exec_command_arg | -T               |
+      | exec_command_arg | 15               |
+      | exec_command_arg | -m               |
+      | exec_command_arg | 232.43.211.235   |
+      | exec_command_arg | -p               |
+      | exec_command_arg | 4322             |
+      | exec_command_arg | <%= cb.pod1ip %> |
+      | exec_command_arg | <%= cb.pod2ip %> |
+    Then the step should succeed
+
+    # run omping on second pod
+    When I run the :exec background client command with:
+      | pod              | <%= cb.pod2 %>                                                      |
+      | oc_opts_end      |                                                                     |
+      | exec_command     | sh                                                                  |
+      | exec_command_arg | -c                                                                  |
+      | exec_command_arg | omping -c 5 -T 10 <%= cb.pod1ip %> <%= cb.pod2ip %> > /tmp/p2g1.log |
+    Then the step should succeed
+    When I run the :exec background client command with:
+      | pod              | <%= cb.pod2 %>                                                                                |
+      | oc_opts_end      |                                                                                               |
+      | exec_command     | sh                                                                                            |
+      | exec_command_arg | -c                                                                                            |
+      | exec_command_arg | omping -c 5 -T 10 -m 232.43.211.235 -p 4322 <%= cb.pod1ip %> <%= cb.pod2ip %> > /tmp/p2g2.log |
+    Then the step should succeed
+
+    # ensure pod joined both multicast groups
+    And I wait up to 10 seconds for the steps to pass:
+    """
+    When I execute on the "<%= cb.pod2 %>" pod:
+      | netstat | -ng |
+    Then the step should succeed
+    And the output should match:
+      | eth0\s+1\s+232.43.211.234 |
+      | eth0\s+1\s+232.43.211.235 |
+    """   
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "<%= cb.pod2 %>" pod:
+      | cat | /tmp/p2g1.log |
+    Then the step should succeed
+    And the output should contain:
+      | <%= cb.pod1ip %> : joined (S,G) = (*, 232.43.211.234), pinging |
+    And the output should not match:
+      | <%= cb.pod1ip %> : multicast, xmt/rcv/%loss = 5/0/0% |
+    When I execute on the "<%= cb.pod2 %>" pod:
+      | cat | /tmp/p2g2.log |
+    Then the step should succeed
+    And the output should contain:
+      | <%= cb.pod1ip %> : joined (S,G) = (*, 232.43.211.235), pinging |
+    And the output should not match:
+      | <%= cb.pod1ip %> : multicast, xmt/rcv/%loss = 5/0/0% |
+    """
+
+  # @author hongli@redhat.com
+  # @case_id OCP-12929
+  @admin
+  Scenario: pods should not be able to receive multicast traffic from other pods in different tenant
+    # create some multicast testing pods in one project
+    Given I have a project
+    And evaluation of `project.name` is stored in the :proj1 clipboard
+    Given I obtain test data file "networking/multicast-rc.json"
+    When I run oc create over "multicast-rc.json" replacing paths:
+      | ["spec"]["replicas"] | 1 |
+    Then the step should succeed
+    Given 1 pod becomes ready with labels:
+      | name=mcast-pods |
+    And evaluation of `pod.ip` is stored in the :proj1_podip clipboard
+    And evaluation of `pod.name` is stored in the :proj1_pod clipboard
+
+    # enable multicast for the netnamespace
+    Given I enable multicast for the "<%= cb.proj1 %>" namespace
+
+    # create some multicast testing pods in another project
+    Given I create a new project
+    And evaluation of `project.name` is stored in the :proj2 clipboard
+    Given I obtain test data file "networking/multicast-rc.json"
+    When I run oc create over "multicast-rc.json" replacing paths:
+      | ["spec"]["replicas"] | 1 |
+    Then the step should succeed
+    Given 1 pod becomes ready with labels:
+      | name=mcast-pods |
+    And evaluation of `pod.ip` is stored in the :proj2_podip clipboard
+    And evaluation of `pod.name` is stored in the :proj2_pod clipboard
+
+    # enable multicast for the netnamespace
+    Given I enable multicast for the "<%= cb.proj2 %>" namespace
+
+    # run omping on pod in first project
+    Given I use the "<%= cb.proj1 %>" project
+    When I run the :exec background client command with:
+      | pod              | <%= cb.proj1_pod %>   |
+      | oc_opts_end      |                       |
+      | exec_command     | omping                |
+      | exec_command_arg | -c                    |
+      | exec_command_arg | 5                     |
+      | exec_command_arg | -T                    |
+      | exec_command_arg | 15                    |
+      | exec_command_arg | <%= cb.proj1_podip %> |
+      | exec_command_arg | <%= cb.proj2_podip %> |
+    Then the step should succeed
+
+    # check the omping result on pod in second project
+    Given I use the "<%= cb.proj2 %>" project
+    When I run the :exec background client command with:
+      | pod              | <%= cb.proj2_pod %>                                                         |
+      | oc_opts_end      |                                                                             |
+      | exec_command     | sh                                                                          |
+      | exec_command_arg | -c                                                                          |
+      | exec_command_arg | omping -c 5 -T 10 <%= cb.proj1_podip %> <%= cb.proj2_podip %> > /tmp/p2.log |
+    Then the step should succeed
+
+    And I wait up to 10 seconds for the steps to pass:
+    """  
+    When I execute on the "<%= cb.proj2_pod %>" pod:
+      | netstat | -ng |
+    Then the step should succeed
+    And the output should match:
+      | eth0\s+1\s+232.43.211.234 |
+    """   
+    And I wait up to 20 seconds for the steps to pass:
+    """
+    When I execute on the "<%= cb.proj2_pod %>" pod:
+      | cat | /tmp/p2.log |
+    Then the step should succeed
+    And the output should contain:
+      | multicast, xmt/rcv/%loss = 5/0/100% |
+    """
+ 
+  # @author hongli@redhat.com
+  # @case_id OCP-12966
+  @admin
+  @destructive
+  Scenario: pods in default project should be able to receive multicast traffic from other default project pods
+    # enable multicast and create testing pods
+    Given I switch to cluster admin pseudo user
+    And I use the "default" project
+    Given I enable multicast for the "default" namespace
+
+    Given admin ensures "mcast-rc" rc is deleted after scenario
+    Given I obtain test data file "networking/multicast-rc.json"
+    When I run the :create client command with:
+      | f | multicast-rc.json |
+    Then the step should succeed
+    Given 3 pods become ready with labels:
+      | name=mcast-pods |
+    And evaluation of `pod(0).ip` is stored in the :pod1ip clipboard
+    And evaluation of `pod(0).name` is stored in the :pod1 clipboard
+    And evaluation of `pod(1).ip` is stored in the :pod2ip clipboard
+    And evaluation of `pod(1).name` is stored in the :pod2 clipboard
+    And evaluation of `pod(2).ip` is stored in the :pod3ip clipboard
+    And evaluation of `pod(2).name` is stored in the :pod3 clipboard
+
+    # run omping as background on the pods
+    When I run the :exec background client command with:
+      | pod              | <%= cb.pod1 %>   |
+      | oc_opts_end      |                  |
+      | exec_command     | omping           |
+      | exec_command_arg | -c               |
+      | exec_command_arg | 5                |
+      | exec_command_arg | -T               |
+      | exec_command_arg | 10               |
+      | exec_command_arg | <%= cb.pod1ip %> |
+      | exec_command_arg | <%= cb.pod2ip %> |
+      | exec_command_arg | <%= cb.pod3ip %> |
+    Then the step should succeed
+
+    When I run the :exec background client command with:
+      | pod              | <%= cb.pod2 %>   |
+      | oc_opts_end      |                  |
+      | exec_command     | omping           |
+      | exec_command_arg | -c               |
+      | exec_command_arg | 5                |
+      | exec_command_arg | -T               |
+      | exec_command_arg | 10               |
+      | exec_command_arg | <%= cb.pod1ip %> |
+      | exec_command_arg | <%= cb.pod2ip %> |
+      | exec_command_arg | <%= cb.pod3ip %> |
+    Then the step should succeed
+
+    When I run the :exec background client command with:
+      | pod              | <%= cb.pod3 %>                                                                     |
+      | oc_opts_end      |                                                                                    |
+      | exec_command     | sh                                                                                 |
+      | exec_command_arg | -c                                                                                 |
+      | exec_command_arg | omping -c 5 -T 10 <%= cb.pod1ip %> <%= cb.pod2ip %> <%= cb.pod3ip %> > /tmp/p3.log |
+    Then the step should succeed
+
+    # ensure interface join to the multicast group
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    When I execute on the "<%= cb.pod3 %>" pod:
+      | netstat | -ng |
+    Then the step should succeed
+    And the output should match:
+      | eth0\s+1\s+232.43.211.234 |
+    """
+
+    # check the result on third pod and should received 5 multicast packets from other pods
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    When I execute on the "<%= cb.pod3 %>" pod:
+      | cat | /tmp/p3.log |
+    Then the step should succeed
+    And the output should match:
+      | <%= cb.pod1ip %>.*joined \(S,G\) = \(\*, 232.43.211.234\), pinging |
+      | <%= cb.pod2ip %>.*joined \(S,G\) = \(\*, 232.43.211.234\), pinging |
+    And the output should not match:
+      | <%= cb.pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
+      | <%= cb.pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
+    """
+    Given I disable multicast for the "default" namespace


### PR DESCRIPTION
Multicast is a k8s upstream feature, it makes no sense to keep openshift multicast cases separately in cucushift and verification-tests.

This PR will make below changes:
1. Copy OCP-12928/OCP-12929/OCP-12966 from cucushift to verification-tests, after this PR merging and updating Automation path in polarion, all the multicast cases will be executed from verification-tests.
2. Update OCP-12928/OCP-12929/OCP-12966  to be executed in both SDN and OVN cluster, right now these three cases can only be executed in SDN.
3. Update OCP-12928/OCP-12929/OCP-12966  to expect not all 5 packets lost in the client side due to Bug 1879241 - [OVN] Pods always lose one multicast packets
4.  Update OCP-12928/OCP-12929/OCP-12966  to allow 10 seconds for the multicast igmp group information shown up when execute "netstate -ng"
5. Add a step to disable multicast in default namespace for  OCP-12928 and OCP-12966
6. Fix indentations in all the cases

SDN log:
http://file.rdu.redhat.com/~weliang/multicast-SDN
OVN log:
http://file.rdu.redhat.com/~weliang/multicast-OVN

/cc @openshift/team-sdn-qe