### PR TITLE
Retry when server refuse connection during restart on SNO

### DIFF
--- a/lib/openshift/resource.rb
+++ b/lib/openshift/resource.rb
@@ -49,6 +49,9 @@ module BushSlicer
       elsif result[:response] =~ /Unable to connect to the server/
         logger.info(result[:response])
         return false
+      elsif result[:response] =~ /connection to the server \S+ was refused - did you specify the right host or port/ && env.nodes.length == 1
+        logger.info(result[:response])
+        return false
       else
         # e.g. when called by user without rights to list Resource
         raise "error getting #{self.class.name} '#{name}' existence: #{result[:response]}"


### PR DESCRIPTION
/cc @gangwgr @xingxingxia @jhou1 @dis016 @pruan-rht 

Tested on the same cluster,

Without the changes in this PR,
```
waiting for operation up to 3600 seconds..
    Given operator "kube-apiserver" becomes non-progressing within <%= cb.wait_time %> seconds                        # features/step_definitions/operators.rb:164
      [05:10:30] INFO> ......
      [05:10:32] INFO> Exit Status: 0
      [05:10:52] INFO> Shell Commands: oc get clusteroperators kube-apiserver --output=yaml --kubeconfig=/home/jenkins/workdir/b86a29ab7df1-rootx/ocp4_admin.kubeconfig
      
      STDERR:
      The connection to the server api.rgangwar-21de3.qe.devcluster.openshift.com:6443 was refused - did you specify the right host or port?
      [05:10:53] INFO> Exit Status: 1
      error getting BushSlicer::ClusterOperator 'kube-apiserver' existence: 
      STDERR:
      The connection to the server api.rgangwar-21de3.qe.devcluster.openshift.com:6443 was refused - did you specify the right host or port?
       (RuntimeError)
      /verification-tests/lib/openshift/resource.rb:54:in `exists?'
      /verification-tests/lib/openshift/resource.rb:60:in `get_checked'
      /verification-tests/lib/openshift/resource.rb:127:in `get_cached_prop'
      /verification-tests/lib/openshift/resource.rb:134:in `raw_resource'
      /verification-tests/lib/openshift/resource.rb:293:in `conditions'
      /verification-tests/features/step_definitions/operators.rb:195:in `block (2 levels) in <top (required)>'
      /verification-tests/lib/base_helper.rb:160:in `wait_for'
      /verification-tests/features/step_definitions/operators.rb:193:in `/^operator "(.+?)" becomes ([\S]+|<%=.+?%>)(?: within ([0-9]+|<%=.+?%>) seconds)?$/'
      features/tierN/apiserver/kube-apiserver.feature:262:in `operator "kube-apiserver" becomes non-progressing within <%= cb.wait_time %> seconds'
```

With the changes in this PR,
```
waiting for operation up to 3600 seconds..
    Given operator "kube-apiserver" becomes available/non-progressing/non-degraded within <%= cb.wait_time %> seconds # features/step_definitions/operators.rb:164
      [05:20:29] INFO> ......
      [05:22:00] INFO> Exit Status: 0
      [05:22:00] INFO> #### Operator kube-apiserver Expected conditions: {"Available"=>"True", "Progressing"=>"False", "Degraded"=>"False"}
      [05:22:00] INFO> #### After 91.10809769103071 seconds and 5 iterations operator kube-apiserver becomes: {"Available"=>"True", "Progressing"=>"False", "Degraded"=>"False"}
waiting for operation up to 3600 seconds..
    # Validation for WriteRequestBodies profile setting
    When I use the "openshift-apiserver" project                                                                      # features/step_definitions/project.rb:110
      [05:22:00] INFO> Shell Commands: oc project openshift-apiserver --kubeconfig=/home/jenkins/workdir/b86a29ab7df1-rootx/ocp4_admin.kubeconfig
      Now using project "openshift-apiserver" on server "https://api.rgangwar-21de3.qe.devcluster.openshift.com:6443".
      [05:22:04] INFO> Exit Status: 0
waiting for operation up to 900 seconds..
```