### PR TITLE
Add missing tags for upgrade-prepare

### DIFF
--- a/features/upgrade/storage/upgrade.feature
+++ b/features/upgrade/storage/upgrade.feature
@@ -365,6 +365,8 @@ Feature: Storage upgrade tests
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
+  @aws-ipi
+  @aws-upi
   Scenario: [AWS-EBS-CSI] [Snapshot operator] should work well before and after upgrade of a cluster - prepare
     Given I switch to cluster admin pseudo user
     Given the master version >= "4.7"


### PR DESCRIPTION
Resolves failure in https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/22309/rehearse-22309-periodic-ci-openshift-verification-tests-master-ocp-4.10-upgrade-from-stable-4.9-upgrade-aws-cucushift-ipi/1450004221884633088/build-log.txt