### PR TITLE
Fix OCP-43331

### DIFF
--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -13,7 +13,6 @@ Feature: Machine-api components upgrade tests
     | cluster_operator           |
     | "machine-api"              |
     | "cluster-autoscaler"       |
-    | "cloud-controller-manager" |
 
   # @author jhou@redhat.com
   # @author huliu@redhat.com
@@ -39,7 +38,33 @@ Feature: Machine-api components upgrade tests
     | cluster_operator           |
     | "machine-api"              | # @case_id OCP-22712
     | "cluster-autoscaler"       | # @case_id OCP-27664
-    | "cloud-controller-manager" | # @case_id OCP-43331
+
+  @upgrade-prepare
+  @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  Scenario:  Cloud-controller-manager cluster operator should be available after upgrade - prepare
+    Given the expression should be true> "True" == "True"
+
+  # @author zhsun@redhat.com
+  # @case_id OCP-43331
+  @upgrade-check
+  @admin
+  @4.10 @4.9
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  Scenario: Cloud-controller-manager cluster operator should be available after upgrade
+    Given evaluation of `cluster_operator('cloud-controller-manager').condition(type: 'Available')` is stored in the :co_available clipboard
+    Then the expression should be true> cb.co_available["status"]=="True"
+
+    Given evaluation of `cluster_operator('cloud-controller-manager').condition(type: 'Degraded')` is stored in the :co_degraded clipboard
+    Then the expression should be true> cb.co_degraded["status"]=="False"
+
+    Given evaluation of `cluster_operator('cloud-controller-manager').condition(type: 'Upgradeable')` is stored in the :co_upgradable clipboard
+    Then the expression should be true> cb.co_upgradable["status"]=="True"
+
+    Given evaluation of `cluster_operator('cloud-controller-manager').condition(type: 'Progressing')` is stored in the :co_progressing clipboard
+    Then the expression should be true> cb.co_progressing["status"]=="False"
 
   @upgrade-prepare
   @admin


### PR DESCRIPTION
Fix OCP-43331, as cloud-controller-manager works from 4.9. Now this failed in 4.7 and 4.8. @jhou1 @miyadav @huali9 please help to take a look.
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/282282/console