### PR TITLE
pod verification fails , because 4.1 had 'app' instead of 'k8s-app' key

### DIFF
--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -206,7 +206,7 @@ Feature: Machine-api components upgrade tests
       | f | cluster-autoscaler.yml |
     Then the step should succeed
     And 1 pod becomes ready with labels:
-      | cluster-autoscaler=default,k8s-app=cluster-autoscaler |
+      | cluster-autoscaler=default |
 
   # @author jhou@redhat.com
   # @case_id OCP-30783


### PR DESCRIPTION
this change should help to not get error , I dont see any issue as with one-label also we can confirm that pod is created successfully 
@jhou1 , @sunzhaohua2 , let me know if any concerns 
trying to fix - https://issues.redhat.com/browse/OCPQE-4934

4.1 - 
```
[miyadav@miyadav ~]$ oc get pods -l cluster-autoscaler=default,k8s-app=cluster-autoscaler
No resources found in openshift-machine-api namespace.
[miyadav@miyadav ~]$ oc get pods -l cluster-autoscaler=default,app=cluster-autoscaler
NAME                                          READY   STATUS    RESTARTS   AGE
cluster-autoscaler-default-5c8c597bfc-wqb75   1/1     Running   0          21m
```
```
4.10
[miyadav@miyadav ManualRun]$ oc get pods -l cluster-autoscaler=default,k8s-app=cluster-autoscaler --kubeconfig 410 
NAME                                          READY   STATUS    RESTARTS   AGE
cluster-autoscaler-default-57f4854f98-4qhjd   1/1     Running   0          9s
[miyadav@miyadav ManualRun]$ oc get pods -l cluster-autoscaler=default,app=cluster-autoscaler --kubeconfig 410 
No resources found in openshift-machine-api namespace.
```
```
4.10
[miyadav@miyadav ManualRun]$ oc get pods -l cluster-autoscaler=default --kubeconfig 410
NAME                                          READY   STATUS    RESTARTS   AGE
cluster-autoscaler-default-57f4854f98-4qhjd   1/1     Running   0          9m21s
4.1
[miyadav@miyadav ~]$ oc get pods -l cluster-autoscaler=default
NAME                                         READY   STATUS    RESTARTS   AGE
cluster-autoscaler-default-7c57f57cd-p7ftw   1/1     Running   0          102s

```
