### PR TITLE
baremetal operator to be enabled by default(vsp&osp)

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -595,3 +595,14 @@ Feature: Machine features testing
     Given I switch to cluster admin pseudo user
     Then evaluation of `cluster_operator('cloud-controller-manager').versions` is stored in the :versions clipboard
     And the expression should be true> cb.versions[0].include? "4"
+
+  # @author miyadav@redhat.com
+  # @case_id OCP-47989
+  @admin
+  @4.10
+  @vsphere-ipi @openstack-ipi @baremetal-ipi 
+  @vsphere-upi @openstack-upi @baremetal-upi
+  Scenario: Baremetal clusteroperator should be enabled in vsphere and osp 
+    Given evaluation of `cluster_operator('baremetal').condition(type: 'Disabled')` is stored in the :co_disabled clipboard
+    Then the expression should be true> cb.co_disabled["status"]=="False"
+   


### PR DESCRIPTION
@jhou1 @huali9 @sunzhaohua2 PTAL , till 4.9 it was supposed to be disabled by default enabled 4.10 onwards on vsp, osp , baremetal

```
`        versions:
        - name: operator
          version: 4.10.0-0.nightly-2022-01-17-223655
      [05:31:42] INFO> Exit Status: 0
    Then the expression should be true> cb.co_disabled["status"]=="False"                                                   # features/step_definitions/common.rb:141
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [05:31:42] INFO> === After Scenario: Baremetal clusteroperator should be enabled in vsphere and osp ===
      [05:31:42] INFO> Shell Commands: rm -r -f -- /home/miyadav/workdir/miyadav-miyadavx
      
      [05:31:43] INFO> Exit Status: 0
      [05:31:44] INFO> === End After Scenario: Baremetal clusteroperator should be enabled in vsphere and osp ===

1 scenario (1 passed)
2 steps (2 passed)
0m13.135s
[05:31:44] INFO> === At Exit ===
`
```