### PR TITLE
Add long-duration tag

### DIFF
--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -2,6 +2,7 @@ Feature: Node components upgrade tests
   # @author minmli@redhat.com
   @upgrade-prepare
   @admin
+  @long-duration
   @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
@@ -46,6 +47,7 @@ Feature: Node components upgrade tests
   # @case_id OCP-13022
   @upgrade-check
   @admin
+  @long-duration
   @4.8 @4.10 @4.9
   @azure-ipi @openstack-ipi @baremetal-ipi @vsphere-ipi @gcp-ipi @aws-ipi
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi


### PR DESCRIPTION
The wait time for this test is 1980s(and it's not enough per the [log here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/24349/rehearse-24349-periodic-ci-openshift-verification-tests-master-ocp-4.10-upgrade-from-stable-4.9-upgrade-verification-tests-openstack-ipi/1468428276362907648/artifacts/upgrade-verification-tests-openstack-ipi/cucushift-upgrade-pre/build-log.txt)), adding this tag to exclude it from common prow jobs and run it in the upcoming long-duration test jobs
@liangxia PTAL