### PR TITLE
OCPQE-7692: Replaces hello-openshift:openshift with multiarch

### DIFF
--- a/features/cli/serviceaccount.feature
+++ b/features/cli/serviceaccount.feature
@@ -42,7 +42,7 @@ Feature: ServiceAccount and Policy Managerment
   Scenario: Could grant admin permission for the service account group to access to its own project
     Given I have a project
     When I run the :new_app client command with:
-      | docker_image | quay.io/openshifttest/hello-openshift:openshift |
+      | docker_image | quay.io/openshifttest/hello-openshift:multiarch |
     Then the step should succeed
     When I run the :policy_add_role_to_group client command with:
       | role       | admin                                     |


### PR DESCRIPTION
Cases involved are: OCP-11494,OCP-11112,OCP-12536,OCP-28016,OCP-12263,OCP-9853,OCP-30394,OCP-30395,OCP-12037,OCP-10719,OCP-21033,OCP-11531

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/246213/console