### PR TITLE
Add ensure_console_tagged

### DIFF
--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -143,7 +143,7 @@ Feature: cluster-logging-operator related test
   # @author qitang@redhat.com
   # @case_id OCP-33721
   @admin
-  @consle
+  @console
   @destructive
   @commonlogging
   @aws-ipi

--- a/features/logging/elasticsearch_operator.feature
+++ b/features/logging/elasticsearch_operator.feature
@@ -87,7 +87,7 @@ Feature: elasticsearch-operator related tests
   # @author qitang@redhat.com
   # @case_id OCP-33883
   @admin
-  @consle
+  @console
   @destructive
   @commonlogging
   @aws-ipi

--- a/features/step_definitions/admin_console.rb
+++ b/features/step_definitions/admin_console.rb
@@ -10,6 +10,7 @@ Given /^default admin-console downloads route is stored in the#{OPT_SYM} clipboa
 end
 
 Given /^I open admin console in a browser$/ do
+  ensure_console_tagged
   base_rules = BushSlicer::WebConsoleExecutor::RULES_DIR + "/base/"
   snippets_dir = BushSlicer::WebConsoleExecutor::SNIPPETS_DIR
 
@@ -32,6 +33,7 @@ Given /^I open admin console in a browser$/ do
 end
 
 Given /^I open admin console in a browser with:$/ do |table|
+  ensure_console_tagged
   base_rules = BushSlicer::WebConsoleExecutor::RULES_DIR + "/base/"
   snippets_dir = BushSlicer::WebConsoleExecutor::SNIPPETS_DIR
 

--- a/features/step_definitions/web.rb
+++ b/features/step_definitions/web.rb
@@ -90,6 +90,7 @@ Given /^I have a browser with:$/ do |table|
 end
 
 Given /^I open registry console in a browser$/ do
+  ensure_console_tagged
   base_rules = BushSlicer::WebConsoleExecutor::RULES_DIR + "/base/"
   snippets_dir = BushSlicer::WebConsoleExecutor::SNIPPETS_DIR
   step "default registry-console route is stored in the :reg_console_url clipboard"
@@ -232,6 +233,7 @@ end
 
 # perhaps we can get rid of this step since it's so short??
 Given /^I open metrics console in the browser$/ do
+  ensure_console_tagged
   metrics_url = env.metrics_console_url + "/metrics"
   step %Q/I access the "#{metrics_url}" url in the web browser/
 end

--- a/features/test/webconsole.feature
+++ b/features/test/webconsole.feature
@@ -45,7 +45,7 @@ Feature: console test
     When I access the "https://github.com" url in the web browser
 
   @admin
-  @consle
+  @console
   @destructive
   Scenario: create operator subscription
     #Given logging service is removed successfully

--- a/lib/world.rb
+++ b/lib/world.rb
@@ -58,6 +58,10 @@ module BushSlicer
       scenario_tags.include? '@admin'
     end
 
+    def tagged_console?
+      scenario_tags.include? '@console'
+    end
+
     def tagged_destructive?
       scenario_tags.include? '@destructive'
     end
@@ -76,6 +80,10 @@ module BushSlicer
 
     def ensure_admin_tagged
       raise 'tag scenario @admin as you use admin access' unless tagged_admin?
+    end
+
+    def ensure_console_tagged
+      raise 'tag scenario @console as you need console' unless tagged_console?
     end
 
     def ensure_destructive_tagged


### PR DESCRIPTION
Add method to force console scenarios are tagged with console tag, to support tests in Prow.