### PR TITLE
case's testdata json was in mal-formatted JSON

### DIFF
--- a/testdata/build/ruby20rhel7-context-docker.json
+++ b/testdata/build/ruby20rhel7-context-docker.json
@@ -116,7 +116,7 @@
         "source": {
           "type": "Git",
           "git": {
-            "uri": "https://github.com/openshift-qe/ruby-hello-world-context-dir",
+            "uri": "https://github.com/openshift-qe/ruby-hello-world-context-dir"
           },
           "contextDir": "test"
         },


### PR DESCRIPTION
case has been broken since last modification in January.

```
STDERR:
error: error parsing ruby20rhel7-context-docker.json: json: offset 2621: invalid character '}' looking for beginning of object key string
```