### PR TITLE
OCPQE-6985: Replaced iperf3 with mcast-pod multi-arch image

### DIFF
--- a/lib/rules/web/ocm_console/cluster_detail_access_control_tab.xyaml
+++ b/lib/rules/web/ocm_console/cluster_detail_access_control_tab.xyaml
@@ -269,3 +269,72 @@ click_delete_button_in_AWS_infrastructure_role_action_dropdown:
     selector:
       xpath: //li/button[text()='Delete']
     op: click
+grant_OCM_roles_and_access_with_valid:
+  action: check_OCM_roles_and_access_part_loaded
+  action: click_grant_role_button_in_tab
+  action: check_grant_OCM_roles_and_access_dialog_loaded
+  action: add_OCM_roles_and_access_role
+  action: check_OCM_roles_and_access_created
+check_OCM_roles_and_access_part_loaded:
+  elements:
+  - selector:
+      xpath: //h3[text()='OCM Roles and Access']
+  - selector:
+      xpath: //button[text()='Grant role']
+check_grant_OCM_roles_and_access_dialog_loaded:
+  elements:
+  - selector:
+      xpath: //span[text()='Grant role']
+  - selector:
+      xpath: //h4[text()='This user will be granted with Cluster Editor role and will be able to manage and configure the cluster.']
+click_grant_role_button_in_tab:
+  elements:
+  - selector:
+      xpath: //div/h3[text()='OCM Roles and Access']/../button[text()='Grant role']
+    op: click
+check_popover_content_for_username:
+  element:
+    selector:
+      xpath: //section[@id='accessControlTabContent']//div[@id='cluster-details-access-control-tab-contents']//table[@role='grid']//thead/tr/th[text()='Username']/button[@class='pf-c-button pf-m-plain']
+    op: click
+  elements:
+  - selector:
+      xpath: //div[@aria-label='Username']/div[@class='pf-c-popover__content']//p[contains(.,'Red Hat login')]
+  - selector:
+      xpath: //div[@aria-label='Username']/div[@class='pf-c-popover__content']//button[@aria-label='Close']
+add_OCM_roles_and_access_role:
+  element:
+    selector:
+      xpath: //input[@id='username']
+    op: send_keys <user_id>
+  action: click_grant_role_button_in_dialog
+check_OCM_roles_and_access_created:
+  elements:
+  - selector:
+      xpath: //tr/td/span[text()='<user_id>']
+    timeout: 30
+  - selector:
+      xpath: //tr/td[text()='Cluster Editor']  
+grant_OCM_roles_and_access_with_invalid:
+  action: check_OCM_roles_and_access_part_loaded
+  action: click_grant_role_button_in_tab
+  action: check_grant_OCM_roles_and_access_dialog_loaded
+  action: add_OCM_roles_and_access_role
+  element:
+    selector:
+      xpath: //div[contains(.,'<error_message>')]
+  action: click_cancel_button
+check_OCM_roles_and_access_disabled:
+  action: check_OCM_roles_and_access_part_loaded
+  element:
+    selector:
+      xpath: //button[@aria-disabled='true' and text()='Grant role']
+remove_OCM_roles_and_access:
+  elements:
+  - selector:
+      xpath: //td[@data-label='Username']/span[text()='<user_id>']/../..//button[@aria-label='Actions']
+    timeout: 30
+    op: click
+  - selector:
+      xpath: //button[text()='Delete']
+    op: click

