### PR TITLE
Fix OCP-21034

### DIFF
--- a/lib/rules/web/admin_console/4.7/status.xyaml
+++ b/lib/rules/web/admin_console/4.7/status.xyaml
@@ -50,4 +50,4 @@ check_name_validation_error:
   - selector:
       xpath: //h4[contains(.,'error occur')]
   - selector:
-      xpath: //div[contains(.,'subdomain must consist of lower case alphanumeric character')]
+      xpath: //div[contains(text(),'subdomain must consist of lower case alphanumeric character')]


### PR DESCRIPTION
The error message will disappear on page when too many results found on fuzzy query, that's the reason why the case failed. So this changes is to make sure only one result can be found