### PR TITLE
Remove unsupported release for OCP-27617

### DIFF
--- a/features/storage/csi_clone.feature
+++ b/features/storage/csi_clone.feature
@@ -219,7 +219,7 @@ Feature: CSI clone testing related feature
   # @case_id OCP-27617
   @admin
   @destructive
-  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.11 @4.10 @4.9 @4.8 @4.7
   @openstack-ipi
   @openstack-upi
   @qeci


### PR DESCRIPTION
Cinder CSI Driver is not released in 4.6, so remove it from Polarion and cucushift code.
@jhou1 PTAL 