### PR TITLE
make sure tags are aligned between prepare and check

### DIFF
--- a/features/upgrade/sdn/ipsec-upgrade.feature
+++ b/features/upgrade/sdn/ipsec-upgrade.feature
@@ -4,6 +4,8 @@ Feature: IPsec upgrade scenarios
   @admin
   @upgrade-prepare
   @4.10 @4.9 @4.8
+  @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: Confirm node-node and pod-pod packets are ESP enrypted on IPsec clusters post upgrade - prepare
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster


### PR DESCRIPTION
This fixes https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/24726/rehearse-24726-periodic-ci-openshift-verification-tests-master-stable-4.9-upgrade-from-stable-4.8-upgrade-verification-tests-baremetal-ipi/1471671965688270848 

```
    Scenario: Confirm node-node and pod-pod packets are ESP enrypted on IPsec clusters post upgrade

And I use the "ipsec-upgrade" project

Message:

    can not switch to project ipsec-upgrade (RuntimeError)
./features/step_definitions/project.rb:118:in `/^I use the "(.+?)" project$/'
features/upgrade/sdn/ipsec-upgrade.feature:75:in `I use the "ipsec-upgrade" project'
  
```

@liangxia @pruan-rht @JianLi-RH @dis016 PTAL