### PR TITLE
fix web rules

### DIFF
--- a/lib/rules/web/admin_console/4.10/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.10/common_ui_elements.xyaml
@@ -834,7 +834,7 @@ wait_form_loaded:
   element:
     selector:
       css: form
-    timeout: 20
+    timeout: 40
 wait_box_loaded:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.10/logs.xyaml
+++ b/lib/rules/web/admin_console/4.10/logs.xyaml
@@ -13,15 +13,15 @@ switch_to_container:
 wait_log_window_loaded:
   elements:
   - selector:
-      xpath: //div[contains(@class,'log-window')]/div[contains(@class,'log-window__header')]
+      xpath: //div[contains(@class,'log-window')]
     timeout: 30
   - selector:
-      xpath: //div[contains(@class,'log-window')]/div[contains(@class,'log-window__body')]
+      xpath: //div[contains(@class,'pf-c-log-viewer__main')]
     timeout: 30
 check_log_content_contains:
   element:
     selector:
-      xpath: //div[contains(@class,'log-window__lines') and contains(.,'<log_content>')]
+      xpath: //span[contains(@class,'text') and contains(.,'<log_content>')]
     timeout: 30
 check_some_context_missing_in_expanded_log_view:
   elements:
@@ -95,12 +95,11 @@ check_event_is_streaming:
 check_logs_not_wrapped:
   elements:
   - selector:
-      xpath: //div[contains(@class,'log-window__lines--wrap')]
-    missing: true
+      xpath: //div[contains(@style,'auto')]
 check_logs_wrapped:
   elements:
   - selector:
-      xpath: //div[contains(@class,'log-window__lines--wrap')]
+      xpath: //div[contains(@style,'hidden')]
 toggle_log_wraps:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.10/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.10/operator_hub.xyaml
@@ -541,6 +541,7 @@ switch_to_yaml_view:
   element:
     selector:
       xpath: //div[contains(@class,'monaco-editor')]
+    timeout: 40
 select_installed_namespace:
   action: click_project_list_dropdown
   action: choose_project_from_dropdown_list

--- a/lib/rules/web/admin_console/4.9/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.9/common_ui_elements.xyaml
@@ -834,7 +834,7 @@ wait_form_loaded:
   element:
     selector:
       css: form
-    timeout: 20
+    timeout: 40
 wait_box_loaded:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.9/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.9/operator_hub.xyaml
@@ -541,6 +541,7 @@ switch_to_yaml_view:
   element:
     selector:
       xpath: //div[contains(@class,'monaco-editor')]
+    timeout: 40
 select_installed_namespace:
   action: click_project_list_dropdown
   action: choose_project_from_dropdown_list


### PR DESCRIPTION
OCP-41926 Ability to view past logs when available for pods only(not build logs)
OCP-41601 Ability to wrap log lines in the log viewer using a toggle    
OCP-20688 Check log streaming panel     
Pass log on 4.10: 
job/ocp-common/job/Runner/292423/console
job/ocp-common/job/Runner/292422/console