### PR TITLE
Fix OCP-11139 failure in PROW

### DIFF
--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -136,26 +136,25 @@ Feature: build 'apps' with CLI
   # @author xiuwang@redhat.com
   # @case_id OCP-11139
   @aws-ipi
-  @gcp-upi
-  @gcp-ipi
-  @4.9
   @aws-upi
+  @gcp-ipi
+  @gcp-upi
+  @4.9
   Scenario: Create applications only with multiple db images
     Given I create a new project
     When I run the :new_app client command with:
-      | image_stream      | openshift/mongodb:latest                             |
       | image_stream      | openshift/mysql                                      |
-      | docker_image      | registry.access.redhat.com/rhscl/postgresql-96-rhel7 |
-      | env               | MONGODB_USER=test                      |
-      | env               | MONGODB_PASSWORD=test                  |
-      | env               | MONGODB_DATABASE=test                  |
-      | env               | MONGODB_ADMIN_PASSWORD=test            |
-      | env               | POSTGRESQL_USER=user                   |
-      | env               | POSTGRESQL_DATABASE=db                 |
-      | env               | POSTGRESQL_PASSWORD=test               |
-      | env               | MYSQL_ROOT_PASSWORD=test               |
-      | l                 | app=testapps                           |
-      | insecure_registry | true                                   |
+      | image             | registry.access.redhat.com/rhscl/postgresql-96-rhel7 |
+      | env               | MONGODB_USER=test                                    |
+      | env               | MONGODB_PASSWORD=test                                |
+      | env               | MONGODB_DATABASE=test                                |
+      | env               | MONGODB_ADMIN_PASSWORD=test                          |
+      | env               | POSTGRESQL_USER=user                                 |
+      | env               | POSTGRESQL_DATABASE=db                               |
+      | env               | POSTGRESQL_PASSWORD=test                             |
+      | env               | MYSQL_ROOT_PASSWORD=test                             |
+      | l                 | app=testapps                                         |
+      | insecure_registry | true                                                 |
     Then the step should succeed
 
     Given I wait for the "mysql" service to become ready up to 300 seconds
@@ -163,28 +162,16 @@ Feature: build 'apps' with CLI
     And I wait up to 120 seconds for the steps to pass:
     """
     When I execute on the pod:
-      | bash | -c | mysql  -h $HOSTNAME -u root -ptest -e "show databases" |
+      | bash | -c | mysql -h $HOSTNAME -u root -ptest -e "show databases" |
     Then the step should succeed
     """
     And the output should contain "mysql"
-    Given I wait for the "mongodb" service to become ready up to 300 seconds
-    And I get the service pods
-    And I wait up to 120 seconds for the steps to pass:
-    """
-    When I execute on the pod:
-      | scl | enable | rh-mongodb36 | mongo $MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD  --eval 'db.version()' |
-    Then the step should succeed
-    """
-    And the output should contain:
-      | 3.6 |
     Given I wait for the "postgresql-96-rhel7" service to become ready up to 300 seconds
     And I get the service pods
     And I wait up to 120 seconds for the steps to pass:
     """
     When I execute on the pod:
-      | bash |
-      | -c |
-      | psql -U user -c 'CREATE TABLE tbl (col1 VARCHAR(20), col2 VARCHAR(20));' db |
+      | bash | -c | psql -U user -c 'CREATE TABLE tbl (col1 VARCHAR(20), col2 VARCHAR(20));' db |
     Then the step should succeed
     """
     And the output should contain:


### PR DESCRIPTION
Fix failures in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/21988/rehearse-21988-periodic-ci-openshift-verification-tests-master-4.9-e2e-cucushift-gcp-ipi/1441255657092157440

Changes,
1. Replace deprecated option `--docker-image` with `--image`
2. Remove non-exist image stream `mongodb`
```
     When I run the :new_app client command with:                                         # features/step_definitions/cli.rb:13
      | image_stream      | openshift/mongodb:latest                             |
      | image_stream      | openshift/mysql                                      |
      | docker_image      | registry.access.redhat.com/rhscl/postgresql-96-rhel7 |
      | env               | MONGODB_USER=test                      |
      | env               | MONGODB_PASSWORD=test                  |
      | env               | MONGODB_DATABASE=test                  |
      | env               | MONGODB_ADMIN_PASSWORD=test            |
      | env               | POSTGRESQL_USER=user                   |
      | env               | POSTGRESQL_DATABASE=db                 |
      | env               | POSTGRESQL_PASSWORD=test               |
      | env               | MYSQL_ROOT_PASSWORD=test               |
      | l                 | app=testapps                           |
      | insecure_registry | true                                   |
      [04:56:27] INFO> Shell Commands: oc new-app --image-stream=openshift/mongodb:latest --image-stream=openshift/mysql --docker-image=registry.access.redhat.com/rhscl/postgresql-96-rhel7 --env=MONGODB_USER\=test --env=MONGODB_PASSWORD\=test --env=MONGODB_DATABASE\=test --env=MONGODB_ADMIN_PASSWORD\=test --env=POSTGRESQL_USER\=user --env=POSTGRESQL_DATABASE\=db --env=POSTGRESQL_PASSWORD\=test --env=MYSQL_ROOT_PASSWORD\=test -l app\=testapps --insecure-registry=true --kubeconfig=/tmp/dir1/workdir/ocp4_testuser-1.kubeconfig
      
      STDERR:
      Flag --docker-image has been deprecated, Deprecated flag use --image
      error: unable to locate any images in image streams with name "openshift/mongodb:latest"
      
      The 'oc new-app' command will match arguments to the following types:
      
        1. Images tagged into image streams in the current project or the 'openshift' project
           - if you don't specify a tag, we'll add ':latest'
        2. Images in the container storage, on remote registries, or on the local container engine
        3. Templates in the current project or the 'openshift' project
        4. Git repository URLs or local paths that point to Git repositories
      
      --allow-missing-images can be used to point to an image that does not exist yet.
      
      See 'oc new-app -h' for examples.
      
      [04:56:30] INFO> Exit Status: 1
    Then the step should succeed                                                         # features/step_definitions/common.rb:4
      the step failed (RuntimeError)
      /verification-tests/features/step_definitions/common.rb:6:in `/^the step should( not)? (succeed|fail)$/'
      features/cli/build.feature:159:in `the step should succeed' 
```