### PR TITLE
Add wait so that descheduler cluster pod comes up fine

### DIFF
--- a/features/upgrade/workloads/descheduler-upgrade.feature
+++ b/features/upgrade/workloads/descheduler-upgrade.feature
@@ -16,6 +16,7 @@ Feature: Descheduler major upgrade should work fine
     When I run the :create admin command with:
       | f | kubedescheduler-<%= cb.master_version %>.yaml |
     Then the step should succeed
+    Given 60 seconds have passed
     And status becomes :running of exactly 1 pods labeled:
       | app=descheduler |
     Given evaluation of `pod.name` is stored in the :pod_name clipboard


### PR DESCRIPTION
With 4.10 there were recent changes to descheduler where the descheduler cluster pod comes up then terminates immediately to start securely, so adding some wait to make sure that test here does not fail.