### PR TITLE
update curl in step store an available router IP

### DIFF
--- a/features/step_definitions/route.rb
+++ b/features/step_definitions/route.rb
@@ -139,7 +139,7 @@ Given /^I store an available router IP in the#{OPT_SYM} clipboard$/ do |cb_name|
   step %Q/I expose the "selector-service" service/
   step %Q/I have a test-client-pod in the project/
   step %Q/I execute on the pod:/, table(%{
-    | bash | -c | curl http://<%= route("selector-service", service("selector-service")).dns(by: user) %>/ --connect-timeout 10 -I -v -s |
+    | curl | http://<%= route("selector-service", service("selector-service")).dns(by: user) %>/ | --connect-timeout | 10 | -Ivs |
   })
 
   cb[cb_name] = @result[:response].match(/Connected to .* \((\d+.\d+.\d+.\d+)\)/).captures


### PR DESCRIPTION
the test-client-pod image hasn't installed bash command yet but `bash` is required in this step, so revert to pot-for-ping for now.

@liangxia Please take a look. Thanks.

cc @quarterpin @melvinjoseph86 @ShudiLi 