### PR TITLE
OVN: use pkill -9 to simulate crash and fix typo

### DIFF
--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -136,10 +136,10 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     """
     And I run the :scale admin command with:
-      | resource  | deployment                 |
-      | name      | network-operator           |
-      | replicas  | 0                          |
-      | n         | openshift-network-operator |
+      | resource | deployment                 |
+      | name     | network-operator           |
+      | replicas | 0                          |
+      | n        | openshift-network-operator |
     Then the step should succeed
     And admin ensures "ovnkube-master" ds is deleted from the "openshift-ovn-kubernetes" project
     And admin executes existing pods die with labels:
@@ -209,7 +209,7 @@ Feature: OVN related networking scenarios
     Given I have a pod-for-ping in the project
     Then evaluation of `pod.ip` is stored in the :hello_pod_ip clipboard
     When I execute on the pod:
-       | bash | -c | ip a show eth0 |
+      | bash | -c | ip a show eth0 |
     Then the step should succeed
     And evaluation of `@result[:response].match(/\h+:\h+:\h+:\h+:\h+:\h+/)[0]` is stored in the :hello_pod_mac clipboard
 
@@ -399,12 +399,12 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
-  Scenario: New corresponding raft leader should be elected if SB db or NB db on existing master is crashed
+  Scenario Outline: New corresponding raft leader should be elected if SB db or NB db on existing master is crashed
     Given the env is using "OVNKubernetes" networkType
     Given admin uses the "openshift-ovn-kubernetes" project
     When I store the ovnkube-master "south" leader pod in the clipboard
     Then the step should succeed
-    When the OVN "south" database is killed on the "<%= cb.south_leader.node_name %>" node
+    When the OVN "south" database is killed with signal "<signal>" on the "<%= cb.south_leader.node_name %>" node
     Then the step should succeed
 
     And I wait up to 30 seconds for the steps to pass:
@@ -417,7 +417,7 @@ Feature: OVN related networking scenarios
 
     When I store the ovnkube-master "north" leader pod in the clipboard
     Then the step should succeed
-    When the OVN "north" database is killed on the "<%= cb.north_leader.node_name %>" node
+    When the OVN "north" database is killed with signal "<signal>" on the "<%= cb.north_leader.node_name %>" node
     Then the step should succeed
 
     And I wait up to 30 seconds for the steps to pass:
@@ -428,6 +428,14 @@ Feature: OVN related networking scenarios
     """
     And admin waits for all pods in the project to become ready up to 120 seconds
 
+    Examples:
+      | signal |
+      | TERM   |
+      | QUIT   |
+      | INT    |
+      | HUP    |
+      | SEGV   |
+      | 9      |
 
   # @author rbrattai@redhat.com
   # @case_id OCP-26138

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1102,8 +1102,9 @@ Given /^admin deletes the ovnkube-master#{OPT_QUOTED} leader$/ do |ovndb|
   @result = resource(leader_pod_name, "pod", project_name: "openshift-ovn-kubernetes").ensure_deleted(user: admin, wait: 300)
 end
 
-Given /^the OVN "([^"]*)" database is killed on the "([^"]*)" node$/ do |ovndb, node_name|
+Given /^the OVN "([^"]*)" database is killed(?: with signal "([^"]*)")? on the "([^"]*)" node$/ do |ovndb, signal, node_name|
   ensure_admin_tagged
+  signal ||= "TERM"
   node = node(node_name)
   host = node.host
   case ovndb
@@ -1112,7 +1113,7 @@ Given /^the OVN "([^"]*)" database is killed on the "([^"]*)" node$/ do |ovndb, 
   else
     kill_match = "OVN_Southbound"
   end
-  @result = host.exec_admin("pkill -f #{kill_match}")
+  @result = host.exec_admin("pkill --signal #{signal} -f #{kill_match}")
   raise "Failed to kill the #{ovndb} database daemon" unless @result[:success]
 end
 
@@ -1437,7 +1438,7 @@ Given /^I save openflow egressip table number to the#{OPT_SYM} clipboard$/ do | 
   else
     cb[cb_name]="101"
   end
-  logger.info "The openfolw egressip related table number #{cb[cb_name]} is stored to the #{cb_name} clipboard."
+  logger.info "The openflow egressip related table number #{cb[cb_name]} is stored to the #{cb_name} clipboard."
 end
 
 Given /^I switch the ovn gateway mode on this cluster$/ do


### PR DESCRIPTION
BZ 2022144: `sbdb` will CrashLoopBackOff when there is a stale PID file.

Regular `pkill` will send `SIGTERM` which allows the container to cleanup
the pid file somehow in one of the hooks.  To simulate a crash we need
to kill without chance of cleanup and leave a stale PID.

Now that https://github.com/openshift/cluster-network-operator/pull/1256
is merged we can test without breaking the cluster

s/openfolw/openflow/
