### PR TITLE
Network policy ACL Logging Upgrade test (Networking Quality OKR)

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -517,18 +517,18 @@ Feature: SDN compoment upgrade testing
     """
 
     When I run the :new_project client command with:
-      | project_name | policy-upgrade6 |
+      | project_name | policy-acl-upgrade1 |
     Then the step should succeed
-    And evaluation of `"policy-upgrade6"` is stored in the :proj1 clipboard
+    And evaluation of `"policy-acl-upgrade1"` is stored in the :proj1 clipboard
     When I run the :annotate admin command with:
       | resource     | namespace                                                |
       | resourcename | <%= cb.proj1 %>                                          |
       | keyval       | k8s.ovn.org/acl-logging={"deny":"alert","allow":"alert"} |
     Then the step should succeed
     When I run the :new_project client command with:
-      | project_name | policy-upgrade7 |
+      | project_name | policy-acl-upgrade2 |
     Then the step should succeed
-    And evaluation of `"policy-upgrade7"` is stored in the :proj2 clipboard
+    And evaluation of `"policy-acl-upgrade2"` is stored in the :proj2 clipboard
     When I run the :label admin command with:
       | resource | namespace       |
       | name     | <%= cb.proj2 %> |
@@ -601,8 +601,8 @@ Feature: SDN compoment upgrade testing
     Given I switch to cluster admin pseudo user
     Given the env is using "OVNKubernetes" networkType
     And evaluation of `"rsyslog-server"` is stored in the :proj0 clipboard
-    And evaluation of `"policy-upgrade6"` is stored in the :proj1 clipboard
-    And evaluation of `"policy-upgrade7"` is stored in the :proj2 clipboard
+    And evaluation of `"policy-acl-upgrade1"` is stored in the :proj1 clipboard
+    And evaluation of `"policy-acl-upgrade2"` is stored in the :proj2 clipboard
     Given I use the "<%= cb.proj0 %>" project
     Given I wait for the "rsyslogserver" service to become ready
     Given a pod becomes ready with labels:

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -576,7 +576,7 @@ Feature: SDN compoment upgrade testing
     
     Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod2name %>" pod:
-      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 2 |
+      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 20 |
     Then the output should not contain "200 OK"
     And I wait up to 20 seconds for the steps to pass:
     """
@@ -644,7 +644,7 @@ Feature: SDN compoment upgrade testing
     
     Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod2name %>" pod:
-      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 2 |
+      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 20 |
     Then the output should not contain "200 OK"
     Then the step should fail
     And I wait up to 20 seconds for the steps to pass:

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -565,7 +565,7 @@ Feature: SDN compoment upgrade testing
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.p2pod1name %>" pod:
-      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 5 |
+      | curl | -I | <%= cb.p1pod1ip %>:8080 | 
     Then the output should contain "200 OK"
     Then the step should succeed
     Given I use the "<%= cb.proj0 %>" project
@@ -629,7 +629,7 @@ Feature: SDN compoment upgrade testing
     And I wait up to 30 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.p2pod1name %>" pod:
-      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 5 |
+      | curl | -I | <%= cb.p1pod1ip %>:8080 | 
     Then the output should contain "200 OK"
     Then the step should succeed
     Given I use the "<%= cb.proj0 %>" project

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -575,7 +575,7 @@ Feature: SDN compoment upgrade testing
     
     Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod2name %>" pod:
-      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 5 |
+      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 2 |
     Then the output should not contain "200 OK"
     Then the step should fail
     Given I use the "<%= cb.proj0 %>" project
@@ -639,7 +639,7 @@ Feature: SDN compoment upgrade testing
     
     Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod2name %>" pod:
