### PR TITLE
Add security tag for cases are likely to expose sensitive information

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -67,6 +67,7 @@ Feature: Machine features testing
 
 
   # @author jhou@redhat.com
+  @security
   @admin
   @4.10 @4.9
   Scenario Outline: Metrics is exposed on https

--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -5,6 +5,7 @@ Feature: Machine misc features testing
   @inactive
   @admin
   @destructive
+  @security
   @4.10 @4.9
   @vsphere-ipi
   Scenario: PVCs can still be provisioned after the password has been changed vSphere


### PR DESCRIPTION
According to https://issues.redhat.com/browse/OCPQE-7097, add security tag for cases are likely to expose sensitive information. @jhou1 @miyadav @huali9 please help to take a look.