### PR TITLE
OCPQE-6702: Replacing squid-proxy with multiarch one

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -121,7 +121,7 @@ end
 Given /^I have a(n authenticated)? proxy configured in the project$/ do |use_auth|
   if use_auth
     step %Q/I run the :create_deploymentconfig client command with:/, table(%{
-      | image | quay.io/openshifttest/squid-proxy |
+      | image | quay.io/openshifttest/squid-proxy:multiarch |
       | name  | squid-proxy                       |
       })
     step %Q/I wait until the status of deployment "squid-proxy" becomes :running/
@@ -135,7 +135,7 @@ Given /^I have a(n authenticated)? proxy configured in the project$/ do |use_aut
     @result = user.cli_exec(:expose, resource: "deploymentconfig", resource_name: "squid-proxy", port: "3128")
   else
     step %Q/I run the :create_deployment client command with:/, table(%{
-      | image | quay.io/openshifttest/squid-proxy |
+      | image | quay.io/openshifttest/squid-proxy:multiarch |
       | name  | squid-proxy                       |
       })
     step %Q/a pod becomes ready with labels:/, table(%{


### PR DESCRIPTION
Testcases ran:

[OCP-11189](http://10.14.89.4:3000/url/generate?key=logs/2021/11/05/16:29:04/Limit_to_create_pod_to_access_hostPID) - security
[OCP-11564](http://10.14.89.4:3000/url/generate?key=logs/2021/11/05/20:37:06/oc_exec_rsh_and_port-forward_should_work_behind_authenticated_proxy-oc) - master
[OCP-14476](http://10.14.89.4:3000/url/generate?key=logs/2021/11/05/14:06:03/Redact_proxy_users_and_passwords_in_build_logs) - buildapi
[OCP-21060](http://10.14.89.4:3000/url/generate?key=logs/2021/11/05/20:37:04/oc_exec_rsh_and_port-forward_should_work_behind_authenticated_proxy-kubectl) - master
