### PR TITLE
use port 6514 in OCP-28541

### DIFF
--- a/testdata/logging/logforwarding/rsyslog/insecure/rsyslogserver_configmap.yaml
+++ b/testdata/logging/logforwarding/rsyslog/insecure/rsyslogserver_configmap.yaml
@@ -10,8 +10,8 @@ data:
     global(processInternalMessages="on")
     module(load="imptcp")
     module(load="imudp" TimeRequery="500")
-    input(type="imptcp" port="514")
-    input(type="imudp" port="514")
+    input(type="imptcp" port="6514")
+    input(type="imudp" port="6514")
     :programname, contains, "kubernetes.var.log.containers" {
       if $msg contains "namespace_name=openshift" or $msg contains "namespace_name=default" or $msg contains "namespace_name=kube" then /var/log/custom/infra-container.log
       if not ($msg contains "namespace_name=openshift" or $msg contains "namespace_name=default" or $msg contains "namespace_name=kube") then /var/log/custom/app-container.log


### PR DESCRIPTION
That is a follow up to https://github.com/openshift/verification-tests/pull/2501.   We forgot to update the port in logforwarding.

Test pass on 4.6
- OCP-28541 - Forward logs via syslog_buffered - ConfigMap
- OCP-27757 - Forward logs to syslog - Configmap

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/239053/console