### PR TITLE
change xpath and function due to 4.9 change

### DIFF
--- a/lib/rules/web/admin_console/4.9/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.9/monitoring_metrics.xyaml
@@ -30,7 +30,7 @@ click_projects_dropdown_developer_mode_admin:
     op: click
   element:
     selector:
-      xpath: span[contains(@class,'pf-c-switch__toggle')]
+      xpath: //span[contains(@class,'pf-c-switch__toggle')]
     op: click
 click_projects_dropdown_developer_mode_user:
   element:

--- a/lib/rules/web/admin_console/4.9/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.9/monitoring_metrics.xyaml
@@ -23,7 +23,16 @@ goto_monitoring:
   params:
     menu_text: Observe
   action: click_primary_menu_developer_mode
-click_projects_dropdown_developer_mode:
+click_projects_dropdown_developer_mode_admin:
+  element:
+    selector:
+      xpath: (//div[@class='co-namespace-bar']//button)[1]
+    op: click
+  element:
+    selector:
+      xpath: span[contains(@class,'pf-c-switch__toggle')]
+    op: click
+click_projects_dropdown_developer_mode_user:
   element:
     selector:
       xpath: (//div[@class='co-namespace-bar']//button)[1]
@@ -31,17 +40,23 @@ click_projects_dropdown_developer_mode:
 input_select_project_developer_mode:
   element:
     selector:
-      xpath: //div[@class='co-namespace-selector']//input[@placeholder='Select Project...']
+      xpath: //div[@class='co-namespace-dropdown']//input[@placeholder='Select project...']
     op: send_keys <project_name>
     type: input
 click_project_link_developer_mode:
   element:
     selector:
-      xpath: //a[text()='<project_name>']
+      xpath: //span[text()='<project_name>']
     timeout: 20
     op: click
-choose_project_developer_mode:
-  action: click_projects_dropdown_developer_mode
+# used for admin
+choose_project_developer_mode_admin:
+  action: click_projects_dropdown_developer_mode_admin
+  action: input_select_project_developer_mode
+  action: click_project_link_developer_mode
+# used for common user
+choose_project_developer_mode_user:
+  action: click_projects_dropdown_developer_mode_user
   action: input_select_project_developer_mode
   action: click_project_link_developer_mode
 check_tech_preview_badge: {}


### PR DESCRIPTION
Developer query browser feature - common user
https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-28106

Developer query browser feature - cluster admin
https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-27830

error:
[12:07:51] INFO> found 0 input elements with selector: {:xpath=>"//div[@class='co-namespace-selector']//input[@placeholder='Select Project...']"}
1. xpath is changed to {:xpath=>"//div[@class='co-namespace-dropdown']//input[@placeholder='Select project...']"}in 4.9
2. also there is `Show default projects` toggle, need to enable it to see all projects for cluster-admin, for normal user there is not such setting, so
```
## used for admin user
click_projects_dropdown_developer_mode_admin:
  element:
    selector:
      xpath: (//div[@class='co-namespace-bar']//button)[1]
    op: click
  element:
    selector:
      xpath: //span[contains(@class,'pf-c-switch__toggle')]
    op: click
## used for common user
click_projects_dropdown_developer_mode_user:
  element:
    selector:
      xpath: (//div[@class='co-namespace-bar']//button)[1]
    op: click
```


see
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3/321442/artifact/embedded_files/2021-09-14T12%3A07%3A51+00%3A00-screenshot.png
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3/321458/artifact/embedded_files/2021-09-15T07%3A35%3A00+00%3A00-screenshot.png

cloned OCP-28106 to OCP-44791, cloned OCP-27830 to OCP-44792, these cases are applied to 4.9 and above versions
tested along with https://github.com/openshift/cucushift/pull/8756

runner-v3 pass:
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/Runner-v3/321468/consoleFull


