### PR TITLE
Sync tags from upgrade-check to upgrade-prepare

### DIFF
--- a/features/upgrade/api_auth/upgrade.feature
+++ b/features/upgrade/api_auth/upgrade.feature
@@ -12,6 +12,7 @@ Feature: apiserver and auth related upgrade check
   # @author pmali@redhat.com
   # @case_id OCP-22734
   @upgrade-check
+  @inactive
   @admin
   Scenario: Check Authentication operators and operands are upgraded correctly
     Given the "authentication" operator version matches the current cluster version
@@ -53,6 +54,7 @@ Feature: apiserver and auth related upgrade check
 
   # @author xxia@redhat.com
   @upgrade-prepare
+  @inactive
   Scenario: Check apiserver operators and operands are upgraded correctly - prepare
     # According to our upgrade workflow, we need an upgrade-prepare and upgrade-check for each scenario.
     # But some of them do not need any prepare steps, which lead to errors "can not find scenarios" in the log.
@@ -128,6 +130,7 @@ Feature: apiserver and auth related upgrade check
   # @author kewang@redhat.com
   @upgrade-prepare
   @admin
+  @4.10 @4.9
   Scenario: Default RBAC role, rolebinding, clusterrole and clusterrolebinding without any missing after upgraded - prepare
     When I run the :get admin command with:
       | resource | clusterroles.rbac |
@@ -179,6 +182,7 @@ Feature: apiserver and auth related upgrade check
   @upgrade-prepare
   @admin
   @destructive
+  @4.10 @4.9
   Scenario: Check the default SCCs should not be stomped by CVO - prepare
     Given as admin I successfully merge patch resource "scc/anyuid" with:
       | {"users": ["system:serviceaccount:test-scc:test-scc"]} |
@@ -231,6 +235,7 @@ Feature: apiserver and auth related upgrade check
   @admin
   @upgrade-prepare
   @users=upuser1,upuser2
+  @4.10 @4.9
   Scenario: Upgrade action will cause re-generation of certificates for headless services to include the wildcard subjects - prepare
     Given I switch to the first user
     When I run the :new_project client command with:
@@ -282,6 +287,16 @@ Feature: apiserver and auth related upgrade check
 
   # @author xxia@redhat.com
   @upgrade-prepare
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: kube-apiserver and openshift-apiserver should have zero-disruption upgrade - prepare
     # According to our upgrade workflow, we need an upgrade-prepare and upgrade-check for each scenario.
     # But some of them do not need any prepare steps, which lead to errors "can not find scenarios" in the log.

--- a/features/upgrade/build/build-upgrade.feature
+++ b/features/upgrade/build/build-upgrade.feature
@@ -2,6 +2,8 @@ Feature: build related upgrade check
   # @author wewang@redhat.com
   @upgrade-prepare
   @users=upuser1,upuser2
+  @proxy
+  @4.10 @4.9
   Scenario: Check docker and sti build works well before and after upgrade - prepare
     Given I switch to the first user
     When I run the :new_project client command with:

--- a/features/upgrade/cloudcredential/upgrade.feature
+++ b/features/upgrade/cloudcredential/upgrade.feature
@@ -2,6 +2,16 @@ Feature: CloudCredentialOperator components upgrade tests
   # @author lwan@redhat.com
   @upgrade-prepare
   @admin
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: Cluster operator cloud-credential should be available after upgrade - prepare
     #Check cloud-credential version
     Given the "cloud-credential" operator version matches the current cluster version

--- a/features/upgrade/etcd/upgrade.feature
+++ b/features/upgrade/etcd/upgrade.feature
@@ -3,6 +3,16 @@ Feature: basic verification for upgrade testing
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: etcd-operator and cluster works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "admin/subscription.yaml"

--- a/features/upgrade/jenkins/upgrade.feature
+++ b/features/upgrade/jenkins/upgrade.feature
@@ -3,6 +3,7 @@ Feature: Jenkins feature upgrade test
   # @author xiuwang@redhat.com
   @upgrade-prepare
   @users=upuser1,upuser2
+  @4.10 @4.9
   Scenario: Jenkins feature upgrade test - prepare
     Given I switch to the first user
     When I run the :new_project client command with:

--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -1,5 +1,15 @@
 Feature: Machine-api components upgrade tests
   @upgrade-prepare
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario Outline: Cluster operator should be available after upgrade - prepare
     # According to our upgrade workflow, we need an upgrade-prepare and upgrade-check for each scenario.
     # But some of them do not need any prepare steps, which lead to errors "can not find scenarios" in the log.
@@ -45,6 +55,16 @@ Feature: Machine-api components upgrade tests
 
 
   @upgrade-prepare
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: There should be no pending or firing alerts for machine-api operators - prepare
     Given the expression should be true> "True" == "True"
 
