### PR TITLE
Remove privileged configuration and support Arm

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -577,15 +577,6 @@ Given /^I create the resources for the receiver with:$/ do | table |
   step %Q/I use the "#{namespace}" project/
 
   unless tagged_upgrade?
-    step %Q/I ensure "#{receiver_name}" service_account is deleted from the "#{namespace}" project after scenario/
-  end
-  @result = user.cli_exec(:create_serviceaccount, serviceaccount_name: receiver_name, n: namespace)
-  raise "Unable to create serviceaccout #{receiver_name}" unless @result[:success]
-
-  if tagged_upgrade?
-    step %Q/SCC "privileged" is added to the "system:serviceaccount:<%= project.name %>:#{receiver_name}" service account without teardown/
-  else
-    step %Q/SCC "privileged" is added to the "system:serviceaccount:<%= project.name %>:#{receiver_name}" service account/
     step %Q/I ensure "#{receiver_name}" config_map is deleted from the "#{namespace}" project after scenario/
     step %Q/I ensure "#{receiver_name}" deployment is deleted from the "#{namespace}" project after scenario/
     step %Q/I ensure "#{receiver_name}" service is deleted from the "#{namespace}" project after scenario/
@@ -596,6 +587,7 @@ Given /^I create the resources for the receiver with:$/ do | table |
     @result = user.cli_exec(:create, f: file, n: namespace)
     raise "Unable to create resoure with #{file}" unless @result[:success]
   end
+
   if receiver_name == "rsyslogserver"
     svc_file = "#{BushSlicer::HOME}/testdata/logging/logforwarding/rsyslog/rsyslogserver_svc.yaml"
     @result = user.cli_exec(:create, f: svc_file, n: namespace)
@@ -604,9 +596,11 @@ Given /^I create the resources for the receiver with:$/ do | table |
     @result = user.cli_exec(:expose, name: receiver_name, resource: 'deployment', resource_name: receiver_name, namespace: namespace)
     raise "Unable to expose the service for #{receiver_name}" unless @result[:success]
   end
+
   step %Q/a pod becomes ready with labels:/, table(%{
     | #{pod_label} |
   })
+
   step %Q/evaluation of `pod` is stored in the :log_receiver clipboard/
 end
 

--- a/testdata/logging/clusterlogforwarder/elasticsearch/6.8/http/insecure/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/6.8/http/insecure/deployment.yaml
@@ -34,9 +34,6 @@ spec:
           protocol: TCP
         - containerPort: 9200
           protocol: TCP
-        securityContext:
-          privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           subPath: elasticsearch.yml
@@ -49,8 +46,6 @@ spec:
           defaultMode: 420
           name: elasticsearch-server
         name: elasticsearch-config
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 

--- a/testdata/logging/clusterlogforwarder/elasticsearch/6.8/http/transport_tls/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/6.8/http/transport_tls/deployment.yaml
@@ -34,9 +34,6 @@ spec:
           protocol: TCP
         - containerPort: 9200
           protocol: TCP
-        securityContext:
-          privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           subPath: elasticsearch.yml
@@ -55,7 +52,5 @@ spec:
         secret:
           defaultMode: 420
           secretName: elasticsearch-server
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/testdata/logging/clusterlogforwarder/elasticsearch/6.8/http/user_auth/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/6.8/http/user_auth/deployment.yaml
@@ -39,9 +39,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -55,8 +52,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/6.8/http/user_auth_with_transport_tls/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/6.8/http/user_auth_with_transport_tls/deployment.yaml
@@ -39,9 +39,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -57,8 +54,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/6.8/https/insecure/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/6.8/https/insecure/deployment.yaml
@@ -28,9 +28,6 @@ spec:
         - containerPort: 9200
           protocol: TCP
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -43,8 +40,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/6.8/https/transport_tls/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/6.8/https/transport_tls/deployment.yaml
@@ -29,9 +29,6 @@ spec:
         - containerPort: 9200
           protocol: TCP
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -44,8 +41,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/6.8/https/user_auth/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/6.8/https/user_auth/deployment.yaml
@@ -39,9 +39,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -57,8 +54,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/6.8/https/user_auth_with_transport_tls/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/6.8/https/user_auth_with_transport_tls/deployment.yaml
@@ -39,9 +39,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -57,8 +54,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/7.12/http/insecure/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/7.12/http/insecure/deployment.yaml
@@ -34,9 +34,6 @@ spec:
           protocol: TCP
         - containerPort: 9200
           protocol: TCP
