### PR TITLE
added support to clone run by subteam for all status, not just PASSED…

### DIFF
--- a/tools/polarshift.rb
+++ b/tools/polarshift.rb
@@ -530,7 +530,7 @@ module BushSlicer
         filtered_cases = query_result['records']["TestRecord"]
         if opts[:subteam]
           filtered_cases, subteams = filtered_cases_by_subteam(subteam_opt: opts[:subteam], cases: filtered_cases)
-          run_title ||= "Clone of '#{case_status}' #{subteams}  cases for #{test_run_id}"
+          run_title ||= "Clone of #{subteams}  cases for #{test_run_id}"
         end
         if filtered_cases.count > 0
           tc_ids = extract_test_case_ids(filtered_cases)


### PR DESCRIPTION
…/FAILED as currently the case

for example, to clone all `networking` case regardless of status
```
./tools/polarshift.rb clone-run 20210612-0147 --subteam="networking" --status='ALL'
```
to clone all `networking` cases for only the FAILED ones
```
./tools/polarshift.rb clone-run 20210612-0147 --subteam="networking" --status='FAILED'
```
@zhaozhanqi I think that's what you wanted.  