### PR TITLE
Fix a possible test flake in 4.9

### DIFF
--- a/features/storage/regression.feature
+++ b/features/storage/regression.feature
@@ -6,10 +6,11 @@ Feature: Regression testing cases
   @aws-ipi
   @gcp-upi
   @gcp-ipi
-  @4.9
   @aws-upi
+  @4.9
   Scenario: RWO volumes are exclusively mounted on different nodes
     Given I have a project
+    Given I store the schedulable workers in the :workers clipboard
 
     Given I obtain test data file "storage/misc/pvc.json"
     Given I create a dynamic pvc from "pvc.json" replacing paths:
@@ -19,14 +20,17 @@ Feature: Regression testing cases
 
     Given I obtain test data file "storage/misc/damonset.json"
     When I run the :create admin command with:
-      | f | damonset.json |
-      | n | <%= project.name %>                                         |
+      | f | damonset.json       |
+      | n | <%= project.name %> |
     Then the step should succeed
 
     And I wait up to 60 seconds for the steps to pass:
     """
-    When I run the :describe client command with:
-      | resource | pod |
-    Then the output should match:
-      | (already\|conflict) |
+    When I run the :get client command with:
+      | resource      | daemonset |
+      | resource_name | dpod      |
+      | o             | yaml      |
+    Then the step should succeed
+    And the expression should be true> @result[:parsed]['status']['numberAvailable'].to_i == 1
+    And the expression should be true> @result[:parsed]['status']['numberUnavailable'].to_i == (cb.workers.length - 1)
     """


### PR DESCRIPTION
Instead of checking the output, check the number of available and unavailable pods.

@liangxia @duanwei33 PTAL

```
      status:
        currentNumberScheduled: 3
        desiredNumberScheduled: 3
        numberAvailable: 1
        numberMisscheduled: 0
        numberReady: 1
        numberUnavailable: 2
        observedGeneration: 1
        updatedNumberScheduled: 3

      [11:30:59] INFO> Exit Status: 0
      [11:30:59] INFO> === After Scenario: RWO volumes are exclusively mounted on different nodes ===
      [11:30:59] INFO> cleaning-up user testuser-0 projects
      [11:31:08] INFO> Shell Commands: oc delete projects --all --kubeconfig=/tmp/workspace/workdir/ocp4_testuser-0.kubeconfig
      project.project.openshift.io "h-7ek" deleted

      [11:31:22] INFO> Exit Status: 0
      [11:31:22] INFO> waiting up to 30 seconds for user clean-up to take place
      [11:31:28] INFO> REST delete_oauthaccesstoken for user 'BushSlicer::APIAccessor:testuser-0@ocp4', base_opts: {:options=>{:api_version=>"v1", :accept=>"application/json", :content_type=>"application/json", :oauth_token=>"sha256~rPL6qUKXKULckq4xQEXIysi4N3fKpbLVgK4ibBKQVxY"}, :base_url=>"https://api.knarra08261.qe.gcp.devcluster.openshift.com:6443", :headers=>{"Accept"=>"<accept>", "Content-Type"=>"<content_type>", "Authorization"=>"Bearer <oauth_token>"}}, opts: {:token_to_delete=>"sha256~-NkGIT1wek3cWdvci2KFpDqSxrhjiG8ae3Bsr3MABJA"}
      [11:31:28] INFO> HTTP DELETE https://api.knarra08261.qe.gcp.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthaccesstokens/sha256~-NkGIT1wek3cWdvci2KFpDqSxrhjiG8ae3Bsr3MABJA
      [11:31:33] INFO> HTTP DELETE took 5.501 sec: 200 OK | application/json 242 bytes

      [11:31:33] INFO> Shell Commands: rm -r -f -- /tmp/workspace/workdir

      [11:31:34] INFO> Exit Status: 0
      [11:31:35] INFO> === End After Scenario: RWO volumes are exclusively mounted on different nodes ===

1 scenario (1 passed)
8 steps (8 passed)
2m25.405s
```