### PR TITLE
update the kafka version

### DIFF
--- a/features/logging/cluster_log_forwarder.feature
+++ b/features/logging/cluster_log_forwarder.feature
@@ -353,8 +353,7 @@ Feature: cluster log forwarder features
   # @case_id OCP-32697
   @admin
   @destructive
-  @upgrade-sanity
-  @4.7
+  @4.10 @4.9 @4.8 @4.7
   Scenario: Forward logs to different kafka topics
     Given I switch to the first user
     And I create a project with non-leading digit name

--- a/testdata/logging/clusterlogforwarder/kafka/amq/04_kafka_my-cluster_amqstreams_template.yaml
+++ b/testdata/logging/clusterlogforwarder/kafka/amq/04_kafka_my-cluster_amqstreams_template.yaml
@@ -19,7 +19,7 @@ objects:
         reconciliationIntervalSeconds: 120
     kafka:
       config:
-        log.message.format.version: "2.7"
+        log.message.format.version: "3.0"
         offsets.topic.replication.factor: 1
         transaction.state.log.min.isr: 1
         transaction.state.log.replication.factor: 1
@@ -40,7 +40,7 @@ objects:
       replicas: 1
       storage:
         type: ephemeral
-      version: 2.7.0
+      version: 3.0.0
     zookeeper:
       replicas: 1
       storage:


### PR DESCRIPTION
The version 2.7.0 deprecated. Must move to 3.0.0
Test Pass on cluster-logging.5.4.0-59 on OCP 4.10 using https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/309214/console