### PR TITLE
fix upgrade failure

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -691,7 +691,7 @@ Given /^I upgrade the operator with:$/ do | table |
   raise "Patch failed with #{@result[:response]}" unless @result[:success]
   # wait till new csv to be installed
   success = wait_for(180, interval: 10) {
-    subscription(subscription).installplan_csv.include? channel
+    (subscription(subscription).installplan_csv.include? channel) || (subscription(subscription).installplan_csv.include? (channel.split('-')[1]))
   }
   raise "the new CSV can't be installed" unless success
   # wait till new csv is ready


### PR DESCRIPTION
Fix failure when checking the new CSV version after changing the channel/source in subscription. With this fix, the case can pass when the channel name is  `5.0`, `stable-5.1`, `stable-5.2`, but it will fail when the channel name is `stable`. Currently I have no idea about how to determine the CSV version of `stable` channel.

```
08-31 20:34:30.212        [12:34:03] INFO> Shell Commands: oc get subscriptions.operators.coreos.com elasticsearch-operator --output=yaml --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_admin.kubeconfig --namespace=openshift-operators-redhat
08-31 20:34:30.212        apiVersion: operators.coreos.com/v1alpha1
08-31 20:34:30.212        kind: Subscription
08-31 20:34:30.212        metadata:
08-31 20:34:30.212          creationTimestamp: "2021-08-31T10:18:25Z"
08-31 20:34:30.212          generation: 2
08-31 20:34:30.212          labels:
08-31 20:34:30.212            operators.coreos.com/elasticsearch-operator.openshift-operators-redhat: ""
08-31 20:34:30.212          name: elasticsearch-operator
08-31 20:34:30.212          namespace: openshift-operators-redhat
08-31 20:34:30.212          resourceVersion: "202115"
08-31 20:34:30.212          uid: 6f2c16be-11ad-4ca4-aa9a-895f2e758642
08-31 20:34:30.212        spec:
08-31 20:34:30.212          channel: stable-5.2
08-31 20:34:30.212          installPlanApproval: Automatic
08-31 20:34:30.212          name: elasticsearch-operator
08-31 20:34:30.212          source: qe-app-registry
08-31 20:34:30.212          sourceNamespace: openshift-marketplace
08-31 20:34:30.212        status:
08-31 20:34:30.212          catalogHealth:
08-31 20:34:30.212          - catalogSourceRef:
08-31 20:34:30.212              apiVersion: operators.coreos.com/v1alpha1
08-31 20:34:30.212              kind: CatalogSource
08-31 20:34:30.212              name: certified-operators
08-31 20:34:30.212              namespace: openshift-marketplace
08-31 20:34:30.212              resourceVersion: "103877"
08-31 20:34:30.212              uid: 031e9c5b-8b72-46c0-9f5b-b09067f2b7c3
08-31 20:34:30.212            healthy: true
08-31 20:34:30.212            lastUpdated: "2021-08-31T11:04:01Z"
08-31 20:34:30.212          - catalogSourceRef:
08-31 20:34:30.212              apiVersion: operators.coreos.com/v1alpha1
08-31 20:34:30.212              kind: CatalogSource
08-31 20:34:30.212              name: community-operators
08-31 20:34:30.212              namespace: openshift-marketplace
08-31 20:34:30.212              resourceVersion: "103783"
08-31 20:34:30.212              uid: a725b2f8-7718-4fd3-844f-f3b03ac01b01
08-31 20:34:30.212            healthy: true
08-31 20:34:30.212            lastUpdated: "2021-08-31T11:04:01Z"
08-31 20:34:30.212          - catalogSourceRef:
08-31 20:34:30.212              apiVersion: operators.coreos.com/v1alpha1
08-31 20:34:30.212              kind: CatalogSource
08-31 20:34:30.212              name: qe-app-registry
08-31 20:34:30.212              namespace: openshift-marketplace
08-31 20:34:30.212              resourceVersion: "103803"
08-31 20:34:30.212              uid: cd2c5b9d-d5e6-4ac3-b9c5-ba26b8faf260
08-31 20:34:30.212            healthy: true
08-31 20:34:30.212            lastUpdated: "2021-08-31T11:04:01Z"
08-31 20:34:30.212          - catalogSourceRef:
08-31 20:34:30.212              apiVersion: operators.coreos.com/v1alpha1
08-31 20:34:30.212              kind: CatalogSource
08-31 20:34:30.212              name: redhat-marketplace
08-31 20:34:30.212              namespace: openshift-marketplace
08-31 20:34:30.212              resourceVersion: "103878"
08-31 20:34:30.212              uid: 9ce80977-a751-4661-b8c7-e22cb631b61c
08-31 20:34:30.212            healthy: true
08-31 20:34:30.212            lastUpdated: "2021-08-31T11:04:01Z"
08-31 20:34:30.212          - catalogSourceRef:
08-31 20:34:30.212              apiVersion: operators.coreos.com/v1alpha1
08-31 20:34:30.212              kind: CatalogSource
08-31 20:34:30.212              name: redhat-operators
08-31 20:34:30.212              namespace: openshift-marketplace
08-31 20:34:30.212              resourceVersion: "103868"
08-31 20:34:30.212              uid: 780af50c-af58-4222-9803-ef87e50dbaa8
08-31 20:34:30.212            healthy: true
08-31 20:34:30.212            lastUpdated: "2021-08-31T11:04:01Z"
08-31 20:34:30.212          conditions:
08-31 20:34:30.212          - lastTransitionTime: "2021-08-31T11:04:01Z"
08-31 20:34:30.212            message: all available catalogsources are healthy
08-31 20:34:30.212            reason: AllCatalogSourcesHealthy
08-31 20:34:30.212            status: "False"
08-31 20:34:30.212            type: CatalogSourcesUnhealthy
08-31 20:34:30.212          - status: "False"
08-31 20:34:30.212            type: ResolutionFailed
08-31 20:34:30.212          currentCSV: elasticsearch-operator.5.2.0-51
08-31 20:34:30.212          installPlanGeneration: 2
08-31 20:34:30.212          installPlanRef:
08-31 20:34:30.212            apiVersion: operators.coreos.com/v1alpha1
08-31 20:34:30.212            kind: InstallPlan
08-31 20:34:30.212            name: install-j9n2b
08-31 20:34:30.212            namespace: openshift-operators-redhat
08-31 20:34:30.212            resourceVersion: "201783"
08-31 20:34:30.212            uid: d4de38dc-d606-4671-a3bb-3b92955baeb3
08-31 20:34:30.212          installedCSV: elasticsearch-operator.5.2.0-51
08-31 20:34:30.212          installplan:
08-31 20:34:30.212            apiVersion: operators.coreos.com/v1alpha1
08-31 20:34:30.212            kind: InstallPlan
08-31 20:34:30.212            name: install-j9n2b
08-31 20:34:30.212            uuid: d4de38dc-d606-4671-a3bb-3b92955baeb3
08-31 20:34:30.212          lastUpdated: "2021-08-31T12:31:32Z"
08-31 20:34:30.212          state: AtLatestKnown
08-31 20:34:30.212        
08-31 20:34:30.212        [12:34:09] INFO> Exit Status: 0
08-31 20:34:30.212        the new CSV can't be installed (RuntimeError)
08-31 20:34:30.212        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/logging.rb:696:in `/^I upgrade the operator with:$/'
08-31 20:34:30.212        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/transform.rb:33:in `call'
08-31 20:34:30.212        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/transform.rb:33:in `block in singleton class'
08-31 20:34:30.212        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/logging.rb:772:in `/^I make sure the logging operators match the cluster version$/'
08-31 20:34:30.212        features/upgrade/logging/upgrade.feature:77:in `I make sure the logging operators match the cluster version'
```

/cc @anpingli @IshwarKanse 