### PR TITLE
Fix prow ci failure for OCP-29693

### DIFF
--- a/features/registry/registry.feature
+++ b/features/registry/registry.feature
@@ -247,6 +247,7 @@ Feature: Testing registry
   # @author xiuwang@redhat.com
   # @case_id OCP-29693
   @admin
+  @qeci
   @proxy @noproxy @disconnected
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi


### PR DESCRIPTION
Test case OCP-29693 requires post-action to create imageContentSourcePolicy image-policy-aosqe, so it is not suitable to test in Prow CI.

/cc @xiuwang @jhou1 @JianLi-RH @dis016 @pruan-rht 