### PR TITLE
fix upgrade failure

### DIFF
--- a/features/upgrade/monitoring/monitoring-upgrade.feature
+++ b/features/upgrade/monitoring/monitoring-upgrade.feature
@@ -23,7 +23,10 @@ Feature: cluster monitoring related upgrade check
   Scenario: upgrade cluster monitoring along with OCP
     Given I switch to cluster admin pseudo user
     And I use the "openshift-monitoring" project
+    And I wait up to 120 seconds for the steps to pass:
+    """
     Given all pods in the project are ready
+    """
     And the expression should be true> cluster_operator('monitoring').condition(type: 'Degraded')['status'] == "False"
 
     #check retention time


### PR DESCRIPTION
http://virt-openshift-05.lab.eng.nay.redhat.com/buildcorp/ocp_upgrade/5012.html
http://virt-openshift-05.lab.eng.nay.redhat.com/buildcorp/ocp_upgrade/5056.html
http://virt-openshift-05.lab.eng.nay.redhat.com/buildcorp/ocp_upgrade/5075.html
http://virt-openshift-05.lab.eng.nay.redhat.com/buildcorp/ocp_upgrade/5137.html

Fixed failures in above jobs: node-exporter daemonset is highly depend on status of node, if machineset config, the daemon set will be created or removed when a node is added or removed, which will lead to an old daemonset will never be found. I will update automation test case to only check existing node-exporter pods.

runner job:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/313071/