### PR TITLE
Update ocm-cli default version to 0.1.61

### DIFF
--- a/lib/launchers/o_c_m_cluster.rb
+++ b/lib/launchers/o_c_m_cluster.rb
@@ -161,7 +161,7 @@ module BushSlicer
     def download_ocm_cli
       url = ENV['OCM_CLI_URL']
       unless url
-        url_prefix = ENV['OCM_CLI_URL_PREFIX'] || 'https://github.com/openshift-online/ocm-cli/releases/download/v0.1.59'
+        url_prefix = ENV['OCM_CLI_URL_PREFIX'] || 'https://github.com/openshift-online/ocm-cli/releases/download/v0.1.61'
         if OS.mac?
           url = "#{url_prefix}/ocm-darwin-amd64"
         elsif OS.linux?


### PR DESCRIPTION
There is an issue with 0.1.59 which blocks users to log in.

Signed-off-by: Andrej Podhradsky <apodhrad@redhat.com>