-      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 5 |
+      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 2 |
     Then the output should not contain "200 OK"
     Then the step should fail
     Given I use the "<%= cb.proj0 %>" project

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -564,6 +564,7 @@ Feature: SDN compoment upgrade testing
     And evaluation of `pod(3).name` is stored in the :p2pod2name clipboard
     And I wait up to 20 seconds for the steps to pass:
     """
+    Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod1name %>" pod:
       | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 5 | 
     Then the output should contain "200 OK"
@@ -572,7 +573,10 @@ Feature: SDN compoment upgrade testing
     When I execute on the "<%= cb.rsyslog_server_pod %>" pod:
       | grep | -w | verdict=allow | /var/log/messages |
     Then the output should contain "verdict=allow"
+    """
     
+    And I wait up to 20 seconds for the steps to pass:
+    """
     Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod2name %>" pod:
       | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 2 |
@@ -626,8 +630,9 @@ Feature: SDN compoment upgrade testing
     Given a pod becomes ready with labels:
       | name=hello-idle |
     And evaluation of `pod(3).name` is stored in the :p2pod2name clipboard
-    And I wait up to 30 seconds for the steps to pass:
+    And I wait up to 20 seconds for the steps to pass:
     """
+    Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod1name %>" pod:
       | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 5 | 
     Then the output should contain "200 OK"
@@ -636,7 +641,10 @@ Feature: SDN compoment upgrade testing
     When I execute on the "<%= cb.rsyslog_server_pod %>" pod:
       | grep | -w | verdict=allow | /var/log/messages |
     Then the output should contain "verdict=allow"
+    """
     
+    And I wait up to 20 seconds for the steps to pass:
+    """
     Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod2name %>" pod:
       | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 2 |

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -363,10 +363,10 @@ Feature: SDN compoment upgrade testing
       | name=test-pods |
     And evaluation of `pod(2).ip_url` is stored in the :p5pod1ip clipboard
     Given I save multus pod on master node to the :multuspod clipboard
-    And I wait up to 30 seconds for the steps to pass:
-    """
     Given I switch to cluster admin pseudo user
     Given I use the "openshift-multus" project
+    And I wait up to 30 seconds for the steps to pass:
+    """
     When I execute on the "<%= cb.multuspod %>" pod:
       | curl | -I | <%= cb.p5pod1ip %>:8080 |
     Then the step should succeed
@@ -562,25 +562,24 @@ Feature: SDN compoment upgrade testing
     Given a pod becomes ready with labels:
       | name=hello-idle |
     And evaluation of `pod(3).name` is stored in the :p2pod2name clipboard
-    And I wait up to 20 seconds for the steps to pass:
-    """
-    Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod1name %>" pod:
       | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 5 | 
     Then the output should contain "200 OK"
     Then the step should succeed
     Given I use the "<%= cb.proj0 %>" project
+    And I wait up to 20 seconds for the steps to pass:
+    """
     When I execute on the "<%= cb.rsyslog_server_pod %>" pod:
       | grep | -w | verdict=allow | /var/log/messages |
     Then the output should contain "verdict=allow"
     """
     
-    And I wait up to 20 seconds for the steps to pass:
-    """
     Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod2name %>" pod:
       | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 2 |
     Then the output should not contain "200 OK"
+    And I wait up to 20 seconds for the steps to pass:
+    """
     Then the step should fail
     Given I use the "<%= cb.proj0 %>" project
     When I execute on the "<%= cb.rsyslog_server_pod %>" pod:
@@ -630,26 +629,26 @@ Feature: SDN compoment upgrade testing
     Given a pod becomes ready with labels:
       | name=hello-idle |
     And evaluation of `pod(3).name` is stored in the :p2pod2name clipboard
-    And I wait up to 20 seconds for the steps to pass:
-    """
-    Given I use the "<%= cb.proj2 %>" project
+
     When I execute on the "<%= cb.p2pod1name %>" pod:
       | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 5 | 
     Then the output should contain "200 OK"
     Then the step should succeed
     Given I use the "<%= cb.proj0 %>" project
+    And I wait up to 20 seconds for the steps to pass:
+    """
     When I execute on the "<%= cb.rsyslog_server_pod %>" pod:
       | grep | -w | verdict=allow | /var/log/messages |
     Then the output should contain "verdict=allow"
     """
     
