### PR TITLE
Avoid printing report outline with profile polarshift

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -22,7 +22,7 @@ default: --publish-quiet --profile devel
 debug: --profile _debug --profile devel
 devel: --profile _devel <%= default_args %>
 tcms: BUSHSLICER_TEST_CASE_MANAGER=tcms <%= tcms_args %>
-polarshift: BUSHSLICER_TEST_CASE_MANAGER=polarshift <%= tcms_args %>
+polarshift: --publish-quiet BUSHSLICER_TEST_CASE_MANAGER=polarshift <%= tcms_args %>
 junit: <%= default_args %> -f junit -o "<%= File.join(report_dir, 'junit-report') %>" --profile dir_embedder
 dir_embedder: -f BushSlicer::SaveToDirEmbeddingFormatter -o "<%= File.join(report_dir, 'embedded_files') %>"
 report_portal: rp_config=<%= "#{report_dir}/report-portal.yml" %> -f ReportPortal::Cucumber::Formatter


### PR DESCRIPTION
/cc @jhou1 @pruan-rht @JianLi-RH @dis016 

Avoid print below messages.
```
 ������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������
 ��� Share your Cucumber Report with your team at https://reports.cucumber.io ���
 ���                                                                          ���
 ��� Command line option:    --publish                                        ���
 ��� Environment variable:   CUCUMBER_PUBLISH_ENABLED=true                    ���
 ��� cucumber.yml:           default: --publish                               ���
 ���                                                                          ���
 ��� More information at https://reports.cucumber.io/docs/cucumber-ruby       ���
 ���                                                                          ���
 ��� To disable this message, specify CUCUMBER_PUBLISH_QUIET=true or use the  ���
 ��� --publish-quiet option. You can also add this to your cucumber.yml:      ���
 ��� default: --publish-quiet                                                 ���
 ������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������
```