--- a/testdata/networking/egress-ingress/qos/iperf-rc.json
+++ b/testdata/networking/egress-ingress/qos/iperf-rc.json
@@ -23,6 +23,7 @@
                 "containers": [
                     {
                         "image": "quay.io/openshifttest/mcast-pod@sha256:7cccaa51ca2da1dba019ca2817674d0f35762e6dd099187184ff73e01f8764e4",
+                        "command": "iperf3",
                         "name": "iperf",
                         "imagePullPolicy": "IfNotPresent",
                         "resources":{

--- a/testdata/networking/egress-ingress/qos/iperf-rc.json
+++ b/testdata/networking/egress-ingress/qos/iperf-rc.json
@@ -22,7 +22,7 @@
             "spec": {
                 "containers": [
                     {
-                        "image": "quay.io/openshifttest/hello-sdn@sha256:afdac7d35d6fc61d0f61c991b7657bb638892add8ed8acc6541cc7b605dcfd80",
+                        "image": "quay.io/openshifttest/mcast-pod@sha256:7cccaa51ca2da1dba019ca2817674d0f35762e6dd099187184ff73e01f8764e4",
                         "name": "iperf",
                         "imagePullPolicy": "IfNotPresent",
                         "resources":{

--- a/testdata/networking/egress-ingress/qos/iperf-rc.json
+++ b/testdata/networking/egress-ingress/qos/iperf-rc.json
@@ -23,7 +23,6 @@
                 "containers": [
                     {
                         "image": "quay.io/openshifttest/mcast-pod@sha256:7cccaa51ca2da1dba019ca2817674d0f35762e6dd099187184ff73e01f8764e4",
-                        "command": "iperf3",
                         "name": "iperf",
                         "imagePullPolicy": "IfNotPresent",
                         "resources":{

--- a/testdata/networking/egress-ingress/qos/iperf-rc.json
+++ b/testdata/networking/egress-ingress/qos/iperf-rc.json
@@ -22,7 +22,7 @@
             "spec": {
                 "containers": [
                     {
-                        "image": "quay.io/openshifttest/iperf3@sha256:440c59251338e9fcf0a00d822878862038d3b2e2403c67c940c7781297953614",
+                        "image": "quay.io/openshifttest/hello-sdn@sha256:afdac7d35d6fc61d0f61c991b7657bb638892add8ed8acc6541cc7b605dcfd80",
                         "name": "iperf",
                         "imagePullPolicy": "IfNotPresent",
                         "resources":{

--- a/testdata/networking/egress-ingress/qos/iperf-server.json
+++ b/testdata/networking/egress-ingress/qos/iperf-server.json
@@ -7,7 +7,7 @@
   "spec": {
       "containers": [{
         "name": "iperf-server",
-        "image": "quay.io/openshifttest/iperf3@sha256:440c59251338e9fcf0a00d822878862038d3b2e2403c67c940c7781297953614",
+        "image": "quay.io/openshifttest/hello-sdn@sha256:afdac7d35d6fc61d0f61c991b7657bb638892add8ed8acc6541cc7b605dcfd80",
     	"command": [
 	      "iperf3"
     	],

--- a/testdata/networking/egress-ingress/qos/iperf-server.json
+++ b/testdata/networking/egress-ingress/qos/iperf-server.json
@@ -11,9 +11,9 @@
     	"command": [
 	      "iperf3"
     	],
-    	 "args":[
+    	"args":[
     	  "-s"
-    	 ]
+    	]
       }]
   }
 }

--- a/testdata/networking/egress-ingress/qos/iperf-server.json
+++ b/testdata/networking/egress-ingress/qos/iperf-server.json
@@ -7,7 +7,7 @@
   "spec": {
       "containers": [{
         "name": "iperf-server",
-        "image": "quay.io/openshifttest/hello-sdn@sha256:afdac7d35d6fc61d0f61c991b7657bb638892add8ed8acc6541cc7b605dcfd80",
+        "image": "quay.io/openshifttest/mcast-pod@sha256:7cccaa51ca2da1dba019ca2817674d0f35762e6dd099187184ff73e01f8764e4",
     	"command": [
 	      "iperf3"
     	],

--- a/testdata/networking/egress-ingress/qos/iperf-server.json
+++ b/testdata/networking/egress-ingress/qos/iperf-server.json
@@ -8,12 +8,9 @@
       "containers": [{
         "name": "iperf-server",
         "image": "quay.io/openshifttest/mcast-pod@sha256:7cccaa51ca2da1dba019ca2817674d0f35762e6dd099187184ff73e01f8764e4",
-    	"command": [
-	      "iperf3"
-    	],
-    	"args":[
+    	  "args":[
     	  "-s"
-    	]
+    	  ]
       }]
   }
 }

--- a/testdata/networking/egress-ingress/qos/iperf-server.json
+++ b/testdata/networking/egress-ingress/qos/iperf-server.json
@@ -8,9 +8,12 @@
       "containers": [{
         "name": "iperf-server",
         "image": "quay.io/openshifttest/mcast-pod@sha256:7cccaa51ca2da1dba019ca2817674d0f35762e6dd099187184ff73e01f8764e4",
-    	  "args":[
+    	"command": [
+	      "iperf3"
+    	],
+    	 "args":[
     	  "-s"
-    	  ]
+    	 ]
       }]
   }
 }

--- a/testdata/networking/iperf_nodeport_service.json
+++ b/testdata/networking/iperf_nodeport_service.json
@@ -15,7 +15,7 @@
         "containers": [
           {
             "name": "iperf-server",
-            "image": "quay.io/openshifttest/hello-sdn@sha256:afdac7d35d6fc61d0f61c991b7657bb638892add8ed8acc6541cc7b605dcfd80",
+            "image": "quay.io/openshifttest/mcast-pod@sha256:7cccaa51ca2da1dba019ca2817674d0f35762e6dd099187184ff73e01f8764e4",
             "ports": [
               {
                 "containerPort": 5201

--- a/testdata/networking/iperf_nodeport_service.json
+++ b/testdata/networking/iperf_nodeport_service.json
@@ -15,7 +15,7 @@
         "containers": [
           {
             "name": "iperf-server",
-            "image": "quay.io/openshifttest/iperf3@sha256:440c59251338e9fcf0a00d822878862038d3b2e2403c67c940c7781297953614",
+            "image": "quay.io/openshifttest/hello-sdn@sha256:afdac7d35d6fc61d0f61c991b7657bb638892add8ed8acc6541cc7b605dcfd80",
             "ports": [
               {
                 "containerPort": 5201


### PR DESCRIPTION
This MR replaces the iperf3 image with the new multi-arch image.
Link to Jenkins runner [job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/parallel-runner/2115/). The one failed test case in this runner job should be discarded as per the slack conversation with @zhaozhanqi  

Refers [OCPQE-6985](https://issues.redhat.com/browse/OCPQE-6985)

This has been tested for the following test cases:

[OCP-10817](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2021/11/24/18%3A05%3A48/Traffic_flow_shouldn_t_be_interrupted_when_master_switches_the_leader_positions?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20211124%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20211124T183438Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=26f5698a3af41b4a3e9c9eb23b3f4f0221dba113977004ac3459e5eebdf204db) - Check QoS after creating pod

[OCP-26139](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2021/11/24/18%3A03%3A56/Check_QoS_after_creating_pod?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20211124%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20211124T183511Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=92086a251d0accf7d71495fdbc5caf86277484ec3d74971afb499c8b702ef928) - Traffic flow shouldn't be interrupted when master switches the leader positions ( Please ignore this failed test case)
