### PR TITLE
OCPQE-6701: new multiarch image for ldap helper service

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -163,7 +163,7 @@ Given /^I have LDAP service in my project$/ do
     stats = {}
     step %Q/I run the :run client command with:/, table(%{
       | name  | ldapserver                                       |
-      | image | quay.io/openshifttest/ldap:openldap-2441-centos7 |
+      | image | quay.io/openshifttest/ldap:multiarch |
       })
     step %Q/the step should succeed/
     step %Q/a pod becomes ready with labels:/, table(%{


### PR DESCRIPTION
This MR replaces the LDAP image with the new multi-arch one.

Refers [OCPQE-5516](https://issues.redhat.com/browse/OCPQE-5516), [OCPQE-6701](https://issues.redhat.com/browse/OCPQE-6701)

This has been tested for the following test cases:

[OCP-10714](http://10.14.89.4:3000/url/generate?key=logs/2021/11/04/07:58:43/Sync_ldap_groups_to_openshift_groups_from_ldap_server-groups_rfc2307_sync-config_yaml_tc5_1664604480) - security
[OCP-10794](http://10.14.89.4:3000/url/generate?key=logs/2021/11/04/08:13:41/Failed_sync_group_should_prompt_tolerate_errors_when_tolarate_errors_flag_is_true) - security
[OCP-11244](http://10.14.89.4:3000/url/generate?key=logs/2021/11/04/07:58:43/Sync_ldap_group_to_openshift_group_with_paging_from_ldap_server) - security
[OCP-11757](http://10.14.89.4:3000/url/generate?key=logs/2021/11/04/08:13:42/Sync_openShift_groups_from_ldap_server_with_blacklist) - security
[OCP-11929](http://10.14.89.4:3000/url/generate?key=logs/2021/11/04/07:58:49/Sync_openshift_groups_with_ldap_server_for_some_specific_groups) - security