### PR TITLE
OCPQE-6705: Replaced with multiarch image

### DIFF
--- a/testdata/authorization/scc/ocp11207/pod1.json
+++ b/testdata/authorization/scc/ocp11207/pod1.json
@@ -11,7 +11,7 @@
     "spec": {
         "containers": [{
             "name": "hello-openshift",
-            "image": "quay.io/openshifttest/client-cert",
+            "image": "quay.io/openshifttest/client-cert:multiarch",
             "ports": [{
                 "containerPort": 9443,
                 "protocol": "TCP"

--- a/testdata/authorization/scc/ocp11207/pod2.json
+++ b/testdata/authorization/scc/ocp11207/pod2.json
@@ -11,7 +11,7 @@
     "spec": {
         "containers": [{
             "name": "hello-openshift",
-            "image": "quay.io/openshifttest/client-cert",
+            "image": "quay.io/openshifttest/client-cert:multiarch",
 
             "ports": [{
                 "containerPort": 9443,


### PR DESCRIPTION
This MR replaces the client-cert image with the new multi-arch image.

Refers [OCPQE-6705](https://issues.redhat.com/browse/OCPQE-6705)

This has been tested for the following test cases:

[OCP-11189](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2021/11/05/05%3A56%3A50/Limit_to_create_pod_to_access_hostPID?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20211105%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20211105T061157Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=de8a6a0940596c3ec461007543fa43236c3ebe366864e8f0506cbaaa6fb5e62d) - limit_to_create_pods
[OCP-11207](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2021/11/05/05%3A54%3A56/Container_securityContext_should_take_precedence_when_it_conflict_with_PSC?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20211105%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20211105T061234Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=02aa32b37a69057ab4b2798eec504322bb14cfff17f1d5e9abcb3e09f9097ade) - container_securitycontext