### PR TITLE
fix failure: unknown parameter name "CLIENT_AUTH"

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -993,7 +993,7 @@ Given /^external elasticsearch server is deployed with:$/ do | table |
   pod_label = "app=elasticsearch-server"
 
   # create secret/elasticsearch-server for ES if needed
-  if http_ssl_enabled = "true"
+  if http_ssl_enabled == "true"
     step %Q/I generate certs for the "elasticsearch-server" receiver in the "<%= project.name %>" project/
     unless tagged_upgrade?
       step %Q/I ensure "elasticsearch-server" secret is deleted from the "<%= project.name %>" project after scenario/


### PR DESCRIPTION
Fix failure:
```
12-30 08:52:24.096          Given external elasticsearch server is deployed with:                                                               # features/step_definitions/logging.rb:965
12-30 08:52:24.096            | version      | 6.8                    |
12-30 08:52:24.096            | scheme       | <scheme>               |
12-30 08:52:24.096            | client_auth  | <client_auth>          |
12-30 08:52:24.096            | project_name | <%= cb.es_proj.name %> |
12-30 08:52:24.096            | secret_name  | pipelinesecret         |
12-30 08:52:24.096        [00:52:13] INFO> Shell Commands: oc project jsf84 --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_testuser-0.kubeconfig
12-30 08:52:24.096        Already on project "jsf84" on server "https://api.xxxx.com:6443".
12-30 08:52:24.096        [00:52:14] INFO> Exit Status: 0
12-30 08:52:24.096        [00:52:19] INFO> Shell Commands: oc process -f /home/jenkins/ws/workspace/ocp-common/Runner/testdata/logging/clusterlogforwarder/elasticsearch/6.8/http/no_user/configmap.yaml -p NAMESPACE\=jsf84 -p CLIENT_AUTH\=none --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_admin.kubeconfig -n jsf84
12-30 08:52:24.096        
12-30 08:52:24.096        STDERR:
12-30 08:52:24.096        error: unknown parameter name "CLIENT_AUTH"
```