### PR TITLE
OCPQE-6707: Replacing multiarch registry image

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -613,7 +613,7 @@ Given /^I have a registry in my project$/ do
   if BushSlicer::Project::SYSTEM_PROJECTS.include?(project(generate: false).name)
     raise "I refuse create registry in a system project: #{project.name}"
   end
-  @result = admin.cli_exec(:new_app, docker_image: "quay.io/openshifttest/registry:2", namespace: project.name)
+  @result = admin.cli_exec(:new_app, docker_image: "quay.io/openshifttest/registry:multiarch", namespace: project.name)
   step %Q/the step should succeed/
   @result = admin.cli_exec(:set_probe, resource: "deploy/registry", readiness: true, liveness: true, get_url: "http://:5000/v2",namespace: project.name)
   step %Q/the step should succeed/
@@ -631,7 +631,7 @@ Given /^I have a registry with htpasswd authentication enabled in my project$/ d
   if BushSlicer::Project::SYSTEM_PROJECTS.include?(project(generate: false).name)
     raise "I refuse create registry in a system project: #{project.name}"
   end
-  @result = admin.cli_exec(:new_app, as_deployment_config:true, docker_image: "quay.io/openshifttest/registry:2", namespace: project.name)
+  @result = admin.cli_exec(:new_app, as_deployment_config:true, docker_image: "quay.io/openshifttest/registry:multiarch", namespace: project.name)
   step %Q/the step should succeed/
   step %Q/a pod becomes ready with labels:/, table(%{
        | deploymentconfig=registry |


### PR DESCRIPTION
This MR replaces the registry image with the new multi-arch one.

Refers OCPQE-5516, [OCPQE-6707](https://issues.redhat.com/browse/OCPQE-6707)

This has been tested for the following test cases:

[OCP-12059](http://10.14.89.4:3000/url/generate?key=logs/2021/11/04/10:11:13/Pull_image_with_secrets_from_private_remote_registry_in_the_OpenShift_registry) - devexp
[OCP-38860](http://10.14.89.4:3000/url/generate?key=logs/2021/11/04/10:11:12/Check_oc_image_mirror_with_multi-arch_images_--filter-by-os_not_wildcard) - master