### PR TITLE
Update censor's keywords

### DIFF
--- a/lib/log.rb
+++ b/lib/log.rb
@@ -188,11 +188,16 @@ module BushSlicer
       return if msg.nil?
       secured_lines = []
       lines = msg.split("\n")
-      censor_kw = %w[client_id client-id client_secret client-secret subscription_id tenant_id access_key_id secret_access_key secret authorization username password oauth token .dockercfg .dockerconfigjson kubeconfig htpasswd ca service-ca tls service-account service_account serviceaccount cloud pull_secret pull-secret cred key]
+      censor_kw = [
+        'data:',
+        '"data":',
+        'kind: secret',
+        '"kind": "secret"'
+      ]
       lines.each do |line|
-        if censor_kw.any? { |kw| line.downcase.match(/^.*#{kw}.*:.*/) }
-          secured_lines << line.downcase.gsub(/:.*/, ': [PROTECTED_DATA]')
-          next
+        if censor_kw.any? { |kw| line.downcase.include?(kw) }
+          secured_lines.clear()
+          break
         end
         secured_lines << line
       end


### PR DESCRIPTION
/cc @jhou1 @dis016 @JianLi-RH @pruan-rht 
Test log,
```
waiting for operation up to 3600 seconds..
    And I run the :get client command with: # features/step_definitions/cli.rb:13
      | resource | secrets |
      [02:37:45] INFO> Shell Commands: oc get secrets --kubeconfig=/home/lxia/workdir/lxiabox-lxiax/ocp4_testuser-43.kubeconfig
      NAME                       TYPE                                  DATA   AGE
      builder-dockercfg-rcr8p    kubernetes.io/dockercfg               1      3s
      builder-token-kgwq2        kubernetes.io/service-account-token   4      3s
      builder-token-rb29r        kubernetes.io/service-account-token   4      3s
      default-dockercfg-tkbpm    kubernetes.io/dockercfg               1      3s
      default-token-kgvlw        kubernetes.io/service-account-token   4      3s
      default-token-pfkql        kubernetes.io/service-account-token   4      3s
      deployer-dockercfg-t9w5x   kubernetes.io/dockercfg               1      3s
      deployer-token-rkwqx       kubernetes.io/service-account-token   4      3s
      deployer-token-s4hdx       kubernetes.io/service-account-token   4      3s
      [02:37:47] INFO> Exit Status: 0
    Then the step should succeed            # features/step_definitions/common.rb:4
waiting for operation up to 3600 seconds..
    And I run the :get client command with: # features/step_definitions/cli.rb:13
      | resource | secrets |
      | o | yaml |
      [02:37:47] INFO> Shell Commands: oc get secrets -o yaml --kubeconfig=/home/lxia/workdir/lxiabox-lxiax/ocp4_testuser-43.kubeconfig
      
      [02:37:49] INFO> Exit Status: 0
    Then the step should succeed            # features/step_definitions/common.rb:4
waiting for operation up to 3600 seconds..
    And I run the :get client command with: # features/step_definitions/cli.rb:13
      | resource | secrets |
      | o | json |
      [02:37:49] INFO> Shell Commands: oc get secrets -o json --kubeconfig=/home/lxia/workdir/lxiabox-lxiax/ocp4_testuser-43.kubeconfig
      
      [02:37:51] INFO> Exit Status: 0
    Then the step should succeed            # features/step_definitions/common.rb:4
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [02:37:51] INFO> === After Scenario: test censor ===
```