### PR TITLE
Fix "comparison of Integer with nil failed"

### DIFF
--- a/lib/openshift/horizontal_pod_autoscaler.rb
+++ b/lib/openshift/horizontal_pod_autoscaler.rb
@@ -12,14 +12,23 @@ module BushSlicer
     }.freeze
 
     def target_cpu_utilization_percentage(user: nil, cached: true, quiet: false)
-      obj = raw_resource(user: user, cached: cached, quiet: quiet)
-      return obj.dig('spec', 'targetCPUUtilizationPercentage')
+      rr = raw_resource(user: user, cached: cached, quiet: quiet)
+      metrics = rr.dig('spec', 'metrics')
+      cpu = metrics.find { |metric|
+        metric.dig('resource', 'name') == 'cpu'
+        return metric.dig('resource', 'target', 'averageUtilization')
+      } unless metrics.nil? || rr.dig('spec', 'targetCPUUtilizationPercentage')
+      return cpu.to_i
     end
 
     def current_cpu_utilization_percentage(user: nil, cached: true, quiet: false)
-      raw_resource(user: user, cached: cached, quiet: quiet).
-        dig('status', 'currentCPUUtilizationPercentage').
-        to_i # it can be nil when zero thus using #to_i
+      rr = raw_resource(user: user, cached: cached, quiet: quiet)
+      metrics = rr.dig('status', 'currentMetrics')
+      cpu = metrics.find { |metric|
+        metric.dig('resource', 'name') == 'cpu'
+        return metric.dig('resource', 'current', 'averageUtilization')
+      } unless metrics.nil? || rr.dig('status', 'currentCPUUtilizationPercentage')
+      return cpu.to_i
     end
   end
 end


### PR DESCRIPTION
Fix failure in https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-verification-tests-master-nightly-4.10-upgrade-from-stable-4.9-upgrade-verification-tests-aws-ipi/1483343307747627008/artifacts/upgrade-verification-tests-aws-ipi/cucushift-upgrade-check/build-log.txt
```
    Given I wait up to 600 seconds for the steps to pass:                     # features/step_definitions/meta_steps.rb:33
      """
      Then expression should be true> hpa('resource-cpu').current_replicas(cached: false) > 2
      And expression should be true> hpa.current_cpu_utilization_percentage > hpa.target_cpu_utilization_percentage
      """
......
      INFO> last 3 messages repeated 4 times
      [10:38:09] INFO> Exit Status: 0
      comparison of Integer with nil failed (ArgumentError)
      (eval):1:in `>'
      (eval):1:in `block in <top (required)>'
      /verification-tests/features/step_definitions/common.rb:142:in `eval'
      /verification-tests/features/step_definitions/common.rb:142:in `/^(?:the )?expression should be true> (.+)$/'
      /verification-tests/features/step_definitions/transform.rb:33:in `call'
      /verification-tests/features/step_definitions/transform.rb:33:in `block in singleton class'
      /verification-tests/features/step_definitions/meta_steps.rb:48:in `block (2 levels) in <top (required)>'
      /verification-tests/lib/base_helper.rb:155:in `wait_for'
      /verification-tests/features/step_definitions/meta_steps.rb:43:in `/^I wait(?: up to ([0-9]+|<%=.+?%>) seconds)? for the steps to pass:$/'
      features/upgrade/node/hpa/upgrade.feature:76:in `I wait up to 600 seconds for the steps to pass:'
```

/cc @jhou1 @dis016 @JianLi-RH @pruan-rht 