### PR TITLE
Conntrack case for upgrade scenario (Networking Quality OKR)

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -367,10 +367,8 @@ Feature: SDN compoment upgrade testing
     When I run the :new_project client command with:
       | project_name | nodeport-upgrade |
     Then the step should succeed
-    When I use the "nodeport-upgrade" project
-    #privileges are needed to support network-pod as hostnetwork pod creation later
-    And SCC "privileged" is added to the "system:serviceaccounts:nodeport-upgrade" group
-    Given I obtain test data file "networking/pod_with_udp_port_4789_nodename.json"
+    Given I use the "nodeport-upgrade" project
+    And I obtain test data file "networking/pod_with_udp_port_4789_nodename.json"
     When I run oc create over "pod_with_udp_port_4789_nodename.json" replacing paths:
       | ["items"][0]["spec"]["template"]["spec"]["nodeName"] | <%= cb.nodes[0].name %> |
     Then the step should succeed

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -361,7 +361,7 @@ Feature: SDN compoment upgrade testing
   # @author anusaxen@redhat.com
   @admin
   @upgrade-prepare
-  Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade	
+  Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade - prepare
     Given I switch to cluster admin pseudo user
     And I store the workers in the :nodes clipboard
     When I run the :new_project client command with:

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -397,8 +397,13 @@ Feature: SDN compoment upgrade testing
     And a pod becomes ready with labels:
       | name=udp-pods |
     And evaluation of `pod` is stored in the :host_pod1 clipboard
-    #Getting nodeport value
-    And evaluation of `service(cb.host_pod1.name).node_port(port: 8080)` is stored in the :nodeport clipboard
+    #Getting service name and nodeport value
+    When I run the :get client command with:
+      | resource | svc                                |
+      | o        | jsonpath={.items[*].metadata.name} |
+    Then the step should succeed
+    And evaluation of `@result[:response]` is stored in the :service_name clipboard
+    And evaluation of `service(cb.service_name).node_port(port: 8080)` is stored in the :nodeport clipboard
 
     # Creating a simple client pod to generate traffic from it towards the exposed node IP address
     Given I obtain test data file "networking/aosqe-pod-for-ping.json"
@@ -411,10 +416,10 @@ Feature: SDN compoment upgrade testing
 
     # The 3 seconds mechanism via for loop will create an Assured conntrack entry which will give us enough time to validate upcoming steps
     When I run the :exec background client command with:
-      | pod              | <%= cb.client_pod.name %>                                                                       |
-      | oc_opts_end      |                                                                                                 |
-      | exec_command     | bash                                                                                            |
-      | exec_command_arg | -c                                                                                              |
+      | pod              | <%= cb.client_pod.name %>                                                                            |
+      | oc_opts_end      |                                                                                                      |
+      | exec_command     | bash                                                                                                 |
+      | exec_command_arg | -c                                                                                                   |
       | exec_command_arg | for n in {1..3}; do echo $n; sleep 1; done>/dev/udp/<%= cb.host_pod1.node_name %>/<%= cb.nodeport %> |
     Then the step should succeed
     


### PR DESCRIPTION
As a part of pre-upgrade we are creating client pod and nodeport service. During post upgrade, which will bump up OVS version as well, we want to make sure conntrack entries under observations are statefully populated

Pre-upgade logs:https://privatebin-it-iso.int.open.paas.redhat.com/?98f9b46555ec6839#AggSwn8HNa2iLuc6PzTsDMW2EVAabm3RvZXd5WBuT8a3

Post upgrade logs:https://privatebin-it-iso.int.open.paas.redhat.com/?948e52bbc75c4f97#BnRXjpp8AbQoDWdNCgaiJr46rGX99cdrGBYDe2y2V7P1

@openshift/team-sdn-qe 