### PR TITLE
Changing logic to grep ep port for ovnkube-node

### DIFF
--- a/features/networking/metrics.feature
+++ b/features/networking/metrics.feature
@@ -84,13 +84,7 @@ Feature: SDN/OVN metrics related networking scenarios
     And evaluation of `cb.ovn_master_metrics_ep_ip + ':' +cb.ovn_master_metrics_ep_port` is stored in the :ovn_master_metrics_ep clipboard
     
     And evaluation of `endpoints('ovn-kubernetes-node').subsets.first.addresses.first.ip.to_s` is stored in the :ovn_node_metrics_ep_ip clipboard
-    When I run the :get client command with:
-      | resource      | ep                                                      |
-      | n             | openshift-ovn-kubernetes                                |
-      | resource_name | ovn-kubernetes-node                                     |
-      | o             | jsonpath={.subsets[*].ports[?(@.name=="metrics")].port} |
-    Then the step should succeed
-    And evaluation of `@result[:response]` is stored in the :ovn_node_metrics_ep_port clipboard
+    And evaluation of `endpoints('ovn-kubernetes-node').subsets.flat_map{ |i| i.ports }.select{ |p| p.name == "metrics" }.first.port.to_s` is stored in the :ovn_node_metrics_ep_port clipboard
     And evaluation of `cb.ovn_node_metrics_ep_ip + ':' +cb.ovn_node_metrics_ep_port` is stored in the :ovn_node_metrics_ep clipboard
     
     Given I use the "openshift-monitoring" project

--- a/features/networking/metrics.feature
+++ b/features/networking/metrics.feature
@@ -84,7 +84,13 @@ Feature: SDN/OVN metrics related networking scenarios
     And evaluation of `cb.ovn_master_metrics_ep_ip + ':' +cb.ovn_master_metrics_ep_port` is stored in the :ovn_master_metrics_ep clipboard
     
     And evaluation of `endpoints('ovn-kubernetes-node').subsets.first.addresses.first.ip.to_s` is stored in the :ovn_node_metrics_ep_ip clipboard
-    And evaluation of `endpoints('ovn-kubernetes-node').subsets.first.ports.first.port.to_s` is stored in the :ovn_node_metrics_ep_port clipboard
+    When I run the :get client command with:
+      | resource      | ep                                                      |
+      | n             | openshift-ovn-kubernetes                                |
+      | resource_name | ovn-kubernetes-node                                     |
+      | o             | jsonpath={.subsets[*].ports[?(@.name=="metrics")].port} |
+    Then the step should succeed
+    And evaluation of `@result[:response]` is stored in the :ovn_node_metrics_ep_port clipboard
     And evaluation of `cb.ovn_node_metrics_ep_ip + ':' +cb.ovn_node_metrics_ep_port` is stored in the :ovn_node_metrics_ep clipboard
     
     Given I use the "openshift-monitoring" project


### PR DESCRIPTION
4.10 has introduced two metrics ports for ovnkube-node 9103 and 9105. It has been 9103 so far until 4.9.
This use case is failing on 4.10 due to reason that existing logic is fetching 9105 port as oppose to 9103

Fixing it to make sure it find port corresponding to 'metrics' value in `oc get ep ovn-kubernetes-node -ojson`
Ran on all 4.8,4.9 and 4.10. Thanks

9105 was added an ovn-metrics in 4.10 basically collecting ovn-controller metrics https://github.com/openshift/cluster-network-operator/pull/1236/files#diff-665322f4b107d73e9e1780a1256948e0f85ad2c260c45e7cb635b8b2866ac5bb

Logs: https://privatebin.corp.redhat.com/?82f0ea2fdfeb92c5#7svy6GD45WPE2mJTJQMA4CQ1tVrqZs9SFztosrCLCAjZ
@openshift/team-sdn-qe 