### PR TITLE
Sync tags between upgrade prepare/check for OCP-34164

### DIFF
--- a/features/upgrade/workloads/scheduler-upgrade.feature
+++ b/features/upgrade/workloads/scheduler-upgrade.feature
@@ -4,6 +4,8 @@ Feature: scheduler with custom policy upgrade check
   @admin
   @destructive
   @4.10 @4.9 @4.8
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine - prepare
     Given the "kube-scheduler" operator version matches the current cluster version
     Given the expression should be true> cluster_operator('kube-scheduler').condition(type: 'Progressing')['status'] == "False"


### PR DESCRIPTION
OCP-34164 only contains iaas tags for upgrade check, but does not have those tags in upgrade prepare, thus upgrade check in Prow failed due to those preparation steps are not executed. 

```
$ grep -r -B8 'Upgrading cluster when using a custom policy for kube-scheduler should work fine'
features/upgrade/workloads/scheduler-upgrade.feature-Feature: scheduler with custom policy upgrade check
features/upgrade/workloads/scheduler-upgrade.feature-  # @author knarra@redhat.com
features/upgrade/workloads/scheduler-upgrade.feature-  @upgrade-prepare
features/upgrade/workloads/scheduler-upgrade.feature-  @admin
features/upgrade/workloads/scheduler-upgrade.feature-  @destructive
features/upgrade/workloads/scheduler-upgrade.feature-  @4.10 @4.9 @4.8
features/upgrade/workloads/scheduler-upgrade.feature:  Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine - prepare
--
features/upgrade/workloads/scheduler-upgrade.feature-  # @author knarra@redhat.com
features/upgrade/workloads/scheduler-upgrade.feature-  # @case_id OCP-34164
features/upgrade/workloads/scheduler-upgrade.feature-  @upgrade-check
features/upgrade/workloads/scheduler-upgrade.feature-  @admin
features/upgrade/workloads/scheduler-upgrade.feature-  @destructive
features/upgrade/workloads/scheduler-upgrade.feature-  @4.10 @4.9 @4.8
features/upgrade/workloads/scheduler-upgrade.feature-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
features/upgrade/workloads/scheduler-upgrade.feature-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
features/upgrade/workloads/scheduler-upgrade.feature:  Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine
```

@JianLi-RH @pruan-rht @jhou1 @dis016  Could you help check ?