### PR TITLE
Length limit of EXECUTOR_NAME as we have 63 chars limit for project name in OCP

### DIFF
--- a/lib/bushslicer.rb
+++ b/lib/bushslicer.rb
@@ -52,8 +52,9 @@ module BushSlicer
     EXECUTOR_NAME_TEMP = "#{HOSTNAME.split('.')[0]}-#{LOCAL_USER}"
   end
   # EXECUTOR_NAME is used as part of project name and workdir,
-  # apppend "-e" to make sure it always ends with proper char
-  EXECUTOR_NAME = "#{EXECUTOR_NAME_TEMP}-e".freeze
+  # truncate it as the project name is limited to 63 chars,
+  # apppend "x" to make sure it always ends with proper char
+  EXECUTOR_NAME = "#{EXECUTOR_NAME_TEMP[0..55]}x".freeze
 
   START_TIME = Time.now
   TIME_SUFFIX = [

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -439,7 +439,7 @@ module BushSlicer
       unless @service_project
         # if the cluster set the default scheduler, set the project running debug pod node-selector=''
         # to overwrite the default scheduler, or the pod can not be run successfully
-        project_name = "proj-" + EXECUTOR_NAME.downcase
+        project_name = "prj-" + EXECUTOR_NAME.downcase
         project = Project.new(name: project_name, env: self)
         unless project.active?
           # 60 seconds is no longer enough


### PR DESCRIPTION
Fix issue in https://coreos.slack.com/archives/C01UHADN91U/p1636349302059500

/cc @jhou1 @JianLi-RH @dis016 @pruan-rht 