### PR TITLE
update not stable steps

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -40,7 +40,6 @@ Feature: Service related networking scenarios
     # access service in project1
     When I execute on the pod:
       | /usr/bin/curl | --connect-timeout | 4 | <%= cb.service1_ip %>:27017 |
-    Then the step should fail
     Then the output should not contain:
       | Hello OpenShift |
 
@@ -588,7 +587,8 @@ Feature: Service related networking scenarios
     Given I ensure "hello-pod" service is deleted
     When I run commands on the host:
       | curl --connect-timeout 5 <%= cb.worker0_ip %>:<%= cb.port %> |
-    Then the step should fail
+    And the output should contain:
+      | Connection refused |      
 
   # @author zzhao@redhat.com
   # @case_id OCP-33850
@@ -823,4 +823,5 @@ Feature: Service related networking scenarios
     Given I ensure "hello-pod" service is deleted
     When I run commands on the host:
       | curl --connect-timeout 5 <%= cb.hostip %>:<%= cb.port %> |
-    Then the step should fail
+    And the output should contain:
+      | Connection refused |      


### PR DESCRIPTION
remove step `Then the step should fail`
since sometimes Exit Status is 0
like 
https://s3.upshift.redhat.com/cucushift-html-logs/logs/2022/04/01/16%3A17%3A19/User_can_expand_the_nodePort_range_by_patch_the_serviceNodePortRange_in_network?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20220402%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20220402T060759Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=33b02ea2d61854cc768300f2e1d2e6c96809a714ff607fb270608431068dd61c