### PR TITLE
adding @inactive to deactivated test cases

### DIFF
--- a/features/admin/pod.feature
+++ b/features/admin/pod.feature
@@ -16,6 +16,7 @@ Feature: pod related features
   # @case_id OCP-10598
   @admin
   @destructive
+  @inactive
   Scenario: Existing pods will not be affected when node is unschedulable
     Given I have a project
     When I run the :create client command with:
@@ -45,6 +46,7 @@ Feature: pod related features
   # @case_id OCP-11116
   @admin
   @destructive
+  @inactive
   Scenario: New pods creation will be disabled on unschedulable nodes
     Given I have a project
     Given I store the schedulable nodes in the :nodes clipboard
@@ -72,6 +74,7 @@ Feature: pod related features
   # @case_id OCP-11466
   @admin
   @destructive
+  @inactive
   Scenario: Recovering an unschedulable node
     Given I have a project
     Given I run the :patch admin command with:
@@ -98,6 +101,7 @@ Feature: pod related features
   # @author chezhang@redhat.com
   # @case_id OCP-11752
   @admin
+  @inactive
   Scenario: Pod will not be copied to nodes which does not match it's node selector
     Given I have a project
     Given I run the :patch admin command with:
@@ -211,6 +215,7 @@ Feature: pod related features
   # @case_id OCP-12338
   @admin
   @destructive
+  @inactive
   Scenario: Secret is valid after node reboot
     Given I have a project
     Given I run the :patch admin command with:

--- a/features/admin/quota.feature
+++ b/features/admin/quota.feature
@@ -139,6 +139,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11566
   @admin
+  @inactive
   Scenario: The quota status is calculated ASAP when editing its quota spec
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
@@ -395,6 +396,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11780
   @admin
+  @inactive
   Scenario: Check Terminating scope of resourcequota
     Given I have a project
     Given I obtain test data file "quota/quota-terminating.yaml"
@@ -549,6 +551,7 @@ Feature: Quota related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-11779
   @admin
+  @inactive
   Scenario: The usage for cpu/mem/pod counts are fixed up ASAP if delete a pod
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
@@ -631,6 +634,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11247
   @admin
+  @inactive
   Scenario: The current quota usage is calculated ASAP when adding a quota
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"

--- a/features/build/buildconfig.feature
+++ b/features/build/buildconfig.feature
@@ -2,6 +2,7 @@ Feature: buildconfig.feature
 
   # @author wzheng@redhat.com
   # @case_id OCP-12121
+  @inactive
   Scenario: Start build from buildConfig/build
     Given I have a project
     When I run the :new_app client command with:

--- a/features/build/dockerbuild.feature
+++ b/features/build/dockerbuild.feature
@@ -123,6 +123,7 @@ Feature: dockerbuild.feature
 
   # @author wzheng@redhat.com
   # @case_id OCP-18501
+  @inactive
   Scenario: Support additional EXPOSE values in new-app
     Given I have a project
     When I run the :new_app client command with:

--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -2,6 +2,7 @@ Feature: build 'apps' with CLI
 
   # @author cryan@redhat.com
   # @case_id OCP-11132
+  @inactive
   Scenario: Create a build config based on the provided image and source code
     Given I have a project
     When I run the :new_build client command with:

--- a/features/cli/configmap.feature
+++ b/features/cli/configmap.feature
@@ -118,6 +118,7 @@ Feature: configMap
   # @author chezhang@redhat.com
   # @case_id OCP-9882
   @smoke
+  @inactive
   Scenario: Set command-line arguments with ConfigMap
     Given I have a project
     Given I obtain test data file "configmap/configmap.yaml"
@@ -149,6 +150,7 @@ Feature: configMap
 
   # @author chezhang@redhat.com
   # @case_id OCP-9884
+  @inactive
   Scenario: Configuring redis using ConfigMap
     Given I have a project
     Given a "redis-config" file is created with the following lines:
