### PR TITLE
OCPQE-9784: Add query for architecture

### DIFF
--- a/doc/prow/query_amd64.json
+++ b/doc/prow/query_amd64.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND arch.KEY:x8664"
+}

--- a/doc/prow/query_arm64.json
+++ b/doc/prow/query_arm64.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND arch.KEY:arm"
+}


### PR DESCRIPTION
This is to support [OCPQE-9784](https://issues.redhat.com//browse/OCPQE-9784), which will be used to add tags for amd64/arm64

/cc @aleskandro @YuLi517 @jhou1 @wsun1 