### PR TITLE
fix logging failure

### DIFF
--- a/lib/rules/web/admin_console/4.10/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.10/dashboards.xyaml
@@ -540,7 +540,7 @@ check_metrics_query_filesystem_filter_by_node_type:
   scripts:
   - command:
       return /sum.*node_filesystem_size_bytes.*kube_node_role.*<node_type>/.test(decodeURI(document.querySelectorAll('div.co-utilization-card__item-chart>div>a')[2].href).replaceAll('\n',''))
-    expect_result: true   
+    expect_result: true
 check_metrics_query_network_filter_by_node_type:
   scripts:
   - command:
@@ -793,5 +793,5 @@ check_no_errors_in_charts:
 check_monitoring_dashboard_card:
   element:
     selector:
-      xpath: //h2[contains(@class,'co-dashboard-card__title') and text()='<card_name>']
+      xpath: //div[contains(@class,'pf-c-card__title') and text()='<card_name>']
     timeout: 60


### PR DESCRIPTION
Fix below failure when running case OCP-37508 on OCP 4.10:
```
    Given evaluation of `["Elastic Nodes", "Elastic Shards", "Elastic Documents", "Total Index Size on Disk", "Elastic Pending Tasks", "Elastic JVM GC time", "Elastic JVM GC Rate", "Elastic Query/Fetch Latency | Sum", "Elastic Query Rate | Top 5", "CPU", "Elastic JVM Heap Used", "Elasticsearch Disk Usage", "File Descriptors In Use", "FluentD emit count", "FluentD Buffer Availability", "Elastic rx bytes", "Elastic Index Failure Rate", "FluentD Output Error Rate"]` is stored in the :cards clipboard # features/step_definitions/common.rb:128
waiting for operation up to 360 seconds..
    Given I wait up to 360 seconds for the steps to pass:                                                                                                                                                                                                                                                                                                                                                                                                                                                             # features/step_definitions/meta_steps.rb:33
      """
      When I perform the :check_monitoring_dashboard_card web action with:
        | card_name | Elastic Cluster Status |
      Then the step should succeed
      """
      [08:11:12] INFO> running web action check_monitoring_dashboard_card ... 
      [08:11:12] INFO> element..
      [08:11:12] INFO> found 0 element elements with selector: {:xpath=>"//h2[contains(@class,'co-dashboard-card__title') and text()='Elastic Cluster Status']"}
      [08:12:12] INFO> last 1 messages repeated 59 times
      [08:12:12] INFO> embedding "2022-01-04T16:12:12+08:00-screenshot.png"
      [08:12:13] INFO> running web action check_monitoring_dashboard_card ... 
      [08:12:13] INFO> element..
      [08:12:13] INFO> found 0 element elements with selector: {:xpath=>"//h2[contains(@class,'co-dashboard-card__title') and text()='Elastic Cluster Status']"}
      [08:13:14] INFO> last 1 messages repeated 59 times
      [08:13:14] INFO> embedding "2022-01-04T16:13:14+08:00-screenshot.png"
      [08:13:15] INFO> running web action check_monitoring_dashboard_card ... 
      [08:13:15] INFO> element..
      [08:13:15] INFO> found 0 element elements with selector: {:xpath=>"//h2[contains(@class,'co-dashboard-card__title') and text()='Elastic Cluster Status']"}
      [08:14:15] INFO> last 1 messages repeated 59 times
      [08:14:15] INFO> embedding "2022-01-04T16:14:15+08:00-screenshot.png"
      [08:14:16] INFO> running web action check_monitoring_dashboard_card ... 
      [08:14:16] INFO> element..
      [08:14:16] INFO> found 0 element elements with selector: {:xpath=>"//h2[contains(@class,'co-dashboard-card__title') and text()='Elastic Cluster Status']"}
      [08:15:16] INFO> last 1 messages repeated 59 times
      [08:15:17] INFO> embedding "2022-01-04T16:15:16+08:00-screenshot.png"
      [08:15:18] INFO> running web action check_monitoring_dashboard_card ... 
      [08:15:18] INFO> element..
      [08:15:18] INFO> found 0 element elements with selector: {:xpath=>"//h2[contains(@class,'co-dashboard-card__title') and text()='Elastic Cluster Status']"}
      [08:16:19] INFO> last 1 messages repeated 60 times
      [08:16:19] INFO> embedding "2022-01-04T16:16:19+08:00-screenshot.png"
      [08:16:20] INFO> running web action check_monitoring_dashboard_card ... 
      [08:16:20] INFO> element..
      [08:16:20] INFO> found 0 element elements with selector: {:xpath=>"//h2[contains(@class,'co-dashboard-card__title') and text()='Elastic Cluster Status']"}
      [08:17:20] INFO> last 1 messages repeated 59 times
      [08:17:20] INFO> embedding "2022-01-04T16:17:20+08:00-screenshot.png"
      the step failed (RuntimeError)
      /Users/qitang/go/src/github.com/openshift/verification-tests/features/step_definitions/common.rb:6:in `/^the step should( not)? (succeed|fail)$/'
      /Users/qitang/go/src/github.com/openshift/verification-tests/features/step_definitions/transform.rb:33:in `call'
      /Users/qitang/go/src/github.com/openshift/verification-tests/features/step_definitions/transform.rb:33:in `block in singleton class'
      /Users/qitang/go/src/github.com/openshift/verification-tests/features/step_definitions/meta_steps.rb:48:in `block (2 levels) in <top (required)>'
      /Users/qitang/go/src/github.com/openshift/verification-tests/lib/base_helper.rb:155:in `wait_for'
      /Users/qitang/go/src/github.com/openshift/verification-tests/features/step_definitions/meta_steps.rb:43:in `/^I wait(?: up to ([0-9]+|<%=.+?%>) seconds)? for the steps to pass:$/'
      features/logging/logging_acceptance.feature:69:in `I wait up to 360 seconds for the steps to pass:'
```