### PR TITLE
Created clusterautoscaler resource

### DIFF
--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -245,6 +245,12 @@ Feature: Machine-api components upgrade tests
     And admin ensures machine number is restored after scenario
 
     Given I clone a machineset and name it "machineset-clone-30783"
+    
+    # Create clusterautoscaler
+    Given I obtain test data file "cloud/cluster-autoscaler.yml"
+    When I run the :create admin command with:
+      | f | cluster-autoscaler.yml |
+    Then the step should succeed
 
     # Delete clusterautoscaler after scenario
     Given admin ensures "default" clusterautoscaler is deleted after scenario


### PR DESCRIPTION
@jhou1 @sunzhaohua2 @huali9 PTAL , the test ws unstable as 3 machines were not always needed on different platforms , I have modified it to make sure more than one is present after scaling , CI issue raised was - https://issues.redhat.com/browse/OCPQE-8285
`
            instanceId: i-053ac240688f3d0c8
            instanceState: running
      kind: List
      metadata:
        resourceVersion: ""
        selfLink: ""
      [06:39:22] INFO> Exit Status: 0
      [06:39:22] INFO> Shell Commands: oc delete machines machineset-clone-30783-6hwjp --wait=false --kubeconfig=/home/miyadav/workdir/miyadav-miyadavx/ocp4_admin.kubeconfig --namespace=openshift-machine-api
      machine.machine.openshift.io "machineset-clone-30783-6hwjp" deleted
      [06:39:24] INFO> Exit Status: 0
      [06:39:25] INFO> oc get machines machineset-clone-30783-6hwjp --output=yaml --kubeconfig=/home/miyadav/workdir/miyadav-miyadavx/ocp4_admin.kubeconfig --namespace=openshift-machine-api
      [06:40:06] INFO> After 18 iterations and 42 seconds:
      
      STDERR:
      Error from server (NotFound): machines.machine.openshift.io "machineset-clone-30783-6hwjp" not found
      [06:40:06] INFO> Shell Commands: oc get machines machineset-clone-30783-6hwjp --output=yaml --kubeconfig=/home/miyadav/workdir/miyadav-miyadavx/ocp4_admin.kubeconfig --namespace=openshift-machine-api
      
      STDERR:
      Error from server (NotFound): machines.machine.openshift.io "machineset-clone-30783-6hwjp" not found
      [06:40:08] INFO> Exit Status: 1
      [06:40:08] INFO> Shell Commands: rm -r -f -- /home/miyadav/workdir/miyadav-miyadavx
      
      [06:40:09] INFO> Exit Status: 0
      [06:40:10] INFO> === End After Scenario: Cluster should automatically scale up and scale down with clusterautoscaler deployed ===
1 scenario (1 passed)
19 steps (19 passed)
4m11.067s
[06:40:10] INFO> === At Exit ===
`