### PR TITLE
skip step to be honored post upgade too

### DIFF
--- a/features/upgrade/sdn/ipsec-upgrade.feature
+++ b/features/upgrade/sdn/ipsec-upgrade.feature
@@ -75,6 +75,7 @@ Feature: IPsec upgrade scenarios
   @upgrade
   @proxy @noproxy @disconnected @connected
   Scenario: Confirm node-node and pod-pod packets are ESP enrypted on IPsec clusters post upgrade
+    Given the env is using "OVNKubernetes" networkType
     Given evaluation of `50` is stored in the :protocol clipboard
     Given I switch to cluster admin pseudo user
     And the default interface on nodes is stored in the :default_interface clipboard

--- a/features/upgrade/sdn/ipsec-upgrade.feature
+++ b/features/upgrade/sdn/ipsec-upgrade.feature
@@ -75,7 +75,7 @@ Feature: IPsec upgrade scenarios
   @upgrade
   @proxy @noproxy @disconnected @connected
   Scenario: Confirm node-node and pod-pod packets are ESP enrypted on IPsec clusters post upgrade
-    Given the env is using "OVNKubernetes" networkType
+    Given the IPsec is enabled on the cluster
     Given evaluation of `50` is stored in the :protocol clipboard
     Given I switch to cluster admin pseudo user
     And the default interface on nodes is stored in the :default_interface clipboard


### PR DESCRIPTION
Need to add OVNK backend check in ```upgrade-check``` scenario too. This will enable ipsec tests to be skipped on non supported profiles during ```upgrade-check``` as well.

Check step was added in upgrade-prepare in the following PR
Ref:https://github.com/openshift/verification-tests/pull/2751

@zhaozhanqi @liangxia Quick merge. Thanks

