### PR TITLE
 Drop spec check, if we found it the source should be created

### DIFF
--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -8,8 +8,8 @@ Feature: cluster-logging-operator related test
   @commonlogging
   Scenario: ServiceMonitor Object for collector is deployed along with cluster logging
     Given I wait for the "fluentd" service_monitor to appear
-    Given the expression should be true> service_monitor('fluentd').service_monitor_endpoint_spec(server_name: "fluentd.openshift-logging.svc").port == "metrics"
-    And the expression should be true> service_monitor('fluentd').service_monitor_endpoint_spec(server_name: "fluentd.openshift-logging.svc").path == "/metrics"
+    #Given the expression should be true> service_monitor('fluentd').service_monitor_endpoint_spec(server_name: "fluentd.openshift-logging.svc").port == "metrics"
+    #And the expression should be true> service_monitor('fluentd').service_monitor_endpoint_spec(server_name: "fluentd.openshift-logging.svc").path == "/metrics"
     Given I wait up to 360 seconds for the steps to pass:
     """
     When I perform the GET prometheus rest client with:

--- a/testdata/logging/clusterlogforwarder/fluentd/insecure/configmap.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/insecure/configmap.yaml
@@ -3,6 +3,7 @@ data:
   fluent.conf: |
     <source>
       @type forward
+      bind ::
       port  24224
     </source>
 


### PR DESCRIPTION
From 5.2, fluentd use different endpoints. To make cases pass on both 4.x and 5.x.  we drop spec checking here, as if we find he metrics, the resource must be created.

5.2 endpoints
 "spec": {
        "endpoints": [
            {
                "bearerTokenSecret": {
                    "key": ""
                },
                "path": "/metrics",
                "port": "metrics",
                "scheme": "https",
                "tlsConfig": {
                    "ca": {},
                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
                    "cert": {},
                    "serverName": "fluentd.openshift-logging.svc"
                }
            },
            {
                "bearerTokenSecret": {
                    "key": ""
                },
                "path": "/metrics",
                "port": "logfile-metrics",
                "scheme": "https",
                "tlsConfig": {
                    "ca": {},
                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
                    "cert": {},
                    "serverName": "fluentd.openshift-logging.svc"
                }
            }
        ],


https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/136214/console