### PR TITLE
remove curator from clusterlogging

### DIFF
--- a/testdata/logging/clusterlogging/cl-storage-with-im-template.yaml
+++ b/testdata/logging/clusterlogging/cl-storage-with-im-template.yaml
@@ -36,10 +36,6 @@ objects:
           type: "kibana"
           kibana:
             replicas: 1
-        curation:
-          type: "curator"
-          curator:
-            schedule: "*/5 * * * *"
         collection:
           logs:
             type: "fluentd"


### PR DESCRIPTION
To fix https://issues.redhat.com/browse/OCPQE-6808 
The issue is: the curator was deployed, but before checking the job status, we didn't update the schedule of cj/curator. Since  curator is deprecated and we imported index management from logging 4.5, here I removed the curator from clusterlogging. 

/cc @anpingli 