### PR TITLE
introduce a case_query to exclude the kuryr network type profiles in test cases

### DIFF
--- a/doc/prow/query_exclude_kuryr-tests.json
+++ b/doc/prow/query_exclude_kuryr-tests.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND automation_script:cucushift AND caseimportance.KEY:(critical high medium) AND caseautomation.KEY:automated AND NOT upstream.KEY:yes AND NOT status:inactive AND NOT env_network_backend.KEY:kuryr"
+}


### PR DESCRIPTION
@liangxia We have test case that needs to be excluded from the test case execution if the install profile is with network type kuryr.
As a first step to this , I would like to introduce a case_query to exclude the network type filter from the case filtration.
Once we finalize the case query, would like to introduce tag something like @exclude_network_kuryr to respective case.
Reference ticket :  OCPQE-7900.
Kindly review above change and feel free to provide comments and suggestion for the same requirement.