### PR TITLE
Sync upgrade tags

### DIFF
--- a/features/upgrade/node/hpa/upgrade.feature
+++ b/features/upgrade/node/hpa/upgrade.feature
@@ -2,6 +2,9 @@ Feature: basic verification for upgrade testing
   # @author weinliu@redhat.com
   @upgrade-prepare
   @admin
+  @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Upgrade - Make sure multiple resources work well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I ensure "node-upgrade" project is deleted

--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -4,12 +4,8 @@ Feature: Egress compoment upgrade testing
   @admin
   @upgrade-prepare
   @4.10 @4.9
-  @aws-upi
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Check egressfirewall is functional post upgrade - prepare
     Given I switch to cluster admin pseudo user
     And I run the :new_project client command with:


### PR DESCRIPTION
This fixes two test failures in Prow, missing proper tag in the `upgrade-prepare` such that upgrade-check had failed.
@liangxia @pruan-rht @JianLi-RH @dis016 PTAL