### PR TITLE
changing packet size  to accommodate various platforms

### DIFF
--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -41,7 +41,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
     #Make sure you got some packets captured at the receiver node.The socat we used earlier will dump any ESP packets less that 40 in length (these are invalid in our clusters). Checking limited number
     #of packets say 1 or 2 should suffice as that would imply the successful communication of ESP traffic across the nodes
     When admin executes on the "<%= cb.hello_pod_worker1 %>" pod:
-       | bash | -c | timeout  --preserve-status 60 tcpdump -c 2 -i br-ex "esp and less 40" |
+       | bash | -c | timeout  --preserve-status 60 tcpdump -c 2 -i br-ex "esp and less 1500" |
     Then the step should succeed
     And the output should not contain "0 packets captured"
 

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1324,7 +1324,10 @@ Given /^the IPsec is enabled on the cluster$/ do
   _admin = admin
   network_operator = BushSlicer::NetworkOperator.new(name: "cluster", env: env)
   default_network = network_operator.default_network(user: admin)
-  raise "env doesn't have IPSec enabled" unless default_network["ipsecConfig"]
+  unless default_network["ipsecConfig"]
+     logger.info "env doesn't have IPSec enabled"
+     skip_this_scenario
+  end 
 end
 
 Given /^the node's active nmcli connection is stored in the#{OPT_SYM} clipboard$/ do |cb_name|

--- a/features/upgrade/sdn/ipsec-upgrade.feature
+++ b/features/upgrade/sdn/ipsec-upgrade.feature
@@ -119,6 +119,6 @@ Feature: IPsec upgrade scenarios
        | name=network-pod0 |
     #Following will confirm node-node encryption
     When admin executes on the "<%= cb.hostnw_pod_worker1 %>" pod:
-       | sh | -c | timeout  --preserve-status 60 tcpdump -c 2 -i br-ex "esp and less 40" |
+       | sh | -c | timeout  --preserve-status 60 tcpdump -c 2 -i br-ex "esp and less 1500" |
     Then the step should succeed
     And the output should not contain "0 packets captured"


### PR DESCRIPTION
This scenario is observing frequent failures and it took some time to diagnose on various platforms.
Socat sendto opens a raw IP socket and sends an IP packet of length less than 40 bytes at the receiver. various link level headers etc are added to that increasing its packet length. ESP traffic have been checked on OVN br-ex  interface and the packet length at such link layer might varies depending on platforms and MTUs. tcpdumps/pcaps experiments revealed that keeping size less than 1500 is able to catch such packets in these tests across all the platforms.

In short link layer modified the size of packet as per platforms and MTUs in picture. Hence changing tcpdump command to be able to successfully capture such packets.

Also this scenario is being running most of time in non-ipsec clusters to skipping it as per auto team suggestion.

@openshift/team-sdn-qe PTAL. I have tested on all platforms. Let me know if somebody want to see logs as their in not a big diff but just change in packet size check. The reason 40 vs 1500 is OSP adds a chunk of headers and make such packets large in such platforms. 