### PR TITLE
update the interval to 2 from 1 to make this more stable

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -111,15 +111,14 @@ Feature: Pod related networking scenarios
       | ovs-vsctl | list | interface |
     Then the step should succeed
     And the output should contain "ingress_policing_rate: 1953"
-
     # test the bandwidth limit with qos for egress
     When I execute on the "<%= cb.iperf_client %>" pod:
-      | sh | -c | iperf3 -c <%= cb.iperf_server %> -i 1 -t 12s |
+      | sh | -c | iperf3 -c <%= cb.iperf_server %> -i 2 -t 24s |
     Then the step should succeed
     And the expression should be true> @result[:response].scan(/[12].[0-9][0-9] Mbits/).size >= 10
     # test the bandwidth limit with qos for ingress
     When I execute on the "<%= cb.iperf_client %>" pod:
-      | sh | -c | iperf3 -c <%= cb.iperf_server %> -i 1 -t 12s -R |
+      | sh | -c | iperf3 -c <%= cb.iperf_server %> -i 2 -t 24s -R |
     Then the step should succeed
     And the expression should be true> @result[:response].scan(/[45].[0-9][0-9] Mbits/).size >= 10
 

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -9,7 +9,7 @@ Given /^I run the ovs commands on the host:$/ do | table |
   else
     # For >=3.10 and runc env, should get containerID from the pod which landed on the node
     logger.info("OCP version >= 3.10 and environment may using runc to launch openvswith")
-    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node.name
     }.first
     container_id = ovs_pod.containers.first.id
@@ -344,17 +344,17 @@ Given /^I wait for the networking components of the node to be terminated$/ do
   network_type = network_operator.network_type(user: admin)
   case network_type
   when "OpenShiftSDN"
-    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node.name
     }.first
-    net_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: _admin) { |pod, hash|
+    net_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: _admin, quiet: true) { |pod, hash|
       pod.node_name == node.name
     }.first
   when "OVNKubernetes"
-    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node.name
     }.first
-    net_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+    net_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node.name
     }.first
   else
@@ -391,7 +391,7 @@ Given /^I wait for the networking components of the node to become ready$/ do
     BushSlicer::Platform::SystemdService.new("ovsdb-server.service", _host).status[:success]
   else
 
-    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node.name
     }.first
     @result = ovs_pod.wait_till_ready(_admin, 60)
@@ -406,7 +406,7 @@ Given /^I wait for the networking components of the node to become ready$/ do
   case network_type
   when "OpenShiftSDN"
 
-    sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node.name
     }.first
 
@@ -418,7 +418,7 @@ Given /^I wait for the networking components of the node to become ready$/ do
     cache_resources sdn_pod
     cb.sdn_pod = sdn_pod
   when "OVNKubernetes"
-    ovnkube_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+    ovnkube_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node.name
     }.first
     cache_resources ovnkube_pod
@@ -449,11 +449,11 @@ Given /^I restart the openvswitch service on the node$/ do
     network_type = network_operator.network_type(user: admin)
     case network_type
     when "OpenShiftSDN"
-      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin, quiet: true) { |pod, hash|
         pod.node_name == node.name
       }.first
     when "OVNKubernetes"
-      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
         pod.node_name == node.name
       }.first
     else
@@ -477,11 +477,11 @@ Given /^I restart the network components on the node( after scenario)?$/ do |aft
       network_type = network_operator.network_type(user: _admin)
       case network_type
       when "OpenShiftSDN"
-        net_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: _admin) { |pod, hash|
+        net_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: _admin, quiet: true) { |pod, hash|
           pod.node_name == _node.name
         }.first
       when "OVNKubernetes"
-        net_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+        net_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
           pod.node_name == _node.name
         }.first
       else
@@ -506,12 +506,12 @@ Given /^I get the networking components logs of the node since "(.+)" ago$/ do |
   network_type = network_operator.network_type(user: admin)
   case network_type
   when "OpenShiftSDN"
-    sdn_pod = cb.sdn_pod || BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    sdn_pod = cb.sdn_pod || BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node.name
     }.first
     @result = admin.cli_exec(:logs, resource_name: sdn_pod.name, n: "openshift-sdn", c: "sdn", since: duration)
   when "OVNKubernetes"
-    ovnkube_pod = cb.ovnkube_pod || BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+    ovnkube_pod = cb.ovnkube_pod || BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node_name
     }.first
     @result = admin.cli_exec(:logs, resource_name: ovnkube_pod.name, n: "openshift-ovn-kubernetes", since: duration)
