### PR TITLE
OCPQE-6703: ssh-git-server-openshift multiarch

### DIFF
--- a/testdata/templates/ssh-git/ssh-git-dc.yaml
+++ b/testdata/templates/ssh-git/ssh-git-dc.yaml
@@ -15,8 +15,8 @@ spec:
       name: git-server
     spec:
       containers:
-      - image: quay.io/openshifttest/ssh-git-server-openshift
-        imagePullPolicy: IfNotPresent 
+      - image: quay.io/openshifttest/ssh-git-server-openshift:multiarch
+        imagePullPolicy: IfNotPresent
         name: git-server
         resources: {}
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
[OCP-10982](http://10.14.89.4:3000/url/generate?key=logs/2021/11/06/04:20:21/oc_new-app_to_gather_git_creds) - buildapi
[OCP-11479](http://10.14.89.4:3000/url/generate?key=logs/2021/11/06/04:20:17/Build_from_private_git_repo_with_wrong_auth_method) - buildapi
[OCP-11720](http://10.14.89.4:3000/url/generate?key=logs/2021/11/06/04:20:14/Build_from_private_git_repo_with_without_ssh_key) - buildapi
[OCP-11896](http://10.14.89.4:3000/url/generate?key=logs/2021/11/06/04:20:14/Create_new-app_from_private_git_repo_with_ssh_key) - buildapi
[OCP-14264](http://10.14.89.4:3000/url/generate?key=logs/2021/11/06/04:20:14/Use_build_source_secret_based_on_annotation_on_Secret_--ssh) - buildapi
[OCP-15507](http://10.14.89.4:3000/url/generate?key=logs/2021/11/06/04:20:14/Creates_a_new_application_based_on_the_source_code_in_a_private_remote_repository) - buildapi

