### PR TITLE
fix failure: can not switch to project openshift-logging

### DIFF
--- a/features/logging/logging_acceptance.feature
+++ b/features/logging/logging_acceptance.feature
@@ -27,6 +27,7 @@ Feature: Logging smoke test case
       | update_channel    | <%= cb.clo_channel %> |
       | install_mode      | OwnNamespace          |
       | approval_strategy | Automatic             |
+    Then I wait for the "openshift-logging" project to appear
     Given cluster logging operator is ready
     # subscribe elasticsearch-operator
     When I perform the :goto_operator_subscription_page web action with:
@@ -39,6 +40,7 @@ Feature: Logging smoke test case
       | install_mode      | AllNamespace         |
       | approval_strategy | Automatic            |
     Then the step should succeed
+    Then I wait for the "openshift-operators-redhat" project to appear
     Given elasticsearch operator is ready in the "openshift-operators-redhat" namespace
     Then I use the "openshift-logging" project
     And default storageclass is stored in the :default_sc clipboard


### PR DESCRIPTION
Fix failure:
```
waiting for operation up to 3600 seconds..
    Given cluster logging operator is ready                                                                                                                                                                                                                                                                                                                                                                                                                                                                           # features/step_definitions/logging.rb:243
      [07:14:40] INFO> Shell Commands: oc project openshift-logging --kubeconfig=/home/qitang/workdir/rhel-8-qitang/ocp4_testuser-30.kubeconfig
      
      STDERR:
      error: A project named "openshift-logging" does not exist on "https://api.qitang.qe.devcluster.openshift.com:6443".
      Your projects are:
      * default
      * kube-node-lease
      * kube-public
      * kube-system
      * openshift
      * openshift-apiserver
      * openshift-apiserver-operator
      * openshift-authentication
      * openshift-authentication-operator
      * openshift-cloud-credential-operator
      * openshift-cluster-csi-drivers
      * openshift-cluster-machine-approver
      * openshift-cluster-node-tuning-operator
      * openshift-cluster-samples-operator
      * openshift-cluster-storage-operator
      * openshift-cluster-version
      * openshift-config
      * openshift-config-managed
      * openshift-config-operator
      * openshift-console
      * openshift-console-operator
      * openshift-console-user-settings
      * openshift-controller-manager
      * openshift-controller-manager-operator
      * openshift-dns
      * openshift-dns-operator
      * openshift-etcd
      * openshift-etcd-operator
      * openshift-host-network
      * openshift-image-registry
      * openshift-infra
      * openshift-ingress
      * openshift-ingress-canary
      * openshift-ingress-operator
      * openshift-insights
      * openshift-kni-infra
      * openshift-kube-apiserver
      * openshift-kube-apiserver-operator
      * openshift-kube-controller-manager
      * openshift-kube-controller-manager-operator
      * openshift-kube-scheduler
      * openshift-kube-scheduler-operator
      * openshift-kube-storage-version-migrator
      * openshift-kube-storage-version-migrator-operator
      * openshift-kubevirt-infra
      * openshift-machine-api
      * openshift-machine-config-operator
      * openshift-marketplace
      * openshift-monitoring
      * openshift-multus
      * openshift-network-diagnostics
      * openshift-network-operator
      * openshift-node
      * openshift-oauth-apiserver
      * openshift-openstack-infra
      * openshift-operator-lifecycle-manager
      * openshift-operators
      * openshift-ovirt-infra
      * openshift-sdn
      * openshift-service-ca
      * openshift-service-ca-operator
      * openshift-user-workload-monitoring
      * openshift-vsphere-infra
      
      [07:14:45] INFO> Exit Status: 1
      can not switch to project openshift-logging (RuntimeError)
      /home/qitang/github.com/verification-tests/features/step_definitions/project.rb:118:in `/^I use the "(.+?)" project$/'
      /home/qitang/github.com/verification-tests/features/step_definitions/transform.rb:33:in `call'
      /home/qitang/github.com/verification-tests/features/step_definitions/transform.rb:33:in `block in singleton class'
      /home/qitang/github.com/verification-tests/features/step_definitions/logging.rb:245:in `/^cluster logging operator is ready$/'
      features/logging/logging_acceptance.feature:28:in `cluster logging operator is ready'
```
It takes some time for the namespace to be created after clicking `Install` button on OCP console, so here add a step to wait for the projects to be created before checking the operators' status.
/cc @anpingli 