### PR TITLE
OCPQE-7067: Move login info to logger.debug when login failed

### DIFF
--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -127,8 +127,8 @@ module BushSlicer
       end
 
       unless res[:success]
-        # logger.error res[:response]
-        raise "cannot login with command: #{res[:instruction]}"
+        logger.debug res[:instruction]
+        raise "cannot login with command"
       end
     end
 


### PR DESCRIPTION
When the login failed due to any reason, the login commands are printed out.
```
11-23 06:48:46.953        [06:48:31] INFO> cleaning-up user testuser-20 projects
11-23 06:48:46.953        
11-23 06:48:46.953        [06:48:32] INFO> Exit Status: 0
11-23 06:48:46.953        
11-23 06:48:46.953        STDERR:
11-23 06:48:46.953        error: net/http: TLS handshake timeout
11-23 06:48:46.953        
11-23 06:48:46.953        [06:48:44] INFO> Exit Status: 1
11-23 06:48:46.953        cannot login with command: `oc login --token=sha256\~****** --server=https://api.******.com:6443 --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_testuser-20.kubeconfig --insecure-skip-tls-verify=true` (RuntimeError)
```

/cc @jhou1 @dis016 @JianLi-RH @pruan-rht 