### PR TITLE
OCPQE-6967: Replaces mysql-56-centos7 image with multiarch one (deployment)

### DIFF
--- a/testdata/deployment/Inline-logs.json
+++ b/testdata/deployment/Inline-logs.json
@@ -79,7 +79,7 @@
                 "containers": [
                     {
                         "name": "hello-openshift",
-                        "image": "quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f",
+                        "image": "quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e",
                         "ports": [
                             {
                                 "containerPort": 3306,
@@ -98,6 +98,10 @@
                             {
                                 "name": "MYSQL_DATABASE",
                                 "value": "root"
+                            },
+                            {
+                              "name": "MYSQL_RANDOM_ROOT_PASSWORD",
+                              "value": "yes"
                             }
                         ],
                         "command": [

--- a/testdata/deployment/deployments_nobc_cpulimit.json
+++ b/testdata/deployment/deployments_nobc_cpulimit.json
@@ -213,7 +213,7 @@
             "containers": [
               {
                 "name": "ruby-helloworld-database",
-                "image": "quay.io/openshifttest/mysql-56-centos7",
+                "image": "quay.io/openshifttest/mysql:multiarch",
                 "ports": [
                   {
                     "containerPort": 3306,
@@ -232,6 +232,10 @@
                   {
                     "name": "MYSQL_DATABASE",
                     "value": "${MYSQL_DATABASE}"
+                  },
+                  {
+                    "name": "MYSQL_RANDOM_ROOT_PASSWORD",
+                    "value": "yes"
                   }
                 ],
                 "resources": {

--- a/testdata/deployment/ocp10725/hook-inheritance-secret-volume.json
+++ b/testdata/deployment/ocp10725/hook-inheritance-secret-volume.json
@@ -76,7 +76,7 @@
                 "containers": [
                     {
                         "name": "mysql-56-centos7",
-                        "image": "quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f",
+                        "image": "quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e",
                         "ports": [
                             {
                                 "containerPort": 3306,
@@ -95,6 +95,10 @@
                             {
                                 "name": "MYSQL_DATABASE",
                                 "value": "root"
+                            },
+                            {
+                                "name": "MYSQL_RANDOM_ROOT_PASSWORD",
+                                "value": "yes"
                             }
                         ],
                         "resources": {},

--- a/testdata/deployment/test-stop-failed-deployment.json
+++ b/testdata/deployment/test-stop-failed-deployment.json
@@ -72,9 +72,12 @@
                             {
                                 "name": "MYSQL_DATABASE",
                                 "value": "root"
+                            }, {
+                                "name": "MYSQL_RANDOM_ROOT_PASSWORD",
+                                "value": "yes"
                             }
                         ],
-                        "image": "quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f",
+                        "image": "quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e",
                         "imagePullPolicy": "Always",
                         "name": "test-stop-failed-deployment",
                         "ports": [


### PR DESCRIPTION
Test cases involved: OCP-11384,OCP-10633,OCP-10725,OCP-11494,OCP-11135,OCP-12133

~~https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/245701/console~~

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/245973/
