### PR TITLE
update fluentd configuration

### DIFF
--- a/testdata/logging/clusterlogforwarder/fluentd/insecure/configmap.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/insecure/configmap.yaml
@@ -6,7 +6,7 @@ data:
       port  24224
     </source>
 
-    <match *_default_** **_kube-*_** **_openshift-*_** **_openshift_**>
+    <match *_default_** **_kube-*_** **_openshift-*_** **_openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_**>
       @type file
       append true
       path /fluentd/log/infra-container.*.log
@@ -33,7 +33,7 @@ data:
       time_slice_wait   1m
       time_format       %Y%m%dT%H%M%S%z
     </match>
-    <match linux-audit.log** k8s-audit.log** openshift-audit.log**>
+    <match linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**>
       @type file
       append true
       path /fluentd/log/audit.*.log

--- a/testdata/logging/clusterlogforwarder/fluentd/secure/cm-mtls-share.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/secure/cm-mtls-share.yaml
@@ -16,7 +16,7 @@ data:
       </security>
     </source>
 
-    <match *_default_** **_kube-*_** **_openshift-*_** **_openshift_**>
+    <match *_default_** **_kube-*_** **_openshift-*_** **_openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_**>
       @type file
       append true
       path /fluentd/log/infra-container.*.log
@@ -43,7 +43,7 @@ data:
       time_slice_wait   1m
       time_format       %Y%m%dT%H%M%S%z
     </match>
-    <match linux-audit.log** k8s-audit.log** openshift-audit.log**>
+    <match linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**>
       @type file
       append true
       path /fluentd/log/audit.*.log

--- a/testdata/logging/clusterlogforwarder/fluentd/secure/cm-mtls.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/secure/cm-mtls.yaml
@@ -12,7 +12,7 @@ data:
       </transport>
     </source>
 
-    <match *_default_** **_kube-*_** **_openshift-*_** **_openshift_**>
+    <match *_default_** **_kube-*_** **_openshift-*_** **_openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_**>
       @type file
       append true
       path /fluentd/log/infra-container.*.log
@@ -39,7 +39,7 @@ data:
       time_slice_wait   1m
       time_format       %Y%m%dT%H%M%S%z
     </match>
-    <match linux-audit.log** k8s-audit.log** openshift-audit.log**>
+    <match linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**>
       @type file
       append true
       path /fluentd/log/audit.*.log

--- a/testdata/logging/clusterlogforwarder/fluentd/secure/cm-serverauth-share.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/secure/cm-serverauth-share.yaml
@@ -14,7 +14,7 @@ data:
       </security>
     </source>
 
-    <match *_default_** **_kube-*_** **_openshift-*_** **_openshift_**>
+    <match *_default_** **_kube-*_** **_openshift-*_** **_openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_**>
       @type file
       append true
       path /fluentd/log/infra-container.*.log
@@ -41,7 +41,7 @@ data:
       time_slice_wait   1m
       time_format       %Y%m%dT%H%M%S%z
     </match>
-    <match linux-audit.log** k8s-audit.log** openshift-audit.log**>
+    <match linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**>
       @type file
       append true
       path /fluentd/log/audit.*.log

--- a/testdata/logging/clusterlogforwarder/fluentd/secure/cm-serverauth.yaml
+++ b/testdata/logging/clusterlogforwarder/fluentd/secure/cm-serverauth.yaml
@@ -10,7 +10,7 @@ data:
       </transport>
     </source>
 
-    <match *_default_** **_kube-*_** **_openshift-*_** **_openshift_**>
+    <match *_default_** **_kube-*_** **_openshift-*_** **_openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_**>
       @type file
       append true
       path /fluentd/log/infra-container.*.log
@@ -37,7 +37,7 @@ data:
       time_slice_wait   1m
       time_format       %Y%m%dT%H%M%S%z
     </match>
-    <match linux-audit.log** k8s-audit.log** openshift-audit.log**>
+    <match linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**>
       @type file
       append true
       path /fluentd/log/audit.*.log


### PR DESCRIPTION
When testing forward logs to fluentd with logging 5.4, some infra container logs are stored into app.log, the root cause is we change the source to `/var/log/pods/` in logging 5.4. 
Update the fluentd configuration to fix this issue. 
