### PR TITLE
fix OCPQE-8500:  use image digest

### DIFF
--- a/testdata/logging/clusterlogforwarder/fluentd/insecure/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/insecure/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: "fluentdserver"
-        image: "quay.io/openshifttest/fluentd:multiarch@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
+        image: "quay.io/openshifttest/fluentd@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
         imagePullPolicy: "IfNotPresent"
         ports:
         - containerPort: 24224

--- a/testdata/logging/clusterlogforwarder/fluentd/secure/deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/secure/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: "fluentdserver"
-        image: "quay.io/openshifttest/fluentd:multiarch@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
+        image: "quay.io/openshifttest/fluentd@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
         imagePullPolicy: "IfNotPresent"
         ports:
         - containerPort: 24224

--- a/testdata/logging/logforwarding/fluentd/insecure/deployment.yaml
+++ b/testdata/logging/logforwarding/fluentd/insecure/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: "fluentdserver"
-        image: "quay.io/openshifttest/fluentd:multiarch@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
+        image: "quay.io/openshifttest/fluentd@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
         imagePullPolicy: "IfNotPresent"
         ports:
         - containerPort: 24224

--- a/testdata/logging/logforwarding/fluentd/secure/deployment.yaml
+++ b/testdata/logging/logforwarding/fluentd/secure/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: "fluentdserver"
-        image: "quay.io/openshifttest/fluentd:multiarch@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
+        image: "quay.io/openshifttest/fluentd@sha256:fd0c0e76fb693eb3b56f7d5b1936deaea27733882047260ad65169e16085c196"
         imagePullPolicy: "IfNotPresent"
         ports:
         - containerPort: 24224


### PR DESCRIPTION
Fix imagepullbackoff issue, for example: [OCPQE-8500](https://issues.redhat.com/browse/OCPQE-8500)

/cc @anpingli 