### PR TITLE
don't run logging upgrade on baremetal  

### DIFF
--- a/features/upgrade/logging/upgrade.feature
+++ b/features/upgrade/logging/upgrade.feature
@@ -7,8 +7,8 @@ Feature: Logging upgrading related features
   @upgrade-prepare
   @users=upuser1,upuser2
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   @singlenode
   @noproxy @connected
   Scenario: Cluster logging checking during cluster upgrade - prepare
@@ -47,8 +47,8 @@ Feature: Logging upgrading related features
   @upgrade-check
   @users=upuser1,upuser2
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   @singlenode
   @noproxy @connected
   @upgrade


### PR DESCRIPTION
don't run logging upgrade on baremetal  as the persistent volumes are provided by nfs pod. the nfs pod may be in the bad status. that may make Logging ES can not find the storage and thus can not be terminated.

https://issues.redhat.com/browse/OCPQE-8922 