### PR TITLE
Do not show secrets info by default

### DIFF
--- a/lib/openshift/secret.rb
+++ b/lib/openshift/secret.rb
@@ -8,19 +8,19 @@ module BushSlicer
     RESOURCE = "secrets"
 
     # see #raw_resource
-    def type(user: nil, cached: true, quiet: false)
+    def type(user: nil, cached: true, quiet: true)
       obj = raw_resource(user: user, cached: cached, quiet: quiet)
       return obj['type']
     end
 
     # @param user [BushSlicer::User] the user to run cli commands with if needed
-    def bearer_token?(user: nil, cached: true, quiet: false)
+    def bearer_token?(user: nil, cached: true, quiet: true)
       type(user: user, cached: cached, quiet: quiet).include?('service-account-token') && raw_resource.dig('data', 'token')
     end
 
     # @param user [BushSlicer::User] the user to run cli commands with if needed
     # @return [String] bearer token
-    def token(user: nil, cached: true, quiet: false)
+    def token(user: nil, cached: true, quiet: true)
       if bearer_token?(user: user, cached: cached, quiet: quiet)
         return value_of(:token)
       else
@@ -28,12 +28,12 @@ module BushSlicer
       end
     end
 
-    def raw_value_of(key, user: nil, cached: true, quiet: false)
+    def raw_value_of(key, user: nil, cached: true, quiet: true)
       obj = raw_resource(user: user, cached: cached, quiet: quiet)
       obj.dig("data", key.to_s)
     end
 
-    def value_of(key, user: nil, cached: true, quiet: false)
+    def value_of(key, user: nil, cached: true, quiet: true)
       value = raw_value_of(key, user: user, cached: cached, quiet: quiet)
       value ? Base64.decode64(value) : nil
     end


### PR DESCRIPTION
/cc @jhou1 @JianLi-RH @dis016 @pruan-rht 

Tested with `features/storage/storage_class.feature:241` on a 4.10 AWS cluster locally, and the secrets info are not show.