### PR TITLE
OCPQE-7067: Move token info from INFO to DEBUG level in logger

### DIFF
--- a/lib/rest.rb
+++ b/lib/rest.rb
@@ -23,7 +23,7 @@ module BushSlicer
         if opts[:_header]
           base_opts[:headers].merge!(normalize_header_list(opts.delete(:_header)))
         end
-        logger.info("REST #{req} for user '#{user}', base_opts: #{base_opts}, opts: #{opts}")
+        logger.debug("REST #{req} for user '#{user}', base_opts: #{base_opts}, opts: #{opts}")
         return delegate_rest_request(req, base_opts, opts)
       end
 


### PR DESCRIPTION
Previously,
```
      [02:52:35] INFO> HTTP GET testuser-43@https://oauth-openshift.apps.***RH***.com/oauth/authorize
      [02:52:36] INFO> HTTP GET took 1.117 sec: 302 Found
      [02:52:36] INFO> REST get_user for user 'BushSlicer::APIAccessor:@ocp4', base_opts: {:options=>{:api_version=>"v1", :accept=>"application/json", :content_type=>"application/json", :oauth_token=>"sha256~******"}, :base_url=>"https://api.***RH***.com:6443", :headers=>{"Accept"=>"<accept>", "Content-Type"=>"<content_type>", "Authorization"=>"Bearer <oauth_token>"}}, opts: {:username=>"~"}
      [02:52:36] INFO> HTTP GET https://api.***RH***.com:6443/apis/user.openshift.io/v1/users/~
      [02:52:37] INFO> HTTP GET took 1.042 sec: 200 OK | application/json 503 bytes
      
      [02:52:37] INFO> cleaning-up user testuser-43 projects
      [02:52:37] INFO> Shell Commands: rm  -f -- /home/jenkins/ws/workspace/Runner-v3-smoke/workdir/ocp4_testuser-43.kubeconfig
```

Now,
```
      [02:56:50] INFO> HTTP GET testuser-43@https://oauth-openshift.apps.***RH***.com/oauth/authorize
      [02:56:51] INFO> HTTP GET took 1.069 sec: 302 Found
      [02:56:51] INFO> HTTP GET https://api.***RH***.com:6443/apis/user.openshift.io/v1/users/~
      [02:56:52] INFO> HTTP GET took 1.026 sec: 200 OK | application/json 503 bytes
      
      [02:56:52] INFO> cleaning-up user testuser-43 projects
      [02:56:52] INFO> Shell Commands: rm  -f -- /home/jenkins/ws/workspace/Runner-v3-smoke/workdir/ocp4_testuser-43.kubeconfig
```