### PR TITLE
Auto descheduler upgrade

### DIFF
--- a/features/step_definitions/descheduler.rb
+++ b/features/step_definitions/descheduler.rb
@@ -24,4 +24,112 @@ Given(/^the "([^"]*)" descheduler CR is restored from the "([^"]*)" after scenar
     @result = _admin.cli_exec(:patch, **opts)
     raise "Cannot restore descheduler: #{name}" unless @result[:success]
 }
-end 
+end
+
+Given /^(cluster-kube-descheduler-operator) channel name is stored in the#{OPT_SYM} clipboard$/ do | packagemanifest, cb_name |
+  cb_name = 'channel' unless cb_name
+  descheduler_envs = env.descheduler_envs
+  unless descheduler_envs.empty?
+    case packagemanifest
+    when "cluster-kube-descheduler-operator"
+      envs = descheduler_envs[:kdo]
+    end
+  end
+  step %Q/I use the "openshift-marketplace" project/
+  # check if the packagemanifest exist
+  raise "Packagemanifest #{packagemanifest} doesn't exist" unless package_manifest(packagemanifest).exists?
+
+  if (descheduler_envs.empty?) || (envs.nil?) || (envs[:channel].nil?)
+    version = cluster_version('version').version.split('-')[0].split('.').take(2).join('.')
+    case version
+    when '4.6','4.7','4.8','4.9','4.10'
+      cb[cb_name] = version
+    else
+      cb[cb_name] = "stable"
+    end
+  else
+    cb[cb_name] = envs[:channel]
+  end
+end
+
+Given /^(cluster-kube-descheduler-operator) catalog source name is stored in the#{OPT_SYM} clipboard$/ do | packagemanifest, cb_name |
+  cb_name = 'source' unless cb_name
+  descheduler_envs = env.descheduler_envs
+  unless descheduler_envs.empty?
+    case packagemanifest
+    when "cluster-kube-descheduler-operator"
+      envs = descheduler_envs[:kdo]
+    end
+  end
+  step %Q/I use the "openshift-marketplace" project/
+  # check if the packagemanifest exist
+  raise "Packagemanifest #{packagemanifest} doesn't exist" unless package_manifest(packagemanifest).exists?
+
+  # get source name, if it's not set, use default source
+  if (descheduler_envs.empty?) || (envs.nil?) || (envs[:catsrc].nil?)
+    if catalog_source("qe-app-registry").exists?
+      cb[cb_name] = "qe-app-registry"
+    elsif catalog_source("redhat-operators").exists?
+      cb[cb_name] = "redhat-operators"
+    else
+      cb[cb_name] = package_manifest(packagemanifest).catalog_source
+    end
+  else
+    #raise "The specified catalog source doesn't exist" unless catalog_source(envs[:catsrc]).exists?
+    cb[cb_name] = envs[:catsrc]
+  end
+end
+
+Given /^kubedescheduler operator has been installed successfully$/ do
+  ensure_destructive_tagged
+  ensure_admin_tagged
+  step %Q/I switch to cluster admin pseudo user/
+  step %Q/evaluation of `cluster_version('version').version` is stored in the :ocp_cluster_version clipboard/
+  step %Q/cluster-kube-descheduler-operator channel name is stored in the :kdo_channel clipboard/
+
+  unless project('openshift-kube-descheduler-operator').exists?
+    namespace_yaml = "#{BushSlicer::HOME}/testdata/descheduler/01_kd-project.yaml"
+    @result = admin.cli_exec(:create, f: namespace_yaml)
+    raise "Error creating namespace" unless @result[:success]
+  end
+
+  step %Q/I use the "openshift-kube-descheduler-operator" project/
+  unless deployment('descheduler-operator').exists?
+    unless operator_group('openshift-kube-descheduler-operator').exists?
+      clo_operator_group_yaml ||= "#{BushSlicer::HOME}/testdata/descheduler/02_kd-og.yaml"
+      @result = admin.cli_exec(:create, f: clo_operator_group_yaml)
+      raise "Error creating operatorgroup" unless @result[:success]
+    end
+
+    unless subscription('cluster-kube-descheduler-operator').exists?
+      step %Q/I use the "openshift-marketplace" project/
+      # first check packagemanifest exists for cluster-kube-descheduler-operator
+      raise "Required packagemanifest 'cluster-kube-descheduler-operator' no found!" unless package_manifest('cluster-kube-descheduler-operator').exists?
+      step %Q/cluster-kube-descheduler-operator catalog source name is stored in the :kdo_catsrc clipboard/
+      step %Q/I use the "openshift-kube-descheduler-operator" project/
+      # create subscription in `openshift-kube-descheduler-operator` namespace:
+      sub_kube_descheduler_yaml ||= "#{BushSlicer::HOME}/testdata/descheduler/kd-sub-template.yaml"
+      step %Q/I process and create:/, table(%{
+        | f | #{sub_kube_descheduler_yaml} |
+        | p | SOURCE=#{cb.kdo_catsrc}      |
+        | p | CHANNEL=#{cb.kdo_channel}    |
+      })
+      raise "Error creating subscription for cluster_descheduler" unless @result[:success]
+    end
+  end
+  # check csv existense
+  success = wait_for(300, interval: 10) {
+    csv = subscription('cluster-kube-descheduler-operator').current_csv
+    !(csv.nil?) && cluster_service_version(csv).exists?
+  }
+  raise "CSV #{csv} isn't created" unless success
+  step %Q/cluster descheduler operator is ready/
+end
+
+Given /^cluster descheduler operator is ready$/ do
+  ensure_admin_tagged
+  step %Q/I use the "openshift-kube-descheduler-operator" project/
+  step %Q/a pod becomes ready with labels:/, table(%{
+    | name=descheduler-operator |
+  })
+end

--- a/features/upgrade/workloads/descheduler-upgrade.feature
+++ b/features/upgrade/workloads/descheduler-upgrade.feature
@@ -1,0 +1,61 @@
+Feature: Descheduler major upgrade should work fine
+  # @author knarra@redhat.com
+  @upgrade-prepare
+  @admin
+  @destructive
+  Scenario: upgrade descheduler from 4.x to 4.y - prepare
+    Given I store master major version in the clipboard
+    Given I switch to cluster admin pseudo user
+    Given kubedescheduler operator has been installed successfully
+    Given I use the "openshift-kube-descheduler-operator" project
+    Given I obtain test data file "descheduler/kubedescheduler-<%= cb.master_version %>.yaml"
+    When I run the :create admin command with:
+      | f | kubedescheduler-<%= cb.master_version %>.yaml |
+    Then the step should succeed
+    And status becomes :running of exactly 1 pods labeled:
+      | app=descheduler |
+    Given evaluation of `pod.name` is stored in the :pod_name clipboard
+    Given I wait up to 180 seconds for the steps to pass:
+    """
+    When I run the :logs client command with:
+      | resource_name | pod/<%= cb.pod_name %> |
+    And the output should contain:
+      | duplicates.go               |
+      | lownodeutilization.go       |
+      | pod_antiaffinity.go         |
+      | node_affinity.go            |
+      | node_taint.go               |
+      | toomanyrestarts.go          |
+      | pod_lifetime.go             |
+      | topologyspreadconstraint.go |
+    """
+
+  # @author knarra@redhat.com
+  # @case_id OCP-40536
+  @upgrade-check
+  @admin
+  @destructive
+  Scenario: [upgrade] - upgrade descheduler from 4.x to 4.y
+    Given I switch to cluster admin pseudo user
+    And I use the "openshift-kube-descheduler-operator" project
+    Given a pod becomes ready with labels:
+      | app=descheduler |
+    Given cluster-kube-descheduler-operator channel name is stored in the :kdo_channel clipboard
+    When I run the :patch client command with:
+      | resource      | subscription                                                                   |
+      | resource_name | cluster-kube-descheduler-operator                                              |
+      | p             | [{"op": "replace", "path": "/spec/channel", "value": "<%= cb.kdo_channel %>"}] |
+      | type          | json                                                                           |
+      | n             | openshift-kube-descheduler-operator                                            |
+    Then the step should succeed
+    And I use the "openshift-kube-descheduler-operator" project
+    Given I wait for the resource "pod" named "<%= pod.name %>" to disappear
+    And status becomes :running of exactly 1 pods labeled:
+      | name=descheduler-operator |
+    And status becomes :running of exactly 1 pods labeled:
+      | app=descheduler |
+    When I run the :get client command with:
+      | resource     | csv                                 |
+      | n            | openshift-kube-descheduler-operator |
+    Then the step should succeed
+    And the output should match "clusterkubedescheduleroperator.*<%= cb.master_version %>.*Succeeded"

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -245,6 +245,17 @@ module BushSlicer
       return @logging_envs
     end
 
+    def descheduler_envs
+      unless @descheduler_envs
+        if opts[:descheduler_envs]
+          @descheduler_envs = opts[:descheduler_envs]
+        else
+          @descheduler_envs = ''
+        end
+      end
+      return @descheduler_envs
+    end
+
     # naming scheme is https://logs.<cluster_id>.openshift.com for Online
     # for OCP it's https://logs.<subdomain>.openshift.com
     def logging_console_url

--- a/testdata/descheduler/01_kd-project.yaml
+++ b/testdata/descheduler/01_kd-project.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kube-descheduler-operator

--- a/testdata/descheduler/02_kd-og.yaml
+++ b/testdata/descheduler/02_kd-og.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-kube-descheduler-operator
+  namespace: openshift-kube-descheduler-operator
+spec:
+  targetNamespaces:
+  - openshift-kube-descheduler-operator

--- a/testdata/descheduler/kd-sub-template.yaml
+++ b/testdata/descheduler/kd-sub-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: subscription-template
+objects:
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: cluster-kube-descheduler-operator
+    namespace: openshift-kube-descheduler-operator
+  spec:
+    channel: "${CHANNEL}"
+    installPlanApproval: Automatic
+    name: cluster-kube-descheduler-operator
+    source: ${SOURCE}
+    sourceNamespace: openshift-marketplace
+parameters:
+  - name: SOURCE
+  - name: CHANNEL

--- a/testdata/descheduler/kubedescheduler-4.7.yaml
+++ b/testdata/descheduler/kubedescheduler-4.7.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.openshift.io/v1beta1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  image: registry.redhat.io/openshift4/ose-descheduler:v4.7.0
+  logLevel: Normal
+  operatorLogLevel: Normal
+  deschedulingIntervalSeconds: 3600
+  profiles:
+    - AffinityAndTaints
+    - TopologyAndDuplicates
+    - LifecycleAndUtilization
+  managementState: Managed
+

--- a/testdata/descheduler/kubedescheduler-4.8.yaml
+++ b/testdata/descheduler/kubedescheduler-4.8.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.openshift.io/v1beta1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  image: registry.redhat.io/openshift4/ose-descheduler:v4.8.0
+  logLevel: Normal
+  operatorLogLevel: Normal
+  deschedulingIntervalSeconds: 3600
+  profiles:
+    - AffinityAndTaints
+    - TopologyAndDuplicates
+    - LifecycleAndUtilization
+  managementState: Managed
+

--- a/testdata/descheduler/kubedescheduler-4.9.yaml
+++ b/testdata/descheduler/kubedescheduler-4.9.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.openshift.io/v1beta1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  image: registry.redhat.io/openshift4/ose-descheduler:v4.9.0
+  logLevel: Normal
+  operatorLogLevel: Normal
+  deschedulingIntervalSeconds: 3600
+  profiles:
+    - AffinityAndTaints
+    - TopologyAndDuplicates
+    - LifecycleAndUtilization
+  managementState: Managed
+

--- a/testdata/descheduler/operatorgroup.yaml
+++ b/testdata/descheduler/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-kube-descheduler-operator
+  namespace: openshift-kube-descheduler-operator
+spec:
+  targetNamespaces:
+  - openshift-kube-descheduler-operator


### PR DESCRIPTION
Adding pre & post upgrade test cases to perform descheduler upgrade. @anpingli as discussed in the meeting today i am adding my questions here.

1) I see the below test only update descheduler operator in production from one version to other, how can i make this test work with nightly builds , stage etc ? Could you please help clarify ? Thanks !!
