### PR TITLE
Update apiVersion for EgressNetworkPolicy

### DIFF
--- a/testdata/networking/egress-ingress/dns-egresspolicy1.json
+++ b/testdata/networking/egress-ingress/dns-egresspolicy1.json
@@ -1,6 +1,6 @@
 {
     "kind": "EgressNetworkPolicy",
-    "apiVersion": "v1",
+    "apiVersion": "network.openshift.io/v1",
     "metadata": {
         "name": "policy-test"
     },

--- a/testdata/networking/egress-ingress/dns-egresspolicy2.json
+++ b/testdata/networking/egress-ingress/dns-egresspolicy2.json
@@ -1,6 +1,6 @@
 {
     "kind": "EgressNetworkPolicy",
-    "apiVersion": "v1",
+    "apiVersion": "network.openshift.io/v1",
     "metadata": {
         "name": "policy-test"
     },

--- a/testdata/networking/egress-ingress/dns-egresspolicy4.json
+++ b/testdata/networking/egress-ingress/dns-egresspolicy4.json
@@ -1,6 +1,6 @@
 {
     "kind": "EgressNetworkPolicy",
-    "apiVersion": "v1",
+    "apiVersion": "network.openshift.io/v1",
     "metadata": {
         "name": "policy-test"
     },

--- a/testdata/networking/egressnetworkpolicy/egressnetworkpolicy_1000.yaml
+++ b/testdata/networking/egressnetworkpolicy/egressnetworkpolicy_1000.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: network.openshift.io/v1
 kind: EgressNetworkPolicy
 metadata:
   name: default

--- a/testdata/networking/egressnetworkpolicy/egressnetworkpolicy_1001.yaml
+++ b/testdata/networking/egressnetworkpolicy/egressnetworkpolicy_1001.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: network.openshift.io/v1
 kind: EgressNetworkPolicy
 metadata:
   name: default

--- a/testdata/networking/egressnetworkpolicy/limit_policy.json
+++ b/testdata/networking/egressnetworkpolicy/limit_policy.json
@@ -1,6 +1,6 @@
 {
     "kind": "EgressNetworkPolicy",
-    "apiVersion": "v1",
+    "apiVersion": "network.openshift.io/v1",
     "metadata": {
         "name": "policy1"
     },


### PR DESCRIPTION
Update apiVersion for kind "EgressNetworkPolicy"  to "network.openshift.io/v1"

Test log: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/402709/

/cc @openshift/team-sdn-qe  