### PR TITLE
Adding @flaky tag so that test gets skipped

### DIFF
--- a/features/upgrade/workloads/scheduler-upgrade.feature
+++ b/features/upgrade/workloads/scheduler-upgrade.feature
@@ -3,6 +3,7 @@ Feature: scheduler with custom policy upgrade check
   @upgrade-prepare
   @admin
   @destructive
+  @flaky
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode
@@ -48,6 +49,7 @@ Feature: scheduler with custom policy upgrade check
   @upgrade-check
   @admin
   @destructive
+  @flaky
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode


### PR DESCRIPTION
I see that test is not suitable to run with 4.10 & 4.11 also if ci/user tries to upgrade from 4.7->4.10 upgrade will still fail as scheduler cannot be upgraded by having policy configmap set. So skipping the test, i will add other tests with checks to make sure that kube-scheduler pods run fine after upgrade.