### PR TITLE
Fix issue OCPQE-5054

### DIFF
--- a/features/upgrade/cloudcredential/upgrade.feature
+++ b/features/upgrade/cloudcredential/upgrade.feature
@@ -6,13 +6,21 @@ Feature: CloudCredentialOperator components upgrade tests
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   Scenario: Cluster operator cloud-credential should be available after upgrade - prepare
+    Given I switch to cluster admin pseudo user
     #Check cloud-credential version
     Given the "cloud-credential" operator version matches the current cluster version
-    # Check cluster operator cloud-credential should be in correct status
+    #Check cluster operator cloud-credential should be in correct status
     Given the expression should be true> cluster_operator('cloud-credential').condition(type: 'Progressing')['status'] == "False"
     Given the expression should be true> cluster_operator('cloud-credential').condition(type: 'Available')['status'] == "True"
     Given the expression should be true> cluster_operator('cloud-credential').condition(type: 'Degraded')['status'] == "False"
-    Given the expression should be true> cluster_operator('cloud-credential').condition(type: 'Upgradeable')['status'] == "True"
+    Given I run the :get client command with:
+      | resource      | cloudcredential           |
+      | resource_name | cluster                   |
+      | template      | {{.spec.credentialsMode}} |
+    And evaluation of `@result[:stdout]` is stored in the :cco_mode clipboard
+    #Upgradeable status supported from 4.2
+    #Upgradeable default false if cco in Manual mode from 4.8
+    Then the expression should be true> env.version_le("4.1", user: user) ? true : cluster_operator('cloud-credential').condition(type: 'Upgradeable')['status'] == (env.version_ge("4.8", user: user) && "<%= cb.cco_mode %>" == "Manual" ? "False" : "True")
 
   # @author lwan@redhat.com
   # @case_id OCP-34260


### PR DESCRIPTION
From ocp 4.8, co cloud-credential Upgradeable default False if cco is in Manual mode, added judgment to this scenario.

version 4.1 
job: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/254866/console

version 4.10 and cco manual mode
job: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/254867/console

version 4.10 and cco non-manual mode
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/254869/console