### PR TITLE
Make sure EXECUTOR_NAME always end with proper char

### DIFF
--- a/lib/bushslicer.rb
+++ b/lib/bushslicer.rb
@@ -50,6 +50,7 @@ module BushSlicer
   else
     EXECUTOR_NAME = "#{HOSTNAME.split('.')[0]}-#{LOCAL_USER}".freeze
   end
+  EXECUTOR_NAME = "#{EXECUTOR_NAME}-e"
 
   START_TIME = Time.now
   TIME_SUFFIX = [

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -439,7 +439,7 @@ module BushSlicer
       unless @service_project
         # if the cluster set the default scheduler, set the project running debug pod node-selector=''
         # to overwrite the default scheduler, or the pod can not be run successfully
-        project_name = "proj-" + EXECUTOR_NAME.downcase + "s"
+        project_name = "proj-" + EXECUTOR_NAME.downcase
         project = Project.new(name: project_name, env: self)
         unless project.active?
           # 60 seconds is no longer enough


### PR DESCRIPTION
`EXECUTOR_NAME` is generated via below code in `lib/bushslicer.rb`. And it's used as part of project name and workdir. We need to make sure it ends with a proper char which is valid for project name and workdir.
```
  if ENV["NODE_NAME"]
    # likely a jenkins environment
    EXECUTOR_NAME = "#{ENV["NODE_NAME"]}-#{ENV["EXECUTOR_NUMBER"]}".freeze
  else
    EXECUTOR_NAME = "#{HOSTNAME.split('.')[0]}-#{LOCAL_USER}".freeze
  end

```
