### PR TITLE
Removing version tags so that test does not get executed

### DIFF
--- a/features/upgrade/workloads/scheduler-upgrade.feature
+++ b/features/upgrade/workloads/scheduler-upgrade.feature
@@ -3,8 +3,6 @@ Feature: scheduler with custom policy upgrade check
   @upgrade-prepare
   @admin
   @destructive
-  @4.10 @4.9 @4.8
-  @flaky
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine - prepare
@@ -48,7 +46,6 @@ Feature: scheduler with custom policy upgrade check
   @upgrade-check
   @admin
   @destructive
-  @4.10 @4.9 @4.8
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine


### PR DESCRIPTION
Removing version tags from upgrade-prepare & upgrade-check so that tests does not get executed. When these tests are being executed in an upgrade path which contains 4.10 kube-scheduler always goes to crashLoopBackOff state due to a recent change introduced in 4.10 (Removal of scheduler-policy)