-        securityContext:
-          privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           subPath: elasticsearch.yml
@@ -49,8 +46,6 @@ spec:
           defaultMode: 420
           name: elasticsearch-server
         name: elasticsearch-config
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 

--- a/testdata/logging/clusterlogforwarder/elasticsearch/7.12/http/transport_tls/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/7.12/http/transport_tls/deployment.yaml
@@ -34,9 +34,6 @@ spec:
           protocol: TCP
         - containerPort: 9200
           protocol: TCP
-        securityContext:
-          privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           subPath: elasticsearch.yml
@@ -55,7 +52,5 @@ spec:
         secret:
           defaultMode: 420
           secretName: elasticsearch-server
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/testdata/logging/clusterlogforwarder/elasticsearch/7.12/http/user_auth/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/7.12/http/user_auth/deployment.yaml
@@ -39,9 +39,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -55,8 +52,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/7.12/http/user_auth_with_transport_tls/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/7.12/http/user_auth_with_transport_tls/deployment.yaml
@@ -39,9 +39,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -57,8 +54,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/7.12/https/insecure/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/7.12/https/insecure/deployment.yaml
@@ -28,9 +28,6 @@ spec:
         - containerPort: 9200
           protocol: TCP
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -42,9 +39,6 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/7.12/https/transport_tls/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/7.12/https/transport_tls/deployment.yaml
@@ -29,9 +29,6 @@ spec:
         - containerPort: 9200
           protocol: TCP
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -43,9 +40,6 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/7.12/https/user_auth/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/7.12/https/user_auth/deployment.yaml
@@ -39,9 +39,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -57,8 +54,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/elasticsearch/7.12/https/user_auth_with_transport_tls/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/elasticsearch/7.12/https/user_auth_with_transport_tls/deployment.yaml
@@ -39,9 +39,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -57,8 +54,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:

--- a/testdata/logging/clusterlogforwarder/fluentd/insecure/configmap.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/insecure/configmap.yaml
@@ -3,7 +3,6 @@ data:
   fluent.conf: |
     <source>
       @type forward
-      bind ::
       port  24224
     </source>
 

--- a/testdata/logging/clusterlogforwarder/fluentd/insecure/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/insecure/deployment.yaml
@@ -25,24 +25,15 @@ spec:
     spec:
       containers:
       - name: "fluentdserver"
-        image: "quay.io/openshifttest/fluentd@sha256:7eece00d1bc784ac1e9722b2580911cd3ead5afd740dad6594be945b3b1dd884"
+        image: "quay.io/openshifttest/fluentd:multiarch@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
         imagePullPolicy: "IfNotPresent"
-        args:
-        - "fluentd"
-        - "-c"
-        - "/fluentd/etc/fluent.conf"
         ports:
         - containerPort: 24224
           name: fluentdserver
-        securityContext:
-          privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /fluentd/etc
           name: config
           readOnly: true
-      serviceAccount: fluentdserver
-      serviceAccountName: fluentdserver
       volumes:
       - configMap:
           defaultMode: 420

--- a/testdata/logging/clusterlogforwarder/fluentd/secure/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/secure/deployment.yaml
@@ -25,18 +25,11 @@ spec:
     spec:
       containers:
       - name: "fluentdserver"
-        image: "quay.io/openshifttest/fluentd@sha256:7eece00d1bc784ac1e9722b2580911cd3ead5afd740dad6594be945b3b1dd884"
+        image: "quay.io/openshifttest/fluentd:multiarch@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
         imagePullPolicy: "IfNotPresent"
-        args:
-        - "fluentd"
-        - "-c"
-        - "/fluentd/etc/fluent.conf"
         ports:
         - containerPort: 24224
           name: fluentdserver