@@ -185,6 +187,7 @@ Feature: configMap
   # @author chezhang@redhat.com
   # @case_id OCP-9880
   @smoke
+  @inactive
   Scenario: Create ConfigMap from file
     Given I have a project
     Given I create the "configmap-test" directory
@@ -278,6 +281,7 @@ Feature: configMap
 
   # @author chezhang@redhat.com
   # @case_id OCP-9881
+  @inactive
   Scenario: Create ConfigMap from literal values
     Given I have a project
     When I run the :create_configmap client command with:
@@ -301,6 +305,7 @@ Feature: configMap
 
   # @author chezhang@redhat.com
   # @case_id OCP-9879
+  @inactive
   Scenario: Create ConfigMap from directories
     Given I have a project
     Given I create the "configmap-test" directory
@@ -351,6 +356,7 @@ Feature: configMap
 
   # @author xiuli@redhat.com
   # @case_id OCP-16721
+  @inactive
   Scenario: Changes to ConfigMap should be auto-updated into container
     Given I have a project
     Given I obtain test data file "configmap/configmap.json"

--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -291,6 +291,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-12528
+  @inactive
   Scenario: Make multiple deployment by oc deploy
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
@@ -313,6 +314,7 @@ Feature: deployment related features
 
   # @author xiaocwan@redhat.com
   # @case_id OCP-10717
+  @inactive
   Scenario: View the logs of the latest deployment
     # check deploy log when deploying
     Given I have a project
@@ -430,6 +432,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-12532
+  @inactive
   Scenario: Manually start deployment by oc deploy
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
@@ -444,6 +447,7 @@ Feature: deployment related features
 
   # @author yinzhou@redhat.com
   # @case_id OCP-12468
+  @inactive
   Scenario: Pre and post deployment hooks
     Given I have a project
     Given I obtain test data file "deployment/testhook.json"
@@ -465,6 +469,7 @@ Feature: deployment related features
 
   # @author yinzhou@redhat.com
   # @case_id OCP-10724
+  @inactive
   Scenario: deployment hook volume inheritance that volume name was null
     Given I have a project
     Given I obtain test data file "deployment/ocp10724/hooks-null-volume.json"
@@ -476,6 +481,7 @@ Feature: deployment related features
   # @author yadu@redhat.com
   # @case_id OCP-9567
   @smoke
+  @inactive
   Scenario: Recreate deployment strategy
     Given I have a project
     When I run the :create client command with:
@@ -514,6 +520,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-12056
+  @inactive
   Scenario: Manual scale dc will update the deploymentconfig's replicas
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
@@ -539,6 +546,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-10728
+  @inactive
   Scenario: Inline deployer hook logs
     Given I have a project
     Given I obtain test data file "deployment/Inline-logs.json"
@@ -686,6 +694,7 @@ Feature: deployment related features
 
   # @author qwang@redhat.com
   # @case_id OCP-12356
+  @inactive
   Scenario: configchange triggers deploy automatically
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
@@ -794,6 +803,7 @@ Feature: deployment related features
   # @author mcurlej@redhat.com
   # @case_id OCP-10902
   @smoke
+  @inactive
   Scenario: Auto cleanup old RCs
     Given I have a project
     Given I obtain test data file "deployment/ocp10902/history-limit-dc.yaml"

--- a/features/cli/downwardapi.feature
+++ b/features/cli/downwardapi.feature
@@ -99,6 +99,7 @@ Feature: Downward API
   # @author qwang@redhat.com
   # @case_id OCP-11977
   @admin
+  @inactive
   Scenario: Using resources downward API via volume plugin should be compatible with metadata downward API
     Given I have a project
     Given I obtain test data file "downwardapi/dapi-resources-metadata-volume-pod.yaml"
@@ -184,6 +185,7 @@ Feature: Downward API
   # @author qwang@redhat.com
   # @case_id OCP-11618
   @admin
