### PR TITLE
disable the snapshot upgrade case which uses hostpath csi driver

### DIFF
--- a/features/upgrade/storage/upgrade.feature
+++ b/features/upgrade/storage/upgrade.feature
@@ -205,6 +205,7 @@ Feature: Storage upgrade tests
   @aws-upi
   @singlenode
   @connected
+  @inactive
   Scenario: Snapshot operator should be in available status after upgrade and can created pod with snapshot - prepare
     Given the master version >= "4.4"
 
@@ -323,6 +324,7 @@ Feature: Storage upgrade tests
   @singlenode
   @connected
   @upgrade
+  @inactive
   Scenario: Snapshot operator should be in available status after upgrade and can created pod with snapshot
     Given I switch to cluster admin pseudo user
 


### PR DESCRIPTION
To fix https://issues.redhat.com/browse/OCPQE-9371
We have snapshot upgrade with AWS EBS CSI Driver, so disable this one which uses hostpath csi driver

@chao007 @ropatil010 PTAL 