### PR TITLE
OCPQE-6967: Replaces mysql-56-centos7 image with multiarch one (build)

### DIFF
--- a/testdata/build/application-template-stibuild.json
+++ b/testdata/build/application-template-stibuild.json
@@ -400,7 +400,7 @@
             "containers": [
               {
                 "name": "ruby-helloworld-database",
-                "image": "quay.io/openshifttest/mysql-56-centos7@sha256:a9fb44bd6753a8053516567a0416db84844e10989140ea2b19ed1d2d8bafc75f",
+                "image": "quay.io/openshifttest/mysql@sha256:7a6a500fbdc89871973f1f2fe1e64ebb2548dea06df2cb1b3a2989236a26289e",
                 "ports": [
                   {
                     "containerPort": 3306,
@@ -429,6 +429,10 @@
                   {
                     "name": "MYSQL_DATABASE",
                     "value": "${MYSQL_DATABASE}"
+                  },
+                  {
+                    "name": "MYSQL_RANDOM_ROOT_PASSWORD",
+                    "value": "yes"
                   }
                 ],
                 "resources": {},


### PR DESCRIPTION

OCP-12040,OCP-11155,OCP-13683,OCP-11044,OCP-11248,OCP-10798,OCP-11834,OCP-12021,OCP-12642,OCP-21063


https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/245948/console


*** Failed scenarios ***

- 12-07 12:31:57.511 cucumber -p polarshift -p dir_embedder features/tierN/admin/groups_users.feature:139 # Scenario: Add/remove edit and admin role to the cluster group in one or more projects (OCP-11155)

Re-run at: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/245984/console

- 12-07 12:31:57.511 cucumber -p polarshift -p dir_embedder features/tierN/cli/oc_export.feature:87 # Scenario Outline: Export resource as json or yaml format by cli (OCP-21063)

Failed for other reasons (--export is not an argument....)