### PR TITLE
Adding 4.10 kubedescheduler yaml file

### DIFF
--- a/testdata/descheduler/kubedescheduler-4.10.yaml
+++ b/testdata/descheduler/kubedescheduler-4.10.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.openshift.io/v1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  image: registry.redhat.io/openshift4/ose-descheduler:v4.10
+  logLevel: Normal
+  operatorLogLevel: Normal
+  deschedulingIntervalSeconds: 3600
+  profiles:
+    - AffinityAndTaints
+    - TopologyAndDuplicates
+    - LifecycleAndUtilization
+  managementState: Managed
+


### PR DESCRIPTION
Fix Jira OCPQE-8364 where one of the issue reported there was kubedescheduler upgrade is failing due to not having the 4.10 yaml file.