### PR TITLE
Wait for 120 seconds for checking multus status

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -595,23 +595,23 @@ Given /^an IP echo service is setup on the master node and the ip is stored in t
   }
 end
 
-
 Given /^the multus is enabled on the cluster$/ do
   ensure_admin_tagged
-
+  multus_status_timeout = 120
   desired_multus_replicas = daemon_set('multus', project('openshift-multus')).replica_counters(user: admin)[:desired]
   available_multus_replicas = daemon_set('multus', project('openshift-multus')).replica_counters(user: admin)[:available]
   #storing desired_multus_replicas value in desired_multus_replicas clipboard variable as well
   cb.desired_multus_replicas = desired_multus_replicas
-  unless (desired_multus_replicas == available_multus_replicas || desired_multus_replicas > env.nodes.count) && available_multus_replicas != 0
-    daemon_set('multus', project('openshift-multus')).describe(admin, quiet:false)
-    BushSlicer::Pod.get_labeled("app=multus", user: admin, project: project("openshift-multus", switch: false)) do |pod|
-      pod.describe(admin, quiet: false)
+  wait_for(multus_status_timeout) {
+    unless (desired_multus_replicas == available_multus_replicas || desired_multus_replicas > env.nodes.count) && available_multus_replicas != 0
+      daemon_set('multus', project('openshift-multus')).describe(admin, quiet:false)
+      BushSlicer::Pod.get_labeled("app=multus", user: admin, project: project("openshift-multus", switch: false)) do |pod|
+        pod.describe(admin, quiet: false)
+      end
+      env.nodes(user:admin, refresh: true, quiet: false)
+      raise "Multus is not running correctly!"
     end
-    env.nodes(user:admin, refresh: true, quiet: false)
-    raise "Multus is not running correctly!"
-  end
-
+  }
 end
 
 Given /^the status of condition#{OPT_QUOTED} for network operator is :(.+)$/ do | type, status |

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -597,15 +597,9 @@ end
 
 Given /^the multus is enabled on the cluster$/ do
   ensure_admin_tagged
-  desired_multus_replicas = daemon_set('multus', project('openshift-multus')).replica_counters(user: admin)[:desired]
-  available_multus_replicas = daemon_set('multus', project('openshift-multus')).replica_counters(user: admin)[:available]
-  #storing desired_multus_replicas value in desired_multus_replicas clipboard variable as well
-  cb.desired_multus_replicas = desired_multus_replicas
   success = wait_for(120, interval: 10)  {
     desired_multus_replicas = daemon_set('multus', project('openshift-multus')).replica_counters(user: admin)[:desired]
     available_multus_replicas = daemon_set('multus', project('openshift-multus')).replica_counters(user: admin)[:available]
-    #storing desired_multus_replicas value in desired_multus_replicas clipboard variable as well
-    cb.desired_multus_replicas = desired_multus_replicas
     if (desired_multus_replicas == available_multus_replicas || desired_multus_replicas > env.nodes.count) && available_multus_replicas != 0 
       true
     else


### PR DESCRIPTION
Before the real multus testing steps running, https://github.com/weliang1/verification-tests/blob/master/features/step_definitions/networking.rb#L605 will check the numbers of desired_multus_replicas , available_multus_replicas and env.nodes.count,  if the conditions are not met, the script will exit with status: 0 and log " Multus is not running correctly!"

The previous running scripts(not multus cases) or other reasons May cause cluster in this bad state. Update the script to give 120 seconds for continue checking multus status before exiting the testing.

@openshift/team-sdn-qe PTAL