### PR TITLE
OCPQE-6708: Replaced sigcapture with hello-openshift multi-arch extended image

### DIFF
--- a/testdata/pods/graceful-delete/0.json
+++ b/testdata/pods/graceful-delete/0.json
@@ -31,8 +31,8 @@
           {
             "name": "TRAP_SIGNALS",
             "value": "yes"
-         }
-      ],
+          }
+        ],
         "resources": {},
         "volumeMounts": [
           {

--- a/testdata/pods/graceful-delete/0.json
+++ b/testdata/pods/graceful-delete/0.json
@@ -19,6 +19,20 @@
             "protocol": "TCP"
           }
         ],
+        "env": [         
+          {
+            "name": "PORT",
+            "value": ""
+          },
+          {
+            "name": "SECOND_PORT",
+            "value": ""
+          },
+          {
+            "name": "TRAP_SIGNALS",
+            "value": "yes"
+         }
+      ],
         "resources": {},
         "volumeMounts": [
           {

--- a/testdata/pods/graceful-delete/0.json
+++ b/testdata/pods/graceful-delete/0.json
@@ -12,7 +12,7 @@
     "containers": [
       {
         "name": "sleep",
-        "image": "quay.io/openshifttest/sigcapture@sha256:e9c7ecf75c57def20f1964a119e858a7a45de9d3b21a384f5a32d9562a15270b",
+        "image": "quay.io/openshifttest/hello-openshift@sha256:0ed6e7163863e52438a5ed189d82e572a6c2ddd1b4db224c2c4b0688fee2c2cc",
         "ports": [
           {
             "containerPort": 8080,

--- a/testdata/pods/graceful-delete/10.json
+++ b/testdata/pods/graceful-delete/10.json
@@ -12,7 +12,7 @@
     "containers": [
       {
         "name": "hello-openshift",
-        "image": "quay.io/openshifttest/sigcapture@sha256:e9c7ecf75c57def20f1964a119e858a7a45de9d3b21a384f5a32d9562a15270b",
+        "image": "quay.io/openshifttest/hello-openshift@sha256:0ed6e7163863e52438a5ed189d82e572a6c2ddd1b4db224c2c4b0688fee2c2cc",
         "ports": [
           {
             "containerPort": 8080,

--- a/testdata/pods/graceful-delete/10.json
+++ b/testdata/pods/graceful-delete/10.json
@@ -31,8 +31,8 @@
           {
             "name": "TRAP_SIGNALS",
             "value": "yes"
-         }
-      ],
+          }
+        ],
         "resources": {},
         "volumeMounts": [
           {

--- a/testdata/pods/graceful-delete/10.json
+++ b/testdata/pods/graceful-delete/10.json
@@ -19,6 +19,20 @@
             "protocol": "TCP"
           }
         ],
+        "env": [         
+          {
+            "name": "PORT",
+            "value": ""
+          },
+          {
+            "name": "SECOND_PORT",
+            "value": ""
+          },
+          {
+            "name": "TRAP_SIGNALS",
+            "value": "yes"
+         }
+      ],
         "resources": {},
         "volumeMounts": [
           {

--- a/testdata/pods/graceful-delete/default.json
+++ b/testdata/pods/graceful-delete/default.json
@@ -31,8 +31,8 @@
           {
             "name": "TRAP_SIGNALS",
             "value": "yes"
-         }
-      ],
+          }
+        ],
         "resources": {},
         "volumeMounts": [
           {

--- a/testdata/pods/graceful-delete/default.json
+++ b/testdata/pods/graceful-delete/default.json
@@ -19,6 +19,20 @@
             "protocol": "TCP"
           }
         ],
+        "env": [         
+          {
+            "name": "PORT",
+            "value": ""
+          },
+          {
+            "name": "SECOND_PORT",
+            "value": ""
+          },
+          {
+            "name": "TRAP_SIGNALS",
+            "value": "yes"
+         }
+      ],
         "resources": {},
         "volumeMounts": [
           {

--- a/testdata/pods/graceful-delete/default.json
+++ b/testdata/pods/graceful-delete/default.json
@@ -12,7 +12,7 @@
     "containers": [
       {
         "name": "sleep",
-        "image": "quay.io/openshifttest/sigcapture@sha256:e9c7ecf75c57def20f1964a119e858a7a45de9d3b21a384f5a32d9562a15270b",
+        "image": "quay.io/openshifttest/hello-openshift@sha256:0ed6e7163863e52438a5ed189d82e572a6c2ddd1b4db224c2c4b0688fee2c2cc",
         "ports": [
           {
             "containerPort": 8080,


### PR DESCRIPTION
This MR replaces the sigcapture image with the new multi-arch image.
Link to Jenkins runner [job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/parallel-runner/1414/). The one failed test case in this runner job should be discarded as it is out of scope.

Refers [OCPQE-6708](https://issues.redhat.com/browse/OCPQE-6708)

This has been tested for the following test cases:

[OCP-10705](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2021/11/18/02%3A47%3A12/Default_termination_grace_period_is_30s_if_it_s_not_set?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20211118%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20211118T192329Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=cb3508582b523c7e6006c1d67464de3b079fabda27c4bb299eee44ef5ff17494) - Default termination grace period is 30s if it's not set

[OCP-11184](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2021/11/18/02%3A47%3A12/Gracefully_delete_a_pod_with_--grace-period_option?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20211118%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20211118T192753Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=b872f50c537d06d9b2493c2bf4551734a7a253340a30ccfd04bd91a825a8cf38) -  Gracefully delete a pod with '--grace-period' option

[OCP-11526](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2021/11/18/02%3A47%3A04/Pod_should_be_immediately_deleted_if_TerminationGracePeriodSeconds_is_0?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20211118%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20211118T192902Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=6ab0a439ea4ba2c767bb38f992395e1e61a71823f5713ef24911178dc5f56e6a) - Pod should be immediately deleted if TerminationGracePeriodSeconds is 0

[OCP-12144](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2021/11/18/02%3A47%3A13/Verify_pod_is_gracefully_deleted_when_DeletionGracePeriodSeconds_is_specified?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20211118%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20211118T193059Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=428c13ae5f7a07d225feac9225b71a756edfb96a36649e5f52eacff7b93d575f) - Verify pod is gracefully deleted when DeletionGracePeriodSeconds is specified.