### PR TITLE
fix OCP-22606 

### DIFF
--- a/features/upgrade/etcd/upgrade.feature
+++ b/features/upgrade/etcd/upgrade.feature
@@ -13,7 +13,6 @@ Feature: basic verification for upgrade testing
   @baremetal-ipi
   @openstack-ipi
   @openstack-upi
-  @flaky
   Scenario: etcd-operator and cluster works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "admin/subscription.yaml"
@@ -28,8 +27,14 @@ Feature: basic verification for upgrade testing
     When I run the :create client command with:
       | f | etcd-cluster.yaml |
     Then the step should succeed
-    Then status becomes :running of exactly 3 pods labeled:
-      | etcd_cluster=example |
+    #bugzilla - id=1979550
+    #Then status becomes :running of exactly 3 pods labeled:
+    #  | etcd_cluster=example |
+    When I run the :get admin command with:
+      | resource | EtcdCluster |
+    Then the step should succeed
+    And the output should match:
+      | example.* |
 
   # @author geliu@redhat.com
   # @case_id OCP-22606
@@ -38,7 +43,6 @@ Feature: basic verification for upgrade testing
   @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
-  @flaky
   Scenario: etcd-operator and cluster works well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "openshift-operators" project


### PR DESCRIPTION
Fix for OCP-22606 .
As a result of the [bz-1979550](https://bugzilla.redhat.com/show_bug.cgi?id=1979550), we had to get a workaround for this test.
As per the etcd-cluster.yaml

`apiVersion: etcd.database.coreos.com/v1beta2

kind: EtcdCluster
metadata:
  name: example
  annotations:
    etcd.database.coreos.com/scope: clusterwide
  namespace: default
spec:
  size: 3
  version: 3.2.13
  `
the script verifies the creation of etcdcluster with name "example".

Please find the link of the successful execution [log](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/3670/parameters/)

Hi @geliu2016 , @jhou1  , @pruan-rht ,
could you please have a look.

