### PR TITLE
Sync upgrade tags

### DIFF
--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -213,6 +213,9 @@ Feature: Routing and DNS related scenarios
   # @author mjoseph@redhat.com
   @upgrade-prepare
   @users=upuser1,upuser2
+  @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: Unidling a route work without user intervention - prepare
     Given I switch to first user
     And I run the :new_project client command with:
@@ -230,7 +233,7 @@ Feature: Routing and DNS related scenarios
     Then the expression should be true> service('service-unsecure').exists?
     When I expose the "service-unsecure" service
     Then the step should succeed
-    
+
     Given I have a test-client-pod in the project
     When I execute on the pod:
       | curl | -ksS | http://<%= route("service-unsecure", service("service-unsecure")).dns %>/ |
@@ -259,7 +262,7 @@ Feature: Routing and DNS related scenarios
     Given I switch to first user
     Given I use the "ocp45955" project
     And the expression should be true> service('service-unsecure').annotation('idling.alpha.openshift.io/unidle-targets', cached: false) == "[{\"kind\":\"ReplicationController\",\"name\":\"web-server-rc\",\"replicas\":1}]"
-  
+
     Given I have a test-client-pod in the project
     When I execute on the pod:
       | curl | -ksS | http://<%= route("service-unsecure", service("service-unsecure")).dns %>/ |

--- a/features/upgrade/sdn/multicast-upgrade.feature
+++ b/features/upgrade/sdn/multicast-upgrade.feature
@@ -1,8 +1,11 @@
  Feature: SDN multicast compoment upgrade testing
- 
+
   # @author weliang@redhat.com
   @admin
   @upgrade-prepare
+  @4.10 @4.9
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   Scenario: Check the multicast works well after upgrade - prepare
     # create some multicast testing pods
     Given I switch to cluster admin pseudo user
@@ -71,7 +74,7 @@
     Then the step should succeed
     And the output should match:
       | eth0\s+1\s+232.43.211.234 |
-    """   
+    """
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.pod3 %>" pod:
@@ -83,7 +86,7 @@
     And the output should not match:
       | <%= cb.pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
       | <%= cb.pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
-    """  
+    """
 
   # @author weliang@redhat.com
   # @case_id OCP-44636
@@ -148,7 +151,7 @@
     Then the step should succeed
     And the output should match:
       | eth0\s+1\s+232.43.211.234 |
-    """   
+    """
     And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.pod3 %>" pod:

--- a/features/upgrade/sdn/sctp-upgrade.feature
+++ b/features/upgrade/sdn/sctp-upgrade.feature
@@ -3,6 +3,9 @@ Feature: SDN sctp compoment upgrade testing
   # @author weliang@redhat.com
   @admin
   @upgrade-prepare
+  @4.10 @4.9
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   Scenario: Check the sctp works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:


### PR DESCRIPTION
This fixes failures from https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/24763/rehearse-24763-periodic-ci-openshift-verification-tests-master-ocp-4.10-upgrade-from-stable-4.9-upgrade-verification-tests-gcp-upi/1472825528590274560

@liangxia @pruan-rht @JianLi-RH @dis016 PTAL