@@ -175,9 +195,15 @@ Feature: Machine-api components upgrade tests
       | aws       | machineset-clone-41175 | "spotMarketOptions": {} | # @case_id OCP-41175
       | gcp       | machineset-clone-41803 | "preemptible": true     | # @case_id OCP-41803
       | azure     | machineset-clone-41804 | "spotVMOptions": {}     | # @case_id OCP-41804
-      
+
   @upgrade-prepare
   @admin
+  @aws-ipi
+  @gcp-ipi
+  @4.10 @4.9
+  @vsphere-ipi
+  @azure-ipi
+  @openstack-ipi
   Scenario: Cluster should automatically scale up and scale down with clusterautoscaler deployed - prepare
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user

--- a/features/upgrade/marketplace/upgrade.feature
+++ b/features/upgrade/marketplace/upgrade.feature
@@ -5,6 +5,16 @@ Feature: Marketplace related scenarios
   @admin
   @upgrade-prepare
   @users=upuser1,upuser2
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: upgrade Marketplace - prepare
     # Check Marketplace version
     Given the "marketplace" operator version matches the current cluster version

--- a/features/upgrade/monitoring/monitoring-upgrade.feature
+++ b/features/upgrade/monitoring/monitoring-upgrade.feature
@@ -2,6 +2,16 @@ Feature: cluster monitoring related upgrade check
   # @author hongyli@redhat.com
   @upgrade-prepare
   @admin
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: upgrade cluster monitoring along with OCP - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "monitoring/upgrade/cm-monitoring-retention.yaml"

--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -2,6 +2,7 @@ Feature: Node components upgrade tests
   # @author minmli@redhat.com
   @upgrade-prepare
   @admin
+  @4.10 @4.9
   Scenario: Make sure nodeConfig is not changed after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :label admin command with:

--- a/features/upgrade/node/scc.feature
+++ b/features/upgrade/node/scc.feature
@@ -3,6 +3,16 @@ Feature: Seccomp part of SCC policy should be kept and working after upgrade
   # @author sunilc@redhat.com
   @upgrade-prepare
   @admin
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: Seccomp part of SCC policy should be kept and working after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "node/scc.yaml"

--- a/features/upgrade/olm/upgrade.feature
+++ b/features/upgrade/olm/upgrade.feature
@@ -5,6 +5,16 @@ Feature: OLM related scenarios
   @admin
   @upgrade-prepare
   @users=upuser1,upuser2
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: upgrade OLM - prepare
     # Check OLM version
     Given the "operator-lifecycle-manager" operator version matches the current cluster version

--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -2,6 +2,16 @@ Feature: Routing and DNS related scenarios
 
   @upgrade-prepare
   @admin
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: ensure ingress works well before and after upgrade - prepare
     # Check console route
     Given I switch to cluster admin pseudo user
@@ -38,6 +48,16 @@ Feature: Routing and DNS related scenarios
 
   @upgrade-prepare
   @admin
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: ensure DNS works well before and after upgrade - prepare
     # Check service name can be resolvede
     Given I switch to cluster admin pseudo user
@@ -80,6 +100,7 @@ Feature: Routing and DNS related scenarios
 
   @upgrade-prepare
   @admin
+  @4.10 @4.9
   Scenario: upgrade with running router pods on all worker nodes - prepare
     # Get the number of worker nodes and scale up router pods
     Given I switch to cluster admin pseudo user
@@ -115,13 +136,17 @@ Feature: Routing and DNS related scenarios
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @azure-ipi
   Scenario: upgrade with route shards - prepare
     # Ensure cluster operator ingress is in normal status
     Given I switch to cluster admin pseudo user
     Given the expression should be true> cluster_operator('ingress').condition(type: 'Available')['status'] == "True"
     Given the expression should be true> cluster_operator('ingress').condition(type: 'Progressing')['status'] == "False"
     Given the expression should be true> cluster_operator('ingress').condition(type: 'Degraded')['status'] == "False"
-    # create project/namespace with the label 
+    # create project/namespace with the label
     Given I switch to the first user
     When I run the :new_project client command with:
       | project_name | ingress-upgrade |

--- a/features/upgrade/samples_operator/upgrade.feature
+++ b/features/upgrade/samples_operator/upgrade.feature
@@ -3,6 +3,7 @@ Feature: image-registry operator upgrade tests
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
+  @4.10 @4.9
   Scenario: samples/openshift-controller-manager/image-registry operators should be in correct status after upgrade - prepare
     Given I switch to cluster admin pseudo user
     # Check cluster operator openshift-samples should be in correct status
@@ -23,6 +24,7 @@ Feature: image-registry operator upgrade tests
   @users=upuser1,upuser2
   @admin
   @destructive
