### PR TITLE
change Monitoring to Observe for 4.9 due to change

### DIFF
--- a/lib/rules/web/admin_console/4.9/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.9/monitoring_metrics.xyaml
@@ -21,7 +21,7 @@ click_primary_menu_developer_mode:
     op: click
 goto_monitoring:
   params:
-    menu_text: Monitoring
+    menu_text: Observe
   action: click_primary_menu_developer_mode
 click_projects_dropdown_developer_mode:
   element:


### PR DESCRIPTION
in 4.9, developer console, Monitoring is changed to Observe, 
see from https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3/321361/artifact/embedded_files/2021-08-17T08%3A44%3A02+00%3A00-screenshot.png

change the 4.9 rule accordingly.
4.9 run pass:
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3/321363/consoleFull