### PR TITLE
Sync upgrade-prepare and upgrade-check tags, and adding 4.8 for eus

### DIFF
--- a/doc/prow/4.10/query_upgrade.json
+++ b/doc/prow/4.10/query_upgrade.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND subcomponent.KEY:upgrade AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT tags:(prod_only stage_only) AND version.KEY:4_10"
+}

--- a/doc/prow/4.8/query_upgrade.json
+++ b/doc/prow/4.8/query_upgrade.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND subcomponent.KEY:upgrade AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT tags:(prod_only stage_only) AND version.KEY:4_8"
+}

--- a/doc/prow/4.8/query_upgrade_sanity.json
+++ b/doc/prow/4.8/query_upgrade_sanity.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND caseimportance.KEY:critical AND version.KEY:4_8 AND NOT tags:(prod_only stage_only)"
+  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND caseimportance.KEY:critical AND version.KEY:4_8 AND NOT tags: (prod_only stage_only) AND NOT subcomponent.KEY:upgrade"
 }

--- a/doc/prow/4.9/query_upgrade.json
+++ b/doc/prow/4.9/query_upgrade.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND subcomponent.KEY:upgrade AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT tags:(prod_only stage_only) AND version.KEY:4_9"
+}

--- a/doc/prow/4.9/query_upgrade_sanity.json
+++ b/doc/prow/4.9/query_upgrade_sanity.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND caseimportance.KEY:critical AND version.KEY:4_9 AND NOT tags:(prod_only stage_only)"
+  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND caseimportance.KEY:critical AND version.KEY:4_9 AND NOT tags: (prod_only stage_only) AND NOT subcomponent.KEY:upgrade"
 }

--- a/features/upgrade/api_auth/upgrade.feature
+++ b/features/upgrade/api_auth/upgrade.feature
@@ -130,7 +130,7 @@ Feature: apiserver and auth related upgrade check
   # @author kewang@redhat.com
   @upgrade-prepare
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Default RBAC role, rolebinding, clusterrole and clusterrolebinding without any missing after upgraded - prepare
@@ -163,7 +163,7 @@ Feature: apiserver and auth related upgrade check
   # @case_id OCP-19470
   @upgrade-check
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Default RBAC role, rolebinding, clusterrole and clusterrolebinding without any missing after upgraded
@@ -186,7 +186,7 @@ Feature: apiserver and auth related upgrade check
   @upgrade-prepare
   @admin
   @destructive
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check the default SCCs should not be stomped by CVO - prepare
@@ -212,7 +212,7 @@ Feature: apiserver and auth related upgrade check
   @upgrade-check
   @admin
   @destructive
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check the default SCCs should not be stomped by CVO
@@ -243,7 +243,7 @@ Feature: apiserver and auth related upgrade check
   @admin
   @upgrade-prepare
   @users=upuser1,upuser2
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Upgrade action will cause re-generation of certificates for headless services to include the wildcard subjects - prepare
@@ -275,7 +275,7 @@ Feature: apiserver and auth related upgrade check
   @admin
   @upgrade-check
   @users=upuser1,upuser2
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Upgrade action will cause re-generation of certificates for headless services to include the wildcard subjects

--- a/features/upgrade/build/build-upgrade.feature
+++ b/features/upgrade/build/build-upgrade.feature
@@ -3,7 +3,7 @@ Feature: build related upgrade check
   @upgrade-prepare
   @users=upuser1,upuser2
   @proxy
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   Scenario: Check docker and sti build works well before and after upgrade - prepare
     Given I switch to the first user
     When I run the :new_project client command with:
@@ -25,7 +25,7 @@ Feature: build related upgrade check
   @upgrade-check
   @users=upuser1,upuser2
   @proxy
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   Scenario: Check docker and sti build works well before and after upgrade
     Given I switch to the first user
     When I use the "build-upgrade" project

--- a/features/upgrade/cloudcredential/upgrade.feature
+++ b/features/upgrade/cloudcredential/upgrade.feature
@@ -21,7 +21,6 @@ Feature: CloudCredentialOperator components upgrade tests
   @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
-  @upgrade-sanity
   Scenario: Cluster operator cloud-credential should be available after upgrade
     # Check cloud-credential operator version after upgraded
     Given the "cloud-credential" operator version matches the current cluster version

