### PR TITLE
Sync tags between upgrade prepare/check for OCP-40536

### DIFF
--- a/features/upgrade/workloads/descheduler-upgrade.feature
+++ b/features/upgrade/workloads/descheduler-upgrade.feature
@@ -4,6 +4,9 @@ Feature: Descheduler major upgrade should work fine
   @upgrade-prepare
   @users=upuser1,upuser2
   @destructive
+  @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: [upgrade] - upgrade descheduler from 4.x to 4.y - prepare
     Given I switch to cluster admin pseudo user
     Given I store master major version in the clipboard


### PR DESCRIPTION
OCP-40536 only contains iaas tags for upgrade check, but does not have those tags in upgrade prepare, thus upgrade check in Prow failed due to those preparation steps are not executed.
```
$ grep -r -B8 'upgrade descheduler from 4.x to 4.y'
features/upgrade/workloads/descheduler-upgrade.feature-Feature: Descheduler major upgrade should work fine
features/upgrade/workloads/descheduler-upgrade.feature-  # @author knarra@redhat.com
features/upgrade/workloads/descheduler-upgrade.feature-  @admin
features/upgrade/workloads/descheduler-upgrade.feature-  @upgrade-prepare
features/upgrade/workloads/descheduler-upgrade.feature-  @users=upuser1,upuser2
features/upgrade/workloads/descheduler-upgrade.feature-  @destructive
features/upgrade/workloads/descheduler-upgrade.feature:  Scenario: [upgrade] - upgrade descheduler from 4.x to 4.y - prepare
--
features/upgrade/workloads/descheduler-upgrade.feature-  # @case_id OCP-40536
features/upgrade/workloads/descheduler-upgrade.feature-  @admin
features/upgrade/workloads/descheduler-upgrade.feature-  @upgrade-check
features/upgrade/workloads/descheduler-upgrade.feature-  @users=upuser1,upuser2
features/upgrade/workloads/descheduler-upgrade.feature-  @destructive
features/upgrade/workloads/descheduler-upgrade.feature-  @4.10 @4.9
features/upgrade/workloads/descheduler-upgrade.feature-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
features/upgrade/workloads/descheduler-upgrade.feature-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
features/upgrade/workloads/descheduler-upgrade.feature:  Scenario: [upgrade] - upgrade descheduler from 4.x to 4.y
```
Hi @kasturinarra @jhou1 @dis016 @pruan-rht @JianLi-RH   Could you help check ?