### PR TITLE
Fix restore descheduler func to handle more cases

### DIFF
--- a/features/step_definitions/descheduler.rb
+++ b/features/step_definitions/descheduler.rb
@@ -12,6 +12,14 @@ Given(/^the "([^"]*)" descheduler CR is restored from the "([^"]*)" after scenar
   patch_json = org_descheduler.to_json
   _admin = admin
   teardown_add {
+    @result = admin.cli_exec(:get, resource: 'kubedescheduler', resource_name: name, o: 'yaml')
+    if @result[:success] and @result[:parsed]['spec']['profileCustomizations']
+      patch_pc_json = [{"op": "remove","path": "/spec/profileCustomizations"}].to_json
+      opts_pc = {resource: 'kubedescheduler', resource_name: name, p: patch_pc_json, type: 'json' }
+      @result_pc = _admin.cli_exec(:patch, **opts_pc)
+      rasie "Cannot restore profileCustomizations" unless @result_pc[:success]
+      opts = {resource: 'kubedescheduler', resource_name: name, p: patch_json, type: 'merge' }
+    end
     opts = {resource: 'kubedescheduler', resource_name: name, p: patch_json, type: 'merge' }
     @result = _admin.cli_exec(:patch, **opts)
     raise "Cannot restore descheduler: #{name}" unless @result[:success]


### PR DESCRIPTION
Add code to make sure descheduler restore happens succesfully when /spec/profileCustomizations is present