### PR TITLE
Simplify docker build

### DIFF
--- a/features/build/dockerbuild.feature
+++ b/features/build/dockerbuild.feature
@@ -190,7 +190,7 @@ Feature: dockerbuild.feature
       | from_literal | value=bar |
     Then the step should succeed
     When I run the :new_build client command with:
-      | D | FROM quay.io/openshifttest/centos:7\nRUN yum install -y httpd\nRUN ls -l /var/run/secret/config |
+      | D | FROM quay.io/openshifttest/centos:7\nRUN ls -l /var/run/secret/config |
     Then the step should succeed
     Then the "centos" image stream was created
     And the "centos-1" build was created
@@ -227,7 +227,7 @@ Feature: dockerbuild.feature
       | from_literal | password=redhat    |
     Then the step should succeed
     When I run the :new_build client command with:
-      | D | FROM quay.io/openshifttest/centos:7\nRUN yum install -y httpd\nRUN ls -l /var/run/secret/secret-1\nRUN ls -l /var/run/secret/secret-2 |
+      | D | FROM quay.io/openshifttest/centos:7\nRUN ls -l /var/run/secret/secret-1\nRUN ls -l /var/run/secret/secret-2 |
     Then the step should succeed
     Then the "centos" image stream was created
     And the "centos-1" build was created
@@ -265,7 +265,7 @@ Feature: dockerbuild.feature
       | from_literal | password=redhat    |
     Then the step should succeed
     When I run the :new_build client command with:
-      | D | FROM quay.io/openshifttest/centos:7\nRUN yum install -y httpd\nRUN ls -l /var/run/secret/secret-1|
+      | D | FROM quay.io/openshifttest/centos:7\nRUN ls -l /var/run/secret/secret-1|
     Then the step should succeed
     Then the "centos" image stream was created
     And the "centos-1" build was created
@@ -301,7 +301,7 @@ Feature: dockerbuild.feature
       | from_literal | value=bar  |
     Then the step should succeed
     When I run the :new_build client command with:
-      | D | FROM quay.io/openshifttest/centos:7\nRUN yum install -y httpd\nRUN ls -l /var/run/secret |
+      | D | FROM quay.io/openshifttest/centos:7\nRUN ls -l /var/run/secret |
     Then the step should succeed
     Then the "centos" image stream was created
     And the "centos-1" build was created

--- a/features/build/dockerbuild.feature
+++ b/features/build/dockerbuild.feature
@@ -154,7 +154,7 @@ Feature: dockerbuild.feature
       | from_literal | password=redhat    |
     Then the step should succeed
     When I run the :new_build client command with:
-      | D | FROM quay.io/openshifttest/centos:7\nRUN yum install -y httpd\nRUN ls -l /var/run/secret/sourcesecret |
+      | D | FROM quay.io/openshifttest/centos:7\nRUN ls -l /var/run/secret/sourcesecret |
     Then the step should succeed
     Then the "centos" image stream was created
     And the "centos-1" build was created


### PR DESCRIPTION
The checkpoint of the scenario is: verify source secret is mounted into builder container when using dockerstrategy to build.
Removing the `yum install` docker step does not help/harm the checkpoints. But it do saves test execution time and produce less execution logs.

From my testing, the scenario passed both with and without the `yum install` step.
But the execution time decreased from `2m22.360s` to `1m16.346s`, and the log size decrease from `30K (577 lines)` to `24K (475 lines)`