### PR TITLE
Update keyword for censor

### DIFF
--- a/lib/log.rb
+++ b/lib/log.rb
@@ -187,10 +187,8 @@ module BushSlicer
     def censor(msg)
       return if msg.nil?
       censor_kw = [
-        'data:',
-        '"data":',
         'kind: secret',
-        '"kind": "secret"'
+        '"kind": "secret"',
       ]
       secured_lines = []
       if (msg.is_a?(String))


### PR DESCRIPTION
1. The `data:` part is also contained in `kind: secret`.
2. `data:` mistakenly mask `metadata:`, which mask most of the commands outputs.

/cc @jhou1 @dis016 @JianLi-RH @pruan-rht 

Tried with non-admin and admin to get secrets in yaml/json within user's/openshift-config project, the sensitive info are protected.
```
waiting for operation up to 3600 seconds..
    When I run the :get client command with:                       # features/step_definitions/cli.rb:13
      | resource | secret |
      | o        | yaml   |
      [02:33:07] INFO> Shell Commands: oc get secret -o yaml --kubeconfig=/home/lxia/workdir/lxiabox-lxiax/ocp4_testuser-43.kubeconfig
      
      [02:33:09] INFO> Exit Status: 0
    Then the step should succeed                                   # features/step_definitions/common.rb:4
waiting for operation up to 3600 seconds..
    When I run the :get client command with:                       # features/step_definitions/cli.rb:13
      | resource | secret |
      | o        | json   |
      [02:33:09] INFO> Shell Commands: oc get secret -o json --kubeconfig=/home/lxia/workdir/lxiabox-lxiax/ocp4_testuser-43.kubeconfig
      
      [02:33:13] INFO> Exit Status: 0
    Then the step should succeed    
...
      [02:33:19] INFO> Shell Commands: oc get secret -o yaml --kubeconfig=/home/lxia/workdir/lxiabox-lxiax/ocp4_admin.kubeconfig --namespace=openshift-config
      
      [02:33:21] INFO> Exit Status: 0
    Then the step should succeed  
```