### PR TITLE
OCP-11286: don't restart kubelet to avoid test failures

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -44,7 +44,7 @@ Feature: SDN related networking scenarios
     Given I select a random node's host
     And the node iptables config is checked
     And the step succeeded
-    And the node service is restarted on the host after scenario
+    And I restart the network components on the node after scenario
     And I register clean-up steps:
     """
     When the node iptables config is checked
@@ -312,7 +312,7 @@ Feature: SDN related networking scenarios
       | curl --connect-timeout 5 <%= cb.svcurl %> |
     Then the step should succeed
     And the output should contain "Hello OpenShift"
-   
+
   # @author anusaxen@redhat.com
   # @case_id OCP-25787
   @admin

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -148,7 +148,7 @@ Given /^the#{OPT_QUOTED} node iptables config is checked$/ do |node_name|
     raise "#{plugin_type} != openshift-ovs-networkpolicy.  This is unsupported?"
   end
 
-  puts "OpenShift version >= 3.9 and uses networkpolicy plugin."
+  logger.info "OpenShift version >= 3.9 and uses networkpolicy plugin."
   filter_matches = [
     'INPUT -m comment --comment "Ensure that non-local NodePort traffic can flow" -j KUBE-NODEPORT-NON-LOCAL',
     'INPUT -m conntrack --ctstate NEW -m comment --comment "kubernetes externally-visible service portals" -j KUBE-EXTERNAL-SERVICES',


### PR DESCRIPTION
restarting kubelet seems to be an old 3.x step
that seems to fail frequently and might be of dubious utility

remove the kubelet restart step and just restart the network service.

The iptables rules should be re-created already as part of the test.

Also replace `puts` with `logger.info` as per deprecation notice.