### PR TITLE
OCPQE-6704: http-header-test multiarch image

### DIFF
--- a/testdata/routing/header-test/dc.json
+++ b/testdata/routing/header-test/dc.json
@@ -18,7 +18,7 @@
         "containers": [
           {
             "name": "header-test-container",
-            "image": "quay.io/openshifttest/http-header-test@sha256:4ccfce22943c2afcc0c9fd575f6856086c5d937c260bf957af337eb8af57986e",
+            "image": "quay.io/openshifttest/http-header-test@sha256:6d5e683cbf96594cabe4d4c36ee7178d025897db5ab0fc2f671ccc8df844a569",
             "ports": [
               {
                 "containerPort": 8080,


### PR DESCRIPTION
Parallel runner job: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/parallel-runner/575/parameters/

Test cases involved:

[OCP-10762](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:22/Check_the_header_forward_format) - network_edge
[OCP-11883](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:22/Be_able_to_add_more_alias_for_service) - network_edge
[OCP-12122](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:20/Alias_will_be_invalid_after_removing_it) - network_edge
[OCP-13254](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:21/The_HTTP_X_FORWARDED_FOR_should_be_the_client_IP_for_ELB_env) - network_edge
[OCP-14678](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:25/Only_the_host_in_whitelist_could_access_the_route_-_unsecure_route) - network_edge
[OCP-14679](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:25/Only_the_host_in_whitelist_could_access_the_route_-_edge_routes) - network_edge
[OCP-14680](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:24/Add_invalid_value_in_annotation_whitelist_to_routes) - network_edge
[OCP-14684](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:25/Only_the_host_in_whitelist_could_access_the_route_-_reencrypt_routes) - network_edge
[OCP-14685](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:16/Only_the_host_in_whitelist_could_access_the_route_-_passthrough_routes) - network_edge
[OCP-15113](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:21/Harden_haproxy_to_prevent_the_PROXY_header_from_being_passed_for_unsecure_route) - network_edge
[OCP-15114](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:52:23/Harden_haproxy_to_prevent_the_PROXY_header_from_being_passed_for_edge_route) - network_edge
[OCP-34231](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:54:50/Configure_Ingresscontroller_to_preserve_existing_header_with_forwardedHeaderPolicy_set_to_Append) - network_edge
[OCP-34233](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:54:49/Configure_Ingresscontroller_to_replace_any_existing_Forwarded_header_with_forwardedHeader_0646902350) - network_edge
[OCP-34234](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:54:50/Configure_Ingresscontroller_to_set_the_headers_if_they_are_not_already_set_with_forwarded_1435547051) - network_edge
[OCP-34235](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:54:52/Configure_Ingresscontroller_to_never_set_the_headers_and_preserve_existing_with_forwarded_3333931271) - network_edge
[OCP-34246](http://10.14.89.4:3000/url/generate?key=logs/2021/11/08/06:54:48/Configure_a_different_header_policy_for_the_route_with_haproxy_router_openshift_io_set-fo_3574889495) - network_edge
