### PR TITLE
Make co/authentication rotation robust in SNO env test

### DIFF
--- a/features/step_definitions/oauth.rb
+++ b/features/step_definitions/oauth.rb
@@ -17,11 +17,20 @@ Given /^the #{QUOTED} oauth CR is restored after scenario$/ do |name|
   org_oauth_json = org_oauth.to_json
   _admin = admin
   teardown_add {
-    puts "Original CR to restore:", org_oauth_json
+    @result = admin.cli_exec(:get, resource: 'oauth', resource_name: name, o: 'yaml')
+    if @result[:success]
+      org_oauth_now = @result[:parsed]
+    else
+      raise "Could not get OAuth: #{name}"
+    end
+    print "Original CR to restore:\n", org_oauth_json
     # Use replace instead of patch, otherwise the patch with org_oauth_json can only add or modify fields, but will not remove fields that were added
     @result = _admin.cli_exec(:replace, f: "-", _stdin: org_oauth_json)
     raise "Cannot restore OAuth: #{name}" unless @result[:success]
-    sleep 60
+    # Check 'spec' first because pods only roll out when 'spec' had been changed
+    if org_oauth_now['spec'] != org_oauth['spec']
+      step %Q/authentication successfully rolls out after config changes/
+    end
   }
 end
 

--- a/features/step_definitions/operators.rb
+++ b/features/step_definitions/operators.rb
@@ -168,6 +168,7 @@ Given /^operator #{QUOTED} becomes #{NO_SPACE_STR}(?: within #{NUMBER} seconds)?
   interval_time = 5
   timeout = Integer(timeout) rescue 60
   interval_time = 20 if timeout > 100
+  interval_time = 5 if env.nodes.length == 1 # interval needs to be short because rotation is quick in SNO env
   actual_results = {}
   stats = {}
 


### PR DESCRIPTION
Fixing [OCPQE-8730](https://issues.redhat.com/browse/OCPQE-8730).

The failure has 2 parts to fix:
One is:
```
01:15:12 INFO> #### Operator authentication Expected conditions: {"Progressing"=>"True"}
#<RuntimeError: The authentication operator still didn't become {"Progressing"=>"True"} after 180 seconds>
```
It actually had become "Progressing"=>"True". But the poll interval is too big and the transition to False is quick in SNO env. We need use small interval for SNO env.

The other issue is:
```
01:15:12 INFO> Shell Commands: oc replace -f - --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_admin.kubeconfig
oauth.config.openshift.io/cluster replaced
error: You must be logged in to the server (Unauthorized)
01:16:44 ERROR> #<RuntimeError: error getting projects by user: 'testuser-40@ocp4'>
```
When oauth.config.openshift.io/cluster is updated, auth pods are rotating and unavailable temporarily, token validation will be broken, i.e. here for request of `getting projects by user`. We need ensure auth pods rotation is complete first.
Pass logs for fix in SNO env: ocp-c1/job/Runner/322630/console
@y4sht @liangxia help review / merge, thanks!