### PR TITLE
fix OCP-45955

### DIFF
--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -241,6 +241,8 @@ Feature: Routing and DNS related scenarios
       | svc_name | service-unsecure |
     Then the step should succeed
     Given I wait for the resource "pod" named "<%= cb.pod_name %>" to disappear within 120 seconds
+    # will recreate test-client-pod in upgrade-check so delete the pod here
+    Given I ensure "hello-pod" pod is deleted
 
     # Check the servcie service-unsecure to see the idle annotation
     And the expression should be true> service('service-unsecure').annotation('idling.alpha.openshift.io/unidle-targets', cached: false) == "[{\"kind\":\"ReplicationController\",\"name\":\"web-server-rc\",\"replicas\":1}]"


### PR DESCRIPTION
Usually the "hello-pod" will be removed after the node rebooting during upgrade, but it might be still running in abnormal scenario, so adding the step to ensure it is deleted in upgrade-prepare then it can be recreated in upgrade-check.

@quarterpin @melvinjoseph86 @ShudiLi please help take a look. thanks.