+  @inactive
   Scenario: Could expose resouces limits and requests via volume plugin from Downward APIs with magics keys
     Given I have a project
     Given I obtain test data file "downwardapi/dapi-resources-volume-magic-keys-pod.yaml"
@@ -237,6 +239,7 @@ Feature: Downward API
   # @author qwang@redhat.com
   # @case_id OCP-11816
   @admin
+  @inactive
   Scenario: Using resources downward API via ENV should be compatible with metadata downward API
     Given I have a project
     Given I obtain test data file "downwardapi/dapi-resources-metadata-env-pod.yaml"

--- a/features/cli/event.feature
+++ b/features/cli/event.feature
@@ -49,6 +49,7 @@ Feature: Event related scenarios
 
   # @author chezhang@redhat.com
   # @case_id OCP-10750
+  @inactive
   Scenario: Check normal and warning information for kubernetes events
     Given I have a project
     Given I obtain test data file "pods/hello-pod.json"
@@ -92,6 +93,7 @@ Feature: Event related scenarios
 
   # @author dma@redhat.com
   # @case_id OCP-10208
+  @inactive
   Scenario: Event should show full failed reason when readiness probe failed
     Given I have a project
     Given I obtain test data file "pods/ocp10208/readiness-probe-exec.yaml"

--- a/features/cli/job.feature
+++ b/features/cli/job.feature
@@ -141,6 +141,7 @@ Feature: job.feature
 
   # @author qwang@redhat.com
   # @case_id OCP-9948
+  @inactive
   Scenario: Create job with activeDeadlineSeconds
     Given I have a project
     Given I obtain test data file "job/job_with_lessthan_runtime_activeDeadlineSeconds.yaml"
@@ -181,6 +182,7 @@ Feature: job.feature
 
   # @author qwang@redhat.com
   # @case_id OCP-10734
+  @inactive
   Scenario: Create job with different pod restartPolicy
     Given I have a project
     Given I obtain test data file "job/job-restartpolicy.yaml"

--- a/features/cli/limits.feature
+++ b/features/cli/limits.feature
@@ -3,6 +3,7 @@ Feature: limit range related scenarios:
   # @author pruan@redhat.com
   # @author azagayno@redhat.com
   @admin
+  @inactive
   Scenario Outline: Limit range default request tests
     Given I have a project
     Given I obtain test data file "limits/<path>/limit.yaml"

--- a/features/cli/oc_delete.feature
+++ b/features/cli/oc_delete.feature
@@ -51,6 +51,7 @@ Feature: oc_delete.feature
   # @case_id OCP-12048
   # @bug_id 1277101
   @admin
+  @inactive
   Scenario: The namespace will not be deleted until all pods gracefully terminate
     Given I have a project
     And evaluation of `project.name` is stored in the :prj1 clipboard
@@ -84,6 +85,7 @@ Feature: oc_delete.feature
 
   # @author cryan@redhat.com
   # @case_id OCP-10705
+  @inactive
   Scenario: Default termination grace period is 30s if it's not set
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/default.json"

--- a/features/cli/oc_help.feature
+++ b/features/cli/oc_help.feature
@@ -2,6 +2,7 @@ Feature: oc related features
 
   # @author chezhang@redhat.com
   # @case_id OCP-11565
+  @inactive
   Scenario: kubectl secret subcommand - help
     Given I have a project
     When I run the :create_secret client command with:
@@ -85,6 +86,7 @@ Feature: oc related features
 
   # @author chezhang@redhat.com
   # @case_id OCP-10812
+  @inactive
   Scenario: Check `oc autoscale` help info
     Given I have a project
     When I run the :autoscale client command with:

--- a/features/cli/oc_import_image.feature
+++ b/features/cli/oc_import_image.feature
@@ -35,6 +35,7 @@ Feature: oc import-image related feature
 
   # @author wjiang@redhat.com
   # @case_id OCP-11760
