### PR TITLE
Move specific commands which contains sensitive info to logger.debug

### DIFF
--- a/lib/local_process.rb
+++ b/lib/local_process.rb
@@ -30,7 +30,11 @@ module BushSlicer
         log_text << opts[:env].inject("") { |r,e| r << e.join('=') << "\n" }
       end
       log_text << result[:command]
-      logger.debug(log_text) unless opts[:quiet]
+      if ['oc login','oc get secret','oc whoami','oc serviceaccount'].any? { |cmd| log_text.include?(cmd) }
+        logger.debug(log_text) unless opts[:quiet]
+      else
+        logger.info(log_text) unless opts[:quiet]
+      end
 
       spawn
     end


### PR DESCRIPTION
Previously we move all the commands to logger.debug as some of the commands contains sensitive info, https://github.com/openshift/verification-tests/pull/2494