### PR TITLE
Updated verification-tests by replacing pod-for-ping with test-client…

### DIFF
--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -24,7 +24,7 @@ Feature: Testing haproxy router
     When I expose the "service-unsecure" service
     Then the step should succeed
 
-    Given I have a pod-for-ping in the project
+    Given I have a test-client-pod in the project
     #access the route without cookies
     Given I wait for the steps to pass:
     """
@@ -85,7 +85,7 @@ Feature: Testing haproxy router
       | service | service-unsecure |
     Then the step should succeed
 
-    Given I have a pod-for-ping in the project
+    Given I have a test-client-pod in the project
     # access the route without cookies
     Given I wait for the steps to pass:
     """
@@ -268,7 +268,6 @@ Feature: Testing haproxy router
   @upgrade-sanity
   Scenario: Set balance leastconn for passthrough routes
     Given I have a project
-    And I store an available router IP in the :router_ip clipboard
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
       | f | web-server-1.yaml |
@@ -293,15 +292,13 @@ Feature: Testing haproxy router
       | overwrite | true |
     Then the step should succeed
 
-    Given I have a pod-for-ping in the project
+    Given I have a test-client-pod in the project
     And I use the "service-secure" service
     Given I wait for the steps to pass:
     """
     When I execute on the pod:
       | curl                                                   |
       | -ksS                                                   |
-      | --resolve                                              |
-      | <%= route("route-pass").dns(by: user) %>:443:<%= cb.router_ip[0] %> |
       | https://<%= route("route-pass").dns(by: user) %> |
     Then the step should succeed
     And the output should contain "Hello-OpenShift web-server-2"
@@ -309,8 +306,6 @@ Feature: Testing haproxy router
     When I execute on the pod:
       | curl                                                   |
       | -ksS                                                   |
-      | --resolve                                              |
-      | <%= route("route-pass").dns(by: user) %>:443:<%= cb.router_ip[0] %> |
       | https://<%= route("route-pass").dns(by: user) %> |
     Then the step should succeed
     And the output should contain "Hello-OpenShift web-server-1"

--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -203,8 +203,7 @@ Feature: Testing route
     When I run the :create client command with:
       | f | service_secure.yaml |
     Then the step should succeed
-    Given I have a pod-for-ping in the project
-    #And CA trust is added to the pod-for-ping
+    Given I have a test-client-pod in the project
     # check reencrypt route
     Given I obtain test data file "routing/reencrypt/route_reencrypt_dest.ca"
     When I run the :create_route_reencrypt client command with:
@@ -238,7 +237,6 @@ Feature: Testing route
   @upgrade-sanity
   Scenario: Config insecureEdgeTerminationPolicy to Redirect for route
     Given I have a project
-    And I store an available router IP in the :router_ip clipboard
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
       | f | web-server-1.yaml |
@@ -266,7 +264,7 @@ Feature: Testing route
     And the output should contain:
       | Redirect |
     # Acess the route
-    Given I have a pod-for-ping in the project
+    Given I have a test-client-pod in the project
     When I execute on the pod:
       | curl |
       | -v |
@@ -287,7 +285,6 @@ Feature: Testing route
   @upgrade-sanity
   Scenario: Config insecureEdgeTerminationPolicy to Allow for route
     Given I have a project
-    And I store an available router IP in the :router_ip clipboard
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
       | f | web-server-1.yaml |
@@ -312,11 +309,11 @@ Feature: Testing route
     Then the step should succeed
     And the output should contain:
       | Allow |
-    Given I have a pod-for-ping in the project
+    Given I have a test-client-pod in the project
+    And I wait up to 60 seconds for the steps to pass:
+    """
     When I execute on the pod:
       | curl                                                                                          |
-      | --resolve                                                                                     |
-      | <%= route("myroute", service("service-unsecure")).dns(by: user) %>:443:<%= cb.router_ip[0] %> |
       | https://<%= route("myroute", service("service-unsecure")).dns(by: user) %>/                   |
       | -k                                                                                            |
       | -v                                                                                            |
@@ -325,10 +322,11 @@ Feature: Testing route
       | Hello-OpenShift |
     And the output should not contain:
       | HTTP/1.1 302 Found |
+    """
+    And I wait up to 60 seconds for the steps to pass:
+    """
     When I execute on the pod:
       | curl                                                                                         |
-      | --resolve                                                                                    |
-      | <%= route("myroute", service("service-unsecure")).dns(by: user) %>:80:<%= cb.router_ip[0] %> |
       | http://<%= route("myroute", service("service-unsecure")).dns(by: user) %>/                   |
       | -v                                                                                           |
       | -c                                                                                           |
