### PR TITLE
removing mongodb reference from the test

### DIFF
--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -143,10 +143,6 @@ Feature: build 'apps' with CLI
     When I run the :new_app client command with:
       | image_stream      | openshift/mysql                                      |
       | image             | registry.access.redhat.com/rhscl/postgresql-96-rhel7 |
-      | env               | MONGODB_USER=test                                    |
-      | env               | MONGODB_PASSWORD=test                                |
-      | env               | MONGODB_DATABASE=test                                |
-      | env               | MONGODB_ADMIN_PASSWORD=test                          |
       | env               | POSTGRESQL_USER=user                                 |
       | env               | POSTGRESQL_DATABASE=db                               |
       | env               | POSTGRESQL_PASSWORD=test                             |


### PR DESCRIPTION
- Updating the OCP-11139 Create applications only with multiple db images	
- Removing mongodb reference from the test