### PR TITLE
OCPQE-6967: Replaces mysql-56-centos7 image with multiarch one (quota)

### DIFF
--- a/testdata/quota/ocp11754/pod-request-limit-valid-3.yaml
+++ b/testdata/quota/ocp11754/pod-request-limit-valid-3.yaml
@@ -7,16 +7,7 @@ metadata:
 spec:
   containers:
   - name: pod-request-limit-valid-3
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e
     resources:
       limits:
         cpu: "200m"

--- a/testdata/quota/ocp11927/pod-request-limit-valid-4.yaml
+++ b/testdata/quota/ocp11927/pod-request-limit-valid-4.yaml
@@ -7,16 +7,7 @@ metadata:
 spec:
   containers:
   - name: pod-request-limit-valid-4
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e
     resources:
       limits:
         cpu: "10"

--- a/testdata/quota/ocp12049/pod-request-limit-valid-1.yaml
+++ b/testdata/quota/ocp12049/pod-request-limit-valid-1.yaml
@@ -7,16 +7,7 @@ metadata:
 spec:
   containers:
   - name: pod-request-limit-valid-1
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e
     resources:
       limits:
         cpu: "500m"

--- a/testdata/quota/ocp12145/pod-request-limit-valid-2.yaml
+++ b/testdata/quota/ocp12145/pod-request-limit-valid-2.yaml
@@ -7,16 +7,7 @@ metadata:
 spec:
   containers:
   - name: pod-request-limit-valid-2
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e
     resources:
       requests:
         cpu: "200m"

--- a/testdata/quota/ocp12206/pod-request-limit-invalid-3.yaml
+++ b/testdata/quota/ocp12206/pod-request-limit-invalid-3.yaml
@@ -7,16 +7,7 @@ metadata:
 spec:
   containers:
   - name: pod-request-limit-invalid-3
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e
     resources:
       limits:
         cpu: "35"

--- a/testdata/quota/ocp12256/pod-request-limit-invalid-2.yaml
+++ b/testdata/quota/ocp12256/pod-request-limit-invalid-2.yaml
@@ -7,16 +7,7 @@ metadata:
 spec:
   containers:
   - name: pod-request-limit-invalid-2
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e
     resources:
       limits:
         cpu: "500m"

--- a/testdata/quota/ocp12292/pod-request-limit-invalid-1.yaml
+++ b/testdata/quota/ocp12292/pod-request-limit-invalid-1.yaml
@@ -7,13 +7,4 @@ metadata:
 spec:
   containers:
   - name: pod-request-limit-invalid-1
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e

--- a/testdata/quota/pod-besteffort-terminating.yaml
+++ b/testdata/quota/pod-besteffort-terminating.yaml
@@ -8,16 +8,7 @@ spec:
   activeDeadlineSeconds: 60
   containers:
   - name: pod-besteffort-terminating
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e
     resources:
       limits:
         cpu: 0

--- a/testdata/quota/pod-besteffort.yaml
+++ b/testdata/quota/pod-besteffort.yaml
@@ -7,16 +7,7 @@ metadata:
 spec:
   containers:
   - name: pod-besteffort
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e
     resources:
       requests:
         cpu: 0

--- a/testdata/quota/pod-completed.yaml
+++ b/testdata/quota/pod-completed.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: pi
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
+    image: quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e
     command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
     resources:
       requests:

--- a/testdata/quota/pod-notterminating.yaml
+++ b/testdata/quota/pod-notterminating.yaml
@@ -8,16 +8,7 @@ spec:
   activeDeadlineSeconds: null
   containers:
   - name: pod-notterminating
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e
     resources:
       limits:
         cpu: "500m"

--- a/testdata/quota/pod-terminating.yaml
+++ b/testdata/quota/pod-terminating.yaml
@@ -8,16 +8,7 @@ spec:
   activeDeadlineSeconds: 60
   containers:
   - name: pod-terminating
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
-    env:
-    - name: MYSQL_USER
-      value: userSUM
-      name: MYSQL_PASSWORD
-      value: P5J6s8wf
-      name: MYSQL_DATABASE
-      value: root
-      name: MYSQL_ROOT_PASSWORD
-      value: W5J6s8wf
+    image: quay.io/openshifttest/hello-openshift@sha256:1e70b596c05f46425c39add70bf749177d78c1e98b2893df4e5ae3883c2ffb5e
     resources:
       limits:
         cpu: "500m"


### PR DESCRIPTION
OCP-11754,OCP-11927,OCP-12049,OCP-12145,OCP-12206,OCP-12256,OCP-12292,OCP-10278,OCP-10801,OCP-11251,OCP-11983,OCP-11348,OCP-10945,OCP-11568,OCP-12086,OCP-11780,OCP-10279,OCP-12080,OCP-11111

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/245981/console

OCP-11780 failed, but it is `inactive`.

Some are just replaced with the hello-openshift multiarch image.
