### PR TITLE
stablize UI test OCP-21144 and OCP-24601

### DIFF
--- a/lib/rules/web/admin_console/4.10/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.10/monitoring_alerts.xyaml
@@ -27,10 +27,11 @@ filter_alert:
   params:
     class_text: co-text-filter
     input_value: <alert_name>
-    content: <alert_name>
+    text: <alert_name>
+    link_url: monitoring
   action: clear_name_filter_if_exists
   action: set_input_class
-  action: check_page_contains
+  action: check_link_and_text
 open_alert_detail:
   action: Disable_all_filters
   action: filter_alert
@@ -45,8 +46,9 @@ open_silence_detail:
   action: click_alert_link_with_text
 check_alert_detail:
   params:
-    content: alertname=Watchdog
-  action: check_page_contains
+    text: Watchdog
+    link_url: monitoring
+  action: check_link_and_text
   action: check_alert_breadcrumb
 check_alert_breadcrumb:
   params:

--- a/lib/rules/web/admin_console/4.8/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.8/monitoring_alerts.xyaml
@@ -27,10 +27,11 @@ filter_alert:
   params:
     class_text: co-text-filter
     input_value: <alert_name>
-    content: <alert_name>
+    text: <alert_name>
+    link_url: monitoring
   action: clear_name_filter_if_exists
   action: set_input_class
-  action: check_page_contains
+  action: check_link_and_text
 open_alert_detail:
   action: Disable_all_filters
   action: filter_alert
@@ -45,8 +46,9 @@ open_silence_detail:
   action: click_alert_link_with_text
 check_alert_detail:
   params:
-    content: alertname=Watchdog
-  action: check_page_contains
+    text: Watchdog
+    link_url: monitoring
+  action: check_link_and_text
   action: check_alert_breadcrumb
 check_alert_breadcrumb:
   params:

--- a/lib/rules/web/admin_console/4.9/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.9/monitoring_alerts.xyaml
@@ -27,10 +27,11 @@ filter_alert:
   params:
     class_text: co-text-filter
     input_value: <alert_name>
-    content: <alert_name>
+    text: <alert_name>
+    link_url: monitoring
   action: clear_name_filter_if_exists
   action: set_input_class
-  action: check_page_contains
+  action: check_link_and_text
 open_alert_detail:
   action: Disable_all_filters
   action: filter_alert
@@ -45,8 +46,9 @@ open_silence_detail:
   action: click_alert_link_with_text
 check_alert_detail:
   params:
-    content: alertname=Watchdog
-  action: check_page_contains
+    text: Watchdog
+    link_url: monitoring
+  action: check_link_and_text
   action: check_alert_breadcrumb
 check_alert_breadcrumb:
   params:


### PR DESCRIPTION
Runner job:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/282224/

Fix the following error:
#<Watir::Exception::LocatorException: Unable to locate element collection from {:xpath=>"//div[contains(.,'Watchdog')]"} due to changing page>
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/watir-7.1.0/lib/watir/element_collection.rb:190:in `rescue in elements_with_tags'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/watir-7.1.0/lib/watir/element_collection.rb:184:in `elements_with_tags'
/home/jenkins/.gem/bundler/ruby/2.7.0/gems/watir-7.1.0/lib/watir/element_collection.rb:103:in `to_a'
lib/webauto/web4cucumber.rb:697:in `get_elements'
lib/webauto/web4cucumber.rb:714:in `get_visible_elements'
lib/webauto/web4cucumber.rb:811:in `block in wait_for_elements'
lib/webauto/web4cucumber.rb:804:in `all?'
lib/webauto/web4cucumber.rb:804:in `wait_for_elements'
lib/webauto/web4cucumber.rb:549:in `handle_element'
lib/webauto/web4cucumber.rb:254:in `block in run_action'
lib/webauto/web4cucumber.rb:248:in `each'
lib/webauto/web4cucumber.rb:248:in `run_action'
lib/webauto/web4cucumber.rb:399:in `handle_action'
lib/webauto/web4cucumber.rb:258:in `block in run_action'
lib/webauto/web4cucumber.rb:248:in `each'
lib/webauto/web4cucumber.rb:248:in `run_action'
lib/webauto/web4cucumber.rb:399:in `handle_action'
lib/webauto/web4cucumber.rb:258:in `block in run_action'
lib/webauto/web4cucumber.rb:248:in `each'
lib/webauto/web4cucumber.rb:248:in `run_action'
features/step_definitions/web.rb:8:in `/^I perform the :(.*?) web( console)? action with:$/'
features/tierN/web/monitoring/alerts-browser.feature:18:in `I perform the :open_alert_detail web action with:'