@@ -343,6 +341,7 @@ Feature: Testing route
     Then the step should succeed
     And the output should match:
       | FALSE.*FALSE |
+    """
 
   # @author hongli@redhat.com
   # @case_id OCP-10024
@@ -372,7 +371,6 @@ Feature: Testing route
   @upgrade-sanity
   Scenario: Set insecureEdgeTerminationPolicy to Redirect for passthrough route
     Given I have a project
-    And I store an available router IP in the :router_ip clipboard
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
       | f | web-server-1.yaml |
@@ -395,8 +393,8 @@ Feature: Testing route
       | p             | {"spec":{"tls":{"insecureEdgeTerminationPolicy":"Redirect"}}} |
     Then the step should succeed
     # Acess the route
-    Given I have a pod-for-ping in the project
-    And I wait up to 20 seconds for the steps to pass:
+    Given I have a test-client-pod in the project
+    And I wait up to 60 seconds for the steps to pass:
     """
     When I execute on the pod:
       | curl |
@@ -425,7 +423,6 @@ Feature: Testing route
   @upgrade-sanity
   Scenario: Set insecureEdgeTerminationPolicy to Redirect and Allow for reencrypt route
     Given I have a project
-    And I store an available router IP in the :router_ip clipboard
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
       | f | web-server-1.yaml |
@@ -531,7 +528,6 @@ Feature: Testing route
   @upgrade-sanity
   Scenario: Check the cookie if using secure mode when insecureEdgeTerminationPolicy to Redirect for edge/reencrypt route
     Given I have a project
-    And I store an available router IP in the :router_ip clipboard
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
       | f | web-server-1.yaml |
@@ -549,7 +545,9 @@ Feature: Testing route
       | insecure_policy | Redirect   |
     Then the step should succeed
 
-    Given I have a pod-for-ping in the project
+    Given I have a test-client-pod in the project
+    And I wait up to 60 seconds for the steps to pass:
+    """
     When I execute on the pod:
       | curl |
       | -v |
@@ -563,6 +561,7 @@ Feature: Testing route
       | Hello-OpenShift |
       | HTTP/1.1 302 Found |
       | ocation: https:// |
+    """
     And I execute on the pod:
       | cat | /tmp/cookie |
     Then the step should succeed
@@ -582,7 +581,7 @@ Feature: Testing route
       | insecure_policy | Redirect                |
     Then the step should succeed
     And I wait up to 60 seconds for a secure web server to become available via the "reen" route
-    And I wait up to 20 seconds for the steps to pass:
+    And I wait up to 60 seconds for the steps to pass:
     """
     When I execute on the pod:
       | curl |

--- a/features/routing/timeout.feature
+++ b/features/routing/timeout.feature
@@ -8,7 +8,6 @@ Feature: Testing timeout route
   @upgrade-sanity
   Scenario: Set timeout server for passthough route
     Given I have a project
-    And I store an available router IP in the :router_ip clipboard
     Given I obtain test data file "routing/routetimeout/httpbin-pod-2.json"
     When I run the :create client command with:
       | f  | httpbin-pod-2.json |
@@ -30,11 +29,9 @@ Feature: Testing timeout route
       | overwrite        | true                                   |
       | keyval           | haproxy.router.openshift.io/timeout=3s |
     Then the step should succeed
-    Given I have a pod-for-ping in the project
+    Given I have a test-client-pod in the project
     When I execute on the pod:
       | curl                                                                                       |
-      | --resolve                                                                                  |
-      | <%= route("pass-route", service("pass-route")).dns(by: user) %>:443:<%= cb.router_ip[0] %> |
       | https://<%= route("pass-route", service("pass-route")).dns(by: user) %>/delay/2            |
       | -k                                                                                         |
     Then the step should succeed
@@ -44,8 +41,6 @@ Feature: Testing timeout route
     When I execute on the pod:
       | curl                                                                                       |
       | -Iv                                                                                        |
-      | --resolve                                                                                  |
-      | <%= route("pass-route", service("pass-route")).dns(by: user) %>:443:<%= cb.router_ip[0] %> |
       | https://<%= route("pass-route", service("pass-route")).dns(by: user) %>/delay/4            |
       | -k                                                                                         |
     Then the step should fail


### PR DESCRIPTION
@lihongan @quarterpin @melvinjoseph86, request for a review. Thanks.

The modification covers below:
haproxy-router.feature: OCP-11903,OCP-11130,OCP-10043,OCP-11679
route.feature OCP-12562,OCP-12564,OCP-9651,OCP-9650,OCP-11036,OCP-13753

A successful jenkins Runner is below:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/224923/