### PR TITLE
Move login info from logger.info to logger.debug

### DIFF
--- a/lib/local_process.rb
+++ b/lib/local_process.rb
@@ -30,7 +30,7 @@ module BushSlicer
         log_text << opts[:env].inject("") { |r,e| r << e.join('=') << "\n" }
       end
       log_text << result[:command]
-      logger.info(log_text) unless opts[:quiet]
+      logger.debug(log_text) unless opts[:quiet]
 
       spawn
     end


### PR DESCRIPTION
Previously,
```
      [02:52:40] INFO> Exit Status: 0
      [02:52:40] INFO> Shell Commands: oc login --token=sha256\~****** --server=https://api.***RH***.com:6443 --kubeconfig=/home/jenkins/ws/workspace/Runner-v3-smoke/workdir/ocp4_testuser-43.kubeconfig --insecure-skip-tls-verify=true
      Logged into "https://api.***RH***.com:6443" as "testuser-43" using the token provided.
      
      You don't have any projects. You can try to create a new project, by running
      
          oc new-project <projectname>
```

Now,
```
      [03:17:16] INFO> Exit Status: 0
      Logged into "https://api.***RH***.com:6443" as "testuser-43" using the token provided.
      
      You don't have any projects. You can try to create a new project, by running
      
          oc new-project <projectname>
```

/cc @jhou1 @JianLi-RH @dis016 @pruan-rht 