### PR TITLE
Add serial tag

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -431,6 +431,7 @@ Feature: Multus-CNI related scenarios
   # @case_id OCP-24488
   @admin
   @aws-ipi
+  @serial
   Scenario: Create pod with Multus bridge CNI plugin without vlan
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster


### PR DESCRIPTION
Tests that does `oc debug ` are not expected to run concurrently, they are likely to fail when initiating the `oc debug node` together. Prove is https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/21446/rehearse-21446-periodic-ci-openshift-release-master-nightly-4.9-e2e-cucushift-aws-ipi/1435443859713691648/build-log.txt

Noticed both tests have failed and their failure time are very close. I manually verified that running the `oc debug` with same arguments at the same time in two terminals, one of them always fails. To work around issues like this, the `@serial` tag is added to ensure these tests run one by one. I'll be adding this tag as I'm monitoring the ci results.

Scenario: Create pod with Multus bridge CNI plugin without vlan
```
      [36m[33m[04:22:48] INFO> Shell Commands: oc debug  --kubeconfig=/tmp/dir3/workdir/ocp4_admin.kubeconfig -n proj-e2e-cucushift-aws-ipi-cucushift-aws-ipi-s --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:df3d8f92ccc08ce88eba171d28135028a1fdbe7a920fc839f2b137187d28a6af node/ip-10-0-141-250.ec2.internal -- chroot /host/ bash -c cd\ \'/tmp/workdir/e2e-cucushift-aws-ipi-cucushift-aws-ipi-\''[0m
      [36m'/sbin/bridge\ -j\ vlan\ show[0m[0m
      [36m[0m
      [36mSTDERR:[0m
      [36mStarting pod/ip-10-0-141-250ec2internal-debug ...[0m
      [36mTo use host binaries, run `chroot /host`[0m
      [36m[0m
      [36mRemoving debug pod ...[0m
      [36merror: unable to create the debug pod "ip-10-0-141-250ec2internal-debug"[0m
```

Scenario: Check the binary files and selinux setting used by storage
```
[36m[33m[04:23:06] INFO> Shell Commands: oc debug  --kubeconfig=/tmp/dir1/workdir/ocp4_admin.kubeconfig -n proj-e2e-cucushift-aws-ipi-cucushift-aws-ipi-s --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:df3d8f92ccc08ce88eba171d28135028a1fdbe7a920fc839f2b137187d28a6af node/ip-10-0-180-120.ec2.internal -- chroot /host/ bash -c cd\ \'/tmp/workdir/e2e-cucushift-aws-ipi-cucushift-aws-ipi-\''[0m
```