### PR TITLE
make sure random node is not windows worker

### DIFF
--- a/features/step_definitions/node.rb
+++ b/features/step_definitions/node.rb
@@ -24,9 +24,9 @@ Given /^fips is (enabled|disabled)$/ do |status|
 end
 
 # select a random node from a cluster.
-Given /^I select a random node's host$/ do
+Given /^I select a random( windows)? node's host$/ do | windows |
   ensure_admin_tagged
-  nodes = env.nodes.select { |n| n.schedulable? }
+  nodes = env.nodes.select { |n| n.schedulable? && (windows ? n.is_windows_worker? : ! n.is_windows_worker?) }
   cache_resources *nodes.shuffle
   @host = node.host
 end

--- a/lib/openshift/node.rb
+++ b/lib/openshift/node.rb
@@ -95,6 +95,11 @@ module BushSlicer
       res = rr.dig('metadata', 'labels', 'node-role.kubernetes.io/master')
       return ! res.nil?
     end
+  
+    def is_windows_worker?(user: nil, cached: true, quiet: false)
+      rr = raw_resource(user: user, cached: cached, quiet: quiet)
+      rr.dig('metadata', 'labels', 'kubernetes.io/os') == "windows"
+    end    
 
     def ready?(user: nil, cached: false, quiet: false)
       status = get_cached_prop(prop: :status, user: user, cached: cached, quiet: quiet)


### PR DESCRIPTION
We often met some cases failed with the following step. 
`select a random node from a cluster`

However for OVN + windows cluster.  it might choose windows worker which is not our expected.  So here I filter the windows worker out. 

Tested pass in my local

@openshift/team-sdn-qe  PTAL, thanks

