### PR TITLE
strip BUSHSLICER_CONFIG inputing

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -36,7 +36,7 @@ module BushSlicer
       @opts[:files].each { |f| raw_configs << load_file(f) }
 
       # merge config from environment if present
-      if ENV["BUSHSLICER_CONFIG"] && !ENV["BUSHSLICER_CONFIG"].empty?
+      if ENV["BUSHSLICER_CONFIG"] && !ENV["BUSHSLICER_CONFIG"].strip.empty?
         raw_configs << YAML.load(ENV["BUSHSLICER_CONFIG"])
       end
 


### PR DESCRIPTION
When user input "\n" for `BUSHSLICER_CONFIG` ENV, it will failed with the following error:
```
01-04 10:59:56.182  + run_installer template -c private-templates/functionality-testing/aos-4_10/upi-on-aws/versioned-installer -l jialiu59
01-04 10:59:56.182  + ruby tools/launch_instance.rb template -c private-templates/functionality-testing/aos-4_10/upi-on-aws/versioned-installer -l jialiu59
01-04 10:59:56.788  /home/jenkins/ws/workspace/ocp-common/Flexy-install/flexy/lib/collections.rb:108:in `merge': no implicit conversion of false into Hash (TypeError)
01-04 10:59:56.788  	from /home/jenkins/ws/workspace/ocp-common/Flexy-install/flexy/lib/collections.rb:108:in `deep_merge'
01-04 10:59:56.788  	from /home/jenkins/ws/workspace/ocp-common/Flexy-install/flexy/lib/configuration.rb:47:in `block in raw'
01-04 10:59:56.788  	from /home/jenkins/ws/workspace/ocp-common/Flexy-install/flexy/lib/configuration.rb:46:in `each'
01-04 10:59:56.788  	from /home/jenkins/ws/workspace/ocp-common/Flexy-install/flexy/lib/configuration.rb:46:in `reduce'
01-04 10:59:56.788  	from /home/jenkins/ws/workspace/ocp-common/Flexy-install/flexy/lib/configuration.rb:46:in `raw'
01-04 10:59:56.788  	from /home/jenkins/ws/workspace/ocp-common/Flexy-install/flexy/lib/configuration.rb:100:in `[]'
01-04 10:59:56.788  	from tools/launch_instance.rb:686:in `launch_template'
01-04 10:59:56.788  	from tools/launch_instance.rb:55:in `block (2 levels) in run'
01-04 10:59:56.788  	from /home/jenkins/.gem/bundler/ruby/2.7.0/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
01-04 10:59:56.789  	from /home/jenkins/.gem/bundler/ruby/2.7.0/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
01-04 10:59:56.789  	from /home/jenkins/.gem/bundler/ruby/2.7.0/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
01-04 10:59:56.789  	from /home/jenkins/.gem/bundler/ruby/2.7.0/gems/commander-4.6.0/lib/commander/runner.rb:58:in `run!'
01-04 10:59:56.789  	from /home/jenkins/.gem/bundler/ruby/2.7.0/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
01-04 10:59:56.789  	from tools/launch_instance.rb:92:in `run'
01-04 10:59:56.789  	from tools/launch_instance.rb:904:in `<main>'
01-04 10:59:56.789  launching..
```

The PR will strip BUSHSLICER_CONFIG env var to avoid that error.

Some local testing:
```
irb(main):001:0> ENV["BUSHSLICER_CONFIG"].empty?
=> false
irb(main):002:0> ENV["BUSHSLICER_CONFIG"]
=> "services:\n  AWS:\n    create_opts:\n      instance_initiated_shutdown_behavior: terminate\n      block_device_mappings:\n      -\n        device_name: /dev/sda1\n        ebs:\n          volume_size: 60\n    config_opts:\n      region: ap-northeast-1\n"
irb(main):003:0> ENV["BUSHSLICER_CONFIG"].strip
=> "services:\n  AWS:\n    create_opts:\n      instance_initiated_shutdown_behavior: terminate\n      block_device_mappings:\n      -\n        device_name: /dev/sda1\n        ebs:\n          volume_size: 60\n    config_opts:\n      region: ap-northeast-1"
irb(main):004:0> " a b \nc\n".strip
=> "a b \nc"
irb(main):005:0> ENV["BUSHSLICER_CONFIG"].strip.empty?
=> false
irb(main):006:0> ENV["BUSHSLICER_CONFIG"]="\n"
=> "\n"
irb(main):007:0> ENV["BUSHSLICER_CONFIG"].strip.empty?
=> true
irb(main):008:0> ENV["BUSHSLICER_CONFIG"].empty?
=> false
```