### PR TITLE
Fix OCPQE-7477

### DIFF
--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -676,7 +676,7 @@ Feature: deployment related features
       | p             | {"spec":{"template":{"spec":{"containers":[{"name":"hello-openshift","image":"quay.io/hello-nonexist"}]}}}} |
     Then the step should succeed
     Given the pod named "hooks-2-deploy" becomes present
-    Given I wait up to 100 seconds for the steps to pass:
+    Given I wait up to 200 seconds for the steps to pass:
     """
     And the pod named "hooks-2-deploy" status becomes :failed
     When I get project pods with labels:


### PR DESCRIPTION
Increasing the time as i see that the pod is still in terminating state which causes pattern hooks-2 to be found With this fix i am hoping we should not be seeing any more failures with respect to this case.