### PR TITLE
Extend debug project wait time

### DIFF
--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -442,8 +442,8 @@ module BushSlicer
         project_name = "proj-" + EXECUTOR_NAME.downcase + "s"
         project = Project.new(name: project_name, env: self)
         unless project.active?
-          # 30 seconds is no longer enough
-          project.wait_to_disappear(admin, 60)
+          # 60 seconds is no longer enough
+          project.wait_to_disappear(admin, 120)
           res = project.create(by: admin, clean_up_registered: true)
           unless res[:success]
             raise "failed to create service project #{project.name}, see log"


### PR DESCRIPTION
Fix error as below in https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/21446/rehearse-21446-periodic-ci-openshift-release-master-nightly-4.9-e2e-cucushift-aws-ipi/1435228405472694272/build-log.txt
```
       [14:16:44] INFO> Shell Commands: oc debug  --kubeconfig=/tmp/dir1/workdir/ocp4_admin.kubeconfig -n proj-e2e-cucushift-aws-ipi-cucushift-aws-ipi-s --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:61e9bf24b15ed423b01099d56850b491ea156bf97d25eae9be903c978db28940 node/ip-10-0-182-213.us-west-1.compute.internal -- chroot /host/ bash -c mkdir\ -v\ -p\ \'/tmp/workdir/e2e-cucushift-aws-ipi-cucushift-aws-ipi-\'
      
      STDERR:
      Error from server (Forbidden): pods "ip-10-0-182-213us-west-1computeinternal-debug" is forbidden: unable to create new content in namespace proj-e2e-cucushift-aws-ipi-cucushift-aws-ipi-s because it is being terminated
      
      [14:16:45] INFO> Exit Status: 1
      error creating dir /tmp/workdir/e2e-cucushift-aws-ipi-cucushift-aws-ipi- (RuntimeError)
      /verification-tests/lib/host.rb:493:in `mkdir'
      /verification-tests/lib/host.rb:93:in `workdir'
      /verification-tests/lib/host.rb:465:in `exec_as'
      /verification-tests/lib/host.rb:182:in `exec'
      /verification-tests/features/step_definitions/node.rb:99:in `/^I run( background)? commands on the host:$/'
      /verification-tests/features/step_definitions/transform.rb:33:in `call'
      /verification-tests/features/step_definitions/transform.rb:33:in `block in singleton class'
      /verification-tests/features/step_definitions/meta_steps.rb:107:in `block (2 levels) in <top (required)>'
      /verification-tests/features/step_definitions/meta_steps.rb:104:in `each'
      /verification-tests/features/step_definitions/meta_steps.rb:104:in `/^I repeat the following steps for each :(\S+) in cb\.([\w]+):$/'
      features/tierN/storage/regression.feature:10:in `I repeat the following steps for each :node in cb.nodes:' 
```