### PR TITLE
Add testdata file for kubedescheduler 4.11

### DIFF
--- a/testdata/descheduler/kubedescheduler-4.11.yaml
+++ b/testdata/descheduler/kubedescheduler-4.11.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.openshift.io/v1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  image: registry.redhat.io/openshift4/ose-descheduler:v4.11
+  logLevel: Normal
+  operatorLogLevel: Normal
+  deschedulingIntervalSeconds: 3600
+  profiles:
+    - AffinityAndTaints
+    - TopologyAndDuplicates
+    - LifecycleAndUtilization
+  managementState: Managed
+


### PR DESCRIPTION
I see that the testdata file for kubedescheduler 4.11 is missing due to which the test is failing, adding the same to resolve the issue.