### PR TITLE
update the replicas of router pods

### DIFF
--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -81,17 +81,18 @@ Feature: Routing and DNS related scenarios
     # Get the number of worker nodes and scale up router pods
     Given I switch to cluster admin pseudo user
     And I store the number of worker nodes to the :num_workers clipboard
+    And evaluation of `cb.num_workers - 1` is stored in the :num_routers clipboard
     When I run the :scale admin command with:
       | resource | ingresscontroller          |
       | name     | default                    |
-      | replicas | <%= cb.num_workers %>      |
+      | replicas | <%= cb.num_routers %>      |
       | n        | openshift-ingress-operator |
     Then the step should succeed
     Given I use the "openshift-ingress" project
     And I wait up to 180 seconds for the steps to pass:
     """
-    Then the expression should be true> deployment("router-default").current_replicas(cached: false) == <%= cb.num_workers %>
-    And <%= cb.num_workers %> pods become ready with labels:
+    Then the expression should be true> deployment("router-default").current_replicas(cached: false) == <%= cb.num_routers %>
+    And <%= cb.num_routers %> pods become ready with labels:
       | ingresscontroller.operator.openshift.io/deployment-ingresscontroller=default |
     """
 
@@ -105,9 +106,10 @@ Feature: Routing and DNS related scenarios
   Scenario: upgrade with running router pods on all worker nodes
     Given I switch to cluster admin pseudo user
     And I store the number of worker nodes to the :num_workers clipboard
+    And evaluation of `cb.num_workers - 1` is stored in the :num_routers clipboard
     Given I use the "openshift-ingress" project
-    Then the expression should be true> deployment("router-default").current_replicas(cached: false) == <%= cb.num_workers %>
-    And <%= cb.num_workers %> pods become ready with labels:
+    Then the expression should be true> deployment("router-default").current_replicas(cached: false) == <%= cb.num_routers %>
+    And <%= cb.num_routers %> pods become ready with labels:
       | ingresscontroller.operator.openshift.io/deployment-ingresscontroller=default |
 
 


### PR DESCRIPTION
Some of vsphere and bare metal profiles scale up rhel worker nodes in the cluster, to ensure router pods can work on those nodes so this case scales router pods to make them run on all worker nodes.
But ingress often hit unscheduled worker node issue during a upgrade and blocked the upgrade, the PR is trying to mitigate the problem by decreasing the number of router pods. Let's keep an eye on upgrade CI to see if it is helpful for troubleshooting and debugging.

@quarterpin @melvinjoseph86 @ShudiLi Please help take a look. Thanks.