### PR TITLE
Increase wait time for disconnected clusters

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -641,7 +641,7 @@ Feature: Machine features testing
     Then the step should succeed
 
     Then I store the last provisioned machine in the :machine_latest clipboard
-    And I wait up to 300 seconds for the steps to pass:
+    And I wait up to 540 seconds for the steps to pass:
     """
     Then the expression should be true> machine(cb.machine_latest).phase(cached: false) == "Running"
     """


### PR DESCRIPTION
@jhou1  @huali9  @sunzhaohua2  PTAL . Disconnect clusters taking more time for machine to move to `Running` status
Validation result - https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/331839/console

In response to  - https://issues.redhat.com/browse/OCPQE-6298 
change to polarion also needed for making `Disconnect as No` for the similar test. [37132 - reported in Jira]