### PR TITLE
Update app name creation

### DIFF
--- a/features/cli/create.feature
+++ b/features/cli/create.feature
@@ -192,7 +192,7 @@ Feature: creating 'apps' with CLI
     Given I have a project
     When I git clone the repo "https://github.com/openshift/ruby-hello-world"
     Then the step should succeed
-    Given an 8 character random string of type :dns952 is stored into the :appname clipboard
+    Given an 8 character random string of type :lowercase_starting_num is stored into the :appname clipboard
     When I run the :new_app client command with:
       | app_repo     | ruby-hello-world         |
       | image_stream | openshift/ruby:latest    |
@@ -210,7 +210,7 @@ Feature: creating 'apps' with CLI
     And the output should contain "Hello"
     And I delete all resources from the project
     #Check https github url
-    Given an 8 character random string of type :dns952 is stored into the :appname1 clipboard
+    Given an 8 character random string of type :lowercase_starting_num is stored into the :appname1 clipboard
     When I run the :new_app client command with:
       | code         | https://github.com/openshift/ruby-hello-world |
       | image_stream | openshift/ruby                                |
@@ -228,7 +228,7 @@ Feature: creating 'apps' with CLI
     And the output should contain "Hello"
     And I delete all resources from the project
     #Check http github url
-    Given an 8 character random string of type :dns952 is stored into the :appname2 clipboard
+    Given an 8 character random string of type :lowercase_starting_num is stored into the :appname2 clipboard
     When I run the :new_app client command with:
       | code         | http://github.com/openshift/ruby-hello-world |
       | image_stream | openshift/ruby:latest                        |
@@ -246,7 +246,7 @@ Feature: creating 'apps' with CLI
     And the output should contain "Hello"
     And I delete all resources from the project
     #Check master branch
-    Given an 8 character random string of type :dns952 is stored into the :appname4 clipboard
+    Given an 8 character random string of type :lowercase_starting_num is stored into the :appname4 clipboard
     When I run the :new_app client command with:
       | code         | https://github.com/openshift/ruby-hello-world#master |
       | image_stream | openshift/ruby                                       |
@@ -258,7 +258,7 @@ Feature: creating 'apps' with CLI
     Then the output should match "Ref:\s+master"
     And I delete all resources from the project
     #Check invalid branch
-    Given an 8 character random string of type :dns952 is stored into the :appname5 clipboard
+    Given an 8 character random string of type :lowercase_starting_num is stored into the :appname5 clipboard
     When I run the :new_app client command with:
       | code         | https://github.com/openshift/ruby-hello-world#invalid |
       | image_stream | openshift/ruby                                        |
@@ -267,7 +267,7 @@ Feature: creating 'apps' with CLI
     Then the output should contain "error"
     And I delete all resources from the project
     #Check non-master branch
-    Given an 8 character random string of type :dns952 is stored into the :appname6 clipboard
+    Given an 8 character random string of type :lowercase_starting_num is stored into the :appname6 clipboard
     When I run the :new_app client command with:
       | code  	     | https://github.com/openshift/ruby-hello-world#beta4 |
       | image_stream | openshift/ruby 	                                   |

--- a/lib/base_helper.rb
+++ b/lib/base_helper.rb
@@ -96,6 +96,11 @@ module BushSlicer
           for n in '0'..'9' do array.push(n) end
 
           (length - 1).times { result << array[rand(array.length)] }
+        when :lowercase_starting_num
+          for c in 'a'..'z' do array.push(c) end
+          for n in '0'..'9' do array.push(n) end
+          result << array[rand(26)] # start with letter
+          (length - 1).times { result << array[rand(array.length)] }
         else # :nospace_sane
           for c in 'a'..'z' do array.push(c) end
           for c in 'A'..'Z' do array.push(c) end


### PR DESCRIPTION
```    
error: ImageStream.image.openshift.io "cjx6--vh" is invalid: metadata.name: Invalid value: "cjx6--vh": must match "[a-z0-9]+(?:[._-][a-z0-9]+)*"
```
When use dns952 type to generate string, non-hyphen may be joined together, it will cause application creation failed.

Passed on my local host. @wewang58 Please help review, thanks