-        securityContext:
-          privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /fluentd/etc
           name: config
@@ -44,8 +37,6 @@ spec:
         - mountPath: /etc/fluentd/secrets
           name: certs
           readOnly: true
-      serviceAccount: fluentdserver
-      serviceAccountName: fluentdserver
       volumes:
       - configMap:
           defaultMode: 420
@@ -55,4 +46,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: fluentdserver
-

--- a/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_configmap.yaml
+++ b/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_configmap.yaml
@@ -10,8 +10,8 @@ data:
     global(processInternalMessages="on")
     module(load="imptcp")
     module(load="imudp" TimeRequery="500")
-    input(type="imptcp" port="514")
-    input(type="imudp" port="514")
+    input(type="imptcp" port="6514")
+    input(type="imudp" port="6514")
     :programname, contains, "kubernetes.var.log.containers" {
       if $msg contains "namespace_name=openshift" or $msg contains "namespace_name=default" or $msg contains "namespace_name=kube" then /var/log/custom/infra-container.log
       if not ($msg contains "namespace_name=openshift" or $msg contains "namespace_name=default" or $msg contains "namespace_name=kube") then /var/log/custom/app-container.log

--- a/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_deployment.yaml
@@ -22,8 +22,6 @@ spec:
         component: "rsyslogserver"
         appname: rsyslogserver
     spec:
-      serviceAccount: rsyslogserver
-      serviceAccountName: rsyslogserver
       containers:
       - name: "rsyslog"
         args:
@@ -32,16 +30,13 @@ spec:
         - "-n"
         command:
         - "/usr/sbin/rsyslogd"
-        image: quay.io/openshifttest/rsyslog@sha256:11a93aa0cd836327f6d22926adf999c726916cdf404c61a7b702f98be4d43d70
+        image: quay.io/openshifttest/rsyslogd-container:multiarch@sha256:51a26abd1626e2e8bc422e0e92994fa823570cb7a6aab7b1ad37cf0b76912193
         imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: true
-          procMount: Default
         ports:
-        - containerPort: 514
+        - containerPort: 6514
           name: rsyslog-pod-tcp
           protocol: TCP
-        - containerPort: 514
+        - containerPort: 6514
           name: rsyslog-pod-udp
           protocol: UDP
         volumeMounts:

--- a/testdata/logging/clusterlogforwarder/rsyslog/rsyslogserver_svc.yaml
+++ b/testdata/logging/clusterlogforwarder/rsyslog/rsyslogserver_svc.yaml
@@ -11,11 +11,11 @@ spec:
   ports:
   - name: rsyslogserver-tcp
     port: 514
-    targetPort: 514
+    targetPort: 6514
     protocol: TCP
   - name: rsyslogserver-udp
     port: 514
-    targetPort: 514
+    targetPort: 6514
     protocol: UDP
   selector:
     appname: rsyslogserver

--- a/testdata/logging/logforwarding/elasticsearch/insecure/deployment.yaml
+++ b/testdata/logging/logforwarding/elasticsearch/insecure/deployment.yaml
@@ -34,9 +34,6 @@ spec:
           protocol: TCP
         - containerPort: 9200
           protocol: TCP
-        securityContext:
-          privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           subPath: elasticsearch.yml
@@ -49,8 +46,6 @@ spec:
           defaultMode: 420
           name: elasticsearch-server
         name: elasticsearch-config
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 

--- a/testdata/logging/logforwarding/elasticsearch/secure/deployment.yaml
+++ b/testdata/logging/logforwarding/elasticsearch/secure/deployment.yaml
@@ -34,9 +34,6 @@ spec:
           protocol: TCP
         - containerPort: 9200
           protocol: TCP
-        securityContext:
-          privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           subPath: elasticsearch.yml
@@ -55,7 +52,5 @@ spec:
         secret:
           defaultMode: 420
           secretName: elasticsearch-server
-      serviceAccount: elasticsearch-server
-      serviceAccountName: elasticsearch-server
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/testdata/logging/logforwarding/fluentd/insecure/deployment.yaml
+++ b/testdata/logging/logforwarding/fluentd/insecure/deployment.yaml
@@ -25,24 +25,15 @@ spec:
     spec:
       containers:
       - name: "fluentdserver"
-        image: "quay.io/openshifttest/fluentd@sha256:7eece00d1bc784ac1e9722b2580911cd3ead5afd740dad6594be945b3b1dd884"
+        image: "quay.io/openshifttest/fluentd:multiarch@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
         imagePullPolicy: "IfNotPresent"
-        args:
-        - "fluentd"
-        - "-c"
-        - "/fluentd/etc/fluent.conf"
         ports:
         - containerPort: 24224
           name: fluentdserver
-        securityContext:
-          privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /fluentd/etc
           name: config
           readOnly: true
-      serviceAccount: fluentdserver
-      serviceAccountName: fluentdserver
       volumes:
       - configMap:
           defaultMode: 420

--- a/testdata/logging/logforwarding/fluentd/secure/deployment.yaml
+++ b/testdata/logging/logforwarding/fluentd/secure/deployment.yaml
@@ -25,18 +25,11 @@ spec:
     spec:
       containers:
       - name: "fluentdserver"
-        image: "quay.io/openshifttest/fluentd@sha256:7eece00d1bc784ac1e9722b2580911cd3ead5afd740dad6594be945b3b1dd884"
+        image: "quay.io/openshifttest/fluentd:multiarch@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
         imagePullPolicy: "IfNotPresent"
-        args:
-        - "fluentd"
-        - "-c"
-        - "/fluentd/etc/fluent.conf"
         ports:
         - containerPort: 24224
           name: fluentdserver
-        securityContext:
-          privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /fluentd/etc
           name: config
@@ -44,8 +37,6 @@ spec:
         - mountPath: /etc/fluentd/secrets
           name: certs
           readOnly: true
-      serviceAccount: fluentdserver
-      serviceAccountName: fluentdserver
       volumes:
       - configMap:
           defaultMode: 420

--- a/testdata/logging/logforwarding/rsyslog/insecure/rsyslogserver_deployment.yaml
+++ b/testdata/logging/logforwarding/rsyslog/insecure/rsyslogserver_deployment.yaml
@@ -22,8 +22,6 @@ spec:
         component: "rsyslogserver"
         appname: rsyslogserver
     spec:
-      serviceAccount: rsyslogserver
-      serviceAccountName: rsyslogserver
       containers:
       - name: "rsyslog"
         args:
@@ -32,16 +30,13 @@ spec:
         - "-n"
         command:
         - "/usr/sbin/rsyslogd"
-        image: quay.io/openshifttest/rsyslog@sha256:11a93aa0cd836327f6d22926adf999c726916cdf404c61a7b702f98be4d43d70
+        image: quay.io/openshifttest/rsyslogd-container:multiarch@sha256:51a26abd1626e2e8bc422e0e92994fa823570cb7a6aab7b1ad37cf0b76912193
         imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: true
-          procMount: Default
         ports:
-        - containerPort: 514
+        - containerPort: 6514
           name: rsyslog-pod-tcp
           protocol: TCP
-        - containerPort: 514
+        - containerPort: 6514
           name: rsyslog-pod-udp
           protocol: UDP
         volumeMounts:

--- a/testdata/logging/logforwarding/rsyslog/rsyslogserver_svc.yaml
+++ b/testdata/logging/logforwarding/rsyslog/rsyslogserver_svc.yaml
@@ -11,11 +11,11 @@ spec:
   ports:
   - name: rsyslogserver-tcp
     port: 514
-    targetPort: 514
+    targetPort: 6514
     protocol: TCP
   - name: rsyslogserver-udp
     port: 514
-    targetPort: 514
+    targetPort: 6514
     protocol: UDP
   selector:
     appname: rsyslogserver


### PR DESCRIPTION
- support non-privileged mode by modifing the Dockerfile. (Main chmod 755 workdir). The images had been pushed to quay.io/openshift-tests.
- Remove the code about sa and scc
- Replace 514 with 6514 in syslog as the non-privilege user can not bind port <1024.
- The rsyslogserver is still using 514. so no change in CLF.
