### PR TITLE
Deactivate some nfs tests

### DIFF
--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -4,6 +4,7 @@ Feature: NFS Persistent Volume
   # @author lxia@redhat.com
   # @case_id OCP-9572
   @admin
+  @inactive
   Scenario: Share NFS with multiple pods with ReadWriteMany mode
     Given I have a project
     And I have a NFS service in the project


### PR DESCRIPTION
As a follow up of storage test cases review, marking tests as 'inactive' in automation as well. There polarion test case has been deactivated.
@duanwei33 @chao007 @ropatil010 @xgu-redhat @Phaow PTAL