### PR TITLE
missing a step to deploy logging operators

### DIFF
--- a/features/upgrade/logging/upgrade.feature
+++ b/features/upgrade/logging/upgrade.feature
@@ -12,7 +12,7 @@ Feature: Logging upgrading related features
     Given I run the :oadm_groups_new admin command with:
       | group_name | project-group-share                |
       | user_name  | <%= user(1, switch: false).name %> |
-    Given I switch to cluster admin pseudo user
+    Given logging operators are installed successfully
     Given I have clusterlogging with persistent storage ES
     Then I wait for the project "logging-upg-prep-1" logs to appear in the ES pod
     When I check the cronjob status


### PR DESCRIPTION
Adding a step to deploy logging operators before create clusterlogging.
https://issues.redhat.com/browse/OCPQE-5975

/cc @anpingli 