### PR TITLE
OCPQE-6967: Replaces mysql-56-centos7 image with multiarch one (templates)

### DIFF
--- a/testdata/templates/OCP-12057/application-template-stibuild_pull_private_sourceimage.json
+++ b/testdata/templates/OCP-12057/application-template-stibuild_pull_private_sourceimage.json
@@ -416,7 +416,7 @@
             "containers": [
               {
                 "name": "ruby-helloworld-database",
-                "image": "quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f",
+                "image": "quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e",
                 "ports": [
                   {
                     "containerPort": 3306,
@@ -445,6 +445,10 @@
                   {
                     "name": "MYSQL_DATABASE",
                     "value": "${MYSQL_DATABASE}"
+                  },
+                  {
+                    "name": "MYSQL_RANDOM_ROOT_PASSWORD",
+                    "value": "yes"
                   }
                 ],
                 "resources": {},

--- a/testdata/templates/ocp10033/sample-app-database-dc-resources-large-invalid.json
+++ b/testdata/templates/ocp10033/sample-app-database-dc-resources-large-invalid.json
@@ -143,7 +143,7 @@
                         "containers": [
                             {
                                 "name": "ruby-helloworld-database",
-                                "image": "quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f",
+                                "image": "quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e",
                                 "ports": [
                                     {
                                         "containerPort": 3306,
@@ -162,6 +162,10 @@
                                     {
                                         "name": "MYSQL_DATABASE",
                                         "value": "${MYSQL_DATABASE}"
+                                    },
+                                    {
+                                        "name": "MYSQL_RANDOM_ROOT_PASSWORD",
+                                        "value": "yes"
                                     }
                                 ],
                                 "resources": {

--- a/testdata/templates/ui/application-template-stibuild-without-customize-route.json
+++ b/testdata/templates/ui/application-template-stibuild-without-customize-route.json
@@ -399,7 +399,7 @@
             "containers": [
               {
                 "name": "ruby-helloworld-database",
-                "image": "quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f",
+                "image": "quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e",
                 "ports": [
                   {
                     "containerPort": 3306,
@@ -428,6 +428,10 @@
                   {
                     "name": "MYSQL_DATABASE",
                     "value": "${MYSQL_DATABASE}"
+                  },
+                  {
+                    "name": "MYSQL_RANDOM_ROOT_PASSWORD",
+                    "value": "yes"
                   }
                 ],
                 "resources": {},


### PR DESCRIPTION
Cases involved: 
OCP-10033,OCP-12057,OCP-11897,OCP-12255,OCP-10289,OCP-11518,OCP-21117,OCP-10695,OCP-21118,OCP-10276,OCP-12247,OCP-12131,OCP-9768,OCP-21111,OCP-10592,OCP-15974,OCP-11627

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/245923/

OCP-12057: fails both on original code and new one, as per
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/245977/