### PR TITLE
add checkpoint from worker to access service

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -282,6 +282,7 @@ Feature: SDN related networking scenarios
     And evaluation of `pod(1).ip_url` is stored in the :pod2_ip clipboard
     And evaluation of `pod(2).ip_url` is stored in the :pod3_ip clipboard
     And evaluation of `pod(3).ip_url` is stored in the :pod4_ip clipboard
+    And evaluation of `service("test-service").url` is stored in the :svcurl clipboard
     And I register clean-up steps:
     """
     Given I ensure "test-rc" replicationcontroller is deleted
@@ -305,6 +306,13 @@ Feature: SDN related networking scenarios
     Then the step should succeed
     And the output should contain "Hello OpenShift"
 
+    #add checkpopint from work to access the service
+    Given I select a random node's host
+    And I run commands on the host:
+      | curl --connect-timeout 5 <%= cb.svcurl %> |
+    Then the step should succeed
+    And the output should contain "Hello OpenShift"
+   
   # @author anusaxen@redhat.com
   # @case_id OCP-25787
   @admin

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -383,6 +383,7 @@ Feature: Service related networking scenarios
     Then the step should succeed
     And the output should contain:
       | The service "<%= project.name %>/test-service" has been marked as idled |
+    And I wait until number of replicas match "0" for replicationController "test-rc"
     Given I have a pod-for-ping in the project
     And I wait up to 30 seconds for the steps to pass:
     """

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -383,7 +383,6 @@ Feature: Service related networking scenarios
     Then the step should succeed
     And the output should contain:
       | The service "<%= project.name %>/test-service" has been marked as idled |
-    And I wait until number of replicas match "0" for replicationController "test-rc"
     Given I have a pod-for-ping in the project
     And I wait up to 30 seconds for the steps to pass:
     """


### PR DESCRIPTION
according to comment in https://bugzilla.redhat.com/show_bug.cgi?id=1983951#c8,  whatever the cluster is share gateway or local gateway.  we need to make sure service can be accessed from worker. 

So here I added one checkpoint in this case

@openshift/team-sdn-qe 

tested on my local

```
      [07:29:55] INFO> Exit Status: 0
      [07:29:56] INFO> Shell Commands: oc debug  --kubeconfig=/home/zzhao/workdir/dhcp-140-240-zzhao/ocp4_admin.kubeconfig -n tests-dhcp-140-240-zzhao --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:56560421f15944c7282635c86e852a49147bfbe2d627bb93663f781c316d816d node/dell-per740-35.rhts.eng.pek2.redhat.com -- chroot /host/ bash -c cd\ \'/tmp/workdir/dhcp-140-240-zzhao\''
      'curl\ --connect-timeout\ 5\ 172.30.150.178:27017
        % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                       Dload  Upload   Total   Spent    Left  Speed
100    17  100    17    0     0   2833      0 --:--:-- --:--:-- --:--:--  2833
      Hello OpenShift!
      
      STDERR:
      Starting pod/dell-per740-35rhtsengpek2redhatcom-debug ...
      To use host binaries, run `chroot /host`
      
      Removing debug pod ...
      
      [07:29:58] INFO> Exit Status: 0
    Then the step should succeed                                                       # features/step_definitions/common.rb:4
    And the output should contain "Hello OpenShift"
```