### PR TITLE
Fix query for network-openshiftsdn

### DIFF
--- a/doc/prow/query_network-openshiftsdn.json
+++ b/doc/prow/query_network-openshiftsdn.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_network_backend.KEY:(__all__ openshift\-sdn)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_network_backend.KEY:(__all__ openshift-sdn)"
 }


### PR DESCRIPTION
In Polarion it is `env_network_backend.KEY:(openshift\-sdn __all__)`, but the `\` show as unknown escape character.

After some testing, found `\` is not needed in the query.