-    And I wait up to 20 seconds for the steps to pass:
-    """
     Given I use the "<%= cb.proj2 %>" project
     When I execute on the "<%= cb.p2pod2name %>" pod:
       | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 2 |
     Then the output should not contain "200 OK"
     Then the step should fail
+    And I wait up to 20 seconds for the steps to pass:
+    """
     Given I use the "<%= cb.proj0 %>" project
     When I execute on the "<%= cb.rsyslog_server_pod %>" pod:
       | grep | -w | verdict=drop | /var/log/messages |

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -506,6 +506,10 @@ Feature: SDN compoment upgrade testing
 
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"policyAuditConfig": {"destination": "udp:<%= cb.svc_ip %>:514" }}}}} |
+    And I wait up to 30 seconds for the steps to pass:
+    """
+      Given the status of condition "Progressing" for network operator is :True
+    """
     And I wait up to 300 seconds for the steps to pass:
     """
       Given the status of condition "Progressing" for network operator is :False

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -610,14 +610,6 @@ Feature: SDN compoment upgrade testing
     And evaluation of `pod(0).name` is stored in the :rsyslog_server_pod clipboard
     Then the step should succeed
 
-    Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
-      | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"policyAuditConfig": {"destination": "udp:<%= cb.svc_ip %>:514" }}}}} |
-    And I wait up to 300 seconds for the steps to pass:
-    """
-      Given the status of condition "Progressing" for network operator is :False
-      And the status of condition "Available" for network operator is :True
-    """
-
     Given I use the "<%= cb.proj1 %>" project
     Given a pod becomes ready with labels:
       | name=test-pods |

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -565,7 +565,7 @@ Feature: SDN compoment upgrade testing
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.p2pod1name %>" pod:
-      | curl | -I | <%= cb.p1pod1ip %>:8080 | 
+      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 5 | 
     Then the output should contain "200 OK"
     Then the step should succeed
     Given I use the "<%= cb.proj0 %>" project
@@ -593,7 +593,7 @@ Feature: SDN compoment upgrade testing
   @aws-upi @gcp-upi @openstack-upi
   @destructive
   @network-ovnkubernetes
-  Scenario: Check network policy ACL logging works post upgrade -prepare
+  Scenario: Check network policy ACL logging works post upgrade 
     Given I switch to cluster admin pseudo user
     Given the env is using "OVNKubernetes" networkType
     And evaluation of `"rsyslog-server"` is stored in the :proj0 clipboard
@@ -629,7 +629,7 @@ Feature: SDN compoment upgrade testing
     And I wait up to 30 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.p2pod1name %>" pod:
-      | curl | -I | <%= cb.p1pod1ip %>:8080 | 
+      | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 5 | 
     Then the output should contain "200 OK"
     Then the step should succeed
     Given I use the "<%= cb.proj0 %>" project


### PR DESCRIPTION
Tested in upgrade path from 4.9->4.10
[
  {
    "completionTime": "2021-11-24T16:01:44Z",
    "image": "registry.ci.openshift.org/ocp/release:4.10.0-0.nightly-2021-11-24-030137",
    "startedTime": "2021-11-24T14:50:19Z",
    "state": "Completed",
    "verified": false,
    "version": "4.10.0-0.nightly-2021-11-24-030137"
  },
  {
    "completionTime": "2021-11-24T13:20:40Z",
    "image": "registry.ci.openshift.org/ocp/release@sha256:9f143e47e6cf2e880af243ab3e23e0b6db0f75559c1782f9edf911906a50878e",
    "startedTime": "2021-11-24T12:52:36Z",
    "state": "Completed",
    "verified": false,
    "version": "4.9.0-0.nightly-2021-11-24-022504"
  }
]


Test logs:-
http://file.rdu.redhat.com/~asood/OCP-44978-pre.log
http://file.rdu.redhat.com/~asood/OCP-44978-post.log

@openshift/team-sdn-qe