### PR TITLE
added ibmcloud support to monitor our IBM cloud daily cluster usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'azure_mgmt_compute', '~>0.18.0'
 gem 'azure_mgmt_resources', '~>0.17.0'
 gem 'azure_mgmt_network', '~>0.17.0'
 
+###### IBM cloud
+gem 'ibm_vpc'
 # gem 'timers'
 ## Logging
 gem 'term-ansicolor'

--- a/lib/launchers/ibmcloud.rb
+++ b/lib/launchers/ibmcloud.rb
@@ -4,18 +4,90 @@ lib_path = File.expand_path(File.dirname(File.dirname(__FILE__)))
 unless $LOAD_PATH.any? {|p| File.expand_path(p) == lib_path}
   $LOAD_PATH.unshift(lib_path)
 end
-
 require 'collections'
 require 'common'
+require 'cgi'
+
+require "ibm_vpc"
 
 module BushSlicer
   class IBMCloud
     include Common::Helper
     include CollectionsIncl
-    attr_reader :config
+    attr_reader :config, :vpc, :regions
+    attr_accessor :region
 
     def initialize(**opts)
       @config = conf[:services, opts.delete(:service_name) || :ibmcloud]
+      authenticator = IbmVpc::Authenticators::IamAuthenticator.new(
+        apikey: @config[:auth][:apikey]
+      )
+      @vpc = IbmVpc::VpcV1.new(authenticator: authenticator)
+      @regions ||= vpc.list_regions.result['regions']
+      if opts[:region]
+        puts("Setting region to #{opts[:region]}...\n")
+        region=(opts[:region])
+      end
     end
+
+    # @return Array of region hash
+    # {"name"=>"us-south", "href"=>"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south", "endpoint"=>"https://us-south.iaas.cloud.ibm.com", "status"=>"available"}
+    def regions
+      @regions ||= self.vpc.list_regions.result['regions']
+    end
+
+    # @return Hash containing region information
+    def get_region(name)
+      region_hash = self.regions.select {|r| r['name'] == name}.first
+      raise "Unsupported region '#{name}" unless region_hash
+      return region_hash
+    end
+
+    def set_region(reg_name)
+      region_info = self.get_region(reg_name)
+      self.vpc.service_url = region_info['endpoint'] + "/v1"
+    end
+    # @returns current region hash
+    def current_region
+      self.vpc.service_url
+      self.regions.select {|r| r['endpoint'].start_with? self.vpc.service_url[0..-4]}.first
+    end
+
+    def instances
+      start = nil
+      instances = []
+      loop do
+        response = self.vpc.list_instances(start: start)
+        instances += response.result["instances"]
+
+        next_link = response.result.dig("next", "href")
+        break if next_link.nil?
+
+        start = CGI.parse(URI(next_link).query)["start"].first
+      end
+      return instances
+    end
+
+    def get_instances_by_status(status: 'running', region: nil)
+      instances = self.instances
+      if instances.count > 0
+        insts = instances.select {|i| i['status'] == status }
+        instances = insts
+      end
+      return instances
+    end
+
+    def instance_uptime(instance)
+      ((Time.now.utc - Time.parse(instance['created_at'])) / (60 * 60)).round(2)
+    end
+
   end
 end
+
+if __FILE__ == $0
+  extend BushSlicer::Common::Helper
+  ibm = BushSlicer::IBMCloud.new(region: 'eu-gb')
+  insts2 = ibm.instances
+  print inst2
+end
+

--- a/tools/cloud_usage.rb
+++ b/tools/cloud_usage.rb
@@ -81,6 +81,18 @@ module BushSlicer
           ps.get_summary(target_region: options.region, options: options)
         end
       end
+      command :"ibmcloud" do |c|
+        c.syntax = "#{File.basename __FILE__} -r <ibmcloud_region_name> [--all]"
+        c.description = 'display summary of running instances'
+        c.option("-r", "--region region_name", "report on this region only")
+        c.option("-u", "--uptime cluter uptime limit", "report for clusters having uptime over this limit")
+        c.action do |args, options|
+          ps = IBMCloudSummary.new(svc_name: "ibmcloud", jenkins: @jenkins)
+          options.config = conf
+          say 'Getting summary...'
+          ps.get_summary(target_region: options.region, options: options)
+        end
+      end
       command :"gce" do |c|
         c.syntax = "#{File.basename __FILE__} -r <gce_region_name> [--all]"
         c.description = 'display summary of running instances'