--- a/features/upgrade/etcd/upgrade.feature
+++ b/features/upgrade/etcd/upgrade.feature
@@ -3,16 +3,9 @@ Feature: basic verification for upgrade testing
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
-  @aws-ipi
-  @gcp-upi
-  @gcp-ipi
-  @4.10 @4.9
-  @aws-upi
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @4.8 @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: etcd-operator and cluster works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "admin/subscription.yaml"
@@ -40,7 +33,7 @@ Feature: basic verification for upgrade testing
   # @case_id OCP-22606
   @upgrade-check
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: etcd-operator and cluster works well after upgrade
@@ -53,7 +46,7 @@ Feature: basic verification for upgrade testing
   # @case_id OCP-22665
   @upgrade-check
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Check etcd image have been udpated to target release value after upgrade

--- a/features/upgrade/jenkins/upgrade.feature
+++ b/features/upgrade/jenkins/upgrade.feature
@@ -3,7 +3,7 @@ Feature: Jenkins feature upgrade test
   # @author xiuwang@redhat.com
   @upgrade-prepare
   @users=upuser1,upuser2
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @vsphere-upi @gcp-upi
   Scenario: Jenkins feature upgrade test - prepare
@@ -20,7 +20,7 @@ Feature: Jenkins feature upgrade test
   # @case_id OCP-16932
   @upgrade-check
   @users=upuser1,upuser2
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @vsphere-upi @gcp-upi
   Scenario: Jenkins feature upgrade test

--- a/features/upgrade/logging/upgrade.feature
+++ b/features/upgrade/logging/upgrade.feature
@@ -5,6 +5,7 @@ Feature: Logging upgrading related features
   @destructive
   @upgrade-prepare
   @users=upuser1,upuser2
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Cluster logging checking during cluster upgrade - prepare
@@ -41,7 +42,7 @@ Feature: Logging upgrading related features
   @destructive
   @upgrade-check
   @users=upuser1,upuser2
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Cluster logging checking during cluster upgrade

--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -1,15 +1,8 @@
 Feature: Machine-api components upgrade tests
   @upgrade-prepare
-  @aws-ipi
-  @gcp-upi
-  @gcp-ipi
-  @4.10 @4.9
-  @aws-upi
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @4.8 @4.7 @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario Outline: Cluster operator should be available after upgrade - prepare
     # According to our upgrade workflow, we need an upgrade-prepare and upgrade-check for each scenario.
     # But some of them do not need any prepare steps, which lead to errors "can not find scenarios" in the log.
@@ -40,7 +33,6 @@ Feature: Machine-api components upgrade tests
 
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
-    @upgrade-sanity
   Examples:
     | cluster_operator           |
     | "machine-api"              | # @case_id OCP-22712
@@ -50,16 +42,9 @@ Feature: Machine-api components upgrade tests
 
   @upgrade-prepare
   @admin
-  @aws-ipi
-  @gcp-upi
-  @gcp-ipi
   @4.10 @4.9
-  @aws-upi
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: There should be no pending or firing alerts for machine-api operators - prepare
     Given the expression should be true> "True" == "True"
 
@@ -84,6 +69,7 @@ Feature: Machine-api components upgrade tests
   @upgrade-prepare
   @admin
   @destructive
+  @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   Scenario: Scale up and scale down a machineSet after upgrade - prepare
     Given the expression should be true> "True" == "True"
@@ -95,7 +81,6 @@ Feature: Machine-api components upgrade tests
   @destructive
   @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
-  @upgrade-sanity
   Scenario: Scale up and scale down a machineSet after upgrade
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -115,7 +100,7 @@ Feature: Machine-api components upgrade tests
   @upgrade-prepare
   @admin
   @destructive
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   Scenario Outline: Spot/preemptible instances should not block upgrade - prepare
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -149,15 +134,15 @@ Feature: Machine-api components upgrade tests
 
     Examples:
       | iaas_type | machineset_name        | value                   |
-      | aws       | machineset-clone-41175 | "spotMarketOptions": {} | 
-      | gcp       | machineset-clone-41803 | "preemptible": true     | 
+      | aws       | machineset-clone-41175 | "spotMarketOptions": {} |
+      | gcp       | machineset-clone-41803 | "preemptible": true     |
       | azure     | machineset-clone-41804 | "spotVMOptions": {}     |
 
   # @author zhsun@redhat.com
   @upgrade-check
   @admin
   @destructive
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   Scenario Outline: Spot/preemptible instances should not block upgrade
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -197,7 +182,7 @@ Feature: Machine-api components upgrade tests
   @upgrade-prepare
   @destructive
   @admin
