### PR TITLE
Fix NoMethodError in censor

### DIFF
--- a/lib/log.rb
+++ b/lib/log.rb
@@ -185,6 +185,7 @@ module BushSlicer
 
     private
     def censor(msg)
+      return if msg.nil?
       secured_lines = []
       lines = msg.split("\n")
       censor_kw = %w[client_id client-id client_secret client-secret subscription_id tenant_id access_key_id secret_access_key secret authorization username password oauth token .dockercfg .dockerconfigjson kubeconfig htpasswd ca service-ca tls service-account service_account serviceaccount cloud pull_secret pull-secret cred key]


### PR DESCRIPTION
This fixes, when the `msg` sent to logger is nil. @liangxia @pruan-rht @anpingli @QiaolingTang PTAL

```
[14:15:41] INFO> 1 iterations for 2 sec, returned 6 pods, 6 matching
      undefined method `split' for nil:NilClass (NoMethodError)
      /home/anli/cucushift-runtime2/verification-tests/lib/log.rb:189:in `censor'
      /home/anli/cucushift-runtime2/verification-tests/lib/log.rb:118:in `log'
      /home/anli/cucushift-runtime2/verification-tests/lib/log.rb:131:in `info'
```
