### PR TITLE
OCPQE-6967: Replaces mysql-56-centos7 image with multiarch one (cli)

### DIFF
--- a/testdata/cli/application-template-stibuild-with-mount-secret.json
+++ b/testdata/cli/application-template-stibuild-with-mount-secret.json
@@ -368,7 +368,7 @@
             "containers": [
               {
                 "name": "ruby-helloworld-database",
-                "image": "quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f",
+                "image": "quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e",
                 "ports": [
                   {
                     "containerPort": 3306,


### PR DESCRIPTION
This replaces mysql-56-centos7 image with a multiarch one on cli features.

Tests involved are: OCP-15029,OCP-21021,OCP-10673,OCP-21037,OCP-12909,OCP-12911,OCP-12913,OCP-12914,OCP-12983,OCP-12893,OCP-12894,OCP-12896, OCP-11147

They were run in this job:

~~https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/245566/~~

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/245995/console


OCP-12909 failed but it is inactive.

OCP-15029 and OCP-21021 also fail due to reasons that are beyond this PR, see other results with no changes from this PR in Polarion.