### PR TITLE
Upgrade ocm-cli default version to 0.1.59

### DIFF
--- a/lib/launchers/o_c_m_cluster.rb
+++ b/lib/launchers/o_c_m_cluster.rb
@@ -161,7 +161,7 @@ module BushSlicer
     def download_ocm_cli
       url = ENV['OCM_CLI_URL']
       unless url
-        url_prefix = ENV['OCM_CLI_URL_PREFIX'] || 'https://github.com/openshift-online/ocm-cli/releases/download/v0.1.54'
+        url_prefix = ENV['OCM_CLI_URL_PREFIX'] || 'https://github.com/openshift-online/ocm-cli/releases/download/v0.1.59'
         if OS.mac?
           url = "#{url_prefix}/ocm-darwin-amd64"
         elsif OS.linux?


### PR DESCRIPTION
This new version contains a fix for obtaining api.url
https://github.com/openshift-online/ocm-cli/issues/226

Signed-off-by: Andrej Podhradsky <apodhrad@redhat.com>