-  @4.10 @4.9
+  @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   Scenario: Cluster should automatically scale up and scale down with clusterautoscaler deployed - prepare
     Given I have an IPI deployment
@@ -218,7 +203,6 @@ Feature: Machine-api components upgrade tests
   @destructive
   @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
-  @upgrade-sanity
   Scenario: Cluster should automatically scale up and scale down with clusterautoscaler deployed
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user

--- a/features/upgrade/marketplace/upgrade.feature
+++ b/features/upgrade/marketplace/upgrade.feature
@@ -5,16 +5,9 @@ Feature: Marketplace related scenarios
   @admin
   @upgrade-prepare
   @users=upuser1,upuser2
-  @aws-ipi
-  @gcp-upi
-  @gcp-ipi
-  @4.10 @4.9
-  @aws-upi
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @4.8 @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: upgrade Marketplace - prepare
     # Check Marketplace version
     Given the "marketplace" operator version matches the current cluster version
@@ -40,7 +33,7 @@ Feature: Marketplace related scenarios
   @admin
   @upgrade-check
   @users=upuser1,upuser2
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: upgrade Marketplace

--- a/features/upgrade/monitoring/monitoring-upgrade.feature
+++ b/features/upgrade/monitoring/monitoring-upgrade.feature
@@ -2,16 +2,9 @@ Feature: cluster monitoring related upgrade check
   # @author hongyli@redhat.com
   @upgrade-prepare
   @admin
-  @aws-ipi
-  @gcp-upi
-  @gcp-ipi
-  @4.10 @4.9
-  @aws-upi
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @4.8 @4.7 @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: upgrade cluster monitoring along with OCP - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "monitoring/upgrade/cm-monitoring-retention.yaml"
@@ -27,7 +20,6 @@ Feature: cluster monitoring related upgrade check
   @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
-  @upgrade-sanity
   Scenario: upgrade cluster monitoring along with OCP
     Given I switch to cluster admin pseudo user
     And I use the "openshift-monitoring" project

--- a/features/upgrade/node/hpa/upgrade.feature
+++ b/features/upgrade/node/hpa/upgrade.feature
@@ -2,7 +2,7 @@ Feature: basic verification for upgrade testing
   # @author weinliu@redhat.com
   @upgrade-prepare
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Upgrade - Make sure multiple resources work well after upgrade - prepare
@@ -49,7 +49,7 @@ Feature: basic verification for upgrade testing
   # @case_id OCP-13016
   @upgrade-check
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Upgrade - Make sure multiple resources work well after upgrade

--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -2,7 +2,7 @@ Feature: Node components upgrade tests
   # @author minmli@redhat.com
   @upgrade-prepare
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Make sure nodeConfig is not changed after upgrade - prepare
@@ -46,7 +46,7 @@ Feature: Node components upgrade tests
   # @case_id OCP-13022
   @upgrade-check
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Make sure nodeConfig is not changed after upgrade

--- a/features/upgrade/node/scc.feature
+++ b/features/upgrade/node/scc.feature
@@ -3,16 +3,9 @@ Feature: Seccomp part of SCC policy should be kept and working after upgrade
   # @author sunilc@redhat.com
   @upgrade-prepare
   @admin
-  @aws-ipi
-  @gcp-upi
-  @gcp-ipi
-  @4.10 @4.9
-  @aws-upi
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @4.8 @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Seccomp part of SCC policy should be kept and working after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "node/scc.yaml"
@@ -24,7 +17,7 @@ Feature: Seccomp part of SCC policy should be kept and working after upgrade
   # @case_id OCP-13065
   @upgrade-check
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Seccomp part of SCC policy should be kept and working after upgrade

--- a/features/upgrade/olm/upgrade.feature
+++ b/features/upgrade/olm/upgrade.feature
@@ -5,16 +5,9 @@ Feature: OLM related scenarios
   @admin
   @upgrade-prepare
   @users=upuser1,upuser2
