### PR TITLE
Support Logging5.3

### DIFF
--- a/features/logging/cluster_log_forwarder.feature
+++ b/features/logging/cluster_log_forwarder.feature
@@ -22,6 +22,7 @@ Feature: cluster log forwarder features
     # check logs in ES
     Given I switch to cluster admin pseudo user
     And I use the "openshift-logging" project
+    Given logging collector name is stored in the :collector_name clipboard
     Given I wait for the "app" index to appear in the ES pod with labels "es-node-master=true"
     And I wait for the project "<%= cb.proj.name %>" logs to appear in the ES pod
     When I perform the HTTP request on the ES pod with labels "es-node-master=true":
@@ -43,8 +44,8 @@ Feature: cluster log forwarder features
     Then the step should succeed
     And I wait for the "instance" cluster_log_forwarder to appear
     Given 10 seconds have passed
-    And <%= daemon_set('fluentd').replica_counters[:desired] %> pods become ready with labels:
-      | logging-infra=fluentd |
+    And <%= daemon_set("<%= cb.collector_name %>").replica_counters[:desired] %> pods become ready with labels:
+      | logging-infra=<%= cb.collector_name %> |
     Given I wait up to 300 seconds for the steps to pass:
     """
     And I execute on the "<%= cb.log_receiver.name %>" pod:
@@ -92,9 +93,8 @@ Feature: cluster log forwarder features
       | f | clusterlogforwarder.yaml |
     Then the step should succeed
     Given 10 seconds have passed
-    And <%= daemon_set('fluentd').replica_counters[:desired] %> pods become ready with labels:
-      | logging-infra=fluentd |
-
+    And <%= daemon_set("<%= cb.collector_name %>").replica_counters[:desired] %> pods become ready with labels:
+      | logging-infra=<%= cb.collector_name %> |
     Given I wait up to 300 seconds for the steps to pass:
     """
     When I perform the HTTP request on the ES pod with labels "es-node-master=true":

--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -12,8 +12,9 @@ Feature: cluster-logging-operator related test
   @4.9
   @aws-upi
   Scenario: ServiceMonitor Object for collector is deployed along with cluster logging
-    Given I wait for the "fluentd" service_monitor to appear
-    And the expression should be true> service_monitor('fluentd').service_monitor_endpoint_spec(port: "metrics").path == "/metrics"
+    Given logging collector name is stored in the :collector_name clipboard
+    Given I wait for the "<%= cb.collector_name %>" service_monitor to appear
+    And the expression should be true> service_monitor("<%= cb.collector_name %>").service_monitor_endpoint_spec(port: "metrics").path == "/metrics"
     Given I wait up to 360 seconds for the steps to pass:
     """
     When I perform the GET prometheus rest client with:
@@ -93,8 +94,9 @@ Feature: cluster-logging-operator related test
       | remove_logging_pods | true                                                                 |
       | crd_yaml            | example.yaml |
     Then the step should succeed
-    Given I wait for the "fluentd" prometheus_rule to appear
-    And I wait for the "fluentd" service_monitor to appear
+    Given logging collector name is stored in the :collector_name clipboard
+    And I wait for the "<%= cb.collector_name %>" prometheus_rule to appear
+    And I wait for the "<%= cb.collector_name %>" service_monitor to appear
     # make all fluentd pods down
     When I run the :patch client command with:
       | resource      | clusterlogging                                                                        |
@@ -197,9 +199,10 @@ Feature: cluster-logging-operator related test
       | remove_logging_pods | true                   |
       | crd_yaml            | cl_fluentd-buffer.yaml |
     Then the step should succeed
+    Given logging collector name is stored in the :collector_name clipboard
     When I run the :extract admin command with:
-      | resource  | configmap/fluentd |
-      | confirm   | true              |
+      | resource  | configmap/<%= cb.collector_name %> |
+      | confirm   | true                               |
     Then the step should succeed
     Given evaluation of `File.read("fluent.conf")` is stored in the :fluent_conf clipboard
     And evaluation of `["flush_mode interval", "flush_interval 5s", "flush_thread_count 2", "flush_at_shutdown true", "retry_type exponential_backoff", "retry_wait 1s", "retry_max_interval 300", "retry_forever true", "total_limit_size 32m", "chunk_limit_size 1m", "overflow_action drop_oldest_chunk"]` is stored in the :configs clipboard
@@ -223,9 +226,10 @@ Feature: cluster-logging-operator related test
       | remove_logging_pods | true                           |
       | crd_yaml            | cl_fluentd-buffer_default.yaml |
     Then the step should succeed
+    Given logging collector name is stored in the :collector_name clipboard
     When I run the :extract admin command with:
-      | resource  | configmap/fluentd |
-      | confirm   | true              |
+      | resource  | configmap/<%= cb.collector_name %> |
+      | confirm   | true                               |
     Then the step should succeed
     And evaluation of `File.read("fluent.conf")` is stored in the :fluent_conf clipboard
     And the expression should be true> (cb.fluent_conf).include? "flush_mode interval"
@@ -236,8 +240,8 @@ Feature: cluster-logging-operator related test
       | type          | merge                                                                       |
     Then the step should succeed
     When I run the :extract admin command with:
-      | resource  | configmap/fluentd |
-      | confirm   | true              |
+      | resource  | configmap/<%= cb.collector_name %> |
+      | confirm   | true                               |
     Then the step should succeed
     And evaluation of `File.read("fluent.conf")` is stored in the :fluent_conf clipboard
     Given the expression should be true> (cb.fluent_conf).include? "flush_mode lazy"

--- a/features/logging/logging_acceptance.feature
+++ b/features/logging/logging_acceptance.feature
@@ -92,8 +92,9 @@ Feature: Logging smoke test case
     """
     # Fluentd Metrics
     Given I use the "openshift-logging" project
-    And I wait for the "fluentd" service_monitor to appear
-    And the expression should be true> service_monitor('fluentd').service_monitor_endpoint_spec(port: "metrics").path == "/metrics"
+    Given logging collector name is stored in the :collector_name clipboard
+    And I wait for the "<%= cb.collector_name %>" service_monitor to appear
+    And the expression should be true> service_monitor("<%= cb.collector_name %>").service_monitor_endpoint_spec(port: "metrics").path == "/metrics"
     Given I wait up to 360 seconds for the steps to pass:
     """
     When I perform the GET prometheus rest client with:

--- a/lib/openshift/cluster_logging.rb
+++ b/lib/openshift/cluster_logging.rb
@@ -98,9 +98,9 @@ module BushSlicer
       es_cluster_health(user: user, cached: cached, quiet: quiet) == 'green'
     end
 
-    def wait_until_es_is_ready(user: nil, quiet: false, timeout: 10*60)
+    def wait_until_es_is_ready(user: nil, quiet: true, timeout: 10*60)
       success = wait_for(timeout) {
-        es_ready?(user: user, cached: false, quiet: quiet)
+        log_store_raw(user: user, cached: false, quiet: quiet ) && es_ready?(user: user, cached: false, quiet: quiet)
       }
       unless success
         raise "elasticsearch cluster did not in green status within #{timeout} seconds"


### PR DESCRIPTION
- Use different daemon-set name and label in In Logging 5.3.
- Fix the exception error when no status in clusterlogging/instance.
- Fix the no openshift-logging record issue when no any pods under openshift-logging namespace.


https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/181687/console (Test Failed due to https://issues.redhat.com/browse/LOG-1774)
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/181698/console

logging_acceptance.feature pass on both 5.2 and 5.3