### PR TITLE
Added regex to CENSOR_CMDS to exclude sensitive commands used in api-server test cases.

### DIFF
--- a/lib/local_process.rb
+++ b/lib/local_process.rb
@@ -11,14 +11,15 @@ module BushSlicer
 
     DEFAULT_TIMEOUT = 3600
     CENSOR_CMDS = [
-      'oc exec .*bearer',    # oc exec elasticsearch-* -- curl "Authorization: Bearer ***"
-      'oc exec .*--dcreds',  # oc exec -- skopeo copy --dcreds username:****
-      'oc rsh .*bearer',     # oc rsh elasticsearch-* -- curl "Authorization: Bearer ***"
-      'oc login .*--token',  # oc login --token=***
-                             # oc login --token ***
-      'oc login .*-p',       # oc login --passwordr= ***
-                             # oc login --password ***
-                             # oc login -p ***
+      'oc exec .*bearer',     # oc exec elasticsearch-* -- curl "Authorization: Bearer ***"
+      'oc exec .*--d?creds',  # oc exec -- skopeo copy --dcreds username:****
+                              # oc exec -- skopeo inspect --tls-verify=false --creds username:****
+      'oc rsh .*bearer',      # oc rsh elasticsearch-* -- curl "Authorization: Bearer ***"
+      'oc login .*--token',   # oc login --token=***
+                              # oc login --token ***
+      'oc login .*-p',        # oc login --passwordr= ***
+                              # oc login --password ***
+                              # oc login -p ***
     ]
 
     attr_reader :pid

--- a/lib/local_process.rb
+++ b/lib/local_process.rb
@@ -11,13 +11,14 @@ module BushSlicer
 
     DEFAULT_TIMEOUT = 3600
     CENSOR_CMDS = [
-      'oc exec .*bearer',   # oc exec elasticsearch-* -- curl "Authorization: Bearer ***"
-      'oc rsh .*bearer',    # oc rsh elasticsearch-* -- curl "Authorization: Bearer ***"
-      'oc login .*--token', # oc login --token=***
-                            # oc login --token ***
-      'oc login .*-p',      # oc login --passwordr= ***
-                            # oc login --password ***
-                            # oc login -p ***
+      'oc exec .*bearer',    # oc exec elasticsearch-* -- curl "Authorization: Bearer ***"
+      'oc exec .*--dcreds',  # oc exec -- skopeo copy --dcreds username:****
+      'oc rsh .*bearer',     # oc rsh elasticsearch-* -- curl "Authorization: Bearer ***"
+      'oc login .*--token',  # oc login --token=***
+                             # oc login --token ***
+      'oc login .*-p',       # oc login --passwordr= ***
+                             # oc login --password ***
+                             # oc login -p ***
     ]
 
     attr_reader :pid


### PR DESCRIPTION
@xingxingxia @wangke19 

- Added the regex pattern to CENSOR_CMDS (from /lib/local_process.rb) for excluding sensitive information shown in commands used in api-server test cases.
- In tests , We are calling _oc exec_ command and passing _skopeo_ command definition as an argument . _skopeo_ command contains the --dcreds option followed a username and password. 
See here http://pastebin.test.redhat.com/1013376
- With this PR , we would avoid printing during the test runs and make sure our sensitive info is not exposed.
- Test case execution result against the PR could find here : http://pastebin.test.redhat.com/1013382
- Reference ticket is OCPQE-7094.
Kindly review the change and let me know your feedback. Thanks


