### PR TITLE
OCPQE-8979: Fix RHEL 8 based Jenkins agent image

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.rhel8
+++ b/tools/jenkins/slaves/Dockerfile.rhel8
@@ -54,7 +54,8 @@ RUN chown -R 1001:0 $HOME && \
     chmod -R g=u $USER_PATHS && \
     chmod -R g+rw $USER_PATHS
 
-# have sudo working just in case
-RUN echo -e '#!/bin/bash\nexec "$@"' > /usr/bin/sudo && chmod 755 /usr/bin/sudo
+# to workaround https://github.com/bitnami/bitnami-docker-jenkins/issues/60
+RUN echo "jenkins:x:1001:$(id -g):Jenkins:$JENKINS_HOME:/sbin/nologin" >> /etc/passwd && \
+    echo "jenkins:x:$(id -g):" >> /etc/groups
 
 USER 1001


### PR DESCRIPTION
The PR fix/work-around below issue.

Issue 1, stderr: No user exists for uid xxx
```
[](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/347019/console#)[](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/347019/console#)[](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/347019/console#)[](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/347019/console#)03-09 12:16:28.025  [Pipeline] {
03-09 12:16:28.069  [Pipeline] stage
03-09 12:16:28.069  [Pipeline] { (clone repos)
03-09 12:16:28.086  [Pipeline] checkout
03-09 12:16:28.951  The recommended git tool is: NONE
03-09 12:16:33.314  using credential e2f7029f-ab8d-4987-8950-39feb80d5fbd
03-09 12:16:33.325  Cloning the remote Git repository
03-09 12:16:33.325  Using shallow clone with depth 1
03-09 12:16:33.325  Avoid fetching tags
03-09 12:16:34.613  ERROR: Error cloning remote repo 'upstream'
03-09 12:16:34.613  hudson.plugins.git.GitException: Command "git fetch --no-tags --force --progress --depth=1 -- git@github.com:openshift/verification-tests.git +refs/heads/*:refs/remotes/upstream/*" returned status code 128:
03-09 12:16:34.613  stdout: 
03-09 12:16:34.613  stderr: No user exists for uid 1002280000
03-09 12:16:34.613  fatal: Could not read from remote repository.
```

Issue 2, /usr/bin/sudo: line 2: exec: -k: invalid option
```
03-09 12:21:43.515  + gem install bundler:2.1.4
03-09 12:21:44.075  WARNING:  You don't have /home/jenkins/bin in your PATH,
03-09 12:21:44.075  	  gem executables will not run.
03-09 12:21:47.371  Successfully installed bundler-2.1.4
03-09 12:21:47.371  Parsing documentation for bundler-2.1.4
03-09 12:21:47.371  Done installing documentation for bundler after 2 seconds
03-09 12:21:47.371  1 gem installed
03-09 12:21:47.371  + bundle _2.1.4_
03-09 12:21:48.191  Fetching gem metadata from https://rubygems.org/.......
03-09 12:21:48.446  Resolving dependencies...
03-09 12:21:48.702  Following files may not be writable, so sudo is needed:
03-09 12:21:48.702    /usr/bin
03-09 12:21:48.702    /usr/share/gems
03-09 12:21:48.702    /usr/share/gems/build_info
03-09 12:21:48.702    /usr/share/gems/cache
03-09 12:21:48.702    /usr/share/gems/doc
03-09 12:21:48.702    /usr/share/gems/extensions
03-09 12:21:48.702    /usr/share/gems/gems
03-09 12:21:48.702    /usr/share/gems/specifications
03-09 12:21:48.702  Fetching bson 4.14.1
03-09 12:21:48.702  /usr/bin/sudo: line 2: exec: -k: invalid option
03-09 12:21:48.702  exec: usage: exec [-cl] [-a name] [command [arguments ...]] [redirection ...]
03-09 12:21:48.702  Bundler::SudoNotPermittedError: Bundler requires sudo access to install at the
03-09 12:21:48.702  moment. Try installing again, granting Bundler sudo access when prompted, or
03-09 12:21:48.702  installing into a different path.
03-09 12:21:48.702  An error occurred while installing bson (4.14.1), and Bundler cannot continue.
03-09 12:21:48.702  Make sure that `gem install bson -v '4.14.1' --source 'https://rubygems.org/'`
03-09 12:21:48.702  succeeds before bundling.
```