### PR TITLE
update OCP-30501 to count the number of linux workers

### DIFF
--- a/features/step_definitions/node.rb
+++ b/features/step_definitions/node.rb
@@ -26,7 +26,7 @@ end
 # select a random node from a cluster.
 Given /^I select a random( windows)? node's host$/ do | windows |
   ensure_admin_tagged
-  nodes = env.nodes.select { |n| n.schedulable? && (windows ? n.is_windows_worker? : ! n.is_windows_worker?) }
+  nodes = env.nodes.select { |n| n.schedulable? && (windows ? n.is_windows? : ! n.is_windows?) }
   cache_resources *nodes.shuffle
   @host = node.host
 end
@@ -56,7 +56,7 @@ Given /^I store the( schedulable| ready and schedulable)?( windows)? (node|maste
   end
 
   ###select windows worker or not
-  cb[cbname] = cb[cbname].select { |n| windows ? n.is_windows_worker? : ! n.is_windows_worker? }
+  cb[cbname] = cb[cbname].select { |n| windows ? n.is_windows? : ! n.is_windows? }
 
   cache_resources *cb[cbname].shuffle
 end
@@ -633,9 +633,14 @@ Given /^I store all worker nodes to the#{OPT_SYM} clipboard$/ do |cb_name|
   cb[cb_name] = nodes.select { |n| n.is_worker? }
 end
 
-Given /^I store the number of worker nodes to the#{OPT_SYM} clipboard$/ do |cb_name|
+Given /^I store the number of( linux| windows)? worker nodes to the#{OPT_SYM} clipboard$/ do |os_type, cb_name|
   nodes = BushSlicer::Node.list(user: admin)
   worker_nodes = nodes.select { |n| n.is_worker? }
+  if os_type =~ /linux/
+    worker_nodes = worker_nodes.select { |n| n.is_linux?}
+  elsif os_type =~ /windows/
+    worker_nodes = worker_nodes.select { |n| n.is_windows?}
+  end
   cb[cb_name] = worker_nodes.length
 end
 

--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -91,7 +91,7 @@ Feature: Routing and DNS related scenarios
   Scenario: upgrade with running router pods on all worker nodes - prepare
     # Get the number of worker nodes and scale up router pods
     Given I switch to cluster admin pseudo user
-    And I store the number of worker nodes to the :num_workers clipboard
+    And I store the number of linux worker nodes to the :num_workers clipboard
     And evaluation of `cb.num_workers - 1` is stored in the :num_routers clipboard
     When I run the :scale admin command with:
       | resource | ingresscontroller          |
@@ -119,7 +119,7 @@ Feature: Routing and DNS related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   Scenario: upgrade with running router pods on all worker nodes
     Given I switch to cluster admin pseudo user
-    And I store the number of worker nodes to the :num_workers clipboard
+    And I store the number of linux worker nodes to the :num_workers clipboard
     And evaluation of `cb.num_workers - 1` is stored in the :num_routers clipboard
     Given I use the "openshift-ingress" project
     Then the expression should be true> deployment("router-default").current_replicas(cached: false) == <%= cb.num_routers %>

--- a/lib/openshift/node.rb
+++ b/lib/openshift/node.rb
@@ -96,10 +96,15 @@ module BushSlicer
       return ! res.nil?
     end
   
-    def is_windows_worker?(user: nil, cached: true, quiet: false)
+    def is_windows?(user: nil, cached: true, quiet: false)
       rr = raw_resource(user: user, cached: cached, quiet: quiet)
       rr.dig('metadata', 'labels', 'kubernetes.io/os') == "windows"
-    end    
+    end
+
+    def is_linux?(user: nil, cached: true, quiet: false)
+      rr = raw_resource(user: user, cached: cached, quiet: quiet)
+      rr.dig('metadata', 'labels', 'kubernetes.io/os') == "linux"
+    end
 
     def ready?(user: nil, cached: false, quiet: false)
       status = get_cached_prop(prop: :status, user: user, cached: cached, quiet: quiet)


### PR DESCRIPTION
To fix https://issues.redhat.com/browse/OCPQE-9496  since router pods cannot be scheduled to windows worker nodes.

@quarterpin @melvinjoseph86 @ShudiLi  Please help take a look. Thanks.