### PR TITLE
update OCP-47087

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -743,13 +743,13 @@ Feature: Service related networking scenarios
       | Hello OpenShift! |
     When I run commands on the host:
       | curl --connect-timeout 5 <%= cb.master0_ip %>:<%= cb.port %> |
-    Then the step should fail
-    And the output should not contain:
-      | Hello OpenShift! |
+    And the output should contain:
+      | Connection refused |
     Given I ensure "hello-pod" service is deleted
     When I run commands on the host:
       | curl --connect-timeout 5 <%= cb.hostip %>:<%= cb.port %> |
-    Then the step should fail
+    And the output should contain:
+      | Connection refused |
 
   # @author zzhao@redhat.com
   # @case_id OCP-10770


### PR DESCRIPTION
sometimes the return is `Exit Status: 0`  even though run curl service and 'Connection refused' like below logs. So here I remove the step success or fail check. 

```
04:55:10 INFO> Shell Commands: oc debug  --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_admin.kubeconfig -n prj-psi-ocp4-cucushift-oc410-standard-slave-7s9zs-0x-1vuo --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ab5d5760a7875277c5b6e3bbc6ce16fe7e886c00fe4953e3b3433200da3b691d node/master-01.qeci-34290.qe.devcluster.openshift.com -- chroot /host/ bash -c cd\ \'/tmp/workdir/psi-ocp4-cucushift-oc410-standard-slave-7s9zs-0x\''
'curl\ --connect-timeout\ 5\ 139.178.65.246:30723
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (7) Failed to connect to 139.178.65.246 port 30723: Connection refused

STDERR:
Starting pod/master-01qeci-34290qedevclusteropenshiftcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
04:55:12 INFO> Exit Status: 0
Thenthe step should fail ==>@  [features/step_definitions/common.rb:4](https://github.com/openshift/verification-tests/blob/82d45b3b6ca88be7e33b79ffc3a1da52fe0a91b2/features/step_definitions/common.rb#L4)
#<RuntimeError: the step succeeded>
[features/step_definitions/common.rb:6](https://github.com/openshift/verification-tests/blob/82d45b3b6ca88be7e33b79ffc3a1da52fe0a91b2/features/step_definitions/common.rb#L6):in `/^the step should( not)? (succeed|fail)$/'
[features/networking/service.feature:746](https://github.com/openshift/verification-tests/blob/82d45b3b6ca88be7e33b79ffc3a1da52fe0a91b2/features/networking/service.feature#L746):in `the step should fail'
And
```
