### PR TITLE
fix OCPQE-9774

### DIFF
--- a/features/test/logging_metrics.feature
+++ b/features/test/logging_metrics.feature
@@ -20,3 +20,7 @@ Feature: test logging and metrics related steps
     And elasticsearch-operator channel name is stored in the :eo_channel clipboard
     Given elasticsearch-operator catalog source name is stored in the :eo_catsrc clipboard
     Given cluster-logging catalog source name is stored in the :clo_catsrc clipboard
+
+  @admin
+  Scenario: check node capacity for logging
+    Given I check if the remaining_resources in woker nodes meet the requirements for logging stack

--- a/features/upgrade/logging/upgrade.feature
+++ b/features/upgrade/logging/upgrade.feature
@@ -14,6 +14,7 @@ Feature: Logging upgrading related features
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   Scenario: Cluster logging checking during cluster upgrade - prepare
+    Given I check if the remaining_resources in woker nodes meet the requirements for logging stack
     Given I switch to the first user
     Given I have "json" log pod in project "logging-upg-prep-1"
     And I have "json" log pod in project "logging-upg-prep-share"


### PR DESCRIPTION
This PR:
1. add a step to check remaining CPU and memory on linux worker nodes before deploying logging to avoid hitting issue like:
```
0/8 nodes are available: 2 node(s) didn't match node selector, 3 Insufficient memory, 3 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate.
```
2. log the clusterlogging and elasticsearch status before checking logging pods' status for failure debugging. 

/cc @anpingli 