### PR TITLE
update click_first_item_in_grid_cell_list

### DIFF
--- a/lib/rules/web/admin_console/4.10/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.10/common_ui_elements.xyaml
@@ -793,7 +793,6 @@ click_first_sub_item_in_resource_detail_list:
       xpath: (//div[@class='co-m-table-grid__body']//a)[1]
     op: click
 click_first_item_in_grid_cell_list:
-  action: check_name_column_header
   elements:
   - selector:
       xpath: (//td[@role='gridcell'][1])[1]

--- a/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
@@ -777,7 +777,6 @@ click_first_sub_item_in_resource_detail_list:
       xpath: (//div[@class='co-m-table-grid__body']//a)[1]
     op: click
 click_first_item_in_grid_cell_list:
-  action: check_name_column_header
   elements:
   - selector:
       xpath: (//td[@role='gridcell'][1])[1]

--- a/lib/rules/web/admin_console/4.7/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.7/common_ui_elements.xyaml
@@ -775,7 +775,6 @@ click_first_sub_item_in_resource_detail_list:
       xpath: (//div[@class='co-m-table-grid__body']//a)[1]
     op: click
 click_first_item_in_grid_cell_list:
-  action: check_name_column_header
   elements:
   - selector:
       xpath: (//td[@role='gridcell'][1])[1]

--- a/lib/rules/web/admin_console/4.8/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.8/common_ui_elements.xyaml
@@ -784,7 +784,6 @@ click_first_sub_item_in_resource_detail_list:
       xpath: (//div[@class='co-m-table-grid__body']//a)[1]
     op: click
 click_first_item_in_grid_cell_list:
-  action: check_name_column_header
   elements:
   - selector:
       xpath: (//td[@role='gridcell'][1])[1]

--- a/lib/rules/web/admin_console/4.9/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.9/common_ui_elements.xyaml
@@ -793,7 +793,6 @@ click_first_sub_item_in_resource_detail_list:
       xpath: (//div[@class='co-m-table-grid__body']//a)[1]
     op: click
 click_first_item_in_grid_cell_list:
-  action: check_name_column_header
   elements:
   - selector:
       xpath: (//td[@role='gridcell'][1])[1]


### PR DESCRIPTION
We only want to click the first item in table no matter its header,  `Name` or `Image name` or something else, so removed `check_name_column_header` check