@@ -642,13 +642,13 @@ Given /^I run command on the#{OPT_QUOTED} node's sdn pod:$/ do |node_name, table
   network_type = network_operator.network_type(user: admin)
   case network_type
   when "OpenShiftSDN"
-    sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+    sdn_pod = BushSlicer::Pod.get_labeled("app=sdn", project: project("openshift-sdn", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node_name
     }.first
     cache_resources sdn_pod
     @result = sdn_pod.exec(network_cmd, container: "sdn", as: admin)
   when "OVNKubernetes"
-    ovnkube_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+    ovnkube_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
       pod.node_name == node_name
     }.first
     cache_resources ovnkube_pod
@@ -680,11 +680,11 @@ Given /^I restart the ovs pod on the#{OPT_QUOTED} node$/ do | node_name |
     network_type = network_operator.network_type(user: admin)
     case network_type
     when "OpenShiftSDN"
-      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin, quiet: true) { |pod, hash|
         pod.node_name == node_name
       }.first
     when "OVNKubernetes"
-      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
         pod.node_name == node_name
       }.first
     else
@@ -790,9 +790,9 @@ Given /^I run cmds on all ovs pods:$/ do | table |
     network_type = network_operator.network_type(user: admin)
     case network_type
     when "OpenShiftSDN"
-      ovs_pods = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin)
+      ovs_pods = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin, quiet: true)
     when "OVNKubernetes"
-      ovs_pods = BushSlicer::Pod.get_labeled("app=ovs-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin)
+      ovs_pods = BushSlicer::Pod.get_labeled("app=ovs-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true)
     else
       raise "unknown network_type"
     end
@@ -821,11 +821,11 @@ Given /^I run command on the#{OPT_QUOTED} node's ovs pod:$/ do |node_name, table
     network_type = network_operator.network_type(user: admin)
     case network_type
     when "OpenShiftSDN"
-      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin) { |pod, hash|
+      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs", project: project("openshift-sdn", switch: false), user: admin, quiet: true) { |pod, hash|
         pod.node_name == node_name
       }.first
     when "OVNKubernetes"
-      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+      ovs_pod = BushSlicer::Pod.get_labeled("app=ovs-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
         pod.node_name == node_name
       }.first
     else
@@ -1373,7 +1373,7 @@ Given /^I store the hostname from external ids in the#{OPT_SYM} clipboard on the
   cb_ovn_hostname ||= "ovn_hostname"
 
   ovsvsctl_cmd = %w(ovs-vsctl list open .)
-  ovn_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+  ovn_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
     pod.node_name == node_name
   }.first
   @result = ovn_pod.exec(*ovsvsctl_cmd, as: admin, container: "ovnkube-node")
@@ -1396,7 +1396,7 @@ Given /^I store the#{OPT_QUOTED} hostname in the#{OPT_SYM} clipboard for the "([
     ovn_cmd = %w(hostname -f)
   end
 
-  ovn_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+  ovn_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
     pod.node_name == node_name
   }.first
   @result = ovn_pod.exec(*ovn_cmd, as: admin, container: "ovnkube-node")
@@ -1416,7 +1416,7 @@ Given /^I set#{OPT_QUOTED} hostname to external ids on the "([^"]*)" node$/ do |
   ovsvsctl_cmd = %w(ovs-vsctl set open .)
   external_hostname = "external_ids:hostname=#{custom_hostname}"
   ovsvsctl_cmd << external_hostname
