### PR TITLE
update hello-sdn image with multiarch image

### DIFF
--- a/features/upgrade/sdn/sctp-upgrade.feature
+++ b/features/upgrade/sdn/sctp-upgrade.feature
@@ -13,7 +13,7 @@ Feature: SDN sctp compoment upgrade testing
     Then the step should succeed
     Given I store the ready and schedulable workers in the :workers clipboard
     And I install machineconfigs load-sctp-module
-    And I wait up to 800 seconds for the steps to pass:
+    And I wait up to 1600 seconds for the steps to pass:
     """
     When I run the :get admin command with:
       |resource|nodes|

--- a/testdata/networking/externalip_pod_upgrade.yaml
+++ b/testdata/networking/externalip_pod_upgrade.yaml
@@ -16,7 +16,7 @@ items:
       spec:
         containers:
         - name: externalip-pod
-          image: "quay.io/openshifttest/hello-sdn@sha256:d5785550cf77b7932b090fcd1a2625472912fb3189d5973f177a5a2c347a1f95"
+          image: "quay.io/openshifttest/hello-sdn@sha256:2af5b5ec480f05fda7e9b278023ba04724a3dd53a296afcd8c13f220dec52197"
           ports:
           - containerPort: 8080
           - containerPort: 8443

--- a/testdata/networking/multus-cni/Pods/generic_multus_pod_upgrade.yaml
+++ b/testdata/networking/multus-cni/Pods/generic_multus_pod_upgrade.yaml
@@ -18,4 +18,4 @@ items:
       spec:
         containers:
         - name: test-pod
-          image: "quay.io/openshifttest/hello-sdn@sha256:d5785550cf77b7932b090fcd1a2625472912fb3189d5973f177a5a2c347a1f95"
+          image: "quay.io/openshifttest/hello-sdn@sha256:2af5b5ec480f05fda7e9b278023ba04724a3dd53a296afcd8c13f220dec52197"


### PR DESCRIPTION
@openshift/team-sdn-qe ^^ PTAL, thanks

fix two issue. 
1. update hello-sdn image with multiarch 
2. update time to 1600 to load sctp module , due to sometimes 800 seconds is not enough to load sctp module for all workers.  see https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-upgrade/job/upgrade-producer/3461/consoleFull