-  @aws-ipi
-  @gcp-upi
-  @gcp-ipi
-  @4.10 @4.9
-  @aws-upi
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @4.8 @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: upgrade OLM - prepare
     # Check OLM version
     Given the "operator-lifecycle-manager" operator version matches the current cluster version
@@ -36,7 +29,7 @@ Feature: OLM related scenarios
   @admin
   @upgrade-check
   @users=upuser1,upuser2
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: upgrade OLM

--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -2,16 +2,9 @@ Feature: Routing and DNS related scenarios
 
   @upgrade-prepare
   @admin
-  @aws-ipi
-  @gcp-upi
-  @gcp-ipi
-  @4.10 @4.9
-  @aws-upi
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @4.8 @4.7 @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: ensure ingress works well before and after upgrade - prepare
     # Check console route
     Given I switch to cluster admin pseudo user
@@ -29,7 +22,6 @@ Feature: Routing and DNS related scenarios
   @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
-  @upgrade-sanity
   Scenario: ensure ingress works well before and after upgrade
     # Check console route after upgraded
     Given I switch to cluster admin pseudo user
@@ -42,16 +34,9 @@ Feature: Routing and DNS related scenarios
 
   @upgrade-prepare
   @admin
-  @aws-ipi
-  @gcp-upi
-  @gcp-ipi
-  @4.10 @4.9
-  @aws-upi
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @4.8 @4.7 @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: ensure DNS works well before and after upgrade - prepare
     # Check service name can be resolvede
     Given I switch to cluster admin pseudo user
@@ -72,7 +57,6 @@ Feature: Routing and DNS related scenarios
   @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
-  @upgrade-sanity
   Scenario: ensure DNS works well before and after upgrade
     # Check service name can be resolvede
     Given I switch to cluster admin pseudo user
@@ -88,7 +72,7 @@ Feature: Routing and DNS related scenarios
 
   @upgrade-prepare
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @baremetal-ipi @vsphere-ipi
   @vsphere-upi
   Scenario: upgrade with running router pods on all worker nodes - prepare
@@ -113,7 +97,7 @@ Feature: Routing and DNS related scenarios
   # @case_id OCP-30501
   @upgrade-check
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @baremetal-ipi @vsphere-ipi
   @vsphere-upi
   Scenario: upgrade with running router pods on all worker nodes
@@ -128,10 +112,9 @@ Feature: Routing and DNS related scenarios
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
-  @gcp-upi
-  @gcp-ipi
-  @4.10 @4.9
-  @azure-ipi
+  @4.8 @4.10 @4.9
+  @gcp-ipi @azure-ipi
+  @gcp-upi @azure-upi
   Scenario: upgrade with route shards - prepare
     # Ensure cluster operator ingress is in normal status
     Given I switch to cluster admin pseudo user
@@ -199,7 +182,7 @@ Feature: Routing and DNS related scenarios
   @upgrade-check
   @users=upuser1,upuser2
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @gcp-ipi @azure-ipi
   @gcp-upi @azure-upi
   Scenario: upgrade with route shards

--- a/features/upgrade/samples_operator/upgrade.feature
+++ b/features/upgrade/samples_operator/upgrade.feature
@@ -3,8 +3,31 @@ Feature: image-registry operator upgrade tests
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   Scenario: samples/openshift-controller-manager/image-registry operators should be in correct status after upgrade - prepare
+    Given I switch to cluster admin pseudo user
+    # Check cluster operator openshift-samples should be in correct status
+    Given the expression should be true> cluster_operator('openshift-samples').condition(type: 'Available')['status'] == "True"
+    Given the expression should be true> cluster_operator('openshift-samples').condition(type: 'Progressing')['status'] == "False"
+    Given the expression should be true> cluster_operator('openshift-samples').condition(type: 'Degraded')['status'] == "False"
+    # Check cluster operator image-registry should be in correct status
+    Given the expression should be true> cluster_operator('image-registry').condition(type: 'Available')['status'] == "True"
+    Given the expression should be true> cluster_operator('image-registry').condition(type: 'Progressing')['status'] == "False"
+    Given the expression should be true> cluster_operator('image-registry').condition(type: 'Degraded')['status'] == "False"
+    # Check cluster operator openshift-controller-manager should be in correct status
+    Given the expression should be true> cluster_operator('openshift-controller-manager').condition(type: 'Available')['status'] == "True"
+    Given the expression should be true> cluster_operator('openshift-controller-manager').condition(type: 'Progressing')['status'] == "False"
+    Given the expression should be true> cluster_operator('openshift-controller-manager').condition(type: 'Degraded')['status'] == "False"
+
+  # @author xiuwang@redhat.com
+  # @case_id OCP-22678
+  @upgrade-check
+  @users=upuser1,upuser2
+  @admin
+  @4.8 @4.10 @4.9
+  @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
+  @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
+  Scenario: samples/openshift-controller-manager/image-registry operators should be in correct status after upgrade
     Given I switch to cluster admin pseudo user
     # Check cluster operator openshift-samples should be in correct status
     Given the expression should be true> cluster_operator('openshift-samples').condition(type: 'Available')['status'] == "True"
