### PR TITLE
Update pod image for sctp testing

### DIFF
--- a/testdata/networking/sctp/sctpclient.yaml
+++ b/testdata/networking/sctp/sctpclient.yaml
@@ -7,7 +7,4 @@ metadata:
 spec:
   containers:
     - name: sctpclient
-      image: quay.io/openshifttest/ubi@sha256:cd014e94a9a2af4946fc1697be604feb97313a3ceb5b4d821253fcdb6b6159ee
-      command: ["/bin/bash", "-c"]
-      args:
-        ["dnf install -y nc && trap 'kill $(jobs -p); exit 0' TERM ; sleep inf & wait"]
+      image: quay.io/openshifttest/centos-network@sha256:48da37205f9b43424e0983d4c5e7e07f77b7ba1504bbe35e2f264c75dcb4cd15

--- a/testdata/networking/sctp/sctpserver.yaml
+++ b/testdata/networking/sctp/sctpserver.yaml
@@ -7,10 +7,7 @@ metadata:
 spec:
   containers:
     - name: sctpserver
-      image: quay.io/openshifttest/ubi@sha256:cd014e94a9a2af4946fc1697be604feb97313a3ceb5b4d821253fcdb6b6159ee
-      command: ["/bin/bash", "-c"]
-      args:
-        ["dnf install -y nc && trap 'kill $(jobs -p); exit 0' TERM ; sleep inf & wait"]
+      image: quay.io/openshifttest/centos-network@sha256:48da37205f9b43424e0983d4c5e7e07f77b7ba1504bbe35e2f264c75dcb4cd15
       ports:
         - containerPort: 30102
           name: sctpserver


### PR DESCRIPTION
Currently, sctp use ubi image plus ["dnf install -y nc && sleep inf"] for sctpserver and sctpclient pod, in disconnected cluster, pod can not execute  ["dnf install -y nc && sleep inf"] and sctp testing will fail in disconnected cluster.

This PR is to update pod image to use quay.io/openshifttest/centos-network which include nc utility being used for sctp testing.

Test log from a disconnected cluster/edge50 bare metal machine:
http://file.rdu.redhat.com/~weliang/sctp.log

/cc @openshift/team-sdn-qe
