### PR TITLE
OCPQE-7624: Replaces ruby build images with multiarch one

### DIFF
--- a/features/build/buildlogic.feature
+++ b/features/build/buildlogic.feature
@@ -64,13 +64,13 @@ Feature: buildlogic.feature
     Given I have a project
     When I run the :new_build client command with:
       | app_repo | https://github.com/openshift/ruby-hello-world   |
-      | D        | FROM quay.io/openshifttest/ruby-25-centos7:build\nRUN echo ok |
+      | D        | FROM quay.io/openshifttest/ruby-27:multiarch\nRUN echo ok |
     Then the step should succeed
     When I get project buildconfigs as YAML
     Then the step should succeed
     Then the output should match:
       | dockerfile   |
-      | FROM quay.io/openshifttest/ruby-25-centos7:build   |
+      | FROM quay.io/openshifttest/ruby-27:multiarch   |
       | RUN echo ok  |
       | uri: https://github.com/openshift/ruby-hello-world |
       | type: [Gg]it |

--- a/features/build/dockerbuild.feature
+++ b/features/build/dockerbuild.feature
@@ -33,7 +33,7 @@ Feature: dockerbuild.feature
   Scenario: Docker build with dockerImage with specified tag
     Given I have a project
     When I run the :new_app client command with:
-      | docker_image | quay.io/openshifttest/ruby-27-centos7:centos7 |
+      | docker_image | quay.io/openshifttest/ruby-27:multiarch |
       | app_repo     | http://github.com/openshift/ruby-hello-world  |
       | strategy     | docker                                        |
     Then the step should succeed
@@ -95,7 +95,7 @@ Feature: dockerbuild.feature
     Given I have a project
     When I run the :new_build client command with:
       | code         | http://github.com/openshift/ruby-hello-world.git |
-      | docker_image | quay.io/openshifttest/ruby-27-centos7:centos7    |
+      | docker_image | quay.io/openshifttest/ruby-27:multiarch          |
       | strategy     | docker                                           |
       | build_arg    | ARG=VALUE                                        |
     Then the step should succeed

--- a/features/build/stibuild.feature
+++ b/features/build/stibuild.feature
@@ -49,14 +49,14 @@ Feature: stibuild.feature
   Scenario: STI build with dockerImage with specified tag
     Given I have a project
     When I run the :new_app client command with:
-      | docker_image | quay.io/openshifttest/ruby-22-centos7:2.2 |
-      | app_repo     | https://github.com/openshift-qe/ruby-ex   |
+      | docker_image | quay.io/openshifttest/ruby-27:multiarch   |
+      | app_repo     | https://github.com/sclorg/ruby-ex   |
     Then the step should succeed
     And the "ruby-ex-1" build completes
     When I run the :patch client command with:
       | resource      | buildconfig                                                                                                                                      |
       | resource_name | ruby-ex                                                                                                                                          |
-      | p             | {"spec": {"strategy": {"sourceStrategy": {"from": {"kind": "DockerImage","name": "quay.io/openshifttest/ruby-25-centos7@sha256:575194aa8be12ea066fc3f4aa9103dcb4291d43f9ee32e4afe34e0063051610b"}}},"type": "Source"}} |
+      | p             | {"spec": {"strategy": {"sourceStrategy": {"from": {"kind": "DockerImage","name": "quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc"}}},"type": "Source"}} |
     Then the step should succeed
     When I run the :start_build client command with:
       | buildconfig | ruby-ex |
@@ -133,7 +133,7 @@ Feature: stibuild.feature
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   @upgrade-sanity
-  Scenario: Mount source secret and configmap to builder container- sourcestrategy 
+  Scenario: Mount source secret and configmap to builder container- sourcestrategy
     Given I have a project
     When I run the :create_secret client command with:
       | secret_type  | generic            |
@@ -142,20 +142,20 @@ Feature: stibuild.feature
       | from_literal | password=redhat    |
     Then the step should succeed
     When I run the :create_configmap client command with:
-      | name         | myconfig  | 
+      | name         | myconfig  |
       | from_literal | key=foo   |
       | from_literal | value=bar |
     Then the step should succeed
     When I run the :new_app client command with:
       | image_stream | ruby                                             |
-      | app_repo     | http://github.com/openshift/ruby-hello-world.git | 
+      | app_repo     | http://github.com/openshift/ruby-hello-world.git |
     Then the step should succeed
     And the "ruby-hello-world-1" build was created
     Given the "ruby-hello-world-1" build completed
     When I run the :patch client command with:
-      | resource      | buildconfig      | 
+      | resource      | buildconfig      |
       | resource_name | ruby-hello-world |
-      | p             | {"spec":{"strategy":{"sourceStrategy":{"volumes":[{"mounts":[{"destinationPath":"/var/run/secret/mysecret"}],"name":"mysecret","source":{"secret":{"secretName":"mysecret"},"type":"Secret"}},{"mounts":[{"destinationPath":"/var/run/secret/myconfig"}],"name":"myconfig","source":{"configMap":{"name":"myconfig"},"type":"ConfigMap"}}]}}}} | 
+      | p             | {"spec":{"strategy":{"sourceStrategy":{"volumes":[{"mounts":[{"destinationPath":"/var/run/secret/mysecret"}],"name":"mysecret","source":{"secret":{"secretName":"mysecret"},"type":"Secret"}},{"mounts":[{"destinationPath":"/var/run/secret/myconfig"}],"name":"myconfig","source":{"configMap":{"name":"myconfig"},"type":"ConfigMap"}}]}}}} |
     Then the step should succeed
     When I run the :start_build client command with:
       | buildconfig | ruby-hello-world |
@@ -168,4 +168,4 @@ Feature: stibuild.feature
       | o             | yaml                     |
     Then the output should contain:
       | mysecret-user-build-volume |
-      | myconfig-user-build-volume | 
+      | myconfig-user-build-volume |

--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -233,13 +233,13 @@ Feature: build 'apps' with CLI
     Given I have a project
     When I run the :tag client command with:
       | source | quay.io/openshifttest/python:3.6 |
-      | dest   | python:latest |
+      | dest   | python:multiarch |
     Then the step should succeed
     And the "python" image stream becomes ready
     When I run the :new_build client command with:
       | app_repo | openshift/ruby:latest |
       | app_repo | https://github.com/openshift/ruby-hello-world |
-      | source_image | <%= project.name %>/python:latest |
+      | source_image | <%= project.name %>/python:multiarch |
       | source_image_path | /tmp:xiuwangtest/ |
       | name | final-app |
       | allow_missing_imagestream_tags| true |
@@ -247,7 +247,7 @@ Feature: build 'apps' with CLI
     When I get project build_config named "final-app" as YAML
     Then the output should match:
       | kind:\s+ImageStreamTag |
-      | name:\s+python:latest |
+      | name:\s+python:multiarch |
       | destinationDir:\s+xiuwangtest |
       | sourcePath:\s+/tmp |
     Given the "final-app-1" build completes
@@ -282,7 +282,7 @@ Feature: build 'apps' with CLI
       | image_name | python |
       | all | true |
       | confirm | true |
-      | from | quay.io/openshifttest/ruby-25-centos7 |
+      | from | quay.io/openshifttest/ruby-27 |
       | n | <%= project.name %> |
     Then the step should succeed
     Given I get project builds
@@ -740,15 +740,15 @@ Feature: build 'apps' with CLI
   Scenario: io.openshift.build.commit.ref displays correctly in build reference on imagestreamtag if building from git branch reference
     Given I have a project
     When I run the :new_app client command with:
-      | app_repo | quay.io/openshifttest/ruby-22-centos7:2.2~https://github.com/openshift/ruby-hello-world#beta4 |
+      | app_repo | quay.io/openshifttest/ruby-27:multiarch~https://github.com/openshift/ruby-hello-world#config |
     Then the step should succeed
     Given the "ruby-hello-world-1" build was created
     And the "ruby-hello-world-1" build completed
     When I run the :describe client command with:
       | resource | imagestreamtag |
     Then the output should contain:
-      | io.openshift.build.commit.ref=beta4 |
-      | OPENSHIFT_BUILD_REFERENCE=beta4     |
+      | io.openshift.build.commit.ref=config |
+      | OPENSHIFT_BUILD_REFERENCE=config    |
 
   # @author xiuwang@redhat.com
   # @case_id OCP-19631
@@ -914,7 +914,7 @@ Feature: build 'apps' with CLI
     Then the step should succeed
     #Insert cm and secret to bc with empty destination - succeed
     When I run the :new_build client command with:
-      | app_repo         | quay.io/openshifttest/ruby-27-centos7:centos7~https://github.com/openshift/ruby-hello-world |
+      | app_repo         | quay.io/openshifttest/ruby-27:multiarch~https://github.com/openshift/ruby-hello-world |
       | build_config_map | cmtest1:.                                                                                   |
       | build_config_map | cmtest2:./newdir                                                                            |
       | strategy         | docker                                                                                      |
@@ -946,7 +946,7 @@ Feature: build 'apps' with CLI
     Then the step should succeed
     #Add a configmaps with a multi-level dirs - succeed
     When I run the :new_build client command with:
-      | app_repo         | quay.io/openshifttest/ruby-27-centos7:centos7~https://github.com/openshift/ruby-hello-world |
+      | app_repo         | quay.io/openshifttest/ruby-27:multiarch~https://github.com/openshift/ruby-hello-world |
       | build_config_map | cmtest1:./newdir1/newdir2/newdir3                                                           |
       | strategy         | docker                                                                                      |
     Then the step should succeed

--- a/features/test/registry.feature
+++ b/features/test/registry.feature
@@ -44,7 +44,7 @@ Feature: registry related test scenario
     And I log into auth registry on the node
     When I docker push on the node to the registry the following images:
       | quay.io/openshifttest/base-alpine@sha256:0b379877aba876774e0043ea5ba41b0c574825ab910d32b43c05926fab4eea22     | busybox:latest |
-      | quay.io/openshifttest/ruby-25-centos7@sha256:575194aa8be12ea066fc3f4aa9103dcb4291d43f9ee32e4afe34e0063051610b | test/centos7   |
+      | quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc | test/centos7   |
     Then the step should succeed
 
   @admin
@@ -68,7 +68,7 @@ Feature: registry related test scenario
     And I add the insecure registry to docker config on the node
     When I docker push on the node to the registry the following images:
       | quay.io/openshifttest/base-alpine@sha256:0b379877aba876774e0043ea5ba41b0c574825ab910d32b43c05926fab4eea22     | busybox:latest |
-      | quay.io/openshifttest/ruby-25-centos7@sha256:575194aa8be12ea066fc3f4aa9103dcb4291d43f9ee32e4afe34e0063051610b | test/centos7   |
+      | quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc | test/centos7   |
     Then the step should fail
 
   Scenario: Obtain registry ip by creating a build in the project

--- a/features/upgrade/build/build-upgrade.feature
+++ b/features/upgrade/build/build-upgrade.feature
@@ -13,7 +13,7 @@ Feature: build related upgrade check
       | app_repo | openshift/ruby~https://github.com/openshift/ruby-ex |
     Then the step should succeed
     When I run the :new_app_as_dc client command with:
-      | app_repo | quay.io/openshifttest/ruby-27-centos7:centos7~https://github.com/openshift/ruby-hello-world |
+      | app_repo | quay.io/openshifttest/ruby-27:multiarch~https://github.com/openshift/ruby-hello-world |
       | strategy | docker                                                                                      |
     Then the step should succeed
     Given I use the "build-upgrade" project

--- a/testdata/build/application-template-dockerbuild.json
+++ b/testdata/build/application-template-dockerbuild.json
@@ -125,7 +125,7 @@
           "dockerStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/openshifttest/ruby-27-centos7:centos7"
