### PR TITLE
Add pkg rsync

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -7,7 +7,7 @@ USER root
 
 RUN set -x && \
     yum -y update && \
-    INSTALL_PKGS="bsdtar git openssh-clients httpd-tools" && \
+    INSTALL_PKGS="bsdtar git openssh-clients httpd-tools rsync" && \
     yum install -y $INSTALL_PKGS && \
     GECKODRIVER_DOWNLOAD_URL="$(curl -sSL https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep -Eo 'http.*linux64.tar.gz' | sed -E 's/.*(https[^"]*).*/\1/' | head -1)" && \
     curl -sSL $GITHUB_API_CURL_OPTS "$GECKODRIVER_DOWNLOAD_URL" | bsdtar -xvf - -C /usr/local/bin && \


### PR DESCRIPTION
This fixes the following [failure in Prow](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/21446/rehearse-21446-periodic-ci-openshift-release-master-nightly-4.9-e2e-cucushift-aws-ipi/1433059395142422528/build-log.txt)

```
    Scenario: Copying files from host to container using oc rsync command with --watch test

Given I wait for the steps to pass:

Message:

    pattern not found: test (RuntimeError)
...

WARNING: rsync command not found in path. Please use your package manager to install it
```

Tested on my laptop which has `rsync` -- test passed
Tested on the verification-tests image which has no `rsync` -- failure reproduced.

@liangxia @pruan-rht PTAL