### PR TITLE
Adjust owners for CLI

### DIFF
--- a/features/cli/OWNERS
+++ b/features/cli/OWNERS
@@ -1,6 +1,7 @@
 approvers:
+  - kasturinarra
 
 reviewers:
-- chengzhang1016
-- zhouying7780
-- xiuwang
+  - zhouying7780
+  - xiuwang
+  - kasturinarra


### PR DESCRIPTION
Add @kasturinarra as reviewer/approver for CLI, to speed up PRs like https://github.com/openshift/verification-tests/pull/2268 

After this PR is merged, you are able to merge CLI PRs by adding `/lgtm` (on a separate line). More detail bot process can be find in https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#the-code-review-process

/cc @kasturinarra @zhouying7780 