### PR TITLE
[WIP]fixing step definition for SNO

### DIFF
--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -121,7 +121,7 @@ Then /^the output should equal #{QUOTED}$/ do |value|
   end
 end
 
-Given /^([0-9]+?) seconds have passed$/ do |num|
+Given /#{NUMBER} seconds have passed$/ do |num|
   sleep(num.to_i)
 end
 

--- a/lib/openshift/resource.rb
+++ b/lib/openshift/resource.rb
@@ -49,6 +49,11 @@ module BushSlicer
       elsif result[:response] =~ /Unable to connect to the server/
         logger.info(result[:response])
         return false
+      # Adding below because when in Single node cluster node restarted then SNO not have other nodes to communicate which cause connection timeout issue.
+      # And to prevent premature exit as describe in OCPQE-8043.
+      elsif result[:response] =~ /connection to the server \S+ was refused - did you specify the right host or port/ && env.nodes.length == 1
+        logger.info(result[:response])
+        return false
       else
         # e.g. when called by user without rights to list Resource
         raise "error getting #{self.class.name} '#{name}' existence: #{result[:response]}"


### PR DESCRIPTION
Raise this PR because step not accepting variable integer value which cause below issue. @liangxia Please review this PR
```
Given <%= cb.wait_time1 %> seconds have passed                                  # features/tierN/apiserver/kube-apiserver.feature:267
   Undefined step: "<%= cb.wait_time1 %> seconds have passed" (Cucumber::Core::Test::Result::Undefined)
   features/tierN/apiserver/kube-apiserver.feature:267:in `<%= cb.wait_time1 %> seconds have passed'
```
Test run - http://pastebin.test.redhat.com/1030580