+  @inactive
   Scenario: Import Image when spec.DockerImageRepository not defined
     Given I have a project
     Given I obtain test data file "image-streams/ocp11760.json"
@@ -55,6 +56,7 @@ Feature: oc import-image related feature
   # @author wjiang@redhat.com
   # @case_id OCP-12052
   @smoke
+  @inactive
   Scenario: Import image when spec.DockerImageRepository with some tags defined when Kind==DockerImage
     Given I have a project
     Given I obtain test data file "image-streams/ocp12052.json"

--- a/features/cli/pod.feature
+++ b/features/cli/pod.feature
@@ -2,6 +2,7 @@ Feature: pods related scenarios
 
   # @author chezhang@redhat.com
   # @case_id OCP-11218
+  @inactive
   Scenario: kubectl describe pod should show qos tier info when pod without limits and request info
     Given I have a project
     Given I obtain test data file "pods/hello-pod.json"
@@ -53,6 +54,7 @@ Feature: pods related scenarios
 
   # @author chezhang@redhat.com
   # @case_id OCP-10729
+  @inactive
   Scenario: Implement supplemental groups for pod
     Given I have a project
     Given I obtain test data file "pods/ocp10729/pod-supplementalGroups.yaml"
@@ -115,6 +117,7 @@ Feature: pods related scenarios
   # @author cryan@redhat.com
   # @case_id OCP-10813
   # @bug_id 1324396
+  @inactive
   Scenario: Update ActiveDeadlineSeconds for pod
     Given I have a project
     Given I obtain test data file "pods/ocp10813/hello-pod.json"

--- a/features/cli/rolling_deploy.feature
+++ b/features/cli/rolling_deploy.feature
@@ -2,6 +2,7 @@ Feature: rolling deployment related scenarios
 
   # @author pruan@redhat.com
   # @case_id OCP-12359
+  @inactive
   Scenario: Rolling-update pods with default value for maxSurge/maxUnavailable
     Given I have a project
     Given I obtain test data file "deployment/rolling.json"

--- a/features/images/rhel8_images.feature
+++ b/features/images/rhel8_images.feature
@@ -40,6 +40,7 @@ Feature: rhel8images.feature
   # @author xiuwang@redhat.com
   # @case_id OCP-22953
   @admin
+  @inactive
   Scenario: Enable hot deploy for ruby app with ruby rhel8 image
     Given I have a project
     When I run the :tag admin command with:
@@ -158,6 +159,7 @@ Feature: rhel8images.feature
   # @author xiuwang@redhat.com
   # @case_id OCP-31249
   @admin
+  @inactive
   Scenario: Using new-app cmd to create app with ruby rhel8 image test
     Given I have a project
     When I run the :tag admin command with:

--- a/features/infrastructure/scheduler.feature
+++ b/features/infrastructure/scheduler.feature
@@ -3,6 +3,7 @@ Feature: Scheduler predicates and priority test suites
   # @author wjiang@redhat.com
   # @case_id OCP-12467
   @admin
+  @inactive
   Scenario: [origin_runtime_646] Fixed predicates rules testing - MatchNodeSelector
     Given I have a project
     Given I obtain test data file "scheduler/pod_with_nodeselector.json"

--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -103,6 +103,7 @@ Feature: cluster-logging-operator related test
   # @case_id OCP-28131
   @admin
   @destructive
+  @inactive
   Scenario: CLO should generate Elasticsearch Index Management
     Given I obtain test data file "logging/clusterlogging/example_indexmanagement.yaml"
     Given I create clusterlogging instance with:

--- a/features/networking/build.feature
+++ b/features/networking/build.feature
@@ -47,6 +47,7 @@ Feature: Testing the isolation during build scenarios
 
   # @author zzhao@redhat.com
   # @bug_id 1487652
+  @inactive
   Scenario Outline: Build-container is constrained to access other projects pod for networkpolicy plugin
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"

