### PR TITLE
OCP-38132: set inactive and fix variable interpolation

### DIFF
--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -521,6 +521,7 @@ Feature: OVN related networking scenarios
   @admin
   @destructive
   @4.10 @4.9
+  @inactive
   Scenario: Should no intermittent packet drop from pod to pod after change hostname
     Given I store the schedulable workers in the :nodes clipboard
     Given admin uses the "openshift-ovn-kubernetes" project

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1412,9 +1412,9 @@ Given /^I set#{OPT_QUOTED} hostname to external ids on the "([^"]*)" node$/ do |
   }.first
   @result = ovn_pod.exec(*ovsvsctl_cmd, as: admin, container: "ovnkube-node")
   if @result[:success]
-    logger.info "Set the ${custom_hostname} to ovn external_ids successfully."
+    logger.info "Set the ovn external_ids to '#{custom_hostname}' successfully."
   else
-    raise "Set the ${custom_hostname} to ovn external_ids failed."
+    raise "Set the ovn external_ids to '#{custom_hostname}' failed."
   end
 end
 


### PR DESCRIPTION
OCP-38132 is inactive

fix variable interpolation, use `#{var}` not `${var}`

```
[15:53:13] INFO> Set the ${custom_hostname} to ovn external_ids successfully.
```

```
[15:57:18] INFO> Set the ovn external_ids to 'master-0-0' successfully.
```