### PR TITLE
Update OCP-37706 tags

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -34,9 +34,9 @@ Feature: Machine features testing
   # @author zhsun@redhat.com
   # @case_id OCP-37706
   @admin
-  @4.10
-  @gcp-ipi @azure-ipi @aws-ipi
-  @gcp-upi @azure-upi @aws-upi
+  @4.9 @4.8 @4.7
+  @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   @upgrade-sanity
   Scenario: Baremetal clusteroperator should be disabled in any deployment that is not baremetal
     Given evaluation of `cluster_operator('baremetal').condition(type: 'Disabled')` is stored in the :co_disabled clipboard


### PR DESCRIPTION
Update OCP-37706 tags @miyadav @huali9 @jhou1 please help to take a look.
baremetal clusteroperator is disabled on all platform in 4.7, 4.8 and 4.9 version and enabled on vsphere and osp in 4.10 version. For 4.10 we have a new test case to cover, refer to https://github.com/openshift/verification-tests/pull/2632