### PR TITLE
new test-client-pod for routing testing

### DIFF
--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -125,7 +125,7 @@ Feature: Testing route
       | f | service_unsecure.yaml |
     Then the step should succeed
 
-    Given I have a pod-for-ping in the project
+    Given I have a test-client-pod in the project
     When I run the :create_route_edge client command with:
       | name    | edge-route       |
       | service | service-unsecure |

--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -347,20 +347,26 @@ Given /^I have a git client pod in the#{OPT_QUOTED} project$/ do |project_name|
 end
 
 # pod-for-ping is a pod that has curl, wget, telnet and ncat
-Given /^I have a pod-for-ping in the#{OPT_QUOTED} project$/ do |project_name|
+# test-client-pod is a pod that for routing testing
+Given /^I have a (pod-for-ping|test-client-pod) in the#{OPT_QUOTED} project$/ do |pod_name, project_name|
   project(project_name, switch: true)
   unless project.exists?(user: user)
     raise "project #{project_name} does not exist"
   end
 
-  @result = user.cli_exec(:create, f: "#{BushSlicer::HOME}/testdata/networking/aosqe-pod-for-ping.json")
-  raise "could not create a pod-for-ping" unless @result[:success]
+  if pod_name == 'test-client-pod'
+    res_file = "#{BushSlicer::HOME}/testdata/routing/test-client-pod.yaml"
+  else
+    res_file = "#{BushSlicer::HOME}/testdata/networking/aosqe-pod-for-ping.json"
+  end
+  @result = user.cli_exec(:create, f: res_file)
+  raise "could not create a #{pod_name}" unless @result[:success]
 
   cb.ping_pod = pod("hello-pod")
   @result = pod("hello-pod").wait_till_ready(user, 300)
   unless @result[:success]
     pod.describe(user, quiet: false)
-    raise "pod-for-ping did not become ready in time"
+    raise "#{pod_name} did not become ready in time"
   end
 end
 

--- a/features/step_definitions/route.rb
+++ b/features/step_definitions/route.rb
@@ -137,7 +137,7 @@ Given /^I store an available router IP in the#{OPT_SYM} clipboard$/ do |cb_name|
     | f |  #{BushSlicer::HOME}/testdata/networking/service_with_selector.json |
   })
   step %Q/I expose the "selector-service" service/
-  step %Q/I have a pod-for-ping in the project/
+  step %Q/I have a test-client-pod in the project/
   step %Q/I execute on the pod:/, table(%{
     | bash | -c | curl http://<%= route("selector-service", service("selector-service")).dns(by: user) %>/ --connect-timeout 10 -I -v -s |
   })

--- a/testdata/routing/test-client-pod.yaml
+++ b/testdata/routing/test-client-pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: hello-pod
+  name: hello-pod
+spec:
+  containers:
+  - image: quay.io/openshifttest/nginx-alpine@sha256:f266733786efb10c4353d4b44ada6f22434e983d22f0975d20803f1817d38f56
+    name: hello-pod
+    ports:
+    - containerPort: 8080
+    - containerPort: 8443


### PR DESCRIPTION
The purpose of the PR is to add new test-client-pod that reusing the (nginx-alpine) image that owned by network edge team, and to decouple the hello-sdn image that used by pod-for-ping.
With the PR, we are expecting to reduce/minimize the risk of updating test image that not owned by ourselves. 
 
No new image is introduced, just copied and updated the step
```
Given /^I have a pod-for-ping in the#{OPT_QUOTED} project$/ do |project_name|
``` 

log:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/220045/console

@quarterpin @melvinjoseph86 @ShudiLi  Please help take a look. Thanks,