### PR TITLE
iscsi-target namespace should not be deleted after scenario

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -501,11 +501,8 @@ Given /^I have a iSCSI setup in the environment$/ do
 
   _project = project("iscsi-target", switch: false)
   if !_project.exists?(user:admin, quiet: true)
-    step %Q{admin creates a project with:}, table(%{
-      | project_name  | iscsi-target |
-      | node_selector |              |
-    })
-    step %Q{the step should succeed}
+    @result = admin.cli_exec(:create_namespace, name: 'iscsi-target')
+    raise 'failed to "iscsi-target" project' unless @result[:success]
   end
 
   _pod = cb.iscsi_pod = pod("iscsi-target", _project)


### PR DESCRIPTION
According to the [log](https://storage.googleapis.com/origin-ci-test/logs/periodic-ci-openshift-verification-tests-master-ocp-4.10-e2e-vsphere-cucushift-upi/1460033053387657216/build-log.txt) iscsi-target namespace was terminated and recreated, there is a chance the termination did not finish and the creation starts.

From a test perspective, the `iscsi-target` namespace does not need to be deleted after scenario, it serves as a test service to provide PV to pods. The `steps` automatically registers clean up, so using `cli_exec` instead.

@duanwei33 @Phaow PTAL

```
      [09:58:24] INFO> Exit Status: 0
      [09:58:24] INFO> === End After Scenario: iSCSI block volumeMode support ===
# testcase for bug: #1583058
# @author piqin@redhat.com
# @author wduan@redhat.com
# @case_id OCP-19150
# Create tester pod

1 scenario (1 passed)
14 steps (14 passed)
1m57.975s



      [10:02:52] INFO> Exit Status: 0
      [10:02:53] INFO> === End After Scenario: iSCSI ReadOnly block volume should not be written in Pod ===

1 scenario (1 passed)
17 steps (17 passed)
1m6.250s
[10:02:53] INFO> === At Exit ===
```