### PR TITLE
Enhance ocp-16495

### DIFF
--- a/features/registry/is.feature
+++ b/features/registry/is.feature
@@ -145,8 +145,10 @@ Feature: Testing imagestream
     Given certification for default image registry is stored to the :reg_crt_name clipboard
 
     When I run the :new_app client command with:
-      | app_repo | ruby~https://github.com/sclorg/ruby-ex.git |
+      | app_repo | quay.io/openshifttest/ruby-27@sha256:cdb6a13032184468b1e0607f36cfb8834c97dbeffeeff800e9e6834323bed8fc~https://github.com/sclorg/ruby-ex.git |
     Then the step should succeed
+    Given the "ruby-27" image stream was created 
+    Given the "ruby-27" image stream becomes ready 
     And the "ruby-ex-1" build was created
     And the "ruby-ex-1" build completes
     And the "ruby-ex:latest" image stream tag was created


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPQE-8323
The build doesn't create due to ruby imagestream not ready, it may caused by sample operator destructive operation.
So update to use a quay image which will reduce dependence on samples operator.

Passed locally.
