### PR TITLE
make the output checkpoint more robust

### DIFF
--- a/features/cli/job.feature
+++ b/features/cli/job.feature
@@ -476,8 +476,9 @@ Feature: job.feature
        | exec_command     | sleep         |
        | exec_command_arg | 300           |
     Then the step should fail
-    And the output should contain:
-       | Invalid value: "70 12 15 11 3": End of range (70) above maximum (59): 70 |
+    And the output should match:
+       | Invalid value: "70 12 15 11 3":                 |
+       | [eE]nd of range \(70\) above maximum \(59\): 70 |
     When I run the :create_cronjob client command with:
        | name             | sjc          |
        | image            | busybox      |
@@ -487,8 +488,9 @@ Feature: job.feature
        | exec_command     | sleep        |
        | exec_command_arg | 300          |
     Then the step should fail
-    And the output should contain:
-       | Invalid value: "30 25 15 1 3": End of range (25) above maximum (23): 25 |
+    And the output should match:
+       | Invalid value: "30 25 15 1 3":                  |
+       | [eE]nd of range \(25\) above maximum \(23\): 25 |
     When I run the :create_cronjob client command with:
        | name             | sjc          |
        | image            | busybox      |
@@ -498,8 +500,9 @@ Feature: job.feature
        | exec_command     | sleep        |
        | exec_command_arg | 300          |
     Then the step should fail
-    And the output should contain:
-       | Invalid value: "30 8 35 11 3": End of range (35) above maximum (31): 35 |
+    And the output should match:
+       | Invalid value: "30 8 35 11 3":                  |
+       | [eE]nd of range \(35\) above maximum \(31\): 35 |
     When I run the :create_cronjob client command with:
        | name             | sjc         |
        | image            | busybox     |
@@ -509,8 +512,9 @@ Feature: job.feature
        | exec_command     | sleep       |
        | exec_command_arg | 300         |
     Then the step should fail
-    And the output should contain:
-       | Invalid value: "30 8 1 13 3": End of range (13) above maximum (12): 13 |
+    And the output should match:
+      | Invalid value: "30 8 1 13 3":                   |
+      | [eE]nd of range \(13\) above maximum \(12\): 13 |
     When I run the :create_cronjob client command with:
        | name             | sjc        |
        | image            | busybox    |
@@ -520,8 +524,9 @@ Feature: job.feature
        | exec_command     | sleep      |
        | exec_command_arg | 300        |
     Then the step should fail
-    And the output should contain:
-       | Invalid value: "30 8 1 8 7": End of range (7) above maximum (6): 7 |
+    And the output should match:
+       | Invalid value: "30 8 1 8 7":                 |
+       | [eE]nd of range \(7\) above maximum \(6\): 7 |
     When I run the :create_cronjob client command with:
        | name             | sjd       |
        | image            | busybox   |


### PR DESCRIPTION
Per the failures in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-cucushift-aws-ipi/1437838750108356608, the output is `end of range` is stead of `End of range`. @kasturinarra made a commit to change the test using `e` -> `E` recently, so I believe the output message contains either `end of range` or `End of range` depending on the versions.

I think no matter it's uppercase or lowercase, the checkpoint needs to be made more robust to evaluate the step as **Passed**.

@kasturinarra @liangxia PTAL.

I've tested this
```
      [03:19:02] INFO> === End After Scenario: User can schedule a Cronjob execution with cron format time ===

1 scenario (1 passed)
66 steps (66 passed)
1m2.128s
[03:19:02] INFO> === At Exit ===
```