### PR TITLE
modification for recreating hello pod for ping

### DIFF
--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -255,7 +255,8 @@ Feature: Routing and DNS related scenarios
     Given I use the "ocp45955" project
     And the expression should be true> service('service-unsecure').annotation('idling.alpha.openshift.io/unidle-targets', cached: false) == "[{\"kind\":\"ReplicationController\",\"name\":\"web-server-rc\",\"replicas\":1}]"
   
-    When I execute on the "hello-pod" pod:
+    Given I have a test-client-pod in the project
+    When I execute on the pod:
       | curl | -ksS | http://<%= route("service-unsecure", service("service-unsecure")).dns %>/ |
     Then the step should succeed
     And the output should contain "Hello-OpenShift web-server-rc"


### PR DESCRIPTION
After the actual upgrade it is notice from CI run, the test-client-pod is not present in the cluster. So the step is modified to include creation of Hello pod and then executing in it.