### PR TITLE
Randomize name of the service project/namespace created by test framework.

### DIFF
--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -450,7 +450,9 @@ module BushSlicer
       unless @service_project
         # if the cluster set the default scheduler, set the project running debug pod node-selector=''
         # to overwrite the default scheduler, or the pod can not be run successfully
-        project_name = "prj-" + EXECUTOR_NAME.downcase
+        # project_suffix creates non identical names for namespace or project running debug pod in test cases.
+        project_suffix = [*"a".."z", *"1".."9"]
+        project_name = "prj-" + EXECUTOR_NAME.downcase + "-" + project_suffix.sample(4).join
         project = Project.new(name: project_name, env: self)
         unless project.active?
           # 60 seconds is no longer enough


### PR DESCRIPTION
@xingxingxia @wangke19 @gangwgr In recent test case failure analysis (Refer https://issues.redhat.com/browse/OCPQE-8433 - Part B) exposed that , the service project or namespace created by test framework for hosting a debug pod for running node commands were always same for all the tests . This may leads to potential issues like failing the test case execution one after other due to existence of namespace(as described in ticket) especially when the service namespace fails or slow in cleanup, deletion etc. So this PR would help us to pick unique name for service project or namespace.
Jenkins job against the PR -  Runner-v3-smoke/3907/console
Kindly review the same and let me know your feedback. Thanks.