### PR TITLE
Fix OCP-45349

### DIFF
--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -162,6 +162,8 @@ Feature: Egress compoment upgrade testing
   @admin
   @upgrade-prepare
   @4.10 @4.9
+  @vsphere-ipi
+  @vsphere-upi
   Scenario: Check sdn egressip is functional post upgrade - prepare
     Given I save ipecho url to the clipboard
     Given I switch to cluster admin pseudo user


### PR DESCRIPTION
Fix the failure in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/24848/rehearse-24848-periodic-ci-openshift-verification-tests-master-nightly-4.10-upgrade-from-stable-4.9-upgrade-verification-tests-vsphere-ipi/1473884216667148288
```
    Scenario: Check sdn egressip is functional post upgrade
When I use the "sdn-egressip-upgrade1" project
Message:
    can not switch to project sdn-egressip-upgrade1 (RuntimeError)
/verification-tests/features/step_definitions/project.rb:118:in `/^I use the "(.+?)" project$/'
features/upgrade/sdn/egress-upgrade.feature:264:in `I use the "sdn-egressip-upgrade1" project'
```
```
$ grep -r -B5 'Check sdn egressip is functional post upgrade' 
features/upgrade/sdn/egress-upgrade.feature-
features/upgrade/sdn/egress-upgrade.feature-  # @author huirwang@redhat.com
features/upgrade/sdn/egress-upgrade.feature-  @admin
features/upgrade/sdn/egress-upgrade.feature-  @upgrade-prepare
features/upgrade/sdn/egress-upgrade.feature-  @4.10 @4.9
features/upgrade/sdn/egress-upgrade.feature:  Scenario: Check sdn egressip is functional post upgrade - prepare
--
features/upgrade/sdn/egress-upgrade.feature-  @admin
features/upgrade/sdn/egress-upgrade.feature-  @upgrade-check
features/upgrade/sdn/egress-upgrade.feature-  @4.10 @4.9
features/upgrade/sdn/egress-upgrade.feature-  @vsphere-ipi
features/upgrade/sdn/egress-upgrade.feature-  @vsphere-upi
features/upgrade/sdn/egress-upgrade.feature:  Scenario: Check sdn egressip is functional post upgrade

```