### PR TITLE
fix OCPQE-9246

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -719,9 +719,9 @@ Given /^I upgrade the operator with:$/ do | table |
       end
       # wait for the ES cluster to be ready
       success = wait_for(600, interval: 10) {
-        elasticsearch('elasticsearch').cluster_health == "green" &&
-        (elasticsearch('elasticsearch').nodes_status.last["upgradeStatus"].empty? ||
-        elasticsearch('elasticsearch').nodes_status.last["upgradeStatus"]["scheduledUpgrade"].nil?)
+        esPods = BushSlicer::Pod.get_labeled("component=elasticsearch", project: project, user: user, quiet: true).map(&:name)
+        readyPods = (elasticsearch('elasticsearch').es_master_ready_pod_names + elasticsearch('elasticsearch').es_client_ready_pod_names(cached: true) + elasticsearch('elasticsearch').es_data_ready_pod_names(cached:true)).uniq
+        elasticsearch('elasticsearch').cluster_health == "green" && (esPods - readyPods).blank? && (readyPods - esPods).blank?
       }
       raise "ES cluster isn't in a good status" unless success
       # check pvc count

--- a/lib/openshift/elasticsearch.rb
+++ b/lib/openshift/elasticsearch.rb
@@ -96,8 +96,8 @@ module BushSlicer
     end
 
     def cluster_health(user: nil, cached: false, quiet: false)
-      return cluster_status(user: user, cached: true, quiet: quiet).dig('status') || 
-        status(user: user, cached: cached, quiet: quiet).dig('clusterHealth')   
+      return cluster_status(user: user, cached: true, quiet: quiet).dig('status') ||
+        status(user: user, cached: cached, quiet: quiet).dig('clusterHealth')
     end
 
     def active_primary_shards(user: nil, cached: false, quiet: false)
@@ -158,6 +158,38 @@ module BushSlicer
 
     def es_master_failed_pod_names(user: nil, cached: false, quiet: true)
       return es_master_pods(user: user, cached: cached, quiet: quiet)['failed']
+    end
+
+    def es_client_pods(user: nil, cached: false, quiet: true)
+      return es_pods(user: user, cached: cached, quiet: quiet)['client']
+    end
+
+    def es_client_ready_pod_names(user: nil, cached: false, quiet: true)
+      return es_client_pods(user: user, cached: cached, quiet: quiet)['ready']
+    end
+
+    def es_client_not_ready_pod_names(user: nil, cached: false, quiet: true)
+      return es_client_pods(user: user, cached: cached, quiet: quiet)['notReady']
+    end
+
+    def es_client_failed_pod_names(user: nil, cached: false, quiet: true)
+      return es_client_pods(user: user, cached: cached, quiet: quiet)['failed']
+    end
+
+    def es_data_pods(user: nil, cached: false, quiet: true)
+      return es_pods(user: user, cached: cached, quiet: quiet)['data']
+    end
+
+    def es_data_ready_pod_names(user: nil, cached: false, quiet: true)
+      return es_data_pods(user: user, cached: cached, quiet: quiet)['ready']
+    end
+
+    def es_data_not_ready_pod_names(user: nil, cached: false, quiet: true)
+      return es_data_pods(user: user, cached: cached, quiet: quiet)['notReady']
+    end
+
+    def es_data_failed_pod_names(user: nil, cached: false, quiet: true)
+      return es_data_pods(user: user, cached: cached, quiet: quiet)['failed']
     end
 
   end


### PR DESCRIPTION
Fix https://issues.redhat.com/browse/OCPQE-9246

During upgrade, ES pods performs rolling-upgrade, the cluster health status will be `green` temporarily, so checking the cluster health and upgrade status in CR elasticsearch isn't proper. Here change to check the ES cluster health and compare the ready pods in CR elasticsearch and the pods in the logging project. 

/cc @anpingli 