### PR TITLE
fix chrome args

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -162,7 +162,7 @@ require_relative 'chrome_extension'
         if @selenium_url
           @browser = Watir::Browser.new :chrome, :http_client=>client, options: options, url: @selenium_url
         else
-          options["goog:chromeOptions"][:switches] = chrome_switches
+          options["goog:chromeOptions"][:args] = chrome_switches
           @browser = Watir::Browser.new :chrome, :http_client=>client, options: options
         end
         logger.info "#{browser.driver.capabilities[:browser_name]} version is #{browser.driver.capabilities[:browser_version]}"


### PR DESCRIPTION
with this change, chrome browser will be launched with correct args(including --disable-dev-shm-usage, which help reduce crash issue)
```
2022-03-29 09:49:34 INFO Watir Creating Browser instance of chrome with user provided options: {:http_client=>#<Watir::HttpClient:0x0000000005449b20 @open_timeout=180, @read_timeout=600>, :options=>{:browser_name=>"chrome", :accept_insecure_certs=>true, "goog:chromeOptions"=>{:element_scroll_behavior=>1, :args=>["--no-sandbox", "--disable-setuid-sandbox", "--disable-gpu", "--disable-infobars", "--disable-dev-shm-usage"]}}}
```
this also fix several JIRA issues such as https://issues.redhat.com/browse/OCPQE-9095
@yanpzhan @liangxia 