--- a/features/networking/multus-ipv6.feature
+++ b/features/networking/multus-ipv6.feature
@@ -3,6 +3,7 @@ Feature: Multus-CNI ipv6 related scenarios
   # @author weliang@redhat.com
   # @case_id OCP-28968
   @admin
+  @inactive
   Scenario: IPv6 testing for OCP-21151: Create pods with multus-cni - macvlan bridge mode
     # Make sure that the multus is enabled
     Given the master version >= "4.1"

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -162,6 +162,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   # @case_id OCP-40569
   @admin
   @destructive
+  @inactive
   Scenario: Allow enablement/disablement ipsec at runtime
     Given the env is using "OVNKubernetes" networkType   
     Given I store all worker nodes to the :workers clipboard

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -390,6 +390,7 @@ Feature: Pod related networking scenarios
   # @case_id OCP-26373
   @admin
   @destructive
+  @inactive
   Scenario: Make sure the route to ovn tunnel for Node's Pod CIDR gets created in both hybrid/non-hybrid mode
   Given the env is using "OVNKubernetes" networkType
   And I select a random node's host
@@ -458,6 +459,7 @@ Feature: Pod related networking scenarios
   # @case_id OCP-33413
   @admin
   @destructive
+  @inactive
   Scenario: xt_u32 kernel module functionality check from NET_ADMIN pods
     Given I have a project
     And I have a pod-for-ping in the project

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -88,6 +88,7 @@ Feature: SDN related networking scenarios
   # @case_id OCP-15251
   @admin
   @destructive
+  @inactive
   Scenario: net.ipv4.ip_forward should be always enabled on node service startup
     Given I select a random node's host
     And the node service is verified
@@ -121,6 +122,7 @@ Feature: SDN related networking scenarios
   # @case_id OCP-14985
   @admin
   @destructive
+  @inactive
   Scenario: The openflow list will be cleaned after deleted the node
     Given the env is using "OpenShiftSDN" networkType
     Given environment has at least 2 schedulable nodes

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -46,6 +46,7 @@ Feature: Service related networking scenarios
   # @author yadu@redhat.com
   # @case_id OCP-15032
   @admin
+  @inactive
   Scenario: The openflow list will be cleaned after delete the services
     Given the env is using one of the listed network plugins:
       | subnet      |
@@ -395,6 +396,7 @@ Feature: Service related networking scenarios
 
   # @author huirwang@redhat.com
   # @case_id OCP-11645
+  @inactive
   Scenario: Create loadbalancer service
     Given I have a project
     Given I obtain test data file "networking/ping_for_pod_containerPort.json"

--- a/features/networking/sriov.feature
+++ b/features/networking/sriov.feature
@@ -727,6 +727,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-34092
   @destructive
   @admin
+  @inactive
   Scenario: sriov-device-plugin can be scheduled on any node
     Given the sriov operator is running well
     When I run the :get admin command with:

--- a/features/node/node.feature
+++ b/features/node/node.feature
@@ -3,6 +3,7 @@ Feature: Node management
   # @author chaoyang@redhat.com
   # @case_id OCP-11084
   @admin
+  @inactive
   Scenario: admin can get nodes
     Given I have a project
     When I run the :get admin command with:

--- a/features/node/seccomp.feature
+++ b/features/node/seccomp.feature
@@ -2,6 +2,7 @@ Feature: Secure Computing Test Scenarios
 
   # @author wmeng@redhat.com
   # @case_id OCP-10483
+  @inactive
   Scenario: seccomp=unconfined used by default
     Given I have a project
     Given I obtain test data file "pods/hello-pod.json"

--- a/features/online/create.feature
+++ b/features/online/create.feature
@@ -1,6 +1,7 @@
 Feature: ONLY ONLINE Create related feature's scripts in this file
 
   # @author bingli@redhat.com
