### PR TITLE
Fix expected output

### DIFF
--- a/features/cli/job.feature
+++ b/features/cli/job.feature
@@ -477,7 +477,7 @@ Feature: job.feature
        | exec_command_arg | 300           |
     Then the step should fail
     And the output should contain:
-       | Invalid value: "70 12 15 11 3": End of range (70) above maximum (59): 70 |
+       | Invalid value: "70 12 15 11 3": end of range (70) above maximum (59): 70 |
     When I run the :create_cronjob client command with:
        | name             | sjc          |
        | image            | busybox      |
@@ -488,7 +488,7 @@ Feature: job.feature
        | exec_command_arg | 300          |
     Then the step should fail
     And the output should contain:
-       | Invalid value: "30 25 15 1 3": End of range (25) above maximum (23): 25 |
+       | Invalid value: "30 25 15 1 3": end of range (25) above maximum (23): 25 |
     When I run the :create_cronjob client command with:
        | name             | sjc          |
        | image            | busybox      |
@@ -499,7 +499,7 @@ Feature: job.feature
        | exec_command_arg | 300          |
     Then the step should fail
     And the output should contain:
-       | Invalid value: "30 8 35 11 3": End of range (35) above maximum (31): 35 |
+       | Invalid value: "30 8 35 11 3": end of range (35) above maximum (31): 35 |
     When I run the :create_cronjob client command with:
        | name             | sjc         |
        | image            | busybox     |
@@ -510,7 +510,7 @@ Feature: job.feature
        | exec_command_arg | 300         |
     Then the step should fail
     And the output should contain:
-       | Invalid value: "30 8 1 13 3": End of range (13) above maximum (12): 13 |
+       | Invalid value: "30 8 1 13 3": end of range (13) above maximum (12): 13 |
     When I run the :create_cronjob client command with:
        | name             | sjc        |
        | image            | busybox    |
@@ -521,7 +521,7 @@ Feature: job.feature
        | exec_command_arg | 300        |
     Then the step should fail
     And the output should contain:
-       | Invalid value: "30 8 1 8 7": End of range (7) above maximum (6): 7 |
+       | Invalid value: "30 8 1 8 7": end of range (7) above maximum (6): 7 |
     When I run the :create_cronjob client command with:
        | name             | sjd       |
        | image            | busybox   |


### PR DESCRIPTION
Failure at https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/21446/rehearse-21446-periodic-ci-openshift-release-master-nightly-4.9-e2e-cucushift-aws-ipi/1432336610912899072
In the expected output, `End` -> `end`

@liangxia @pruan-rht @geliu2016 PTAL