+  @inactive
   Scenario: OpenShift can upgrade when image-registry/sample operator is unmanaged - prepare
     Given I switch to cluster admin pseudo user
     Given admin updated the operator crd "configs.imageregistry" managementstate operand to Unmanaged
@@ -84,6 +86,7 @@ Feature: image-registry operator upgrade tests
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
+  @inactive
   Scenario: Upgrade imagestream from old version which not implement node credentials - prepare
     Given I switch to cluster admin pseudo user
     When I run the :extract admin command with:

--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -3,6 +3,13 @@ Feature: Egress compoment upgrade testing
   # @author huirwang@redhat.com
   @admin
   @upgrade-prepare
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: Check egressfirewall is functional post upgrade - prepare
     Given I switch to cluster admin pseudo user
     And I run the :new_project client command with:
@@ -10,7 +17,7 @@ Feature: Egress compoment upgrade testing
     Then the step should succeed
     When I use the "egressfw-upgrade1" project
     Given I obtain test data file "networking/list_for_pods.json"
-    When I run oc create over "list_for_pods.json" replacing paths:  
+    When I run oc create over "list_for_pods.json" replacing paths:
       | ["items"][0]["spec"]["replicas"] | 1 |
     Then the step should succeed
     Given a pod becomes ready with labels:
@@ -33,7 +40,7 @@ Feature: Egress compoment upgrade testing
     """
     When I execute on the "<%= cb.pod1 %>" pod:
       | curl | -I | --connect-timeout | 5 | redhat.com |
-    Then the step should fail 
+    Then the step should fail
     And the output should not contain "HTTP/1.0"
     """
 
@@ -64,12 +71,13 @@ Feature: Egress compoment upgrade testing
     And evaluation of `pod(0).name` is stored in the :pod1 clipboard
     When I execute on the "<%= cb.pod1 %>" pod:
       | curl | -I | --connect-timeout | 5 | redhat.com |
-    Then the step should fail 
+    Then the step should fail
     And the output should not contain "HTTP/1.0"
 
   # @author huirwang@redhat.com
   @admin
   @upgrade-prepare
+  @4.10 @4.9
   Scenario: Check ovn egressip is functional post upgrade - prepare
     Given I switch to cluster admin pseudo user
     And I save ipecho url to the clipboard
@@ -138,7 +146,7 @@ Feature: Egress compoment upgrade testing
     And evaluation of `@result[:response].chomp.match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)` is stored in the :valid_ip clipboard
     When I execute on the "<%= cb.pod1 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.ipecho_url %> |
-    Then the step should succeed 
+    Then the step should succeed
     And the output should contain "<%= cb.valid_ip %>"
 
     # Remove label from egressip node and delete egress ip object
@@ -149,7 +157,7 @@ Feature: Egress compoment upgrade testing
       | o              | jsonpath={.items[*].metadata.name} |
     And evaluation of `@result[:response].chomp` is stored in the :egress_node clipboard
     When I run the :label admin command with:
-      | resource | node                               |   
-      | name     | <%= cb.egress_node %>              |   
+      | resource | node                               |
+      | name     | <%= cb.egress_node %>              |
       | key_val  | k8s.ovn.org/egress-assignable-     |
     Then the step should succeed

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -3,6 +3,16 @@ Feature: SDN compoment upgrade testing
   # @author huirwang@redhat.com
   @admin
   @upgrade-prepare
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: network operator should be available after upgrade - prepare
   # According to our upgrade workflow, we need an upgrade-prepare and upgrade-check for each scenario.
   # But some of them do not need any prepare steps, which lead to errors "can not find scenarios" in the log.
@@ -40,6 +50,7 @@ Feature: SDN compoment upgrade testing
   # @author zzhao@redhat.com
   @admin
   @upgrade-prepare
+  @4.10 @4.9
   Scenario: Check the networkpolicy works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
@@ -94,6 +105,16 @@ Feature: SDN compoment upgrade testing
   # @author asood@redhat.com
   @admin
   @upgrade-prepare
+  @aws-ipi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @aws-upi
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: Check the namespace networkpolicy for an application works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
@@ -153,7 +174,7 @@ Feature: SDN compoment upgrade testing
     When I use the "policy-upgrade1" project
     When I execute on the "<%= cb.pod1 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
-    Then the step should fail 
+    Then the step should fail
     And the output should not contain "Hello"
     When I execute on the "<%= cb.pod3 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
@@ -167,11 +188,11 @@ Feature: SDN compoment upgrade testing
     And the output should contain "Hello"
     When I execute on the "<%= cb.pod5 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
-    Then the step should fail 
+    Then the step should fail
     And the output should not contain "Hello"
     When I execute on the "<%= cb.pod4 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod3ip %>:8080 |
