### PR TITLE
Fix Watir chromedriver deprecated options

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -105,7 +105,7 @@ require_relative 'chrome_extension'
           )
         end
       end
-      client = Selenium::WebDriver::Remote::Http::Default.new
+      client = Watir::HttpClient.new
       client.open_timeout = 180
       client.read_timeout = 600 # ff legacy vs `I have a jenkins v2 application`
       headless
@@ -137,20 +137,18 @@ require_relative 'chrome_extension'
       elsif @browser_type == :chrome
         logger.info "Launching Chrome"
 
-	      #https://bugs.chromium.org/p/chromium/issues/detail?id=1056073
-	      chrome_caps[:acceptInsecureCerts] = true
-        if Integer === @scroll_strategy
-          chrome_caps[:element_scroll_behavior] = @scroll_strategy
-        end
         if self.class.container?
           chrome_switches.concat %w[--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-infobars --disable-dev-shm-usage]
         end
-        # options = Selenium::WebDriver::Chrome::Options.new
-        # options.add_extension proxy_chrome_ext_file if proxy_chrome_ext_file
-        options = {}
+        options = {browser_name: 'chrome',
+                   accept_insecure_certs: true}
         options[:extensions] = [proxy_chrome_ext_file] if proxy_chrome_ext_file
-        url_or_switches = @selenium_url ? {url: @selenium_url} : {switches: chrome_switches}
-        @browser = Watir::Browser.new :chrome, desired_capabilities: chrome_caps, options: options, **url_or_switches
+        if @selenium_url
+          @browser = Watir::Browser.new :chrome, options: options, url: @selenium_url
+        else
+          options[:options] = {switches: chrome_switches}
+          @browser = Watir::Browser.new :chrome, options: options
+        end
         logger.info "#{browser.driver.capabilities[:browser_name]} version is #{browser.driver.capabilities[:browser_version]}"
         logger.info "Chromedriver version is #{browser.driver.capabilities['chrome']['chromedriverVersion']}"
         if @size


### PR DESCRIPTION
This is a proposed fix for chrome driver with `desired_capabilities` deprecated. Tested locally, but may need extended testing using CI. @yapei @liangxia PTAL.

```
      [10:24:36] INFO> === End After Scenario: One logging acceptance case for all cluster ===

1 scenario (1 passed)
89 steps (89 passed)
13m7.801s
[10:24:36] INFO> === At Exit ===
```