### PR TITLE
Fix snapshot cases due to aws_cred issue

### DIFF
--- a/features/storage/csi_snapshot.feature
+++ b/features/storage/csi_snapshot.feature
@@ -25,13 +25,13 @@ Feature: Volume snapshot test
     Then the step should succeed
     Given I ensure "mypod-ori" pod is deleted
 
-    Given admin creates a VolumeSnapshotClass replacing paths:
-      | ["metadata"]["name"] | snapclass-<%= project.name %> |
+    #Given admin creates a VolumeSnapshotClass replacing paths:
+    #  | ["metadata"]["name"] | snapclass-<%= project.name %> |
     Given I obtain test data file "storage/csi/volumesnapshot_v1.yaml"
     When I run oc create over "volumesnapshot_v1.yaml" replacing paths:
-      | ["metadata"]["name"]                            | mysnapshot                    |
-      | ["spec"]["volumeSnapshotClassName"]             | snapclass-<%= project.name %> |
-      | ["spec"]["source"]["persistentVolumeClaimName"] | mypvc-ori                     |
+      | ["metadata"]["name"]                            | mysnapshot |
+      | ["spec"]["volumeSnapshotClassName"]             | <csi-vsc>  |
+      | ["spec"]["source"]["persistentVolumeClaimName"] | mypvc-ori  |
     Then the step should succeed
     And the "mysnapshot" volumesnapshot becomes ready
     Given I obtain test data file "storage/csi/pvc-snapshot.yaml"
@@ -56,21 +56,21 @@ Feature: Volume snapshot test
     @aws-ipi
     @aws-upi
     Examples:
-      | csi-sc       |
-      | gp2-csi      | # @case_id OCP-27727
+      | csi-sc  | csi-vsc     |
+      | gp2-csi | csi-aws-vsc | # @case_id OCP-27727
 
     @azure-ipi
     @azure-upi
     Examples:
-      | csi-sc       |
-      | managed-csi  | # @case_id OCP-41449
+      | csi-sc      | csi-vsc           |
+      | managed-csi | csi-azuredisk-vsc | # @case_id OCP-41449
 
     @openstack-ipi
     @openstack-upi
     @upgrade-sanity
     Examples:
-      | csi-sc       |
-      | standard-csi | # @case_id OCP-37568
+      | csi-sc       | csi-vsc      |
+      | standard-csi | standard-csi |# @case_id OCP-37568
 
   # @author wduan@redhat.com
   @admin
@@ -103,13 +103,13 @@ Feature: Volume snapshot test
     Then the step should succeed
     Given I ensure "mypod-ori" pod is deleted
 
-    Given admin creates a VolumeSnapshotClass replacing paths:
-      | ["metadata"]["name"] | snapclass-<%= project.name %> |
+    #Given admin creates a VolumeSnapshotClass replacing paths:
+    #  | ["metadata"]["name"] | snapclass-<%= project.name %> |
     Given I obtain test data file "storage/csi/volumesnapshot_v1.yaml"
     When I run oc create over "volumesnapshot_v1.yaml" replacing paths:
-      | ["metadata"]["name"]                            | mysnapshot                    |
-      | ["spec"]["volumeSnapshotClassName"]             | snapclass-<%= project.name %> |
-      | ["spec"]["source"]["persistentVolumeClaimName"] | mypvc-ori                     |
+      | ["metadata"]["name"]                            | mysnapshot |
+      | ["spec"]["volumeSnapshotClassName"]             | <csi-vsc>  |
+      | ["spec"]["source"]["persistentVolumeClaimName"] | mypvc-ori  |
     Then the step should succeed
     And the "mysnapshot" volumesnapshot becomes ready
     Given I obtain test data file "storage/csi/pvc-snapshot.yaml"
@@ -138,5 +138,5 @@ Feature: Volume snapshot test
     @openstack-upi
     @upgrade-sanity
     Examples:
-      | csi-sc       |
-      | standard-csi | # @case_id OCP-37569
+      | csi-sc       | csi-vsc      |
+      | standard-csi | standard-csi | # @case_id OCP-37569


### PR DESCRIPTION
Looks like the aws_cred could not get from the secret in AWS disconnect cluster with [failed log](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2021/11/09/09%3A04%3A35/Volume_snapshot_create_and_restore_test-gp2-csi?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20211111%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20211111T002218Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=8d2788a2d9a5cc861140e3ba37617130131ca6e4805b3d7f8d4bde849d336b84) when using the env.iaas[:type] :
`09:31:03 INFO> Shell Commands: oc get secrets aws-creds --output=yaml --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_admin.kubeconfig --namespace=kube-system`
STDERR:
Error from server (NotFound): secrets "aws-creds" not found

[pass log](https://privatebin-it-iso.int.open.paas.redhat.com/?cca9f102d8efc198#75mtahWvfkJzk94AazRcgyKm9Boqz2bTZa1k3VEAYkJJ)

@Phaow PTAL This will fix the aws disconnect evn issue and wait to see if env.iaas[:type] will be fixed.