### PR TITLE
Adding flaky tag so that test wont be picked up during prepare

### DIFF
--- a/features/upgrade/workloads/scheduler-upgrade.feature
+++ b/features/upgrade/workloads/scheduler-upgrade.feature
@@ -4,6 +4,7 @@ Feature: scheduler with custom policy upgrade check
   @admin
   @destructive
   @4.10 @4.9 @4.8
+  @flaky
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine - prepare


### PR DESCRIPTION
One of the upgrade-prepare test case always gets picked up even after marking it 'Not Automated' and removing content from 'AutomationScript' field. As suggested by vadim adding @flaky tag so that test wont be picked up. Having this test case run is causing kube-scheduler upgrades to fail.