-  ovn_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin) { |pod, hash|
+  ovn_pod = BushSlicer::Pod.get_labeled("app=ovnkube-node", project: project("openshift-ovn-kubernetes", switch: false), user: admin, quiet: true) { |pod, hash|
     pod.node_name == node_name
   }.first
   @result = ovn_pod.exec(*ovsvsctl_cmd, as: admin, container: "ovnkube-node")


### PR DESCRIPTION
sometimes with interval is 1, this transfer is 0.00 Byte.  So here update the interval to 2 to make sure the result more stable. 

```
      [06:06:23] INFO> Shell Commands: oc exec iperf-rc-d4nmg  --kubeconfig=/home/zzhao/workdir/dhcp-140-240-zzhaox/ocp4_testuser-22.kubeconfig -n 3pk8p  -i -- sh -c iperf3\ -c\ 10.129.2.195\ -i\ 1\ -t\ 12s
      Connecting to host 10.129.2.195, port 5201
      [  5] local 10.131.1.138 port 39148 connected to 10.129.2.195 port 5201
      [ ID] Interval           Transfer     Bitrate         Retr  Cwnd
      [  5]   0.00-1.00   sec  2.05 MBytes  17.2 Mbits/sec   48   17.4 KBytes       
      [  5]   1.00-2.00   sec   426 KBytes  3.49 Mbits/sec   18   17.4 KBytes       
      [  5]   2.00-3.00   sec  0.00 Bytes  0.00 bits/sec   15   17.4 KBytes       
      [  5]   3.00-4.00   sec   487 KBytes  3.99 Mbits/sec   15   17.4 KBytes       
      [  5]   4.00-5.00   sec  0.00 Bytes  0.00 bits/sec   15   17.4 KBytes       
      [  5]   5.00-6.00   sec   487 KBytes  3.99 Mbits/sec   12   17.4 KBytes       
      [  5]   6.00-7.00   sec  0.00 Bytes  0.00 bits/sec   15   17.4 KBytes       
      [  5]   7.00-8.00   sec   426 KBytes  3.49 Mbits/sec   15   17.4 KBytes       
      [  5]   8.00-9.00   sec  0.00 Bytes  0.00 bits/sec   16   8.69 KBytes       
      [  5]   9.00-10.00  sec   426 KBytes  3.49 Mbits/sec   14   17.4 KBytes       
      [  5]  10.00-11.00  sec  0.00 Bytes  0.00 bits/sec   13   8.69 KBytes       
      [  5]  11.00-12.00  sec   426 KBytes  3.49 Mbits/sec   14   17.4 KBytes       
      - - - - - - - - - - - - - - - - - - - - - - - - -
      [ ID] Interval           Transfer     Bitrate         Retr
      [  5]   0.00-12.00  sec  4.67 MBytes  3.26 Mbits/sec  210             sender
      [  5]   0.00-12.00  sec  3.72 MBytes  2.60 Mbits/sec                  receiver
```

After changing interval to 2, the result become more stable as below shown.
```
      [06:52:45] INFO> Shell Commands: oc exec iperf-rc-t84q2  --kubeconfig=/home/zzhao/workdir/dhcp-140-240-zzhaox/ocp4_testuser-22.kubeconfig -n sx53l  -i -- sh -c iperf3\ -c\ 10.129.2.219\ -i\ 2\ -t\ 24s
      Connecting to host 10.129.2.219, port 5201
      [  5] local 10.131.1.142 port 43048 connected to 10.129.2.219 port 5201
      [ ID] Interval           Transfer     Bitrate         Retr  Cwnd
      [  5]   0.00-2.00   sec  2.17 MBytes  9.11 Mbits/sec   61   17.4 KBytes       
      [  5]   2.00-4.00   sec   304 KBytes  1.25 Mbits/sec   30   17.4 KBytes       
      [  5]   4.00-6.00   sec   608 KBytes  2.49 Mbits/sec   27   17.4 KBytes       
      [  5]   6.00-8.00   sec   304 KBytes  1.25 Mbits/sec   30   17.4 KBytes       
      [  5]   8.00-10.00  sec   608 KBytes  2.49 Mbits/sec   30   17.4 KBytes       
      [  5]  10.00-12.00  sec   304 KBytes  1.25 Mbits/sec   27   17.4 KBytes       
      [  5]  12.00-14.00  sec   608 KBytes  2.49 Mbits/sec   30   17.4 KBytes       
      [  5]  14.00-16.00  sec   304 KBytes  1.25 Mbits/sec   27   17.4 KBytes       
      [  5]  16.00-18.00  sec   608 KBytes  2.49 Mbits/sec   30   17.4 KBytes       
      [  5]  18.00-20.00  sec   608 KBytes  2.49 Mbits/sec   30   17.4 KBytes       
      [  5]  20.00-22.00  sec   304 KBytes  1.25 Mbits/sec   27   17.4 KBytes       
      [  5]  22.00-24.00  sec   608 KBytes  2.49 Mbits/sec   30   17.4 KBytes       
      - - - - - - - - - - - - - - - - - - - - - - - - -
      [ ID] Interval           Transfer     Bitrate         Retr
      [  5]   0.00-24.00  sec  7.22 MBytes  2.52 Mbits/sec  379             sender
      [  5]   0.00-24.00  sec  6.51 MBytes  2.28 Mbits/sec                  receiver
```

@openshift/team-sdn-qe PTAL, thanks