### PR TITLE
Updated OCP-18482 on IPv6 Cluster

### DIFF
--- a/features/routing/rate-limit.feature
+++ b/features/routing/rate-limit.feature
@@ -59,18 +59,18 @@ Feature: Testing haproxy rate limit related features
 
     Given I switch to cluster admin pseudo user
     And I use the router project
-    And I wait up to 30 seconds for the steps to pass:
+    And I wait up to 60 seconds for the steps to pass:
     """
     When I execute on the "<%=cb.router_pod %>" pod:
-      | bash | -lc | grep -w "<%= cb.proj_name %>:unsecure-route" haproxy.config -A15 \| grep <%=cb.pod_ip %> |
+      | bash | -lc | grep -w "<%= cb.proj_name %>:unsecure-route" haproxy.config -A20 \| grep <%=cb.pod_ip %> |
     Then the output should contain:
       | maxconn 1 |
     When I execute on the "<%=cb.router_pod %>" pod:
-      | bash | -lc | grep -w "<%= cb.proj_name %>:secured-edge-route" haproxy.config -A15 \| grep <%=cb.pod_ip %> |
+      | bash | -lc | grep -w "<%= cb.proj_name %>:secured-edge-route" haproxy.config -A20 \| grep <%=cb.pod_ip %> |
     Then the output should contain:
       | maxconn 2 |
     When I execute on the "<%=cb.router_pod %>" pod:
-      | bash | -lc | grep -w  "<%= cb.proj_name %>:route-reencrypt" haproxy.config -A15 \| grep <%=cb.pod_ip %> |
+      | bash | -lc | grep -w  "<%= cb.proj_name %>:route-reencrypt" haproxy.config -A20 \| grep <%=cb.pod_ip %> |
     Then the output should contain:
       | maxconn 3 |
     """


### PR DESCRIPTION
@lihongan @quarterpin @melvinjoseph86 
Please help to view the changes: I have changed to A15 to A20 for fixing the IPv6 cluster issue, also I have changed the waiting time from 30 to 60 seconds to make sure getting the info.

Please refer to the log link below:
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/173056/console