### PR TITLE
upgrade auto test - OCP-39845

### DIFF
--- a/features/step_definitions/file.rb
+++ b/features/step_definitions/file.rb
@@ -32,6 +32,20 @@ Given /^I save the (output|response) to file>(.+)$/ do |part, filepath|
   File.write(File.expand_path(filepath.strip), @result[part])
 end
 
+Given /^I get time difference using "(.+)" and "(.+)" in (.+) file$/ do  |s1, s2, filename|
+   ##This isn't a generic step-definition yet & specific to logs of machineset-controller##	
+   split1 = File.open(filename){ |f| f.read }.split(s1)[0].split("Watching")[0]
+   split2 = File.open(filename){ |f| f.read }.split(s2)[0].split(s1)[2].strip
+   
+   #Calculating time difference in seconds
+   time_start = DateTime.parse split1
+   time_end = DateTime.parse split2
+   time_difference = ((time_end - time_start)* 24 * 60 * 60).to_i
+        if time_difference > 30
+		raise ("Upgrade can cause issues for new machinesets")
+	else 	
+   end	
+ end
 # This step is used to delete lines from file. If multiline match is needed,
 #   then write another step. If pattern starts with '/' or '%r{' treat as RE.
 #   Relative paths are considered inside workdir.

--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -258,3 +258,37 @@ Feature: Machine-api components upgrade tests
     Then the expression should be true> machine_set.desired_replicas(cached: false) == 1
     """
     Then the machineset should have expected number of running machines
+
+  @upgrade-prepare
+  @admin
+  @aws-ipi
+  @gcp-ipi
+  @4.7 @4.8 @4.10 @4.9
+  @vsphere-ipi
+  @azure-ipi
+  @openstack-ipi
+  Scenario: Registering Components delays should not be more than liveliness probe - prepare 
+    Given the expression should be true> "True" == "True"
+
+  # @author miyadav@redhat.com
+  # @case_id OCP-39845
+  @upgrade-check
+  @admin
+  @4.7 @4.8 @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
+  Scenario: Registering Components delays should not be more than liveliness probe 
+    Given I have an IPI deployment
+    And I switch to cluster admin pseudo user
+    And I use the "openshift-machine-api" project
+
+    And 1 pod becomes ready with labels:
+      | api=clusterapi,k8s-app=controller |
+
+    When I run the :logs admin command with:
+      | resource_name | <%= pod.name %>       |
+      | c             | machineset-controller |
+
+    And I save the output to file> logtime.txt 
+    Given I get time difference using "Registering Components." and "Starting the Cmd." in logtime.txt file
+    Then the step should succeed
+


### PR DESCRIPTION
@jhou1  @huali9 @sunzhaohua2 PTAL , when possible , the test works fine , but some times unable to get values for split2 , I have debugged but couldn't figured out , why is that happening sometimes .

This is created for - https://url.corp.redhat.com/internal

  ```
 I1103 14:45:10.175436       1 machine_webhook.go:589] Validating AWS providerSpec
      I1103 14:45:11.227074       1 machine_webhook.go:490] Validate webhook called for Machine: miyadav-0311-85g24-master-1
      I1103 14:45:11.227095       1 machine_webhook.go:589] Validating AWS providerSpec
      I1103 14:45:12.141879       1 machine_webhook.go:490] Validate webhook called for Machine: miyadav-0311-85g24-master-2
      I1103 14:45:12.141902       1 machine_webhook.go:589] Validating AWS providerSpec
      I1103 14:48:30.984960       1 machineset_webhook.go:86] Validate webhook called for MachineSet: miyadav-0311-85g24-worker-us-east-2c
      I1103 14:48:30.984983       1 machine_webhook.go:589] Validating AWS providerSpec
      I1103 14:48:30.997484       1 machineset_webhook.go:86] Validate webhook called for MachineSet: miyadav-0311-85g24-worker-us-east-2a
      I1103 14:48:30.997504       1 machine_webhook.go:589] Validating AWS providerSpec
      I1103 14:48:31.034504       1 machineset_webhook.go:86] Validate webhook called for MachineSet: miyadav-0311-85g24-worker-us-east-2b
      I1103 14:48:31.034526       1 machine_webhook.go:589] Validating AWS providerSpec
      
      [14:52:02] INFO> Exit Status: 0
    And I save the output to file> logtime.txt                                                              # features/step_definitions/file.rb:30
    #split("Starting the Cmd.")[0].split("Registering Components.")[2].stri
    Given I get time difference using "Registering Components." and "Starting the Cmd." in logtime.txt file # features/step_definitions/file.rb:35
    Then the step should succeed                                                                            # features/step_definitions/common.rb:4
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [14:52:02] INFO> === After Scenario: [Upgrade] - Registering Components delays should not be more than liveliness probe ===
      [14:52:02] INFO> Shell Commands: rm -r -f -- /home/miyadav/workdir/miyadav-miyadav-e
      
      [14:52:03] INFO> Exit Status: 0
      [14:52:04] INFO> === End After Scenario: [Upgrade] - Registering Components delays should not be more than liveliness probe ===

1 scenario (1 passed)
8 steps (8 passed)
0m22.163s
[14:52:04] INFO> === At Exit ===

```

`