+              "name": "quay.io/openshifttest/ruby-27:multiarch"
             },
             "env": [
               {

--- a/testdata/build/ocp11224/test-buildconfig.json
+++ b/testdata/build/ocp11224/test-buildconfig.json
@@ -41,7 +41,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/openshifttest/ruby-25-centos7@sha256:575194aa8be12ea066fc3f4aa9103dcb4291d43f9ee32e4afe34e0063051610b"
+          "name": "quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc"
         }
       },
       "env": [

--- a/testdata/build/ocp11474/test-buildconfig-s2i.json
+++ b/testdata/build/ocp11474/test-buildconfig-s2i.json
@@ -41,7 +41,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/openshifttest/ruby-25-centos7@sha256:575194aa8be12ea066fc3f4aa9103dcb4291d43f9ee32e4afe34e0063051610b"
+          "name": "quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc"
         },
         "pullSecret": {"name" : "pull"}
       }

--- a/testdata/build/ocp11550/test-buildconfig.json
+++ b/testdata/build/ocp11550/test-buildconfig.json
@@ -41,7 +41,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/openshifttest/ruby-25-centos7@sha256:575194aa8be12ea066fc3f4aa9103dcb4291d43f9ee32e4afe34e0063051610b"
+          "name": "quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc"
         }
       },
       "env": [

--- a/testdata/build/ruby20rhel7-invalidcontext-docker.json
+++ b/testdata/build/ruby20rhel7-invalidcontext-docker.json
@@ -125,7 +125,7 @@
           "dockerStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/openshifttest/ruby-25-centos7@sha256:575194aa8be12ea066fc3f4aa9103dcb4291d43f9ee32e4afe34e0063051610b"
+              "name": "quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc"
             },
             "env": [
               {

--- a/testdata/build/ruby22rhel7-template-docker.json
+++ b/testdata/build/ruby22rhel7-template-docker.json
@@ -123,7 +123,7 @@
           "dockerStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/openshifttest/ruby-27-centos7:centos7"
+              "name": "quay.io/openshifttest/ruby-27:multiarch"
             },
             "env": [
               {

--- a/testdata/downwardapi/ocp10628/downward-example.yaml
+++ b/testdata/downwardapi/ocp10628/downward-example.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: quay.io/openshifttest/ruby-25-centos7@sha256:575194aa8be12ea066fc3f4aa9103dcb4291d43f9ee32e4afe34e0063051610b
+      image: quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc
       command: [ "/bin/sh", "-c", "env" ]
       env:
         - name: POD_NAME

--- a/testdata/templates/OCP-12057/application-template-stibuild_pull_private_sourceimage.json
+++ b/testdata/templates/OCP-12057/application-template-stibuild_pull_private_sourceimage.json
@@ -136,7 +136,7 @@
             {
               "from": {
                 "kind": "DockerImage",
-                "name": "quay.io/openshifttest/ruby-25-centos7@sha256:575194aa8be12ea066fc3f4aa9103dcb4291d43f9ee32e4afe34e0063051610b"
+                "name": "quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc"
               },
               "pullSecret": { "name": "pull" },
               "paths": [

--- a/testdata/templates/ocp11023/build.yaml
+++ b/testdata/templates/ocp11023/build.yaml
@@ -10,5 +10,5 @@ spec:
         value: sample-app
       from:
         kind: DockerImage
-        name: quay.io/openshifttest/ruby-25-centos7@sha256:575194aa8be12ea066fc3f4aa9103dcb4291d43f9ee32e4afe34e0063051610b 
+        name: quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc
     type: Source

--- a/testdata/templates/ocp11552/ruby22rhel7-template-docker.json
+++ b/testdata/templates/ocp11552/ruby22rhel7-template-docker.json
@@ -134,7 +134,7 @@
           "dockerStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/openshifttest/ruby-27-centos7:centos7"
+              "name": "quay.io/openshifttest/ruby-27:multiarch"
             },
             "env": [
               {


### PR DESCRIPTION
Information about testing of these changes is reported in Polarshift, testrun OS-20211207-1759.

Some tests fail for reasons that seem to be beyond the changes from this PR
