### PR TITLE
Hide sensitive oc commands' output from framework improvement

### DIFF
--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -305,8 +305,13 @@ module BushSlicer
 
       add_proxy_env_opt(user.env, opts)
       cli_tool = tool_from_opts!(opts)
+      if key == :serviceaccounts_get_token
+        # no worry if opts already has set it; below will override
+        opts << [:_quiet, true]
+      end
+      new_opts = Common::Rules.merge_opts(logged_users[user.id], opts)
       executor(cli_tool: cli_tool).
-        run(key, Common::Rules.merge_opts(logged_users[user.id], opts))
+        run(key, new_opts)
     end
 
     def clean_up


### PR DESCRIPTION
This PR is added for https://github.com/openshift/cucushift/pull/8915#issuecomment-981426788 .
Once this is merged, https://github.com/openshift/cucushift/pull/8915 is not needed.
This only deals with one command for figuring out the place to hide sensitive oc commands' output via framework level, such that it can merge quicker. For more commands, separate PR could follow up, I'd like to leave to core auto guys : )
Pass log: https://url.corp.redhat.com/runner-v3-smoke-3756-console
@jhou1 @liangxia @dis016 @JianLi-RH @pruan-rht : please review / merge, thanks ~ !
CC @kasturinarra @zhouying7780 @wangke19 @lihongyan1 @XiyunZhao of original PR.