### PR TITLE
externalIP-upgrade use separate pod YAML files

### DIFF
--- a/features/upgrade/sdn/externalIP-upgrade.feature
+++ b/features/upgrade/sdn/externalIP-upgrade.feature
@@ -27,10 +27,10 @@ Feature: SDN externalIP compoment upgrade testing
     """
 
     # Create a pod
-    Given I obtain test data file "networking/externalip_pod.yaml"
+    Given I obtain test data file "networking/externalip_pod_upgrade.yaml"
     When I run the :create client command with:
-      | f | externalip_pod.yaml |
-      | n | externalip-upgrade  |
+      | f | externalip_pod_upgrade.yaml |
+      | n | externalip-upgrade          |
     Then the step should succeed
     Given a pod becomes ready with labels:
       | name=externalip-pod    |
@@ -69,5 +69,6 @@ Feature: SDN externalIP compoment upgrade testing
     """
     ### delete this project,make sure project is deleted
     Given the "externalip-upgrade" project is deleted
+
     
     

--- a/testdata/networking/externalip_pod.yaml
+++ b/testdata/networking/externalip_pod.yaml
@@ -1,23 +1,13 @@
+kind: Pod
 apiVersion: v1
-kind: List
-items:
-- apiVersion: v1
-  kind: ReplicationController
-  metadata:
-    labels:
-      name: externalip-pod
+metadata:
+  name: externalip-pod
+  labels:
     name: externalip-pod
-  spec:
-    replicas: 1
-    template:
-      metadata:
-        labels:
-          name: externalip-pod
-      spec:
-        containers:
-        - name: externalip-pod
-          image: "quay.io/openshifttest/hello-sdn@sha256:d5785550cf77b7932b090fcd1a2625472912fb3189d5973f177a5a2c347a1f95"
-          ports:
-          - containerPort: 8080
-          - containerPort: 8443
-       
+spec:
+  containers:
+  - name: externalip-container
+    image: "quay.io/openshifttest/hello-sdn@sha256:d5785550cf77b7932b090fcd1a2625472912fb3189d5973f177a5a2c347a1f95"
+    ports:
+    - containerPort: 8080
+    - containerPort: 8443

--- a/testdata/networking/externalip_pod_upgrade.yaml
+++ b/testdata/networking/externalip_pod_upgrade.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    labels:
+      name: externalip-pod
+    name: externalip-pod
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          name: externalip-pod
+      spec:
+        containers:
+        - name: externalip-pod
+          image: "quay.io/openshifttest/hello-sdn@sha256:d5785550cf77b7932b090fcd1a2625472912fb3189d5973f177a5a2c347a1f95"
+          ports:
+          - containerPort: 8080
+          - containerPort: 8443


### PR DESCRIPTION
Used same pod YAML in regular externalIP testing and externalIP-upgrade testing cause https://issues.redhat.com/browse/OCPQE-6246

This PR is to create two separate pod YAML file, update externalIP-upgrade.feature to use externalip_pod_upgrade.yaml, and regular externalIP testing still use externalip_pod.yaml

Test log:
OCP-24669 using externalip_pod.yaml
http://file.rdu.redhat.com/~weliang/OCP-24669

externalIP-upgrade using externalip_pod_upgrade.yaml
http://file.rdu.redhat.com/~weliang/externalIP-upgrade

/cc @openshift/team-sdn-qe