### PR TITLE
fix OCP-41175 

### DIFF
--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -134,9 +134,9 @@ Feature: Machine-api components upgrade tests
 
     Examples:
       | iaas_type | machineset_name        | value                   |
-      | aws       | machineset-clone-41175 | "spotMarketOptions": {} | # @case_id OCP-41175
-      | gcp       | machineset-clone-41803 | "preemptible": true     | # @case_id OCP-41803
-      | azure     | machineset-clone-41804 | "spotVMOptions": {}     | # @case_id OCP-41804
+      | aws       | machineset-clone-41175 | "spotMarketOptions": {} | 
+      | gcp       | machineset-clone-41803 | "preemptible": true     | 
+      | azure     | machineset-clone-41804 | "spotVMOptions": {}     |
 
   # @author zhsun@redhat.com
   @upgrade-check


### PR DESCRIPTION
Fix OCP-41175, now there is a `prepare` in the automation script for this case, which results the case in the waiting status. This fix can modify the automation script and make sure this case could be run. @jhou1 @miyadav @huali9 please help to take a look.

prepare: https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/198223/console
post: https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Runner/198225/console