### PR TITLE
Enhance OCP-27690

### DIFF
--- a/features/storage/csi_clone.feature
+++ b/features/storage/csi_clone.feature
@@ -118,6 +118,8 @@ Feature: CSI clone testing related feature
       | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc-ori  |
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/local |
     Then the step should succeed
+    And the pod named "mypod-ori" becomes ready
+    And the "mypvc-ori" PVC becomes :bound
 
     # Clone mypvc-ori with 1Gi size failed
     Given I obtain test data file "storage/csi/pvc-clone.yaml"


### PR DESCRIPTION
Add steps to make sure the pvc is in "bound" status before the clone action. 
Also fix [OCPQE-7457](https://issues.redhat.com/browse/OCPQE-7457) to have enough info when it fails.