### PR TITLE
Wait until damonset appears and use accurate values in ryslogserver

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -224,6 +224,7 @@ end
 
 Given /^I wait until fluentd is ready$/ do
   step %Q/logging collector name is stored in the :collector_name clipboard/
+  step %Q/I wait for the "<%= cb.collector_name %>" daemon_set to appear up to 300 seconds/
   step %Q/#{daemon_set("#{cb.collector_name}").replica_counters[:desired]} pods become ready with labels:/, table(%{
     | logging-infra=#{cb.collector_name} |
   })

--- a/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_configmap.yaml
+++ b/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_configmap.yaml
@@ -20,8 +20,8 @@ data:
     :programname, contains, "k8s-audit.log" /var/log/custom/audit.log
     :programname, contains, "openshift-audit.log" /var/log/custom/audit.log
     :msg, contains, "docker"{
-      if $msg contains "viaq_index_name:infra-write" then /var/log/clf/infra-container.log
-      if $msg contains "viaq_index_name:app-write" then /var/log/clf/app-container.log
+      if $msg contains "infra-write" then /var/log/clf/infra-container.log
+      if $msg contains "app-write" then /var/log/clf/app-container.log
     }
     :msg, contains, "_STREAM_ID" /var/log/clf/infra.log
     :msg, contains, "auditID" /var/log/clf/audit.log


### PR DESCRIPTION
The fail cases
OCP-29843 Scenario: ClusterLogForwarder: Forward logs to fluentd as insecure
OCP-32643 Forward logs to remote-syslog

Pass Runner job
https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/195290/console
