### PR TITLE
Fix apiversion for kubedescheduler cluster object

### DIFF
--- a/testdata/descheduler/kubedescheduler-4.9.yaml
+++ b/testdata/descheduler/kubedescheduler-4.9.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.openshift.io/v1beta1
+apiVersion: operator.openshift.io/v1
 kind: KubeDescheduler
 metadata:
   name: cluster


### PR DESCRIPTION
KubeDescheduler apiVersion has been changed to v1 so fixing the same.