### PR TITLE
Sync tags between upgrade prepare/check for OCP-44901

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -376,6 +376,8 @@ Feature: SDN compoment upgrade testing
   @admin
   @upgrade-prepare
   @4.10 @4.9 @4.8
+  @azure-upi @aws-upi
+  @azure-ipi @aws-ipi
   Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade - prepare
     Given I switch to cluster admin pseudo user
     And I store the workers in the :nodes clipboard


### PR DESCRIPTION
OCP-44901 only contains iaas tags for upgrade check, but does not have those tags in upgrade preapre, thus upgrade check failed due to project does not exist. E.g, failure in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/24870/rehearse-24870-periodic-ci-openshift-verification-tests-master-nightly-4.10-upgrade-from-eus-4.8-upgrade-paused/1474297167140098048

```
$ grep -r -B5 'Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade'
features/upgrade/sdn/policy-upgrade.feature-
features/upgrade/sdn/policy-upgrade.feature-  # @author anusaxen@redhat.com
features/upgrade/sdn/policy-upgrade.feature-  @admin
features/upgrade/sdn/policy-upgrade.feature-  @upgrade-prepare
features/upgrade/sdn/policy-upgrade.feature-  @4.10 @4.9 @4.8
features/upgrade/sdn/policy-upgrade.feature:  Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade - prepare
--
features/upgrade/sdn/policy-upgrade.feature-  @admin
features/upgrade/sdn/policy-upgrade.feature-  @upgrade-check
features/upgrade/sdn/policy-upgrade.feature-  @4.10 @4.9 @4.8
features/upgrade/sdn/policy-upgrade.feature-  @azure-upi @aws-upi
features/upgrade/sdn/policy-upgrade.feature-  @azure-ipi @aws-ipi
features/upgrade/sdn/policy-upgrade.feature:  Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade
```

/cc @JianLi-RH @pruan-rht @jhou1 @dis016 