### PR TITLE
Tag network-multitenant test case

### DIFF
--- a/features/networking/isolation.feature
+++ b/features/networking/isolation.feature
@@ -288,8 +288,9 @@ Feature: networking isolation related scenarios
   @aws-ipi
   @gcp-upi
   @gcp-ipi
-  @4.9
   @aws-upi
+  @4.9
+  @network-multitenant
   Scenario: Make the network of given projects be accessible globally
     # Create 3 projects and each contains 1 pod and 1 service
     Given the env is using multitenant network


### PR DESCRIPTION
This resolves OCPQE-5737.

Once tag is added, the test is skipped from Prow. Former failure: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/21988/rehearse-21988-periodic-ci-openshift-verification-tests-master-4.9-e2e-cucushift-gcp-ipi/1440601527981969408

@liangxia @zhaozhanqi PTAL