+  @inactive
   Scenario Outline: Maven repository can be used to providing dependency caching for xPaas templates
     Given I have a project
     When I run the :new_app client command with:

--- a/features/online/notification.feature
+++ b/features/online/notification.feature
@@ -11,6 +11,7 @@ Feature: Online "Notification" related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-10334
+  @inactive
   Scenario: Enable/Disable online notification in web console - UI
     Given I have a project
     When I perform the :goto_notification_page web console action with:

--- a/features/quickstarts/quickstarts.feature
+++ b/features/quickstarts/quickstarts.feature
@@ -1,6 +1,7 @@
 Feature: quickstarts.feature
 
   # @author haowang@redhat.com
+  @inactive
   Scenario Outline: quickstart test
     Given I have a project
     When I run the :new_app client command with:

--- a/features/service_catalog_tsb/tsb.feature
+++ b/features/service_catalog_tsb/tsb.feature
@@ -3,6 +3,7 @@ Feature: Template service broker related features
   # @author zitang@redhat.com
   # @case_id OCP-21690
   @admin
+  @inactive
   Scenario: [CVP] Clusterserviceclass and clusterserviceplan of templateinstance were created
     Given admin checks that the "template-service-broker" cluster_service_broker exists
     When I run the :get client command with:

--- a/features/storage/cloud_provider.feature
+++ b/features/storage/cloud_provider.feature
@@ -3,6 +3,7 @@ Feature: kubelet restart and node restart
   # @author lxia@redhat.com
   @admin
   @destructive
+  @inactive
   Scenario Outline: kubelet restart should not affect attached/mounted volumes
     Given I have a project
     When I run the :new_app client command with:

--- a/features/storage/local-storage-operator.feature
+++ b/features/storage/local-storage-operator.feature
@@ -3,6 +3,7 @@ Feature: local-storage-operator related features
   # @author lxia@redhat.com
   # @case_id OCP-24493
   @admin
+  @inactive
   Scenario: Operator local-storage exist in OperatorHub
     Given I switch to cluster admin pseudo user
     And admin uses the "openshift-marketplace" project

--- a/features/storage/persistent_volume.feature
+++ b/features/storage/persistent_volume.feature
@@ -42,6 +42,7 @@ Feature: Persistent Volume Claim binding policies
 
   # @author yinzhou@redhat.com
   # @case_id OCP-11933
+  @inactive
   Scenario: deployment hook volume inheritance -- with persistentvolumeclaim Volume
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"

--- a/features/svc-catalog_asb/apb-update.feature
+++ b/features/svc-catalog_asb/apb-update.feature
@@ -2,6 +2,7 @@ Feature: Update sql apb related feature
 
   # @author zitang@redhat.com
   @admin
+  @inactive
   Scenario Outline: Plan of serviceinstance can be updated
     Given I save the first service broker registry prefix to :prefix clipboard
     #provision postgresql

--- a/features/svc-catalog_asb/asb.feature
+++ b/features/svc-catalog_asb/asb.feature
@@ -147,6 +147,7 @@ Feature: Ansible-service-broker related scenarios
 
   # @author chezhang@redhat.com
   @admin
+  @inactive
   Scenario Outline: Multiple Plans support for DB APBs
     # Get the registry name from the configmap
     When I switch to cluster admin pseudo user
@@ -221,6 +222,7 @@ Feature: Ansible-service-broker related scenarios
   # @author zitang@redhat.com
   # @case_id OCP-15354
   @admin
+  @inactive
   Scenario: Check multiple broker support for service catalog
     Given admin checks that the "ansible-service-broker" cluster_service_broker exists
     And admin checks that the "template-service-broker" cluster_service_broker exists

--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -4,6 +4,7 @@ Feature: Service-catalog related scenarios
   # @case_id OCP-15600
   @admin
   @destructive
+  @inactive
   Scenario: service-catalog walkthrough example
     Given I have a project
     When I run the :get admin command with:
