### PR TITLE
Remove IPI check, as test runs on UPI too

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -269,8 +269,7 @@ Feature: MachineHealthCheck Test Scenarios
   # @case_id OCP-33714
   @admin
   Scenario: Leverage OpenAPI validation within MHC
-    Given I have an IPI deployment
-    And I switch to cluster admin pseudo user
+    Given I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project
 
     Given I obtain test data file "cloud/mhc/mhc_validations.yaml"


### PR DESCRIPTION
@sunzhaohua2 @jhou1  PTAL ..

Test runs fine on UPI clusters 
```

      STDERR:
      The MachineHealthCheck "mhc-malformed" is invalid: spec.maxUnhealthy: Invalid value: "": spec.maxUnhealthy in body should match '^((100|[0-9]{1,2})%|[0-9]+)$'
      
      [06:22:07] INFO> Exit Status: 1
      """
      When I run oc create over "mhc_validations.yaml" replacing paths:
        | ["spec"]["maxUnhealthy"] | #{cb.resource} |
      Then the output should match:
        | maxUnhealthy: Invalid value: ".*": spec.maxUnhealthy |
      """
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [06:22:07] INFO> === After Scenario: Leverage OpenAPI validation within MHC ===
      [06:22:07] INFO> Shell Commands: rm -r -f -- /root/workdir/7ed35be48865-
      
      [06:22:08] INFO> Exit Status: 0
      [06:22:09] INFO> === End After Scenario: Leverage OpenAPI validation within MHC ===

1 scenario (1 passed)
5 steps (5 passed)
0m21.663s
[06:22:09] INFO> === At Exit ===
```
`