### PR TITLE
Protect sensitive information from logger

### DIFF
--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -2,7 +2,6 @@ Feature: Machine misc features testing
 
   # @author miyadav@redhat.com
   # @case_id OCP-34940
-  @inactive
   @admin
   @destructive
   @4.10 @4.9

--- a/features/storage/csi_snapshot.feature
+++ b/features/storage/csi_snapshot.feature
@@ -1,7 +1,6 @@
 Feature: Volume snapshot test
 
   # @author wduan@redhat.com
-  @inactive
   @admin
   @4.8 @4.7 @4.10 @4.9
   Scenario Outline: Volume snapshot create and restore test
@@ -74,8 +73,6 @@ Feature: Volume snapshot test
       | standard-csi | standard-csi |# @case_id OCP-37568
 
   # @author wduan@redhat.com
-  @admin
-  @inactive
   @admin
   @4.8 @4.7 @4.10 @4.9
   Scenario Outline: Volume snapshot create and restore test with block

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -107,7 +107,6 @@ Feature: storageClass related feature
       | aws-ebs     | st1         | us-east-1d    | false      | 500Gi | # @case_id OCP-10424
 
   # @author lxia@redhat.com
-  @inactive
   @admin
   @destructive
   @4.8 @4.7 @4.10 @4.9

--- a/lib/log.rb
+++ b/lib/log.rb
@@ -115,7 +115,7 @@ module BushSlicer
         timestamp = ''
       end
 
-      m = {msg: msg, level: level, timestamp: timestamp}
+      m = {msg: censor(msg), level: level, timestamp: timestamp}
       if @dup_buffer
         @dup_buffer.push(m)
       else
@@ -181,6 +181,21 @@ module BushSlicer
 
     def reset_dedup
       @dup_buffer.reset if @dup_buffer
+    end
+
+    private
+    def censor(msg)
+      secured_lines = []
+      lines = msg.split("\n")
+      censor_kw = %w[client_id client-id client_secret client-secret subscription_id tenant_id access_key_id secret_access_key secret authorization username password oauth token .dockercfg .dockerconfigjson kubeconfig htpasswd ca service-ca tls service-account service_account serviceaccount cloud pull_secret pull-secret cred key]
+      lines.each do |line|
+        if censor_kw.any? { |kw| line.downcase.match(/^.*#{kw}.*:.*/) }
+          secured_lines << line.downcase.gsub(/:.*/, ': [PROTECTED_DATA]')
+          next
+        end
+        secured_lines << line
+      end
+      secured_lines.join("\n")
     end
 
     # map messages to unique characters, then run a regular expression to


### PR DESCRIPTION
This will protect sensitive information in logger. The logger format it generates will look like. 
@liangxia @pruan-rht @JianLi-RH @dis016 PTAL

```
     apiVersion: v1
      data:
        azure_client_id: [PROTECTED_DATA]
        azure_client_secret: [PROTECTED_DATA]
```