### PR DESCRIPTION
example of output
```
+--------------------------------------+--------+--------------+----------+----------+--------+--------------------------+
|                 name                 | uptime | flexy_job_id |   type   | cost ($) | region |       inst_prefix        |
+--------------------------------------+--------+--------------+----------+----------+--------+--------------------------+
| jshu-0223-test2-cbtkc-worker-3-2ktnd | 0.5    | 79021        | bx2-4x16 | 0.1      | eu-gb  | jshu-0223-test2-cbtkc    |
| jshu-0223-test2-cbtkc-worker-2-t8hvj | 0.51   | 79021        | bx2-4x16 | 0.1      | eu-gb  | jshu-0223-test2-cbtkc    |
| jshu-0223-test2-cbtkc-worker-1-pxpg6 | 0.51   | 79021        | bx2-4x16 | 0.1      | eu-gb  | jshu-0223-test2-cbtkc    |
| jshu-0223-test2-cbtkc-master-1       | 0.66   | 79021        | bx2-4x16 | 0.13     | eu-gb  | jshu-0223-test2-cbtkc    |
| jshu-0223-test2-cbtkc-master-2       | 0.66   | 79021        | bx2-4x16 | 0.13     | eu-gb  | jshu-0223-test2-cbtkc    |
| jshu-0223-test2-cbtkc-master-0       | 0.66   | 79021        | bx2-4x16 | 0.13     | eu-gb  | jshu-0223-test2-cbtkc    |
| mihuangf211920-p898l-master-0        | 12.62  | 78857        | bx2-4x16 | 2.42     | eu-gb  | mihuangf211920-p898l     |
| mihuangf211920-p898l-master-2        | 12.62  | 78857        | bx2-4x16 | 2.42     | eu-gb  | mihuangf211920-p898l     |
| mihuangf211920-p898l-master-1        | 12.62  | 78857        | bx2-4x16 | 2.42     | eu-gb  | mihuangf211920-p898l     |
| mihuangf211920-p898l-bootstrap       | 12.74  | 78857        | bx2-4x16 | 2.45     | eu-gb  | mihuangf211920-p898l     |
| mihuangf221734-ht4nb-worker-3-rrjlw  | 14.17  | 78833        | bx2-4x16 | 2.72     | eu-gb  | mihuangf221734-ht4nb     |
| mihuangf221734-ht4nb-worker-2-g76wz  | 14.18  | 78833        | bx2-4x16 | 2.72     | eu-gb  | mihuangf221734-ht4nb     |
| mihuangf221734-ht4nb-worker-1-nktgm  | 14.18  | 78833        | bx2-4x16 | 2.72     | eu-gb  | mihuangf221734-ht4nb     |
| mihuangf221734-ht4nb-master-1        | 14.38  | 78833        | bx2-4x16 | 2.76     | eu-gb  | mihuangf221734-ht4nb     |
| mihuangf221734-ht4nb-master-2        | 14.38  | 78833        | bx2-4x16 | 2.76     | eu-gb  | mihuangf221734-ht4nb     |
| mihuangf221734-ht4nb-master-0        | 14.38  | 78833        | bx2-4x16 | 2.76     | eu-gb  | mihuangf221734-ht4nb     |
| mihuangf22ibmcloud-8rdcz-master-1    | 15.83  | 78810        | bx2-4x16 | 3.04     | eu-gb  | mihuangf22ibmcloud-8rdcz |
| mihuangf22ibmcloud-8rdcz-master-0    | 15.83  | 78810        | bx2-4x16 | 3.04     | eu-gb  | mihuangf22ibmcloud-8rdcz |
| mihuangf22ibmcloud-8rdcz-master-2    | 15.83  | 78810        | bx2-4x16 | 3.04     | eu-gb  | mihuangf22ibmcloud-8rdcz |
| mihuangf22ibmcloud-8rdcz-bootstrap   | 15.95  | 78810        | bx2-4x16 | 3.06     | eu-gb  | mihuangf22ibmcloud-8rdcz |
| mihuangf22ibm-gblqp-worker-3-8gtg2   | 16.99  | 78782        | bx2-4x16 | 3.26     | eu-gb  | mihuangf22ibm-gblqp      |
| mihuangf22ibm-gblqp-worker-2-xm8qf   | 17.0   | 78782        | bx2-4x16 | 3.26     | eu-gb  | mihuangf22ibm-gblqp      |
| mihuangf22ibm-gblqp-worker-1-rlgwv   | 17.01  | 78782        | bx2-4x16 | 3.27     | eu-gb  | mihuangf22ibm-gblqp      |
| mihuangf22ibm-gblqp-master-0         | 17.19  | 78782        | bx2-4x16 | 3.3      | eu-gb  | mihuangf22ibm-gblqp      |
| mihuangf22ibm-gblqp-master-1         | 17.19  | 78782        | bx2-4x16 | 3.3      | eu-gb  | mihuangf22ibm-gblqp      |
| mihuangf22ibm-gblqp-master-2         | 17.19  | 78782        | bx2-4x16 | 3.3      | eu-gb  | mihuangf22ibm-gblqp      |
| mihuang-ibmcloud-77kh5-master-2      | 19.79  | not found    | bx2-4x16 | 3.8      | eu-gb  |                          |
| mihuang-ibmcloud-77kh5-master-0      | 19.79  | not found    | bx2-4x16 | 3.8      | eu-gb  |                          |
| mihuang-ibmcloud-77kh5-master-1      | 19.79  | not found    | bx2-4x16 | 3.8      | eu-gb  |                          |
| mihuang-ibmcloud-77kh5-bootstrap     | 19.92  | not found    | bx2-4x16 | 3.82     | eu-gb  |                          |
| mihuang-ibm-vx9ns-master-0           | 32.95  | not found    | bx2-4x16 | 6.33     | eu-gb  |                          |
| mihuang-ibm-vx9ns-master-2           | 32.95  | not found    | bx2-4x16 | 6.33     | eu-gb  |                          |
| mihuang-ibm-vx9ns-master-1           | 32.95  | not found    | bx2-4x16 | 6.33     | eu-gb  |                          |
| mihuang-ibm-vx9ns-bootstrap          | 33.08  | not found    | bx2-4x16 | 6.35     | eu-gb  |                          |
| chaoyang-ibm411-b6nfx-worker-3-rrdh9 | 41.34  | 78428        | bx2-4x16 | 7.94     | eu-gb  | chaoyang-ibm411-b6nfx    |
| chaoyang-ibm411-b6nfx-worker-2-bskv7 | 41.34  | 78428        | bx2-4x16 | 7.94     | eu-gb  | chaoyang-ibm411-b6nfx    |
| chaoyang-ibm411-b6nfx-worker-1-b2lcb | 41.34  | 78428        | bx2-4x16 | 7.94     | eu-gb  | chaoyang-ibm411-b6nfx    |
| chaoyang-ibm411-b6nfx-worker-1-pzbvv | 41.34  | 78428        | bx2-4x16 | 7.94     | eu-gb  | chaoyang-ibm411-b6nfx    |
| chaoyang-ibm411-b6nfx-master-1       | 41.53  | 78428        | bx2-4x16 | 7.97     | eu-gb  | chaoyang-ibm411-b6nfx    |
| chaoyang-ibm411-b6nfx-master-2       | 41.53  | 78428        | bx2-4x16 | 7.97     | eu-gb  | chaoyang-ibm411-b6nfx    |
| chaoyang-ibm411-b6nfx-master-0       | 41.53  | 78428        | bx2-4x16 | 7.97     | eu-gb  | chaoyang-ibm411-b6nfx    |
+--------------------------------------+--------+--------------+----------+----------+--------+--------------------------+
There are 41 running instances in eu-gb

These 'IBMCloud eu-gb' clusters have been alive longer than 18 hrs.
+----------------+-----------+--------+----------------+------------------------+
|      name      |  job_id   | uptime | total_cost ($) |          user          |
+----------------+-----------+--------+----------------+------------------------+
| chaoyang-ibm41 | 78428     | 41.34  | 55.67          | chaoyang               |
| mihuang-ibm    | not found | 19.79  | 40.56          | mihuang-ibmcloud-77kh5 |
| mihuang-ibmcl  | not found | 19.79  | 15.22          | mihuang-ibmcloud-77kh5 |
+----------------+-----------+--------+----------------+------------------------+
+-----------------+----------+-----------------+-----------+
|    platform     |  region  | total instances | costs ($) |
+-----------------+----------+-----------------+-----------+
| IBMCloud        | au-syd   | 0               | 0.0       |
| IBMCloud        | br-sao   | 0               | 0.0       |
| IBMCloud        | ca-tor   | 0               | 0.0       |
| IBMCloud        | eu-de    | 0               | 0.0       |
| IBMCloud        | eu-gb    | 41              | 154.94    |
| IBMCloud        | jp-osa   | 0               | 0.0       |
| IBMCloud        | jp-tok   | 0               | 0.0       |
| IBMCloud        | us-east  | 0               | 0.0       |
| IBMCloud        | us-south | 0               | 0.0       |
+-----------------+----------+-----------------+-----------+
| Total instances |          | 41              | 154.94    |
+-----------------+----------+-----------------+-----------+
```