-    Then the step should succeed 
+    Then the step should succeed
     And the output should contain "Hello"
     """
 
@@ -224,10 +245,10 @@ Feature: SDN compoment upgrade testing
     Then the step should succeed
     When I execute on the "<%= cb.pod5 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
-    Then the step should fail 
+    Then the step should fail
     When I execute on the "<%= cb.pod4 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod3ip %>:8080 |
-    Then the step should succeed 
+    Then the step should succeed
     And the output should contain "Hello"
     """
     #Steps to modify policy post upgrade for bug 1973679
@@ -258,6 +279,7 @@ Feature: SDN compoment upgrade testing
   # @author asood@redhat.com
   @admin
   @upgrade-prepare
+  @4.10 @4.9
   Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
@@ -344,7 +366,7 @@ Feature: SDN compoment upgrade testing
   @admin
   @upgrade-check
   @4.10 @4.9
-  Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade 
+  Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade
     Given I switch to cluster admin pseudo user
     When I use the "policy-upgrade3" project
     Given a pod becomes ready with labels:

--- a/features/upgrade/sdn/service-upgrade.feature
+++ b/features/upgrade/sdn/service-upgrade.feature
@@ -3,6 +3,7 @@ Feature: service upgrade scenarios
   # @author zzhao@redhat.com
   @admin
   @upgrade-prepare
+  @4.10 @4.9
   Scenario: Check the idle service works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
@@ -53,6 +54,7 @@ Feature: service upgrade scenarios
   # @author zzhao@redhat.com
   @admin
   @upgrade-prepare
+  @4.10 @4.9
   Scenario: Check the nodeport service works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:

--- a/features/upgrade/security_compliance/fips.feature
+++ b/features/upgrade/security_compliance/fips.feature
@@ -3,6 +3,7 @@ Feature: fips enabled verification for upgrade
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
+  @4.10 @4.9
   Scenario: FIPS mode checking command works for a cluster with fip mode on - prepare
     Given fips is enabled
 

--- a/features/upgrade/web/console-upgrade.feature
+++ b/features/upgrade/web/console-upgrade.feature
@@ -3,6 +3,16 @@ Feature: web console related upgrade check
   @console
   @upgrade-prepare
   @users=upuser1,upuser2
+  @aws-ipi
+  @aws-upi
+  @gcp-upi
+  @gcp-ipi
+  @4.10 @4.9
+  @vsphere-ipi
+  @azure-ipi
+  @baremetal-ipi
+  @openstack-ipi
+  @openstack-upi
   Scenario: check console accessibility - prepare
     Given I switch to the first user
     When I run the :new_project client command with:
@@ -39,7 +49,7 @@ Feature: web console related upgrade check
     Then the step should succeed
     When I perform the :check_resource_item_name web action with:
       | resource_name | hello-daemonset |
-    Then the step should succeed    
+    Then the step should succeed
 
   # @author yanpzhan@redhat.com
   # @case_id OCP-22597

--- a/features/upgrade/workloads/oc-upgrade.feature
+++ b/features/upgrade/workloads/oc-upgrade.feature
@@ -50,6 +50,7 @@ Feature: basic verification for upgrade oc client testing
   # @author yinzhou@redhat.com
   @upgrade-prepare
   @users=upuser1,upuser2
+  @4.10 @4.9
   Scenario: Check some container related oc commands still work for ocp45 after upgrade - prepare
     Given the master version >= "4.5"
     Given I switch to the first user

--- a/features/upgrade/workloads/scheduler-upgrade.feature
+++ b/features/upgrade/workloads/scheduler-upgrade.feature
@@ -3,6 +3,7 @@ Feature: scheduler with custom policy upgrade check
   @upgrade-prepare
   @admin
   @destructive
+  @4.10 @4.9
   Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine - prepare
     Given the "kube-scheduler" operator version matches the current cluster version
     Given the expression should be true> cluster_operator('kube-scheduler').condition(type: 'Progressing')['status'] == "False"


### PR DESCRIPTION
No tests had been picked up during the test in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/22309/rehearse-22309-periodic-ci-openshift-verification-tests-master-ocp-4.10-upgrade-from-stable-4.9-upgrade-aws-cucushift-ipi/1448864435190894592. 

**Before**
```
verification-tests ➤ cucumber --tag "@aws-ipi and @upgrade-prepare" --dry-run                               git:master*

0 scenarios
0 steps
```

The tags are not automatically added to the `@upgrade-prepare` scenarios because these scenarios does not have the case_id annotation, so our tooling skipped them. Manually added these tags in order for tests to be executed in Prow.

**After**
```
verification-tests ➤ cucumber --tag "@aws-ipi and @upgrade-prepare" --dry-run
...
18 scenarios (18 skipped)
194 steps (194 skipped)
```

@liangxia PTAL