### PR TITLE
Remove specific codes for 3.x in master(for 4.x)

### DIFF
--- a/features/step_definitions/registry.rb
+++ b/features/step_definitions/registry.rb
@@ -249,10 +249,6 @@ Given /^I secure the default docker(?: (daemon set))? registry$/ do |deployment_
   step %Q/the step should succeed/
 
   _oadm_command = "oc adm"
-  if env.version_lt("3.3", user: user)
-    _oadm_command = "oadm"
-  end
-
   _host.exec_admin(_oadm_command + " ca create-server-cert --signer-cert=#{signer_path}/ca.crt --signer-key=#{signer_path}/ca.key --signer-serial=#{signer_path}/ca.serial.txt --hostnames=#{cb.default_reg_svc_ip},docker-registry.default.svc.cluster.local,docker-registry.default.svc --cert=registry.crt --key=registry.key")
   step %Q/the step should succeed/
 

--- a/features/step_definitions/ssl.rb
+++ b/features/step_definitions/ssl.rb
@@ -23,12 +23,8 @@ Given /^the custom certs are generated with:$/ do |table|
   @result = _host.exec_admin("rm -f #{opts[:key]} #{opts[:crt]}")
   step %Q/the step should succeed/
   _oadm_command = "oc adm"
-  if env.version_lt("3.3", user: user)
-    _oadm_command = "oadm"
-  end
   create_custom_cert_cmd = _oadm_command + " ca create-server-cert --signer-cert=#{opts[:signer_cert]} --signer-key=#{opts[:signer_key]} --signer-serial=#{opts[:signer_serial]} --hostnames=#{opts[:hostnames]} --cert=#{opts[:cert]} --key=#{opts[:key]}"
   @result = _host.exec_admin(create_custom_cert_cmd)
   step %Q/the step should succeed/
-
 end
 


### PR DESCRIPTION
For version < 3.3, the command is `oadm`
For version >= 3.3, the command is `oc adm`
In master branch, we can assume the version >= 4.1

/cc @jhou1 @pruan-rht @xiuwang 