### PR TITLE
Optimize the query and tags

### DIFF
--- a/doc/prow/4.10/query_aws_ipi_tests.json
+++ b/doc/prow/4.10/query_aws_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(aws __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_aws_upi_tests.json
+++ b/doc/prow/4.10/query_aws_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(aws __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_azure_ipi_tests.json
+++ b/doc/prow/4.10/query_azure_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(azure __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_azure_upi_tests.json
+++ b/doc/prow/4.10/query_azure_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(azure __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_baremetal_ipi_tests.json
+++ b/doc/prow/4.10/query_baremetal_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(baremetal __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_baremetal_upi_tests.json
+++ b/doc/prow/4.10/query_baremetal_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(baremetal __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_gcp_ipi_tests.json
+++ b/doc/prow/4.10/query_gcp_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(gce __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_gcp_upi_tests.json
+++ b/doc/prow/4.10/query_gcp_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(gce __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_openstack_ipi_tests.json
+++ b/doc/prow/4.10/query_openstack_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(openstack16 __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_openstack_upi_tests.json
+++ b/doc/prow/4.10/query_openstack_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ openstack16) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_upgrade.json
+++ b/doc/prow/4.10/query_upgrade.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND subcomponent.KEY:upgrade AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT tags:(prod_only stage_only) AND version.KEY:4_10"
-}

--- a/doc/prow/4.10/query_vsphere_ipi_tests.json
+++ b/doc/prow/4.10/query_vsphere_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-   "case_query":"products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(vsphere __all__ vsphere67 vsphere70) AND caseimportance.KEY:(critical high medium) AND version.KEY:4_10 AND NOT tags:(stage_only prod_only)"
-}

--- a/doc/prow/4.10/query_vsphere_upi_tests.json
+++ b/doc/prow/4.10/query_vsphere_upi_tests.json
@@ -1,3 +1,0 @@
-{
-   "case_query":"products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(vsphere __all__ vsphere67 vsphere70) AND caseimportance.KEY:(critical high medium) AND version.KEY:4_10 AND NOT tags:(stage_only prod_only)"
-}

--- a/doc/prow/4.11/query_aws_ipi_tests.json
+++ b/doc/prow/4.11/query_aws_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(aws __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_aws_upi_tests.json
+++ b/doc/prow/4.11/query_aws_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(aws __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_azure_ipi_tests.json
+++ b/doc/prow/4.11/query_azure_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(azure __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_azure_upi_tests.json
+++ b/doc/prow/4.11/query_azure_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(azure __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_baremetal_ipi_tests.json
+++ b/doc/prow/4.11/query_baremetal_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(baremetal __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_baremetal_upi_tests.json
+++ b/doc/prow/4.11/query_baremetal_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(baremetal __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_gcp_ipi_tests.json
+++ b/doc/prow/4.11/query_gcp_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(gce __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_gcp_upi_tests.json
+++ b/doc/prow/4.11/query_gcp_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(gce __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_openstack_ipi_tests.json
+++ b/doc/prow/4.11/query_openstack_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(openstack16 __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_openstack_upi_tests.json
+++ b/doc/prow/4.11/query_openstack_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ openstack16) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_upgrade.json
+++ b/doc/prow/4.11/query_upgrade.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND subcomponent.KEY:upgrade AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT tags:(prod_only stage_only) AND version.KEY:4_11"
-}

--- a/doc/prow/4.11/query_vsphere_ipi_tests.json
+++ b/doc/prow/4.11/query_vsphere_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-   "case_query":"products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(vsphere __all__ vsphere67 vsphere70) AND caseimportance.KEY:(critical high medium) AND version.KEY:4_11 AND NOT tags:(stage_only prod_only)"
-}

--- a/doc/prow/4.11/query_vsphere_upi_tests.json
+++ b/doc/prow/4.11/query_vsphere_upi_tests.json
@@ -1,3 +1,0 @@
-{
-   "case_query":"products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(vsphere __all__ vsphere67 vsphere70) AND caseimportance.KEY:(critical high medium) AND version.KEY:4_11 AND NOT tags:(stage_only prod_only)"
-}

--- a/doc/prow/4.7/query_upgrade_sanity.json
+++ b/doc/prow/4.7/query_upgrade_sanity.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND caseimportance.KEY:critical AND version.KEY:4_7 AND NOT tags:(prod_only stage_only)"
-}

--- a/doc/prow/4.8/query_upgrade.json
+++ b/doc/prow/4.8/query_upgrade.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND subcomponent.KEY:upgrade AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT tags:(prod_only stage_only) AND version.KEY:4_8"
-}

--- a/doc/prow/4.8/query_upgrade_sanity.json
+++ b/doc/prow/4.8/query_upgrade_sanity.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND caseimportance.KEY:critical AND version.KEY:4_8 AND NOT tags: (prod_only stage_only) AND NOT subcomponent.KEY:upgrade"
-}

--- a/doc/prow/4.9/query_aws_ipi_tests.json
+++ b/doc/prow/4.9/query_aws_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(aws __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_aws_upi_tests.json
+++ b/doc/prow/4.9/query_aws_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(aws __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_azure_ipi_tests.json
+++ b/doc/prow/4.9/query_azure_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(azure __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_azure_upi_tests.json
+++ b/doc/prow/4.9/query_azure_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(azure __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_baremetal_ipi_tests.json
+++ b/doc/prow/4.9/query_baremetal_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(baremetal __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_baremetal_upi_tests.json
+++ b/doc/prow/4.9/query_baremetal_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(baremetal __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_gcp_ipi_tests.json
+++ b/doc/prow/4.9/query_gcp_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(gce __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_gcp_upi_tests.json
+++ b/doc/prow/4.9/query_gcp_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(gce __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_openstack_ipi_tests.json
+++ b/doc/prow/4.9/query_openstack_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(openstack16 __all__) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_openstack_upi_tests.json
+++ b/doc/prow/4.9/query_openstack_upi_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ openstack16) AND caseimportance.KEY:(critical high medium) AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_upgrade.json
+++ b/doc/prow/4.9/query_upgrade.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND subcomponent.KEY:upgrade AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT tags:(prod_only stage_only) AND version.KEY:4_9"
-}

--- a/doc/prow/4.9/query_upgrade_sanity.json
+++ b/doc/prow/4.9/query_upgrade_sanity.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND NOT status:inactive AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND caseimportance.KEY:critical AND version.KEY:4_9 AND NOT tags: (prod_only stage_only) AND NOT subcomponent.KEY:upgrade"
-}

--- a/doc/prow/4.9/query_vsphere_ipi_tests.json
+++ b/doc/prow/4.9/query_vsphere_ipi_tests.json
@@ -1,3 +1,0 @@
-{
-   "case_query":"products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(vsphere __all__ vsphere67 vsphere70) AND caseimportance.KEY:(critical high medium) AND version.KEY:4_9  AND NOT tags:(stage_only prod_only)"
-}

--- a/doc/prow/4.9/query_vsphere_upi_tests.json
+++ b/doc/prow/4.9/query_vsphere_upi_tests.json
@@ -1,3 +1,0 @@
-{
-   "case_query":"products.KEY:ocp AND type:testcase AND NOT status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(vsphere __all__ vsphere67 vsphere70) AND caseimportance.KEY:(critical high medium) AND version.KEY:4_9  AND NOT tags:(stage_only prod_only)"
-}

--- a/doc/prow/README.md
+++ b/doc/prow/README.md
@@ -7,8 +7,8 @@ Please follow this step by step guide to create a new Prow job to run cucushift 
 ## Create a Test Run Query
 
 1. Go to OSE project in Polarion, select `Workitems`, in the search box create your test run query matching your test profile. When constructing the test run query, select only `Critical`,`High` and `Medium` automated test cases.
-2. Upon completion of the query, click the `Convert Query to Text`. See the example of *query_aws_ipi_tests.json*.
-3. Copy your query and create a `$version/query_$profile_tests.json`, add a PR in this repo and ask qe-productivity for review.
+2. Upon completion of the query, click the `Convert Query to Text`. See the example of *query_aws-ipi.json*.
+3. Copy your query and create a `doc/prow/query_$tag.json`, add a PR in this repo and ask qe-productivity for review.
 
 The team should review the test query succesfully matches the profile and merge it.
 
@@ -20,10 +20,7 @@ The following commands will retrieve all test case ids and add the tag `@aws-ipi
 
 ```bash
 cd verficiation-tests
-# x.y are versions, e.g, 4.9
-QUERY_FILE="../path-to-folder/verification-tests/doc/prow/x.y/query_aws_ipi_tests.json"
-TAGS="@aws-ipi,@4.9"
-tools/case_id_splitter.rb add-tags --tags ${TAGS} --ids $(tools/polarshift.rb query-cases -f ${QUERY_FILE} | grep -o -E 'OCP-[0-9]+' | tr '\n' ',')
+bash tools/cucushift-add-tags.sh doc/prow/query_aws-ipi.json doc/prow/query_4.9.json
 ```
 
 Upon completion of the steps, create a pull request in `verfication-tests` and `cucushift` respectively. Add clear and consistent summary to your PR and ask qe-productivity for review.

--- a/doc/prow/query_4.10.json
+++ b/doc/prow/query_4.10.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND version.KEY:4_10"
+}

--- a/doc/prow/query_4.11.json
+++ b/doc/prow/query_4.11.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND version.KEY:4_11"
+}

--- a/doc/prow/query_4.6.json
+++ b/doc/prow/query_4.6.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND version.KEY:4_6"
+}

--- a/doc/prow/query_4.7.json
+++ b/doc/prow/query_4.7.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND version.KEY:4_7"
+}

--- a/doc/prow/query_4.8.json
+++ b/doc/prow/query_4.8.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND version.KEY:4_8"
+}

--- a/doc/prow/query_4.9.json
+++ b/doc/prow/query_4.9.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND version.KEY:4_9"
+}

--- a/doc/prow/query_aws-ipi.json
+++ b/doc/prow/query_aws-ipi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(aws __all__)"
+}

--- a/doc/prow/query_aws-upi.json
+++ b/doc/prow/query_aws-upi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(aws __all__)"
+}

--- a/doc/prow/query_azure-ipi.json
+++ b/doc/prow/query_azure-ipi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(azure __all__)"
+}

--- a/doc/prow/query_azure-upi.json
+++ b/doc/prow/query_azure-upi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(azure __all__)"
+}

--- a/doc/prow/query_baremetal-ipi.json
+++ b/doc/prow/query_baremetal-ipi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(baremetal __all__)"
+}

--- a/doc/prow/query_baremetal-upi.json
+++ b/doc/prow/query_baremetal-upi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(baremetal __all__)"
+}

--- a/doc/prow/query_connected-tests.json
+++ b/doc/prow/query_connected-tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND automation_script:cucushift AND caseautomation.KEY:automated AND NOT upstream.KEY:yes AND NOT status:inactive AND env_disconnected.KEY:(_all_ no)"
-}

--- a/doc/prow/query_connected.json
+++ b/doc/prow/query_connected.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND env_disconnected.KEY:(_all_ no)"
+}

--- a/doc/prow/query_disconnected-tests.json
+++ b/doc/prow/query_disconnected-tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND automation_script:cucushift AND caseautomation.KEY:automated AND NOT upstream.KEY:yes AND NOT status:inactive AND env_disconnected.KEY:(_all_ yes)"
-}

--- a/doc/prow/query_disconnected.json
+++ b/doc/prow/query_disconnected.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND env_disconnected.KEY:(_all_ yes)"
+}

--- a/doc/prow/query_gcp-ipi.json
+++ b/doc/prow/query_gcp-ipi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(gce __all__)"
+}

--- a/doc/prow/query_gcp-upi.json
+++ b/doc/prow/query_gcp-upi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(gce __all__)"
+}

--- a/doc/prow/query_inactive.json
+++ b/doc/prow/query_inactive.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND status:inactive"
+}

--- a/doc/prow/query_inactive_tests.json
+++ b/doc/prow/query_inactive_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "type:testcase AND status:inactive AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT upstream.KEY:yes"
-}

--- a/doc/prow/query_noproxy.json
+++ b/doc/prow/query_noproxy.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND env_behind_proxy.KEY:(_all_ no)"
+}

--- a/doc/prow/query_noproxy_tests.json
+++ b/doc/prow/query_noproxy_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND automation_script:cucushift AND caseautomation.KEY:automated AND NOT upstream.KEY:yes AND NOT status:inactive AND env_behind_proxy.KEY:(_all_ no)"
-}

--- a/doc/prow/query_openstack-ipi.json
+++ b/doc/prow/query_openstack-ipi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(openstack16 __all__)"
+}

--- a/doc/prow/query_openstack-upi.json
+++ b/doc/prow/query_openstack-upi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ openstack16)"
+}

--- a/doc/prow/query_proxy.json
+++ b/doc/prow/query_proxy.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND env_behind_proxy.KEY:(_all_ http_proxy https_proxy)"
+}

--- a/doc/prow/query_proxy_tests.json
+++ b/doc/prow/query_proxy_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND automation_script:cucushift AND caseautomation.KEY:automated AND NOT upstream.KEY:yes AND NOT status:inactive AND env_behind_proxy.KEY:(_all_ http_proxy https_proxy)"
-}

--- a/doc/prow/query_singlenode-tests.json
+++ b/doc/prow/query_singlenode-tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND automation_script:cucushift AND caseautomation.KEY:automated AND NOT upstream.KEY:yes AND NOT status:inactive AND env_single_node.KEY:(_all_ yes)"
-}

--- a/doc/prow/query_singlenode.json
+++ b/doc/prow/query_singlenode.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND env_single_node.KEY:(_all_ yes)"
+}

--- a/doc/prow/query_stage-only.json
+++ b/doc/prow/query_stage-only.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND tags:stage_only"
+}

--- a/doc/prow/query_stage_only_tests.json
+++ b/doc/prow/query_stage_only_tests.json
@@ -1,3 +1,0 @@
-{
-  "case_query": "products.KEY:ocp AND automation_script:cucushift AND caseautomation.KEY:automated AND NOT upstream.KEY:yes AND NOT status:inactive AND tags:stage_only"
-}

--- a/doc/prow/query_upgrade.json
+++ b/doc/prow/query_upgrade.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND subcomponent.KEY:upgrade"
+}

--- a/doc/prow/query_vsphere-ipi.json
+++ b/doc/prow/query_vsphere-ipi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(vsphere __all__ vsphere67 vsphere70)"
+}

--- a/doc/prow/query_vsphere-upi.json
+++ b/doc/prow/query_vsphere-upi.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:(critical high medium) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(vsphere __all__ vsphere67 vsphere70)"
+}

--- a/tools/cucushift-add-tags.sh
+++ b/tools/cucushift-add-tags.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
+for filePath in $@ ; do
+	fileName="$(basename $filePath)"
+	temp="${fileName#query_}"
+	tag="@${temp%.json}"
+
+	echo "Adding tag: ${tag}"
+	tools/case_id_splitter.rb add-tags --tags "${tag}" --ids $(tools/polarshift.rb query-cases -f "${filePath}" | grep -o -E 'OCP-[0-9]+' | tr '\n' ',')
+done


### PR DESCRIPTION
Changes,
1. Unify the file names from `query_xxx_tests.json`, `query_xxx-tests.json`, `query_xxx.json` to `query_xxx.json`, where xxx is the tag name (without `@`)
2. Split query from `4.y/query_xxx` to two queries `query_4.y.json` and `query_xxx`, where xxx is the format of iaas-xpi (e.g, aws-ipi). So that we have less duplicate queries. Original query file number is:  12 (aws-ipi,aws-upi,..) * 6 (4.6,4.7,...,4.11); now the number is: 12 + 6
3. Add a shell script `tools/cucushift-add-tags.sh` to simplify adding tags in batch.