### PR TITLE
Added 180 seconds of wait time in upgrade.feature

### DIFF
--- a/features/upgrade/storage/upgrade.feature
+++ b/features/upgrade/storage/upgrade.feature
@@ -90,10 +90,14 @@ Feature: Storage upgrade tests
     Given the "storage" operator version matches the current cluster version
 
     # Check cluster operator storage should be in correct status
+    # Added wait time for OCPQE-9247
+    Given I wait up to 180 seconds for the steps to pass:
+    """
     Given the expression should be true> cluster_operator('storage').condition(type: 'Progressing')['status'] == "False"
     Given the expression should be true> cluster_operator('storage').condition(type: 'Available')['status'] == "True"
     Given the expression should be true> cluster_operator('storage').condition(type: 'Degraded')['status'] == "False"
     Given the expression should be true> cluster_operator('storage').condition(type: 'Upgradeable')['status'] == "True"
+    """
 
     # There should be one and only one default storage class
     # Comment out the step of get default SC from co storage due to BUG 1868424, not deleting them as we will add them back after bug fixed


### PR DESCRIPTION
Scenario updated: Cluster operator storage should be in correct status and dynamic provisioning should work well after upgrade

Execution run log: 
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/389873/

Issue/bug number:
https://issues.redhat.com/browse/OCPQE-9247
