### PR TITLE
Updated for OCP-14059

### DIFF
--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -615,7 +615,7 @@ Feature: Testing route
     Given I switch to cluster admin pseudo user
     And I use the "openshift-console" project
     And I use the "console" service
-    And the expression should be true> service('console').annotation('service.alpha.openshift.io/serving-cert-secret-name') == "console-serving-cert"
+    And the expression should be true> service('console').annotation('service.alpha.openshift.io/serving-cert-secret-name') == "console-serving-cert" || service('console').annotation('service.beta.openshift.io/serving-cert-secret-name') == "console-serving-cert"
 
     Given I use the router project
     And all default router pods become ready


### PR DESCRIPTION
Modified for bug 2030574 console service uses older "service.alpha.openshift.io" for the service serving certificates

4.9.0-0.nightly-2022-01-17-015913:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/281215/

4.10.0-0.nightly-2022-01-18-044014:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/281233/

@lihongan, @quarterpin, @melvinjoseph86 Please review the change of OCP-14059, thanks.