@@ -37,29 +60,6 @@ Feature: image-registry operator upgrade tests
     Given the expression should be true> cluster_operator('image-registry').condition(type: 'Available')['status'] == "True"
     Given the expression should be true> cluster_operator('image-registry').condition(type: 'Progressing')['status'] == "False"
     Given the expression should be true> cluster_operator('image-registry').condition(type: 'Degraded')['status'] == "False"
-
-  # @author xiuwang@redhat.com
-  # @case_id OCP-22678
-  @upgrade-check
-  @users=upuser1,upuser2
-  @admin
-  @4.10 @4.9
-  @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
-  @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
-  Scenario: samples/openshift-controller-manager/image-registry operators should be in correct status after upgrade
-    Given I switch to cluster admin pseudo user
-    # Check cluster operator openshift-samples should be in correct status
-    Given the expression should be true> cluster_operator('openshift-samples').condition(type: 'Available')['status'] == "True"
-    Given the expression should be true> cluster_operator('openshift-samples').condition(type: 'Progressing')['status'] == "False"
-    Given the expression should be true> cluster_operator('openshift-samples').condition(type: 'Degraded')['status'] == "False"
-    # Check cluster operator image-registry should be in correct status
-    Given the expression should be true> cluster_operator('image-registry').condition(type: 'Available')['status'] == "True"
-    Given the expression should be true> cluster_operator('image-registry').condition(type: 'Progressing')['status'] == "False"
-    Given the expression should be true> cluster_operator('image-registry').condition(type: 'Degraded')['status'] == "False"
-    # Check cluster operator openshift-controller-manager should be in correct status
-    Given the expression should be true> cluster_operator('openshift-controller-manager').condition(type: 'Available')['status'] == "True"
-    Given the expression should be true> cluster_operator('openshift-controller-manager').condition(type: 'Progressing')['status'] == "False"
-    Given the expression should be true> cluster_operator('openshift-controller-manager').condition(type: 'Degraded')['status'] == "False"
 
   # @author wzheng@redhat.com
   # @case_id OCP-27983

--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -3,7 +3,7 @@ Feature: Egress compoment upgrade testing
   # @author huirwang@redhat.com
   @admin
   @upgrade-prepare
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Check egressfirewall is functional post upgrade - prepare
@@ -44,7 +44,7 @@ Feature: Egress compoment upgrade testing
   # @case_id OCP-44315
   @admin
   @upgrade-check
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Check egressfirewall is functional post upgrade
@@ -69,7 +69,7 @@ Feature: Egress compoment upgrade testing
   # @author huirwang@redhat.com
   @admin
   @upgrade-prepare
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi
   @vsphere-upi
   Scenario: Check ovn egressip is functional post upgrade - prepare
@@ -123,7 +123,7 @@ Feature: Egress compoment upgrade testing
   # @case_id OCP-44316
   @admin
   @upgrade-check
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi
   @vsphere-upi
   Scenario: Check ovn egressip is functional post upgrade
