### PR TITLE
Hide several CMDs which contains sensitive info by default

### DIFF
--- a/lib/local_process.rb
+++ b/lib/local_process.rb
@@ -30,7 +30,13 @@ module BushSlicer
         log_text << opts[:env].inject("") { |r,e| r << e.join('=') << "\n" }
       end
       log_text << result[:command]
-      if ['oc login','oc get secret','oc whoami','oc serviceaccount'].any? { |cmd| log_text.include?(cmd) }
+      censor_cmds = [
+        'oc exec alertmanager',
+        'oc exec elasticsearch',
+        'oc exec prometheus',
+        'oc login',
+      ]
+      if censor_cmds.any? { |cmd| log_text.downcase.include?(cmd) }
         logger.debug(log_text) unless opts[:quiet]
       else
         logger.info(log_text) unless opts[:quiet]


### PR DESCRIPTION
Sometimes we need to hide the CMDs (e.g, `oc login`), sometimes we need to hide the CMDs' output (e.g, `oc get secrets -o yaml`).

/cc @jhou1 @dis016 @JianLi-RH @pruan-rht 

Add several cases which we need to hide the CMDs.
```
11-26 09:34:42.612      When I run the :exec admin command with:                                                               # features/step_definitions/cli.rb:31
11-26 09:34:42.612        | n                | openshift-monitoring                                                                                                                                          |
11-26 09:34:42.612        | pod              | prometheus-k8s-0                                                                                                                                              |
11-26 09:34:42.612        | c                | prometheus                                                                                                                                                    |
11-26 09:34:42.612        | oc_opts_end      |                                                                                                                                                               |
11-26 09:34:42.612        | exec_command     | sh                                                                                                                                                            |
11-26 09:34:42.612        | exec_command_arg | -c                                                                                                                                                            |
11-26 09:34:42.612        | exec_command_arg | curl -k -H "Authorization: Bearer <%= cb.sa_token %>" https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query?query=etcd_server_quota_backend_bytes |
11-26 09:34:42.612        [09:34:41] INFO> Shell Commands: oc exec prometheus-k8s-0  --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_admin.kubeconfig -n openshift-monitoring  -c prometheus -- sh -c curl\ -k\ -H\ \"Authorization:\ Bearer\ ******\"\ https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query\?query\=etcd_server_quota_backend_bytes
11-26 09:34:42.612        
11-26 09:34:42.612        [09:34:42] INFO> Exit Status: 0
11-26 09:34:42.612      Then the step should succeed                                                                           # features/step_definitions/common.rb:4
```