### PR TITLE
Disable wait print to compact the junit result file size

### DIFF
--- a/lib/base_helper.rb
+++ b/lib/base_helper.rb
@@ -142,7 +142,9 @@ module BushSlicer
       #   is reached
       def wait_for(seconds, interval: 1, stats: nil)
         if seconds > 60
-          Kernel.puts("waiting for operation up to #{seconds} seconds..")
+          unless ENV['DISABLE_WAIT_PRINT'] == 'true'
+            Kernel.puts("waiting for operation up to #{seconds} seconds..")
+          end
         end
         iterations = 0
 


### PR DESCRIPTION
Currnet junit output has in the <CD_DATA> file statements like the following, which does not provide any useful data for failure analysis. Added an environment variable `DISABLE_WAIT_PRINT` which when set to `true` will not print out the statement. The purpose is to make the junit result file size smaller and only contain applicable data.
```
  <system-out>
    <![CDATA[waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
```

with env set: https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/149757/console
file size: .rw-r--r--  1.0k pruan 25 Aug 15:40   -- junit-report/TEST-features-tierN-admin-master_config.xml

w/o env set: https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/149933/console
file size: .rw-r--r--   450 pruan 25 Aug 15:41   -- junit-report/TEST-features-tierN-admin-master_config.xml