### PR TITLE
Shorten logs generate by OCP-19470

### DIFF
--- a/features/upgrade/api_auth/upgrade.feature
+++ b/features/upgrade/api_auth/upgrade.feature
@@ -135,12 +135,12 @@ Feature: apiserver and auth related upgrade check
   @azure-upi @aws-upi @openstack-upi @vsphere-upi @gcp-upi
   Scenario: Default RBAC role, rolebinding, clusterrole and clusterrolebinding without any missing after upgraded - prepare
     When I run the :get admin command with:
-      | resource | clusterroles.rbac |
-      | o        | yaml              |
+      | resource | clusterroles.rbac                         |
+      | o        | jsonpath={.items[*].metadata.annotations} |
     Then the output should contain:
-      | autoupdate: "true" |
+      | autoupdate":"true" |
     And the output should not contain:
-      | autoupdate: "false" |
+      | autoupdate":"false" |
     # Make some changes on clusterrole resources before upgrade
     Given as admin I successfully patch resource "clusterrole.rbac/system:build-strategy-custom" with:
       | {"rules": [{"apiGroups": ["","build.openshift.io"],"resources": ["builds/custom"],"verbs": [ "get" ]}] } |


### PR DESCRIPTION
The original command generate too many logs.
```
$ oc get clusterroles.rbac -o yaml | wc
  17610   31457  339285
```
/cc @wangke19 @xingxingxia @jhou1 