### PR TITLE
OCPQE-6990: replace origin-base with base-alpine

### DIFF
--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -15,9 +15,9 @@ Feature: Check status via oc status, wait etc
     When I run the :status client command
     Then the step should succeed
     Then the output should match:
-      | rc/<%= cb.stdrc_name %> runs quay.io/openshift/origin-base |
-      | rc/<%= cb.stdrc_name %> created                            |
-      | \\d warning.*oc status.* to see details                    |
+      | rc/<%= cb.stdrc_name %> runs quay.io/openshifttest/base-alpine:multiarch |
+      | rc/<%= cb.stdrc_name %> created                                          |
+      | \\d warning.*oc status.* to see details                                  |
     When I run the :status client command with:
       | suggest |     |
     Then the step should succeed

--- a/testdata/cli/standalone-rc.yaml
+++ b/testdata/cli/standalone-rc.yaml
@@ -18,7 +18,7 @@ spec:
             - start
             - master
             - --config=/config/master-config.yaml
-          image: "quay.io/openshift/origin-base"
+          image: "quay.io/openshifttest/base-alpine:multiarch"
           name: origin
           ports:
             - containerPort: 8443

--- a/testdata/rc/idling-echo-server.yaml
+++ b/testdata/rc/idling-echo-server.yaml
@@ -20,7 +20,7 @@ items:
           deploymentconfig: idling-echo
       spec:
         containers:
-        - image: quay.io/openshifttest/origin-base@sha256:cbd0e2931e6ae8cbd1522cd7226cff89629c21a3652f6fd57d84f405d432c07a
+        - image: quay.io/openshifttest/base-alpine@sha256:0b379877aba876774e0043ea5ba41b0c574825ab910d32b43c05926fab4eea22
           name: idling-tcp-echo
           command:
             - /usr/bin/socat
@@ -29,7 +29,7 @@ items:
           ports:
           - containerPort: 8675
             protocol: TCP
-        - image: quay.io/openshifttest/origin-base@sha256:cbd0e2931e6ae8cbd1522cd7226cff89629c21a3652f6fd57d84f405d432c07a
+        - image: quay.io/openshifttest/base-alpine@sha256:0b379877aba876774e0043ea5ba41b0c574825ab910d32b43c05926fab4eea22
           name: idling-udp-echo
           command:
             - /usr/bin/socat


### PR DESCRIPTION
test run:[OS-20211208-0703](https://polarion.engineering.redhat.com/polarion/#/project/OSE/testrun?id=OS-20211208-0703)