### PR TITLE
fix failure: unterminated string meets end of file ...mon_set("<%= cb.collector_name 

### DIFF
--- a/features/logging/cluster_log_forwarder.feature
+++ b/features/logging/cluster_log_forwarder.feature
@@ -41,7 +41,7 @@ Feature: cluster log forwarder features
     Then the step should succeed
     And I wait for the "instance" cluster_log_forwarder to appear
     Given 10 seconds have passed
-    And <%= daemon_set("<%= cb.collector_name %>").replica_counters[:desired] %> pods become ready with labels:
+    And <%= daemon_set(cb.collector_name).replica_counters[:desired] %> pods become ready with labels:
       | logging-infra=<%= cb.collector_name %> |
     Given I wait up to 300 seconds for the steps to pass:
     """
@@ -90,7 +90,7 @@ Feature: cluster log forwarder features
       | f | clusterlogforwarder.yaml |
     Then the step should succeed
     Given 10 seconds have passed
-    And <%= daemon_set("<%= cb.collector_name %>").replica_counters[:desired] %> pods become ready with labels:
+    And <%= daemon_set(cb.collector_name).replica_counters[:desired] %> pods become ready with labels:
       | logging-infra=<%= cb.collector_name %> |
     Given I wait up to 300 seconds for the steps to pass:
     """


### PR DESCRIPTION
Fix failure:
```
11-03 10:41:43.937      And <%= daemon_set("<%= cb.collector_name %>").replica_counters[:desired] %> pods become ready with labels:         # features/step_definitions/pod.rb:134
11-03 10:41:43.937        | logging-infra=<%= cb.collector_name %> |
11-03 10:41:43.937        (eval):1: unterminated string meets end of file
11-03 10:41:43.937        ...mon_set("<%= cb.collector_name 
11-03 10:41:43.937        ...                               ^
11-03 10:41:43.937        (eval):1: syntax error, unexpected end-of-input, expecting ')' (SyntaxError)
11-03 10:41:43.937        /home/jenkins/ws/workspace/ocp-common/Runner/lib/world.rb:492:in `eval'
11-03 10:41:43.937        /home/jenkins/ws/workspace/ocp-common/Runner/lib/world.rb:492:in `block in transform_value'
11-03 10:41:43.937        /home/jenkins/ws/workspace/ocp-common/Runner/lib/world.rb:492:in `gsub'
11-03 10:41:43.937        /home/jenkins/ws/workspace/ocp-common/Runner/lib/world.rb:492:in `transform_value'
11-03 10:41:43.937        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/transform.rb:28:in `block (2 levels) in singleton class'
11-03 10:41:43.937        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/transform.rb:28:in `map'
11-03 10:41:43.937        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/transform.rb:28:in `block in singleton class'
11-03 10:41:43.937        /home/jenkins/ws/workspace/ocp-common/Runner/lib/test_case_manager_filter.rb:55:in `done'
11-03 10:41:43.937        features/logging/cluster_log_forwarder.feature:44:in `<%= daemon_set("<%= cb.collector_name %>").replica_counters[:desired] %> pods become ready with labels:'
```

/cc @anpingli 