### PR TITLE
OCPQE-8979: Fix ID issue

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.rhel8
+++ b/tools/jenkins/slaves/Dockerfile.rhel8
@@ -54,8 +54,7 @@ RUN chown -R 1001:0 $HOME && \
     chmod -R g=u $USER_PATHS && \
     chmod -R g+rw $USER_PATHS
 
-# to workaround https://github.com/bitnami/bitnami-docker-jenkins/issues/60
-RUN echo "jenkins:x:1001:$(id -g):Jenkins:$JENKINS_HOME:/sbin/nologin" >> /etc/passwd && \
-    echo "jenkins:x:$(id -g):" >> /etc/groups
+# to fix https://github.com/bitnami/bitnami-docker-jenkins/issues/60
+RUN echo 'id -un 2>/dev/null || echo "default:x:`id -u`:`id -g`:Default Application User:${HOME}:/sbin/nologin" >> /etc/passwd' > /usr/local/bin/configure-agent
 
 USER 1001


### PR DESCRIPTION
We run the container with a very large random uid, but it does not have name mapping to it in /etc/passwd.  And the git used in the RHEL 8 image need that.
```
sh-4.2$ id
uid=1002280000 gid=0(root) groups=0(root),1002280000

sh-4.2$ id -un
id: cannot find name for user ID 1002280000
1002280000
```

/cc @jhou1 @JianLi-RH @dis016 @pruan-rht 