### PR TITLE
Add CENSOR_CMD and use regexp for CMD check

### DIFF
--- a/lib/local_process.rb
+++ b/lib/local_process.rb
@@ -11,10 +11,13 @@ module BushSlicer
 
     DEFAULT_TIMEOUT = 3600
     CENSOR_CMDS = [
-      'oc exec alertmanager',
-      'oc exec elasticsearch',
-      'oc exec prometheus',
-      'oc login',
+      'oc exec .*bearer',   # oc exec elasticsearch-* -- curl "Authorization: Bearer ***"
+      'oc rsh .*bearer',    # oc rsh elasticsearch-* -- curl "Authorization: Bearer ***"
+      'oc login .*--token', # oc login --token=***
+                            # oc login --token ***
+      'oc login .*-p',      # oc login --passwordr= ***
+                            # oc login --password ***
+                            # oc login -p ***
     ]
 
     attr_reader :pid
@@ -36,7 +39,7 @@ module BushSlicer
         log_text << opts[:env].inject("") { |r,e| r << e.join('=') << "\n" }
       end
       log_text << result[:command]
-      if CENSOR_CMDS.any? { |cmd| log_text.downcase.include?(cmd) }
+      if CENSOR_CMDS.any? { |cmd| result[:command].downcase.match?(cmd) }
         logger.debug(log_text) unless opts[:quiet]
       else
         logger.info(log_text) unless opts[:quiet]


### PR DESCRIPTION
What's the changes in the PR,
1. Add one more CENSOR_CMD `oc rsh`
2. Use regexpr for CMD check

In default/info mode,
```
      [01:50:49] INFO> Exit Status: 0
      Logged into "https://api.***:6443" as "testuser-43" using the token provided.
```
In debug mode,
```
      [01:49:56] INFO> Exit Status: 0
      [01:49:56] DEBUG> Shell Commands: oc login --token=sha256\~*** --server=https://api.***:6443 --kubeconfig=/home/lxia/workdir/lxiabox-lxiax/ocp4_testuser-43.kubeconfig --insecure-skip-tls-verify=true
      Logged into "https://api.***:6443" as "testuser-43" using the token provided.
```

/cc @jhou1 @xingxingxia @dis016 @JianLi-RH @pruan-rht 