### PR TITLE
added libraries for Debian based system

### DIFF
--- a/tools/os_deps/deps.deb
+++ b/tools/os_deps/deps.deb
@@ -15,3 +15,5 @@ xvfb
 python-dev
 libssl-dev
 ansible
+libxml2-dev
+libcurl4-openssl-dev


### PR DESCRIPTION
These are needed to run `cucushift` under Debian system.