### PR TITLE
Fix OCP-41198 upgrade scenarios

### DIFF
--- a/features/upgrade/api_auth/upgrade.feature
+++ b/features/upgrade/api_auth/upgrade.feature
@@ -265,6 +265,7 @@ Feature: apiserver and auth related upgrade check
       | f | headless-services.yaml |
     Then the step should succeed
     Given I use the "service-ca-upgrade" project
+    And I wait for the "test-serving-cert" secret to appear
     And I run the :extract client command with:
       | resource | secret/test-serving-cert |
       | confirm  | true                     |
@@ -291,9 +292,9 @@ Feature: apiserver and auth related upgrade check
   @upgrade
   Scenario: Upgrade action will cause re-generation of certificates for headless services to include the wildcard subjects
     Given the master version >= "4.8"
-    Given I switch to the first user
+    Given I switch to cluster admin pseudo user
     Given I use the "service-ca-upgrade" project
-    And I run the :extract client command with:
+    When I run the :extract client command with:
       | resource | secret/test-serving-cert |
       | confirm  | true                     |
     Then the step should succeed


### PR DESCRIPTION
Failures: [OCPQE-8683](https://issues.redhat.com/browse/OCPQE-8683)
For originally reported failure in its "Description", reason is auto execution of steps is fast, need add waiting.
For another failure in its later comment, reason is upgrade framework does not ensure post-upgrade job uses the same test user as the pre-upgrade job.
Pass log:
Pre-upgrade: ocp-c1 job/Runner/363732/console
Post-upgrade: ocp-c1 job/Runner/363741/console
@y4sht please review, thx!