### PR TITLE
OCPQE-6967: Replaces mysql-56-centos7 image with multiarch one (secret)

### DIFF
--- a/testdata/secrets/ocp12281/first-secret-pod.yaml
+++ b/testdata/secrets/ocp12281/first-secret-pod.yaml
@@ -7,15 +7,15 @@ metadata:
 spec:
   containers:
   - name: first-secret-pod
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
+    image: quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e
     env:
     - name: MYSQL_USER
       value: userSUM
-      name: MYSQL_PASSWORD
+    - name: MYSQL_PASSWORD
       value: P5J6s8wf
-      name: MYSQL_DATABASE
+    - name: MYSQL_DATABASE
       value: root
-      name: MYSQL_ROOT_PASSWORD
+    - name: MYSQL_ROOT_PASSWORD
       value: W5J6s8wf
     volumeMounts:
     - name: volume

--- a/testdata/secrets/secret-pod-2.yaml
+++ b/testdata/secrets/secret-pod-2.yaml
@@ -7,15 +7,15 @@ metadata:
 spec:
   containers:
   - name: secret-pod-2
-    image: quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f
+    image: quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e
     env:
     - name: MYSQL_USER
       value: userSUM
-      name: MYSQL_PASSWORD
+    - name: MYSQL_PASSWORD
       value: P5J6s8wf
-      name: MYSQL_DATABASE
+    - name: MYSQL_DATABASE
       value: root
-      name: MYSQL_ROOT_PASSWORD
+    - name: MYSQL_ROOT_PASSWORD
       value: W5J6s8wf
     volumeMounts:
     - name: mysql-volume


### PR DESCRIPTION
Test cases involved: OCP-12281,OCP-12310

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/245934/
