### PR TITLE
Automated 33047

### DIFF
--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -90,3 +90,23 @@ Then(/^admin ensures machine number is restored after scenario$/) do
     end
   }
 end
+
+Given /^I run the steps #{NUMBER} times or exit when co machine-api is degraded:$/ do |num, steps_string|
+  eval_regex = /\#\{(.+?)\}/
+  eval_found = steps_string =~ eval_regex
+  step %Q{evaluation of `cluster_operator('machine-api').condition(type: 'Degraded')` is stored in the :co_degraded clipboard}
+  begin
+    logger.dedup_start
+    (1..Integer(num)).each { |i|
+      cb.i = i
+      if eval_found && cb.co_degraded["status"]=="False"
+        steps steps_string.gsub(eval_regex) { |s| "<%= #{$1} %>"}
+      else
+        steps steps_string
+      end
+    }
+  ensure
+    logger.dedup_flush
+  end
+end
+


### PR DESCRIPTION
@jhou1 @sunzhaohua2 @huali9 PTAL , here in the test we wanted to make sure that when machine-controller pod is deleted continuously (simulating crash) the status of the machine-api cluster operator should go degraded , it was a [issue](https://bugzilla.redhat.com/show_bug.cgi?id=1859221) wherein it was not getting reported .

Here is the validation result - https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/276602/console 
 