@@ -95,6 +96,7 @@ Feature: Service-catalog related scenarios
   # @case_id OCP-15604
   @admin
   @destructive
+  @inactive
   Scenario: Create/get/update/delete for ClusterServiceBroker resource
     Given I have a project
     When I run the :get admin command with:
@@ -173,6 +175,7 @@ Feature: Service-catalog related scenarios
   # @case_id OCP-15603
   @admin
   @destructive
+  @inactive
   Scenario: Create/get/update/delete for ServiceInstance resource
     Given I have a project
     When I run the :get admin command with:
@@ -233,6 +236,7 @@ Feature: Service-catalog related scenarios
   # @case_id OCP-15605
   @admin
   @destructive
+  @inactive
   Scenario: Create/get/update/delete for ServiceBinding resource
     Given I have a project
     When I run the :get admin command with:
@@ -308,6 +312,7 @@ Feature: Service-catalog related scenarios
   # @case_id OCP-15602
   @admin
   @destructive
+  @inactive
   Scenario: Create/get/update/delete for Clusterserviceclass/Clusterserviceplan resource
     Given I have a project
     When I run the :get admin command with:

--- a/features/upgrade/api_auth/upgrade.feature
+++ b/features/upgrade/api_auth/upgrade.feature
@@ -2,6 +2,7 @@ Feature: apiserver and auth related upgrade check
   # @author pmali@redhat.com
   # @case_id OCP-22734
   @upgrade-prepare
+  @inactive
   Scenario: Check Authentication operators and operands are upgraded correctly - prepare
     # According to our upgrade workflow, we need an upgrade-prepare and upgrade-check for each scenario.
     # But some of them do not need any prepare steps, which lead to errors "can not find scenarios" in the log.
@@ -62,6 +63,7 @@ Feature: apiserver and auth related upgrade check
   # @case_id OCP-22673
   @upgrade-check
   @admin
+  @inactive
   Scenario: Check apiserver operators and operands are upgraded correctly
     Given the "kube-apiserver" operator version matches the current cluster version
     And the "openshift-apiserver" operator version matches the current cluster version

--- a/features/upgrade/samples_operator/upgrade.feature
+++ b/features/upgrade/samples_operator/upgrade.feature
@@ -61,6 +61,7 @@ Feature: image-registry operator upgrade tests
   @upgrade-check
   @users=upuser1,upuser2
   @admin
+  @inactive
   Scenario: OpenShift can upgrade when image-registry/sample operator is unmanaged
     Given I switch to cluster admin pseudo user
     Given I use the "default" project
@@ -140,6 +141,7 @@ Feature: image-registry operator upgrade tests
   @upgrade-check
   @users=upuser1,upuser2
   @admin
+  @inactive
   Scenario: Upgrade imagestream from old version which not implement node credentials
     Given I switch to cluster admin pseudo user
     When I use the "devexp-p1" project

--- a/features/upgrade/svcat/upgrade.feature
+++ b/features/upgrade/svcat/upgrade.feature
@@ -6,6 +6,7 @@ Feature: Service Catalog related scenarios
   @admin
   @upgrade-prepare
   @users=upuser1,upuser2
+  @inactive
   Scenario: upgrade svcat - prepare
     # Check SVCAT version
     Given the "service-catalog-apiserver" operator version matches the current cluster version

--- a/features/upgrade/tsb/upgrade.feature
+++ b/features/upgrade/tsb/upgrade.feature
@@ -6,6 +6,7 @@ Feature: TSB related scenarios
   @admin
   @upgrade-prepare
   @users=upuser1,upuser2
+  @inactive
   Scenario: upgrade TSB - prepare
     # Create a namespace and an operator in it
     Given I switch to cluster admin pseudo user


### PR DESCRIPTION
The following test cases have already been deactivated from Polarion(query `type:testcase AND status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes`). To make sure their inactive status is reflected in our code base, the `@inactive` tag has been added.
