### PR TITLE
fix slack class name collision

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,4 @@ gem 'oga' # replacemen for nokogiri when we thought we can workaround it
 # gem 'text-table'
 # gem 'terminal-table'
 gem 'parallel_tests'
+gem 'slack-ruby-client'

--- a/tools/instance_summary.rb
+++ b/tools/instance_summary.rb
@@ -146,7 +146,7 @@ module BushSlicer
           filtered_list = res_list.map {|r| r[4] if r[0] !='Workloads' }.compact
           users = filtered_list
         end
-        slack_client = BushSlicer::Slack.new
+        slack_client = BushSlicer::CoreosSlack.new
         valid_users, unknown_users = translate_to_slack_users(users: users, slack_client: slack_client)
         tag_users_msg =  valid_users + " please terminate your long-lived clusters if they are no longer in use\n"
         tag_users_msg += "\nThese clusters have no owners association #{unknown_users}\n" if unknown_users.size > 0

--- a/tools/openshift_qe_slack.rb
+++ b/tools/openshift_qe_slack.rb
@@ -5,7 +5,7 @@ require 'common'
 require 'slack-ruby-client'
 
 module BushSlicer
-  class Slack
+  class CoreosSlack
     include Common::Helper
 
     attr_accessor :client, :usergroup_id, :token, :user_list, :users_map, :channel
@@ -84,8 +84,8 @@ module BushSlicer
 end
 
 if __FILE__ == $0
-  slack = BushSlicer::Slack.new(channel: '#pruan_slack_bot_sandbox')
-  #slack = OpenshiftQE::Slack.new #(channel: '#ocp-qe-scale-ci-results')
+  slack = BushSlicer::CoreosSlack.new(channel: '#pruan_slack_bot_sandbox')
+  #slack = OpenshiftQE::CoreosSlack.new #(channel: '#ocp-qe-scale-ci-results')
   #slack.build_user_lookup_table
   #slack.build_user_lookup_table(pre_compiled_result: 'creds/slack_users_map.yaml')
   # clusters =  [[nil, nil, 29.71, nil],


### PR DESCRIPTION
1. Gemfile needs to be update to install slack-ruby-client
2. Must use a different name than 'Slack' since the 'slack-ruby-client'
has the same class name.