@@ -222,14 +222,14 @@ Feature: Egress compoment upgrade testing
     """
 
   # @author huirwang@redhat.com
-  # @case_id OCP-45349 
+  # @case_id OCP-45349
   @admin
   @upgrade-check
   @4.10 @4.9
-  Scenario: Check sdn egressip is functional post upgrade 
+  Scenario: Check sdn egressip is functional post upgrade
     Given I run the :get admin command with:
-      | resource      | hostsubnet                                  |    
-      | o             | jsonpath={.items[?(@.egressCIDRs)].host}    |    
+      | resource      | hostsubnet                                  |
+      | o             | jsonpath={.items[?(@.egressCIDRs)].host}    |
     Then the step should succeed
     And evaluation of `@result[:response].split(" ")` is stored in the :egress_nodes clipboard
     And I register clean-up steps:
@@ -249,12 +249,12 @@ Feature: Egress compoment upgrade testing
 
     #Get configured EgressIPs
     When I run the :get admin command with:
-      | resource       | netnamespace             |   
+      | resource       | netnamespace             |
       | resource_name  | sdn-egressip-upgrade1    |
       | o              | jsonpath={.egressIPs[0]} |
     And evaluation of `@result[:response].chomp` is stored in the :egress_ip1 clipboard
     When I run the :get admin command with:
-      | resource       | netnamespace             |   
+      | resource       | netnamespace             |
       | resource_name  | sdn-egressip-upgrade2    |
       | o              | jsonpath={.egressIPs[0]} |
     And evaluation of `@result[:response].chomp` is stored in the :egress_ip2 clipboard

--- a/features/upgrade/sdn/ipsec-upgrade.feature
+++ b/features/upgrade/sdn/ipsec-upgrade.feature
@@ -3,6 +3,7 @@ Feature: IPsec upgrade scenarios
   # @author anusaxen@redhat.com
   @admin
   @upgrade-prepare
+  @4.10 @4.9 @4.8
   Scenario: Confirm node-node and pod-pod packets are ESP enrypted on IPsec clusters post upgrade - prepare
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -13,7 +14,7 @@ Feature: IPsec upgrade scenarios
     Then the step should succeed
     When I use the "ipsec-upgrade" project
     Given I obtain test data file "networking/list_for_pods.json"
-    #Creating two test pods for pod-pod encryption check. Pods needs to be deployment/rc backed so that they can be migrate successfuly to the upgraded cluster.Creating each separat as they need to be on diff 
+    #Creating two test pods for pod-pod encryption check. Pods needs to be deployment/rc backed so that they can be migrate successfuly to the upgraded cluster.Creating each separat as they need to be on diff
     #nodes
     When I run oc create over "list_for_pods.json" replacing paths:
       | ["items"][0]["spec"]["template"]["spec"]["nodeName"]           | <%= cb.workers[1].name %> |
@@ -58,11 +59,12 @@ Feature: IPsec upgrade scenarios
        | sh | -c | timeout  --preserve-status 2 tcpdump -i <%= cb.default_interface %> esp |
     Then the step should succeed
     And the output should contain "ESP"
-      
+
   # @author anusaxen@redhat.com
   # @case_id OCP-44834
   @admin
   @upgrade-check
+  @4.10 @4.9 @4.8
   Scenario: Confirm node-node and pod-pod packets are ESP enrypted on IPsec clusters post upgrade
     Given evaluation of `50` is stored in the :protocol clipboard
     Given I switch to cluster admin pseudo user
@@ -110,5 +112,5 @@ Feature: IPsec upgrade scenarios
     #Following will confirm node-node encryption
     When admin executes on the "<%= cb.hostnw_pod_worker1 %>" pod:
        | sh | -c | timeout  --preserve-status 60 tcpdump -c 2 -i br-ex "esp and less 40" |
-    Then the step should succeed 
+    Then the step should succeed
     And the output should not contain "0 packets captured"

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -3,9 +3,9 @@ Feature: SDN compoment upgrade testing
   # @author huirwang@redhat.com
   @admin
   @upgrade-prepare
+  @4.8 @4.7 @4.10 @4.9
   @aws-ipi @gcp-ipi @vsphere-ipi @azure-ipi @baremetal-ipi @openstack-ipi
   @aws-upi @gcp-upi @openstack-upi
-  @4.10 @4.9
   Scenario: network operator should be available after upgrade - prepare
   # According to our upgrade workflow, we need an upgrade-prepare and upgrade-check for each scenario.
   # But some of them do not need any prepare steps, which lead to errors "can not find scenarios" in the log.
@@ -19,7 +19,6 @@ Feature: SDN compoment upgrade testing
   @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
-  @upgrade-sanity
   Scenario: network operator should be available after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "openshift-network-operator" project
@@ -37,7 +36,7 @@ Feature: SDN compoment upgrade testing
   # @author zzhao@redhat.com
   @admin
   @upgrade-prepare
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check the networkpolicy works well after upgrade - prepare
@@ -77,7 +76,7 @@ Feature: SDN compoment upgrade testing
   # @case_id OCP-22735
   @admin
   @upgrade-check
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check the networkpolicy works well after upgrade
@@ -96,9 +95,9 @@ Feature: SDN compoment upgrade testing
   # @author asood@redhat.com
   @admin
   @upgrade-prepare
+  @4.8 @4.7 @4.10 @4.9
   @aws-ipi @gcp-ipi @vsphere-ipi @azure-ipi @baremetal-ipi @openstack-ipi
   @aws-upi @gcp-upi @openstack-upi
-  @4.10 @4.9
   Scenario: Check the namespace networkpolicy for an application works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
@@ -187,7 +186,6 @@ Feature: SDN compoment upgrade testing
   @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
-  @upgrade-sanity
   Scenario: Check the namespace networkpolicy for an application works well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "policy-upgrade1" project
@@ -257,7 +255,7 @@ Feature: SDN compoment upgrade testing
   # @author asood@redhat.com
   @admin
   @upgrade-prepare
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade - prepare
@@ -345,7 +343,7 @@ Feature: SDN compoment upgrade testing
   # @case_id OCP-40620
   @admin
   @upgrade-check
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade
@@ -377,6 +375,7 @@ Feature: SDN compoment upgrade testing
   # @author anusaxen@redhat.com
   @admin
   @upgrade-prepare
+  @4.8 @4.10 @4.9
   Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade - prepare
     Given I switch to cluster admin pseudo user
     And I store the workers in the :nodes clipboard
@@ -400,12 +399,12 @@ Feature: SDN compoment upgrade testing
       | port          | 8080                     |
       | protocol      | UDP                      |
     Then the step should succeed
-    
+
   # @author anusaxen@redhat.com
   # @case_id OCP-44901
   @admin
   @upgrade-check
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-upi
   Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade
     Given I switch to cluster admin pseudo user
@@ -438,7 +437,7 @@ Feature: SDN compoment upgrade testing
       | exec_command_arg | -c                                                                                                   |
       | exec_command_arg | for n in {1..3}; do echo $n; sleep 1; done>/dev/udp/<%= cb.host_pod1.node_name %>/<%= cb.nodeport %> |
     Then the step should succeed
-    
+
     #Creating network test pod to levearage conntrack tool
     Given I obtain test data file "networking/net_admin_cap_pod.yaml"
     When I run oc create over "net_admin_cap_pod.yaml" replacing paths:

--- a/features/upgrade/sdn/service-upgrade.feature
+++ b/features/upgrade/sdn/service-upgrade.feature
@@ -3,7 +3,7 @@ Feature: service upgrade scenarios
   # @author zzhao@redhat.com
   @admin
   @upgrade-prepare
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check the idle service works well after upgrade - prepare
@@ -32,7 +32,7 @@ Feature: service upgrade scenarios
   # @case_id OCP-44259
   @admin
   @upgrade-check
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check the idle service works well after upgrade
@@ -58,7 +58,7 @@ Feature: service upgrade scenarios
   # @author zzhao@redhat.com
   @admin
   @upgrade-prepare
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check the nodeport service works well after upgrade - prepare
@@ -96,7 +96,7 @@ Feature: service upgrade scenarios
   # @case_id OCP-44302
   @admin
   @upgrade-check
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check the nodeport service works well after upgrade

--- a/features/upgrade/security_compliance/fips.feature
+++ b/features/upgrade/security_compliance/fips.feature
@@ -3,7 +3,7 @@ Feature: fips enabled verification for upgrade
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: FIPS mode checking command works for a cluster with fip mode on - prepare
@@ -47,7 +47,7 @@ Feature: fips enabled verification for upgrade
   @upgrade-check
   @users=upuser1,upuser2
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: FIPS mode checking command works for a cluster with fip mode on

--- a/features/upgrade/storage/upgrade.feature
+++ b/features/upgrade/storage/upgrade.feature
@@ -3,7 +3,7 @@ Feature: Storage upgrade tests
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
-  @4.10 @4.9
+  @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Cluster operator storage should be in correct status and dynamic provisioning should work well after upgrade - prepare
@@ -76,7 +76,6 @@ Feature: Storage upgrade tests
   @4.8 @4.7 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
-  @upgrade-sanity
   Scenario: Cluster operator storage should be in correct status and dynamic provisioning should work well after upgrade
     Given I switch to cluster admin pseudo user
     # Check storage operator version after upgraded
@@ -157,7 +156,7 @@ Feature: Storage upgrade tests
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
-  @4.10 @4.9
+  @4.8 @4.7 @4.10 @4.9
   @baremetal-ipi
   Scenario: Cluster operator storage should be in correct status after upgrade - prepare
     Given I switch to cluster admin pseudo user
@@ -174,7 +173,6 @@ Feature: Storage upgrade tests
   @admin
   @4.8 @4.7 @4.10 @4.9
   @baremetal-ipi
-  @upgrade-sanity
   Scenario: Cluster operator storage should be in correct status after upgrade
     Given I switch to cluster admin pseudo user
     # Check storage operator version after upgraded
@@ -190,6 +188,7 @@ Feature: Storage upgrade tests
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
+  @4.8
   @aws-ipi
   @aws-upi
   Scenario: Snapshot operator should be in available status after upgrade and can created pod with snapshot - prepare
@@ -304,6 +303,7 @@ Feature: Storage upgrade tests
   # @case_id OCP-28630
   @upgrade-check
   @admin
+  @4.8
   @aws-ipi
   @aws-upi
   Scenario: Snapshot operator should be in available status after upgrade and can created pod with snapshot
@@ -363,7 +363,7 @@ Feature: Storage upgrade tests
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @aws-ipi
   @aws-upi
   Scenario: [AWS-EBS-CSI] [Snapshot operator] should work well before and after upgrade of a cluster - prepare
@@ -458,7 +458,7 @@ Feature: Storage upgrade tests
   @upgrade-check
   @users=upuser1,upuser2
   @admin
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @aws-ipi
   @aws-upi
   Scenario: [AWS-EBS-CSI] [Snapshot operator] should work well before and after upgrade of a cluster

--- a/features/upgrade/web/console-upgrade.feature
+++ b/features/upgrade/web/console-upgrade.feature
@@ -3,16 +3,9 @@ Feature: web console related upgrade check
   @console
   @upgrade-prepare
   @users=upuser1,upuser2
-  @aws-ipi
-  @aws-upi
-  @gcp-upi
-  @gcp-ipi
-  @4.10 @4.9
-  @vsphere-ipi
-  @azure-ipi
-  @baremetal-ipi
-  @openstack-ipi
-  @openstack-upi
+  @4.8 @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: check console accessibility - prepare
     Given I switch to the first user
     When I run the :new_project client command with:
@@ -57,7 +50,7 @@ Feature: web console related upgrade check
   @admin
   @console
   @users=upuser1,upuser2
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: check console accessibility

--- a/features/upgrade/workloads/oc-upgrade.feature
+++ b/features/upgrade/workloads/oc-upgrade.feature
@@ -50,7 +50,7 @@ Feature: basic verification for upgrade oc client testing
   # @author yinzhou@redhat.com
   @upgrade-prepare
   @users=upuser1,upuser2
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check some container related oc commands still work for ocp45 after upgrade - prepare
@@ -67,7 +67,7 @@ Feature: basic verification for upgrade oc client testing
   @upgrade-check
   @admin
   @users=upuser1,upuser2
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Check some container related oc commands still work for ocp45 after upgrade

--- a/features/upgrade/workloads/scheduler-upgrade.feature
+++ b/features/upgrade/workloads/scheduler-upgrade.feature
@@ -3,7 +3,7 @@ Feature: scheduler with custom policy upgrade check
   @upgrade-prepare
   @admin
   @destructive
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine - prepare
     Given the "kube-scheduler" operator version matches the current cluster version
     Given the expression should be true> cluster_operator('kube-scheduler').condition(type: 'Progressing')['status'] == "False"
@@ -45,7 +45,7 @@ Feature: scheduler with custom policy upgrade check
   @upgrade-check
   @admin
   @destructive
-  @4.10 @4.9
+  @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine


### PR DESCRIPTION
This PR adds 4.8 tag to the upgrade-prepare and ugprade-check for EUS tests.
Also I synced the tags between upgrade-prepare and upgrad-check which could help reduce some test flakes.
@liangxia @JianLi-RH @dis016 @pruan-rht PTAL