### PR TITLE
default values to create machineset for clusters 

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -332,12 +332,12 @@ Feature: Machine features testing
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
     Then admin ensures machine number is restored after scenario
-
-    Given I store the last provisioned machine in the :machine clipboard
-    When evaluation of `machine(cb.machine).aws_ami_id` is stored in the :default_ami_id clipboard
-    And evaluation of `machine(cb.machine).aws_availability_zone` is stored in the :default_availability_zone clipboard
-    And evaluation of `machine(cb.machine).aws_subnet` is stored in the :default_subnet clipboard
-    And evaluation of `machine(cb.machine).aws_iamInstanceProfile` is stored in the :default_iamInstanceProfile clipboard
+    
+    Given I pick a earliest created machineset and store in :machineset clipboard
+    When evaluation of `machine_set(cb.machineset).aws_machineset_ami_id` is stored in the :default_ami_id clipboard
+    And evaluation of `machine_set(cb.machineset).aws_machineset_availability_zone` is stored in the :default_availability_zone clipboard
+    And evaluation of `machine_set(cb.machineset).aws_machineset_iamInstanceProfile` is stored in the :default_iamInstanceProfile clipboard
+    And evaluation of `machine_set(cb.machineset).aws_machineset_subnet` is stored in the :default_subnet clipboard
     Then admin ensures "<name>" machineset is deleted after scenario
 
     Given I obtain test data file "cloud/ms-aws/<file_name>"

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -5,6 +5,13 @@ Given(/^I pick a random( windows)? machineset to scale$/) do | windows |
   cache_resources *machine_sets.shuffle
 end
 
+Given(/^I pick a earliest created machineset and store in#{OPT_SYM} clipboard$/) do | cb_name | 
+  ensure_admin_tagged
+  machine_sets = BushSlicer::MachineSet.list(user: admin, project: project("openshift-machine-api"))
+  cache_resources *machine_sets
+  cb[cb_name] = machine_sets.min_by(&:created_at).name
+end
+
 When(/^I scale the machineset to ([\+\-]?)#{NUMBER}$/) do | op, num |
   ensure_destructive_tagged
 

--- a/lib/openshift/machine_set.rb
+++ b/lib/openshift/machine_set.rb
@@ -51,5 +51,26 @@ module BushSlicer
       flavor = ms_provider_spec['instanceType'] || ms_provider_spec['vmSize'] || ms_provider_spec['machineType'] || ms_provider_spec['flavor']
       return flavor
     end
+
+    def aws_machineset_subnet(user: nil, cached: true, quiet: true)
+      raw_resource(user: user, cached: cached ,quiet: quiet).
+      dig('spec', 'template', 'spec', 'providerSpec', 'value', 'subnet','filters')
+    end
+
+    def aws_machineset_ami_id(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'template', 'spec', 'providerSpec', 'value', 'ami','id')
+    end
+
+    def aws_machineset_availability_zone(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'template', 'spec', 'providerSpec', 'value', 'placement','availabilityZone')
+    end
+
+    def aws_machineset_iamInstanceProfile(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'template', 'spec', 'providerSpec', 'value', 'iamInstanceProfile', 'id')
+    end
+
   end
 end

--- a/lib/openshift/machine_set.rb
+++ b/lib/openshift/machine_set.rb
@@ -57,6 +57,12 @@ module BushSlicer
       dig('spec', 'template', 'spec', 'providerSpec', 'value', 'subnet','filters')
     end
 
+    def aws_machineset_subnet_proxy(user: nil, cached: true, quiet: true)
+      raw_resource(user: user, cached: cached ,quiet: quiet).
+      dig('spec', 'template', 'spec', 'providerSpec', 'value', 'subnet','id')
+    end
+
+
     def aws_machineset_ami_id(user: nil, cached: true, quiet: false)
        raw_resource(user: user, cached: cached ,quiet: quiet).
          dig('spec', 'template', 'spec', 'providerSpec', 'value', 'ami','id')

--- a/testdata/cloud/ms-aws/proxy-clusters/ms_default_values.yaml
+++ b/testdata/cloud/ms-aws/proxy-clusters/ms_default_values.yaml
@@ -1,0 +1,37 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster:
+  name:            
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster:
+      machine.openshift.io/cluster-api-machineset:
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster:
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset:
+    spec:
+      metadata: {}
+      taints:
+      - effect: "NoSchedule"
+        key: "mapi"
+        value: "mapi_test"
+      providerSpec:
+        value:
+          ami:
+            id: 
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          placement:
+            availabilityZone: 
+          subnet:
+             id:      
+          iamInstanceProfile:
+              id:        
+ 

--- a/testdata/cloud/ms-aws/proxy-clusters/ms_tenancy_dedicated.yaml
+++ b/testdata/cloud/ms-aws/proxy-clusters/ms_tenancy_dedicated.yaml
@@ -1,0 +1,37 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster:
+  name:
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster:
+      machine.openshift.io/cluster-api-machineset:
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster:
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset:
+    spec:
+      metadata: {}
+      taints:
+      - effect: "NoSchedule"
+        key: "mapi"
+        value: "mapi_test"
+      providerSpec:
+        value:
+          ami:
+            id:
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          placement:
+            availabilityZone:
+            tenancy: dedicated
+          subnet:
+              id: 
+          iamInstanceProfile:
+              id: 


### PR DESCRIPTION
@pruan-rht , have a look if time permits ..

The clusters which are installed behind proxy , have a slightly different yaml for machineset 

where subnet id can be got using something like 
`x.spec.template.spec.providerSpec.value.subnet.id` whereas for all other clusters configs it is like `x.spec.template.spec.providerSpec.value.subnet.filters` and also the testdata file that we use have list for subnet , whereas it is just key value pair for proxy clusters.

the changes done using this PR will make it work for all profiles where proxy is not used .(It was earlier failing for non-proxy as well) 
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/296030/console 

Please provide if any suggestion I could try , basically need condition to modify subnet values by identifying the profile ( proxy or non proxy) to be able to use a different test data file or may be a seperate step definition for the step - 
`  | ["spec"]["template"]["spec"]["providerSpec"]["value"]["subnet"]["filters"][0]["values"]   | <%= cb.default_subnet[0].values[1] %>       |` 
or 
`  | ["spec"]["template"]["spec"]["providerSpec"]["value"]["subnet"]["id"]   | <%= cb.default_subnet %>       |`

