### PR TITLE
Fix prow ci `images` job

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -2,11 +2,7 @@ FROM quay.io/centos/centos:8
 
 LABEL vendor="Red Hat inc."
 LABEL maintainer="OCP QE Team"
-
 USER root
-
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
 
 RUN set -x && \
     yum -y update && \
@@ -20,17 +16,18 @@ RUN set -x && \
     GECKODRIVER_RE='^.*"browser_download_url": ?"(http[^"]*linux64.tar.gz)".*$' && \
     curl -sSL $GITHUB_API_CURL_OPTS "$GECKODRIVER_SPEC" | sed -En "s#$GECKODRIVER_RE#\1#p" | xargs -d '\n' curl -sSL | bsdtar -xvf - -C /usr/local/bin && \
     chmod +x /usr/local/bin/chromedriver /usr/local/bin/geckodriver && \
-    curl -sSL https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -o /tmp/epel-release-latest-8.noarch.rpm && \
-    yum install -y /tmp/epel-release-latest-8.noarch.rpm
-
-ADD . /verification-tests/
-RUN chmod 777 /verification-tests/
-RUN mv /tierN/ /verification-tests/features/tierN/
-RUN set -x && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm  && \
     yum module reset ruby && \
     yum module -y enable ruby:2.7 && \
-    yum module -y install ruby:2.7
-RUN /verification-tests/tools/install_os_deps.sh
-RUN /verification-tests/tools/hack_bundle.rb
+    yum module -y install ruby:2.7 && \
+    yum clean all -y && rm -rf /var/cache/yum /tmp/* /verification-tests/Gemfile.lock
 
-RUN yum clean all -y && rm -rf /var/cache/yum /tmp/* /verification-tests/Gemfile.lock
+ADD . /verification-tests/
+
+RUN set -x && \
+    mv /tierN/ /verification-tests/features/tierN/ && \
+    chgrp -R 0 /verification-tests && \
+    chmod -R g=u /verification-tests && \
+    /verification-tests/tools/install_os_deps.sh && \
+    /verification-tests/tools/hack_bundle.rb && \
+    yum clean all -y && rm -rf /var/cache/yum /tmp/* /verification-tests/Gemfile.lock


### PR DESCRIPTION
CentOS reached its EOL and the `images` prow test is still based on it.

While doing another [PR](https://github.com/openshift/verification-tests/pull/2702), a few errors on these tests occurred (see build logs in the bottom).

This PR is to be merged **after** (**blocked by**) the [cucushift one](https://github.com/openshift/cucushift/pull/9031/files). 
Its scope is twofold: moving from CentOS Stream 8 and refactoring the layers of the built image in CI.


The job should start working fine when the [cucushift PR](https://github.com/openshift/verification-tests/pull/2702) is merged and the [generated cucushift image](https://github.com/openshift/release/blob/cf72ec45499cc4a402803a59117ed0d5a4af52ae/ci-operator/config/openshift/cucushift/openshift-cucushift-master.yaml) promoted, as it is the base for [the buildconfig of the verification-tests images job](https://github.com/openshift/release/blob/e03e035f29aebad00a4af27f116258582f356c6c/ci-operator/config/openshift/verification-tests/openshift-verification-tests-master.yaml).

@lxia @jhou for review.
cc: @pruan-rht 

Please also take a look at the consideration in the TODO comment at the first lines of the changed Dockerfile.

If this PR is good for you, we'd maybe add the same fixes to
[Dockerfile.verification-tests in cucushift](https://github.com/openshift/cucushift/blob/master/Dockerfile.verification-tests) and [Dockefile.centos](https://github.com/openshift/verification-tests/blob/master/tools/openshift-ci/Dockerfile.centos) here. I'm not 100% sure of their scope.


```
CentOS Linux 8 - AppStream                      0.0  B/s |   0  B     01:24    
Errors during downloading metadata for repository 'appstream':
  - Curl error (28): Timeout was reached for http://vault.centos.org/centos/8/AppStream/x86_64/os/repodata/d8472d61c5e53a3e9cbffb68e0dddbd04a07c2b7d864b07ddd211c6ad1380c6e-primary.xml.gz [Operation too slow. Less than 1000 bytes/sec transferred the last 30 seconds]
  - Curl error (28): Timeout was reached for http://vault.centos.org/centos/8/AppStream/x86_64/os/repodata/768e088faaaba73d00aee49f134e22d5d1803171ffb167260c8b55f4165e0372-filelists.xml.gz [Operation too slow. Less than 1000 bytes/sec transferred the last 30 seconds]
  - Curl error (28): Timeout was reached for http://vault.centos.org/centos/8/AppStream/x86_64/os/repodata/5ea46cc5dfdd4a6f9c181ef29daa4a386e7843080cd625843267860d444df2f3-comps-AppStream.x86_64.xml [Operation too slow. Less than 1000 bytes/sec transferred the last 30 seconds]
  - Curl error (28): Timeout was reached for http://vault.centos.org/centos/8/AppStream/x86_64/os/repodata/d8472d61c5e53a3e9cbffb68e0dddbd04a07c2b7d864b07ddd211c6ad1380c6e-primary.xml.gz [Connection timed out after 30000 milliseconds]
Error: Failed to download metadata for repo 'appstream': Yum repo downloading error: Downloading error(s): repodata/d8472d61c5e53a3e9cbffb68e0dddbd04a07c2b7d864b07ddd211c6ad1380c6e-primary.xml.gz - Cannot download, all mirrors were already tried without success; repodata/768e088faaaba73d00aee49f134e22d5d1803171ffb167260c8b55f4165e0372-filelists.xml.gz - Cannot download, all mirrors were already tried without success; repodata/5ea46cc5dfdd4a6f9c181ef29daa4a386e7843080cd625843267860d444df2f3-comps-AppStream.x86_64.xml - Cannot download, all mirrors were already tried without success; repodata/75e00d390273f65b94d63a5ac7db2677d832bfa95b3d7eecf6[51](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_verification-tests/2702/pull-ci-openshift-verification-tests-master-images/1496559954159472640#1:build-log.txt%3A51)c6f45e33f8ff-modules.yaml.xz - Cannot download, all mirrors were already tried without success
error: build error: error building at STEP "RUN set -x &&     yum -y update &&     INSTALL_PKGS="bsdtar git openssh-clients httpd-tools rsync" &&     yum install -y $INSTALL_PKGS &&     yum install -y --setopt=tsflags=nodocs https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm &&     CHROMEDRIVER_URL="https://chromedriver.storage.googleapis.com/" &&     CHROMEDRIVER_VERSION=$(curl -sSL "$CHROMEDRIVER_URL/LATEST_RELEASE") &&     curl -sSL "$CHROMEDRIVER_URL/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" | bsdtar --no-same-owner --no-same-permissions -xvf - -C /usr/local/bin &&     GECKODRIVER_SPEC="https://api.github.com/repos/mozilla/geckodriver/releases/latest" &&     GECKODRIVER_RE='^.*"browser_download_url": ?"(http[^"]*linux64.tar.gz)".*$' &&     curl -sSL $GITHUB_API_CURL_OPTS "$GECKODRIVER_SPEC" | sed -En "s#$GECKODRIVER_RE#\1#p" | xargs -d '\n' curl -sSL | bsdtar -xvf - -C /usr/local/bin &&     chmod +x /usr/local/bin/chromedriver /usr/local/bin/geckodriver &&     curl -sSL https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -o /tmp/epel-release-latest-8.noarch.rpm &&     yum install -y /tmp/epel-release-latest-8.noarch.rpm": error while running runtime: exit status 1

```
