### PR TITLE
Special debug code to execute after scenario step in case of special test case failures.

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -73,6 +73,10 @@ After do |_scenario|
   debug_in_after_hook
 
   begin
+    # Calling additional debug statement and when the scenario is failed along with custom error message in execution.
+    if (self.scenario.failed?) && (logger.handled_error?)
+      print_debugging_info(localhost)
+    end
     ## raise inside block only if error can affect next scenarios execution ##
     # Manager will call clean-up including self.after_scenario
     manager.after_scenario

--- a/lib/world.rb
+++ b/lib/world.rb
@@ -50,6 +50,20 @@ module BushSlicer
       end
     end
 
+    def print_debugging_info(host)
+      # Intention of method is to execute additional debug statement to analyze unexpected trickier failures.
+      logger.handled_error = ''
+      res = admin.cli_exec(:get, resource: "nodes", _quiet: true)
+      nodes = host.exec_raw("echo '#{res[:response]}' | grep -E 'SchedulingDisabled|NotReady' | awk '(NR>1)'", quiet: true)
+      res = admin.cli_exec(:get, resource: "co", _quiet: true)
+      cos = host.exec_raw("echo '#{res[:response]}' | grep -v '.True.*False.*False' | awk '(NR>1)'", quiet: true)
+      res = admin.cli_exec(:get, all_namespaces: true, resource: "pods", _quiet: true)
+      pods = host.exec_raw("echo '#{res[:response]}' | grep -Ev 'Running|Completed' | awk '(NR>1)'", quiet: true)
+      logger.info("List of abnormal nodes :\n" + nodes[:response])
+      logger.info("List of abnormal co :\n" + cos[:response])
+      logger.info("List of abnormal pods :\n" + pods[:response])
+    end
+
     def scenario_tags
       scenario.source_tag_names
     end


### PR DESCRIPTION
As you see in both [OCPQE-8172](https://issues.redhat.com/browse/OCPQE-8172) and [OCPQE-8117](https://issues.redhat.com/browse/OCPQE-8117) tickets, in these cases, it is difficult for us to debug test case failures or taking longer time to identify the root cause. To minimize the effort on debugging such failures , we want to introduce certain debug code to execute right after the unexpected failures during execution.
I have investigated with cucushift framework ( with my limited knowledge :) ) and made few dummy changes and that makes execution of debug statements "after scenario" step. The intention is NOT to execute debug statements for every case but need to execute only in case of failures w.r.t kube-apiserver such as,
1. xxxx:6443 connection is refused.
2. xxxx:6443 timeout.
3. server is currently unable to handle the request (get projects.project.openshift.io)
Currently i'm unable to get the test case result or it's scope to make such decision for above code. I would need your review and suggestions to achieve the solution.
Note: These are random failures and not stick to any specific test case , Hence I see that it's needs to be handled in core instead of step implementation.
Attached local execution results for both positive and negative scenarios - http://pastebin.test.redhat.com/1043194
@wangke19 @liangxia @qe-productivity-team Please share your thoughts.
