### PR TITLE
Fix OCP-27333

### DIFF
--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -380,6 +380,6 @@ Feature: Operator related networking scenarios
       | resource_name | <%= cb.network_operator_pod %> |
       | since         | 30s                            |
     Then the step should succeed
-    And the output should contain:
-      | cannot change ovn-kubernetes MTU |
+    And the output should match:
+      | cannot change.*(MTU\|mtu) |
     """


### PR DESCRIPTION
/cc @anuragthehatter @zhaozhanqi 

```
      INFO> last 3 messages repeated 4 times
      [17:18:55] INFO> Exit Status: 0
      [17:18:56] INFO> Shell Commands: oc logs network-operator-56cddd8c4b-hr7xz --since 30s --kubeconfig=/alabama/workdir/e2e-aws-cucushift-ipi-destructive-cucushift-aws-ipi-destructive--e/ocp4_admin.kubeconfig
      I1029 17:18:46.547592       1 log.go:184] Reconciling Network.operator.openshift.io cluster
      I1029 17:18:46.548103       1 log.go:184] Not applying unsafe change: invalid configuration: [cannot change openshift-sdn mtu]
      
      INFO> last 3 messages repeated 5 times
      [17:19:07] INFO> Exit Status: 0
      pattern not found: cannot change ovn-kubernetes MTU (RuntimeError)
      /verification-tests/features/step_definitions/common.rb:103:in `block (3 levels) in <top (required)>'
      /verification-tests/features/step_definitions/common.rb:97:in `each'
      /verification-tests/features/step_definitions/common.rb:97:in `block (2 levels) in <top (required)>'
      /verification-tests/features/step_definitions/common.rb:56:in `each'
      /verification-tests/features/step_definitions/common.rb:56:in `/^(the|all)? outputs?( by order)? should( not)? (contain|match)(?: (\d+) times)?:$/'
      /verification-tests/features/step_definitions/transform.rb:33:in `call'
      /verification-tests/features/step_definitions/transform.rb:33:in `block in singleton class'
      /verification-tests/features/step_definitions/meta_steps.rb:48:in `block (2 levels) in <top (required)>'
      /verification-tests/lib/base_helper.rb:155:in `wait_for'
      /verification-tests/features/step_definitions/meta_steps.rb:43:in `/^I wait(?: up to ([0-9]+|<%=.+?%>) seconds)? for the steps to pass:$/'
      features/networking/operator.feature:377:in `I wait up to 60 seconds for the steps to pass:' 
```