### PR TITLE
Fix the logic to deal with tags when there are multiple Examples

### DIFF
--- a/tools/case_id_splitter.rb
+++ b/tools/case_id_splitter.rb
@@ -221,7 +221,7 @@ module BushSlicer
           elsif content[i] =~ /^\s+(Examples:)/
             insert_at_line = i
             indention = '    '
-            break
+            next
           end
         end
 


### PR DESCRIPTION
When there are multiple `Examples` in the Scenario Outlines, we should deal with all the tags in every Examples until to the last one, rather than break at the first one.

/cc @JianLi-RH @dis016 @pruan-rht @jhou1 