### PR TITLE
Fix invalid project name and path

### DIFF
--- a/lib/bushslicer.rb
+++ b/lib/bushslicer.rb
@@ -48,7 +48,7 @@ module BushSlicer
     # likely a jenkins environment
     EXECUTOR_NAME = "#{ENV["NODE_NAME"]}-#{ENV["EXECUTOR_NUMBER"]}".freeze
   else
-    EXECUTOR_NAME = "#{HOSTNAME.split('.')[0]}-#{LOCAL_USER}".freeze
+    EXECUTOR_NAME = "#{HOSTNAME.split('.')[0]}-#{LOCAL_USER}".chomp('-').freeze
   end
 
   START_TIME = Time.now

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -439,7 +439,7 @@ module BushSlicer
       unless @service_project
         # if the cluster set the default scheduler, set the project running debug pod node-selector=''
         # to overwrite the default scheduler, or the pod can not be run successfully
-        project_name = "proj-" + EXECUTOR_NAME.downcase + "s"
+        project_name = "tests-" + EXECUTOR_NAME.downcase
         project = Project.new(name: project_name, env: self)
         unless project.active?
           # 30 seconds is no longer enough


### PR DESCRIPTION
https://github.com/openshift/verification-tests/pull/2252 has fixed the invalid project name, the project name and workdir path are inconsistent because `@workdir` is also referencing the `EXECUTOR_NAME`. See a failure as: `bash: line 0: cd: /tmp/workdir/e2e-cucushift-aws-ipi-cucushift-aws-ipi-: No such file or directory` in the [Prow test](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/21446/rehearse-21446-periodic-ci-openshift-release-master-nightly-4.9-e2e-cucushift-aws-ipi/1435194584421371904/build-log.txt)

This is an attempt to fix the failure. @liangxia @pruan-rht PTAL