### PR TITLE
print browser and driver version for debugging

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -129,6 +129,8 @@ require_relative 'chrome_extension'
         # options.log_level = 'trace'
 
         @browser = Watir::Browser.new :firefox, :http_client=>client, desired_capabilities: caps, options: options, url: @selenium_url
+        logger.info "#{browser.driver.capabilities[:browser_name]} version is #{browser.driver.capabilities[:browser_version]}"
+        logger.info "Geckodriver version is #{browser.driver.capabilities['moz:geckodriverVersion']}"
         if @size
           browser.window.resize_to(*@size)
         end
@@ -149,6 +151,8 @@ require_relative 'chrome_extension'
         options[:extensions] = [proxy_chrome_ext_file] if proxy_chrome_ext_file
         url_or_switches = @selenium_url ? {url: @selenium_url} : {switches: chrome_switches}
         @browser = Watir::Browser.new :chrome, desired_capabilities: chrome_caps, options: options, **url_or_switches
+        logger.info "#{browser.driver.capabilities[:browser_name]} version is #{browser.driver.capabilities[:browser_version]}"
+        logger.info "Chromedriver version is #{browser.driver.capabilities['chrome']['chromedriverVersion']}"
         if @size
           browser.window.resize_to(*@size)
         end


### PR DESCRIPTION

```
      [06:33:51] INFO> Exit Status: 0
      [06:33:52] INFO> running web action goto_admin_console_root ... 
      [06:33:52] INFO> url..
      [06:33:52] INFO> Navigating to: https://console-openshift-console.apps.qe-ui49-0908.qe.devcluster.openshift.com/
      [06:33:54] INFO> Launching Chrome
      [06:34:14] INFO> Chrome version is 93.0.4577.63
      [06:34:14] INFO> Chromedriver version is 93.0.4577.15 (660fc11082ba57405eca2e8c49c3e1af756fbfae-refs/branch-heads/4577@{#203})

```

```
      [06:39:25] INFO> Exit Status: 0
      [06:39:25] INFO> running web action goto_admin_console_root ... 
      [06:39:25] INFO> url..
      [06:39:25] INFO> Navigating to: https://console-openshift-console.apps.qe-ui49-0908.qe.devcluster.openshift.com/
      [06:39:26] INFO> Launching Firefox Marionette/Geckodriver
      [06:39:41] INFO> Firefox Marionette version is 92.0
      [06:39:41] INFO> Geckodriver version is 0.26.0
```