### PR TITLE
OCPQE-9784: Add architecture-aware tags

### DIFF
--- a/features/admin/pod.feature
+++ b/features/admin/pod.feature
@@ -9,6 +9,7 @@ Feature: pod related features
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Endpoints should update in time and no delay
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
@@ -147,6 +148,7 @@ Feature: pod related features
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Pods will still be created by DaemonSet when nodes are SchedulingDisabled
     Given I have a project
     Given I store the schedulable workers in the :nodes clipboard
@@ -183,6 +185,7 @@ Feature: pod related features
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: When node labels change, DaemonSet will add pods to newly matching nodes and delete pods from not-matching nodes
     Given I have a project
     Given I run the :patch admin command with:

--- a/features/admin/project.feature
+++ b/features/admin/project.feature
@@ -10,6 +10,7 @@ Feature: project permissions
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Pod creation should fail when pod's node selector conflicts with project node selector
     Given a 5 characters random string of type :dns is stored into the :proj_name clipboard
     When I run the :oadm_new_project admin command with:
@@ -33,6 +34,7 @@ Feature: project permissions
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: The job and HPA should be deleted when project has been deleted
     Given I have a project
     Given I obtain test data file "hpa/hpa.yaml"

--- a/features/admin/quota.feature
+++ b/features/admin/quota.feature
@@ -37,6 +37,7 @@ Feature: Quota related scenarios
     @singlenode
     @proxy @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | path     | file                           | pod_name                  | expr1             | expr2                       |
       | ocp11754 | pod-request-limit-valid-3.yaml | pod-request-limit-valid-3 | cpu\\s+100m\\s+30 | memory\\s+(134217728\|128Mi)\\s+16Gi | # @case_id OCP-11754
@@ -53,6 +54,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The quota usage should NOT be incremented if Requests and Limits aren't specified
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
@@ -92,6 +94,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The quota usage should NOT be incremented if Requests > Limits
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
@@ -135,6 +138,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The quota usage should NOT be incremented if Requests = Limits but exceeding hard quota
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
@@ -231,6 +235,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check BestEffort scope of resourcequota
     Given I have a project
     Given I obtain test data file "quota/quota-besteffort.yaml"
@@ -291,6 +296,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check NotBestEffort scope of resourcequota
     Given I have a project
     Given I obtain test data file "quota/quota-notbesteffort.yaml"
@@ -371,6 +377,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check NotTerminating scope of resourcequota
     Given I have a project
     Given I obtain test data file "quota/quota-notterminating.yaml"
@@ -536,6 +543,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Could create quota if existing resources exceed to the hard quota but prevent to create further resources
     Given I have a project
     Given I obtain test data file "quota/quota_template.yaml"
@@ -671,6 +679,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Quota events for compute resource failures shouldn't be redundant
     Given I have a project
     Given I obtain test data file "templates/ocp10033/quota.yaml"
@@ -750,6 +759,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The quota usage should be incremented if Requests = Limits and in the range of hard quota but exceed the real node available resources
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
@@ -797,6 +807,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The quota usage should be released when pod completed
     Given I have a project
     When I run the :create_quota admin command with:
@@ -841,6 +852,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Quota with BestEffort and NotBestEffort scope
     Given I have a project
     When I run the :create_quota admin command with:
@@ -899,6 +911,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Quota with Terminating and NotTerminating scope
     Given I have a project
     When I run the :create_quota admin command with:
@@ -966,6 +979,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Quota combined scopes
     Given I have a project
     When I run the :create_quota admin command with:
@@ -1065,6 +1079,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Quota scope conflict BestEffort and NotBestEffort
     Given I have a project
     When I run the :create_quota admin command with:
@@ -1085,6 +1100,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Quota scope conflict Terminating and NotTerminating
     Given I have a project
     When I run the :create_quota admin command with:
@@ -1105,6 +1121,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Negative test for requests.storage of quota
     Given I have a project
     When I run the :create_quota admin command with:
@@ -1156,6 +1173,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Annotation selector supports special characters
     Given I have a project
     Given admin ensures "crq-<%= project.name %>" cluster_resource_quota is deleted after scenario
@@ -1191,6 +1209,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Quota requests.storage with PVC existing
     Given I have a project
     Given I obtain test data file "storage/nfs/claim-rox.json"
@@ -1248,6 +1267,7 @@ Feature: Quota related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Prevent creating further PVC if existing PVC exceeds the quota of requests.storage
     Given I have a project
     # Only quota requests.storage < 5Gi

--- a/features/admin/scc.feature
+++ b/features/admin/scc.feature
@@ -9,6 +9,7 @@ Feature: SCC policy related scenarios
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: deployment hook volume inheritance with hostPath volume
     Given I have a project
     # Create hostdir pod again with new SCC
@@ -43,6 +44,7 @@ Feature: SCC policy related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create or update scc with illegal capability name should fail with prompt message
     Given I have a project
     Given cluster role "cluster-admin" is added to the "first" user

--- a/features/admin/scheduler.feature
+++ b/features/admin/scheduler.feature
@@ -8,6 +8,7 @@ Feature: Scheduler related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: When no scheduler name is supplied, the pod is automatically scheduled using the default-scheduler
     Given I have a project
     Given I obtain test data file "scheduler/multiple-schedulers/pod-no-scheduler.yaml"

--- a/features/build/buildconfig.feature
+++ b/features/build/buildconfig.feature
@@ -89,6 +89,7 @@ Feature: buildconfig.feature
     @singlenode
     @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | template                  |
       | test-buildconfig-s2i.json | # @case_id OCP-11474
@@ -103,6 +104,7 @@ Feature: buildconfig.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Using secret to pull a docker image which be used as source input
     Given I have a project
     When I run the :create_secret client command with:

--- a/features/build/buildlogic.feature
+++ b/features/build/buildlogic.feature
@@ -9,6 +9,7 @@ Feature: buildlogic.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Build with specified Dockerfile via new-build -D
     Given I have a project
     When I run the :new_build client command with:
@@ -66,6 +67,7 @@ Feature: buildlogic.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create new build config use dockerfile with source repo
     Given I have a project
     When I run the :new_build client command with:
@@ -113,6 +115,7 @@ Feature: buildlogic.feature
     @singlenode
     @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | template                            |
       | buildconfig-s2i-dockerimage.json    | # @case_id OCP-11149
@@ -126,6 +129,7 @@ Feature: buildlogic.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Build with specified Dockerfile to image with same image name via new-build
     Given I have a project
     When I run the :new_build client command with:
@@ -168,6 +172,7 @@ Feature: buildlogic.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Build from private git repo with/without ssh key
     Given I have a project
     And I have an ssh-git service in the project
@@ -218,6 +223,7 @@ Feature: buildlogic.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create new-app from private git repo with ssh key
     Given I have a project
     When I run the :new_app client command with:
@@ -260,6 +266,7 @@ Feature: buildlogic.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check s2i build substatus and times
     Given I have a project
     Given I obtain test data file "build/application-template-stibuild.json"
@@ -287,6 +294,7 @@ Feature: buildlogic.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check docker build substatus and times
     Given I have a project
     Given I obtain test data file "build/application-template-dockerbuild.json"
@@ -481,6 +489,7 @@ Feature: buildlogic.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Pipeline build can be pruned automatically
     Given I have a project
     And I have a jenkins v2 application
@@ -538,6 +547,7 @@ Feature: buildlogic.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Mirroring built image doesn't degrade scheme2 ,keep consistent SHA's
     Given I have a project
     Given I save a htpasswd registry auth to the :combine_dockercfg clipboard

--- a/features/build/dockerbuild.feature
+++ b/features/build/dockerbuild.feature
@@ -9,6 +9,7 @@ Feature: dockerbuild.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Docker build with both SourceURI and context dir
     Given I have a project
     Given I obtain test data file "build/ruby20rhel7-context-docker.json"
@@ -36,6 +37,7 @@ Feature: dockerbuild.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Docker build with dockerImage with specified tag
     Given I have a project
     When I run the :new_app client command with:
@@ -100,6 +102,7 @@ Feature: dockerbuild.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Add ARGs in docker build
     Given I have a project
     When I run the :new_build client command with:
@@ -163,6 +166,7 @@ Feature: dockerbuild.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Mount source secret to builder container- dockerstrategy
     Given I have a project
     When I run the :create_secret client command with:
@@ -204,6 +208,7 @@ Feature: dockerbuild.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Mount source configmap to builder container- dockerstrategy
     Given I have a project
     When I run the :create_configmap client command with:
@@ -244,6 +249,7 @@ Feature: dockerbuild.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Mount multi paths to builder container
     Given I have a project
     When I run the :create_secret client command with:
@@ -286,6 +292,7 @@ Feature: dockerbuild.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Can't add relative path for mount path
     Given I have a project
     When I run the :create_secret client command with:
@@ -324,6 +331,7 @@ Feature: dockerbuild.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Mount source name must be unique
     Given I have a project
     When I run the :create_secret client command with:

--- a/features/build/env.feature
+++ b/features/build/env.feature
@@ -83,6 +83,7 @@ Feature: env.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Can set env vars on buildconfig with new-app --env and --env-file test
     Given I have a project
     When I run the :new_app client command with:

--- a/features/build/metrics.feature
+++ b/features/build/metrics.feature
@@ -10,6 +10,7 @@ Feature: Builds and samples related metrics test
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Alerts on imagestream import retries
     When as admin I successfully merge patch resource "config.samples.operator.openshift.io/cluster" with:
       | {"spec":{"samplesRegistry":"registry.unconnected.redhat.com"}} |
@@ -71,6 +72,7 @@ Feature: Builds and samples related metrics test
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check build metrics
     Given I have a project
     When I run the :new_app client command with:
@@ -199,6 +201,7 @@ Feature: Builds and samples related metrics test
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Monitoring, Alerting, and Degraded Status Reporting-Samples-operator
     When as admin I successfully merge patch resource "config.samples.operator.openshift.io/cluster" with:
       | {"spec":{"samplesRegistry":"registry.unconnected.redhat.com"}} |

--- a/features/build/stibuild.feature
+++ b/features/build/stibuild.feature
@@ -39,6 +39,7 @@ Feature: stibuild.feature
     @singlenode
     @proxy @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | template          |
       | ocp12041-s2i.json | # @case_id OCP-12041
@@ -52,6 +53,7 @@ Feature: stibuild.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: STI build with dockerImage with specified tag
     Given I have a project
     When I run the :new_app client command with:
@@ -93,6 +95,7 @@ Feature: stibuild.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create app with template eap73-basic-s2i with jbosseap rhel7 image
     Given I have a project
     When I run the :new_app client command with:
@@ -116,6 +119,7 @@ Feature: stibuild.feature
   @upgrade-sanity
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Test s2i build in disconnect cluster
     Given I have a project
     When I have an http-git service in the project
@@ -147,6 +151,7 @@ Feature: stibuild.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Mount source secret and configmap to builder container- sourcestrategy
     Given I have a project
     When I run the :create_secret client command with:

--- a/features/cli/allinone-volume.feature
+++ b/features/cli/allinone-volume.feature
@@ -9,6 +9,7 @@ Feature: All in one volume
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Project secrets, configmap and downward API into the same volume with normal keys and path
     Given I have a project
     Given I obtain test data file "pods/allinone-volume/configmap.yaml"

--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -76,6 +76,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create a build config based on the source code in the current git repository
     Given I have a project
     And I git clone the repo "https://github.com/openshift/ruby-hello-world.git"
@@ -144,6 +145,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create applications only with multiple db images
     Given I create a new project
     When I run the :new_app client command with:
@@ -187,6 +189,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Add multiple source inputs
     Given I have a project
     Given I obtain test data file "templates/ocp11227/ruby22rhel7-template-sti.json"
@@ -219,6 +222,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Add a image with multiple paths as source input
     Given I have a project
     Given I obtain test data file "templates/ocp10771/ruby22rhel7-template-sti.json"
@@ -244,6 +248,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Using a docker image as source input using new-build cmd
     Given I have a project
     When I run the :tag client command with:
@@ -312,6 +317,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Cannot create secret from local file and with same name via oc new-build
     Given I have a project
     Given I obtain test data file "secrets/testsecret1.json"
@@ -346,6 +352,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Using a docker image as source input for docker build
     Given I have a project
     Given I obtain test data file "templates/ocp11552/ruby22rhel7-template-docker.json"
@@ -409,6 +416,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Change runpolicy to SerialLatestOnly build
     Given I have a project
     When I run the :new_build client command with:
@@ -629,6 +637,7 @@ Feature: build 'apps' with CLI
     @singlenode
     @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | num1 | num2 | num3 | num4 | num5 |
       | 5    | 5    | 5    | 5    | 5    | # @case_id OCP-15019
@@ -700,6 +709,7 @@ Feature: build 'apps' with CLI
     @singlenode
     @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | cmd       |
       | new_build | # @case_id OCP-12066
@@ -743,6 +753,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Handle build naming collisions
     Given I have a project
     When I run the :new_build client command with:
@@ -774,6 +785,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: io.openshift.build.commit.ref displays correctly in build reference on imagestreamtag if building from git branch reference
     Given I have a project
     When I run the :new_app client command with:
@@ -797,6 +809,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Insert configmap when create a buildconfig
     Given I have a project
     Given a "configmap.test" file is created with the following lines:
@@ -935,6 +948,7 @@ Feature: build 'apps' with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Allow using a configmap as an input to a docker build
     Given I have a project
     Given a "configmap1.test" file is created with the following lines:

--- a/features/cli/configmap.feature
+++ b/features/cli/configmap.feature
@@ -10,6 +10,7 @@ Feature: configMap
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Consume ConfigMap in environment variables
     Given I have a project
     Given I obtain test data file "configmap/configmap.yaml"
@@ -50,6 +51,7 @@ Feature: configMap
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Consume ConfigMap via volume plugin
     Given I have a project
     Given I obtain test data file "configmap/configmap.yaml"
@@ -98,6 +100,7 @@ Feature: configMap
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Perform CRUD operations against a ConfigMap resource
     Given I have a project
     Given I obtain test data file "configmap/configmap-example.yaml"

--- a/features/cli/create.feature
+++ b/features/cli/create.feature
@@ -12,6 +12,7 @@ Feature: creating 'apps' with CLI
   @singlenode
   @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Process with special FSGroup id can be ran when using RunAsAny as the RunAsGroupStrategy
     Given I have a project
     Given I obtain test data file "pods/pod_with_special_fsGroup.json"
@@ -162,6 +163,7 @@ Feature: creating 'apps' with CLI
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: 4.x Could not create any context in non-existent project
     Given I create a new application with:
       | docker image | openshift/ruby-20-centos7~https://github.com/openshift/ruby-hello-world |
@@ -201,6 +203,7 @@ Feature: creating 'apps' with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create an application from source code test
     Given I have a project
     When I git clone the repo "https://github.com/openshift/ruby-hello-world"

--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -8,6 +8,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Restart a failed deployment by oc deploy
     Given I have a project
     Given I obtain test data file "deployment/dc-with-pre-mid-post.yaml"
@@ -45,6 +46,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Manually make deployment
     Given I have a project
     Given I obtain test data file "deployment/manual.json"
@@ -89,6 +91,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: CLI rollback output to file
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
@@ -179,6 +182,7 @@ Feature: deployment related features
     @upgrade-sanity
     @singlenode
     @proxy @noproxy @connected
+    @arm64 @amd64
     Examples:
       | change_scaling_settings | change_strategy | changed_val1  | changed_val2       |
       | :false                  | :false          |               |                    | # @case_id OCP-12116
@@ -193,6 +197,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: CLI rollback with one component
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
@@ -242,6 +247,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Can't stop a deployment in Failed status
     Given I have a project
     Given I obtain test data file "deployment/test-stop-failed-deployment.json"
@@ -282,6 +288,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Stop a "Running" deployment
     Given I have a project
     Given I obtain test data file "deployment/dc-with-pre-mid-post.yaml"
@@ -312,6 +319,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Rollback via CLI when previous version failed
     Given I have a project
     When I run the :create_deploymentconfig client command with:
@@ -460,6 +468,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Blue-Green Deployment
     Given I have a project
     When I run the :new_app client command with:
@@ -570,6 +579,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: start deployment when the latest deployment is completed
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
@@ -637,6 +647,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Start new deployment when deployment running
     Given I have a project
     Given I obtain test data file "deployment/dc-with-pre-mid-post.yaml"
@@ -663,6 +674,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: When the latest deployment failed auto rollback to the active deployment
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
@@ -719,6 +731,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: DeploymentConfig should allow valid value of resource requirements
     Given I have a project
     Given I obtain test data file "quota/limits.yaml"
@@ -761,6 +774,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Scale up when deployment running
     Given I have a project
     When I run the :create_deploymentconfig client command with:
@@ -932,6 +946,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @connected
+  @arm64 @amd64
   Scenario: Trigger info is retained for deployment caused by image changes 37 new feature
     Given the master version >= "3.7"
     Given I have a project
@@ -954,6 +969,7 @@ Feature: deployment related features
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: A/B Deployment for OCP 4.5 or greater
     Given the master version >= "4.5"
     Given I have a project

--- a/features/cli/downwardapi.feature
+++ b/features/cli/downwardapi.feature
@@ -9,6 +9,7 @@ Feature: Downward API
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Pods can get IPs via downward API under race condition
     Given I have a project
     Given I obtain test data file "downwardapi/ocp10707/pod-downwardapi-env.yaml"
@@ -30,6 +31,7 @@ Feature: Downward API
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: downward api pod name and pod namespace as env variables
     Given I have a project
     Given I obtain test data file "downwardapi/ocp10628/downward-example.yaml"
@@ -54,6 +56,7 @@ Feature: Downward API
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Container consume infomation from the downward API using a volume plugin
     Given I have a project
     Given I obtain test data file "downwardapi/pod-dapi-volume.yaml"

--- a/features/cli/hpa.feature
+++ b/features/cli/hpa.feature
@@ -9,6 +9,7 @@ Feature: hpa scale
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: HPA shouldn't scale up target if the replicas of dc is 0
     Given I have a project
     Given I obtain test data file "hpa/dc-hello-openshift.yaml"
@@ -52,6 +53,7 @@ Feature: hpa scale
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: HPA shouldn't scale up target if the replicas of rc is 0
     Given I have a project
     Given I obtain test data file "hpa/rc-hello-openshift.yaml"
@@ -93,6 +95,7 @@ Feature: hpa scale
   @upgrade-sanity
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Creates autoscaler for replication controller by oc autoscale
     Given I have a project
     Given I obtain test data file "hpa/rc-hello-openshift.yaml"

--- a/features/cli/job.feature
+++ b/features/cli/job.feature
@@ -8,6 +8,7 @@ Feature: job.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create job with multiple completions
     Given I have a project
     Given I obtain test data file "templates/ocp11206/job.yaml"
@@ -58,6 +59,7 @@ Feature: job.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create job with pod parallelism
     Given I have a project
     Given I obtain test data file "job/job_with_0_activeDeadlineSeconds.yaml"
@@ -181,6 +183,7 @@ Feature: job.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Specifying your own pod selector for job
     Given I have a project
     Given I obtain test data file "job/job-manualselector.yaml"
@@ -314,6 +317,7 @@ Feature: job.feature
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Create job with specific deadline
     Given I have a project
     Given I obtain test data file "job/job_with_0_activeDeadlineSeconds.yaml"
@@ -373,6 +377,7 @@ Feature: job.feature
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: User can schedule a Cronjob execution with cron format time
     Given I have a project
     When I run the :create_cronjob client command with:

--- a/features/cli/limits.feature
+++ b/features/cli/limits.feature
@@ -26,6 +26,7 @@ Feature: limit range related scenarios:
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | path     | expr1                                                | expr2                                                |
       | ocp10697 | Container\\s+cpu\\s+\-\\s+\-\\s+200m\\s+200m\\s+\-   | Container\\s+memory\\s+\-\\s+\-\\s+1Gi\\s+1Gi\\s+\-  | # @case_id OCP-10697
@@ -56,6 +57,7 @@ Feature: limit range related scenarios:
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | path | expr1 | expr2 | expr3 | expr4 | expr5 | expr6 | expr7 | expr8 | expr9 | expr10 | expr11 |expr12 | expr13| expr14 | expr15 | expr16 | expr17 | expr18 | expr19| expr20 |
       | ocp11745 | 400m | default request | 400m | max | 200m | 200m | default | 400m | max | 200m | 2Gi | default request | 2Gi | max | 1Gi | 1Gi | default | 2Gi  | max   | 1Gi    | # @case_id OCP-11745
@@ -83,6 +85,7 @@ Feature: limit range related scenarios:
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | path | expr1 | expr2 | expr3 | expr4 | expr5 | expr6 | expr7 | expr8 | expr9 | expr10 |
       | ocp12286 | 2Gi | min | 2Gi | max | 1Gi | 400m | min | 400m | max | 200m |
@@ -98,6 +101,7 @@ Feature: limit range related scenarios:
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Limit range does not allow min > defaultRequest
     Given I have a project
     Given I obtain test data file "limits/ocp12250/limit.yaml"
@@ -120,6 +124,7 @@ Feature: limit range related scenarios:
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Limit range does not allow defaultRequest > default
     Given I have a project
     Given I obtain test data file "limits/ocp11918/limit.yaml"
@@ -142,6 +147,7 @@ Feature: limit range related scenarios:
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Limit range does not allow defaultRequest > max
     Given I have a project
     Given I obtain test data file "limits/ocp12043/limit.yaml"
@@ -164,6 +170,7 @@ Feature: limit range related scenarios:
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Limit range does not allow maxLimitRequestRatio > Limit/Request
     Given I have a project
     Given I obtain test data file "limits/ocp12139/limit.yaml"
@@ -195,6 +202,7 @@ Feature: limit range related scenarios:
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Limit range with all values set with proper values
     Given I have a project
     Given I obtain test data file "limits/ocp12315/limit.yaml"

--- a/features/cli/oc_delete.feature
+++ b/features/cli/oc_delete.feature
@@ -9,6 +9,7 @@ Feature: oc_delete.feature
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Gracefully delete a pod with '--grace-period' option
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/10.json"
@@ -127,6 +128,7 @@ Feature: oc_delete.feature
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Verify pod is gracefully deleted when DeletionGracePeriodSeconds is specified.
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/10.json"
@@ -159,6 +161,7 @@ Feature: oc_delete.feature
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Pod should be immediately deleted if TerminationGracePeriodSeconds is 0
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/0.json"

--- a/features/cli/oc_env.feature
+++ b/features/cli/oc_env.feature
@@ -10,6 +10,7 @@ Feature: oc_env.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set environment variables when creating application using non-DeploymentConfig template
     Given I have a project
     When I run the :new_app client command with:

--- a/features/cli/oc_expose.feature
+++ b/features/cli/oc_expose.feature
@@ -9,6 +9,7 @@ Feature: oc_expose.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Access app througth secure service and regenerate service serving certs if it about to expire
     Given the master version >= "3.3"
     Given I have a project

--- a/features/cli/oc_idle.feature
+++ b/features/cli/oc_idle.feature
@@ -9,6 +9,7 @@ Feature: oc idle
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: CLI - Idle all the service in the same project
     Given I have a project
     Given I obtain test data file "rc/idle-rc-1.yaml"
@@ -59,6 +60,7 @@ Feature: oc idle
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: CLI - Idle service by label
     Given I have a project
     Given I obtain test data file "rc/idle-rc-2.yaml"
@@ -102,6 +104,7 @@ Feature: oc idle
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: CLI - Idle service from file
     Given I have a project
     Given I obtain test data file "rc/idle-rc-2.yaml"
@@ -150,6 +153,7 @@ Feature: oc idle
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: CLI - Idle service with dry-run
     Given I have a project
     Given I obtain test data file "rc/idle-rc-2.yaml"

--- a/features/cli/oc_import_image.feature
+++ b/features/cli/oc_import_image.feature
@@ -8,6 +8,7 @@ Feature: oc import-image related feature
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Do not create tags for ImageStream if image repository does not have tags
     When I have a project
     Given I obtain test data file "image-streams/is_without_tags.json"
@@ -32,6 +33,7 @@ Feature: oc import-image related feature
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Could not import the tag when reference is true
     Given I have a project
     Given I obtain test data file "image-streams/ocp10721.json"
@@ -95,6 +97,7 @@ Feature: oc import-image related feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Tags should be added to ImageStream if image repository is from an external docker registry
     Given I have a project
     Given I obtain test data file "image-streams/external.json"
@@ -122,6 +125,7 @@ Feature: oc import-image related feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Allow imagestream request deployment config triggers by different mode('TagreferencePolicy':source/local)
     Given I have a project
     When I run the :tag client command with:
@@ -190,6 +194,7 @@ Feature: oc import-image related feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Allow imagestream request build config triggers by different mode('TagreferencePolicy':source/local)
     Given I have a project
     When I run the :import_image client command with:

--- a/features/cli/oc_patch_apply.feature
+++ b/features/cli/oc_patch_apply.feature
@@ -10,6 +10,7 @@ Feature: oc patch/apply related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: oc patch can update one or more fields of rescource
     Given I have a project
     And I run the :create_deploymentconfig client command with:

--- a/features/cli/oc_portforward.feature
+++ b/features/cli/oc_portforward.feature
@@ -9,6 +9,7 @@ Feature: oc_portforward.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Forward multi local ports to a pod
     Given I have a project
     And evaluation of `rand(5000..7999)` is stored in the :porta clipboard

--- a/features/cli/oc_process.feature
+++ b/features/cli/oc_process.feature
@@ -10,6 +10,7 @@ Feature: oc_process.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Supply oc new-app parameter list+env vars via a file
     Given I have a project
     Given a "test1.env" file is created with the following lines:

--- a/features/cli/oc_registry.feature
+++ b/features/cli/oc_registry.feature
@@ -8,6 +8,7 @@ Feature: oc registry command scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check function of oc registry command
     Given I have a project
     When I run the :registry_info client command with:

--- a/features/cli/oc_secrets.feature
+++ b/features/cli/oc_secrets.feature
@@ -62,6 +62,7 @@ Feature: oc_secrets.feature
   @upgrade-sanity
   @singlenode
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: [origin_platformexp_391] Project admin can process local directory or files and convert it to kubernetes secret
     Given I have a project
     When the "tmpfoo" file is created with the following lines:

--- a/features/cli/oc_set_build_hook.feature
+++ b/features/cli/oc_set_build_hook.feature
@@ -11,6 +11,7 @@ Feature: oc_set_build_hook
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set post-build-commit on buildconfig via oc set build-hook
     Given I have a project
     When I process and create "https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json"

--- a/features/cli/oc_set_deployment_hook.feature
+++ b/features/cli/oc_set_deployment_hook.feature
@@ -10,6 +10,7 @@ Feature: set deployment-hook/build-hook with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set pre/mid/post deployment hooks on deployment config via oc set deployment-hook
     Given I have a project
     When I run the :new_app client command with:
@@ -100,6 +101,7 @@ Feature: set deployment-hook/build-hook with CLI
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set invalid pre/mid/post deployment hooks on deployment config via oc set deployment-hook
     Given I have a project
     When I run the :new_app client command with:

--- a/features/cli/oc_set_env.feature
+++ b/features/cli/oc_set_env.feature
@@ -9,6 +9,7 @@ Feature: oc_set_env.feature
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Set environment variables for resources using oc set env
     Given I have a project
     Given I obtain test data file "build/application-template-stibuild.json"
@@ -70,6 +71,7 @@ Feature: oc_set_env.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Remove environment variables for resources using oc set env
     Given I have a project
     Given I obtain test data file "build/application-template-stibuild.json"

--- a/features/cli/oc_set_probe.feature
+++ b/features/cli/oc_set_probe.feature
@@ -155,6 +155,7 @@ Feature: oc_set_probe.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set a probe to open a TCP socket test
     Given I have a project
     When I run the :new_app client command with:
@@ -218,6 +219,7 @@ Feature: oc_set_probe.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set a probe over HTTPS/HTTP test
     Given I have a project
     When I run the :new_app client command with:
@@ -270,6 +272,7 @@ Feature: oc_set_probe.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set an exec action probe test
     Given I have a project
     When I run the :new_app client command with:

--- a/features/cli/oc_volume.feature
+++ b/features/cli/oc_volume.feature
@@ -11,6 +11,7 @@ Feature: oc_volume.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create a pod that consumes the secret in a volume
     Given I have a project
     Given I obtain test data file "pods/allinone-volume/secret.yaml"
@@ -58,6 +59,7 @@ Feature: oc_volume.feature
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Add secret volume to dc and rc
     Given I have a project
     When I run the :new_app_as_dc client command with:

--- a/features/cli/pod.feature
+++ b/features/cli/pod.feature
@@ -27,6 +27,7 @@ Feature: pods related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: kubectl describe pod should show qos tier info
     Given I have a project
     Given I obtain test data file "quota/pod-notbesteffort.yaml"
@@ -111,6 +112,7 @@ Feature: pods related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Pod should be immediately deleted if it's not scheduled even if graceful termination period is set
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/10.json"
@@ -169,6 +171,7 @@ Feature: pods related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: /dev/shm can be automatically shared among all of a pod's containers
     Given I have a project
     Given I obtain test data file "pods/pod_with_two_containers.json"
@@ -227,6 +230,7 @@ Feature: pods related scenarios
   @singlenode
   @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: 4.0 Oauth provider info should be consumed in a pod
     Given I have a project
     When I run the :new_app client command with:

--- a/features/cli/policy.feature
+++ b/features/cli/policy.feature
@@ -9,6 +9,7 @@ Feature: change the policy of user/service account
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: User can view ,add, remove and modify roleBinding via admin role user
     Given I have a project
     When I run the :get client command with:
@@ -63,6 +64,7 @@ Feature: change the policy of user/service account
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Could get projects for new role which has permission to get projects
     Given an 8 characters random string of type :dns is stored into the :random clipboard
     And admin ensures "clusterrole-12430-<%= cb.random %>" cluster_role is deleted after scenario
@@ -86,6 +88,7 @@ Feature: change the policy of user/service account
   @singlenode
   @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [origin_platformexp_214] User can view, add , modify and delete specific role to/from new added project via admin role user
     Given I have a project
     Given I obtain test data file "authorization/policy/projectviewservice.json"
@@ -145,6 +148,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: DaemonSet only support Always restartPolicy
     Given I have a project
     Given cluster role "sudoer" is added to the "first" user
@@ -175,6 +179,7 @@ Feature: change the policy of user/service account
   @aws-upi
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Basic user could not get deeper storageclass object info
     Given I have a project
     When I run the :get client command with:
@@ -224,6 +229,7 @@ Feature: change the policy of user/service account
   @aws-upi
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: User with role storage-admin can check deeper storageclass object info
     Given I have a project
     And admin ensures "sc-<%= project.name %>" storageclasses is deleted after scenario
@@ -286,6 +292,7 @@ Feature: change the policy of user/service account
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: User with role storage-admin can check deeper pv object info
     Given I have a project
     And admin ensures "pv-<%= project.name %>" pv is deleted after scenario
@@ -349,6 +356,7 @@ Feature: change the policy of user/service account
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: User with role storage-admin can get pvc object info
     Given I have a project
     And evaluation of `project.name` is stored in the :project clipboard
@@ -396,6 +404,7 @@ Feature: change the policy of user/service account
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Basic user could not get pv object info
     Given I have a project
     Then I run the :get client command with:
@@ -422,6 +431,7 @@ Feature: change the policy of user/service account
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: User can know if he can create podspec against the current scc rules via CLI
     Given I have a project
     Given I obtain test data file "authorization/scc/PodSecurityPolicySubjectReview_privileged_false.json"
@@ -459,6 +469,7 @@ Feature: change the policy of user/service account
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: User can know which serviceaccount and SA groups can create the podspec against the current sccs by CLI
     Given I have a project
     Given I obtain test data file "authorization/scc/PodSecurityPolicyReview.json"
@@ -536,6 +547,7 @@ Feature: change the policy of user/service account
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: User can know whether the PodSpec he's describing will actually be allowed by the current SCC rules via CLI
     Given I have a project
     Given I obtain test data file "authorization/scc/PodSecurityPolicySubjectReview.json"

--- a/features/cli/projects.feature
+++ b/features/cli/projects.feature
@@ -10,6 +10,7 @@ Feature: projects related features via cli
   @singlenode
   @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Could delete all resources when delete the project
     Given a 5 characters random string of type :dns is stored into the :prj_name clipboard
     When I run the :new_project client command with:
@@ -81,6 +82,7 @@ Feature: projects related features via cli
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: User can get node selector from a project
     Given  an 8 character random string of type :dns is stored into the :oadmproj1 clipboard
     Given  an 8 character random string of type :dns is stored into the :oadmproj2 clipboard
@@ -114,6 +116,7 @@ Feature: projects related features via cli
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Could remove user and group from the current project
     Given I have a project
     When I run the :oadm_policy_add_role_to_user client command with:
@@ -156,6 +159,7 @@ Feature: projects related features via cli
   @singlenode
   @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Process with default FSGroup id can be ran when using the default MustRunAs as the RunAsGroupStrategy
     Given I have a project
     Given I obtain test data file "pods/hello-pod.json"

--- a/features/cli/resources.feature
+++ b/features/cli/resources.feature
@@ -9,6 +9,7 @@ Feature: resouces related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Return description of resources with cli describe
     Given I have a project
     And I create a new application with:

--- a/features/cli/route.feature
+++ b/features/cli/route.feature
@@ -10,6 +10,7 @@ Feature: route related features via cli
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Expose routes from services
     Given I have a project
     When I run the :new_app client command with:
@@ -42,6 +43,7 @@ Feature: route related features via cli
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Be unable to add an existed alias name for service
     Given I have a project
     Given I obtain test data file "routing/unsecure/route_unsecure.json"

--- a/features/cli/rsh.feature
+++ b/features/cli/rsh.feature
@@ -9,6 +9,7 @@ Feature: rsh.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check oc rsh for simpler access to a remote shell
     Given I have a project
     Then evaluation of `project.name` is stored in the :proj_name clipboard

--- a/features/cli/secrets.feature
+++ b/features/cli/secrets.feature
@@ -8,6 +8,7 @@ Feature: secrets related scenarios
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: deployment hook volume inheritance --with secret volume
     Given I have a project
     And I run the :create_secret client command with:
@@ -42,6 +43,7 @@ Feature: secrets related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Pods do not have access to each other's secrets in the same namespace
     Given I have a project
     Given I obtain test data file "secrets/ocp12281/first-secret.json"
@@ -94,6 +96,7 @@ Feature: secrets related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Pods do not have access to each other's secrets with the same secret name in different namespaces
     Given I have a project
     Given evaluation of `project.name` is stored in the :project0 clipboard
@@ -177,6 +180,7 @@ Feature: secrets related scenarios
     @singlenode
     @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | type   | build_secret         | path      | command | expression               |
       | docker | testsecret1:mysecret1| mysecret1 | ls      | true                     | # @case_id OCP-11947
@@ -191,6 +195,7 @@ Feature: secrets related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Consume the same Secrets as environment variables in multiple pods
     Given I have a project
     Given I obtain test data file "secrets/secret.yaml"
@@ -248,6 +253,7 @@ Feature: secrets related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Using Secrets as Environment Variables
     Given I have a project
     Given I obtain test data file "secrets/secret.yaml"
@@ -320,6 +326,7 @@ Feature: secrets related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Mapping specified secret volume should update when secret is updated
     Given I have a project
     Given I obtain test data file "secrets/secret1.json"
@@ -359,6 +366,7 @@ Feature: secrets related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Allow specifying secret data using strings and images
     Given I have a project
     Given I obtain test data file "secrets/secret-datastring-image.json"
@@ -412,6 +420,7 @@ Feature: secrets related scenarios
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: oc new-app to gather git creds
     Given I have a project
     When I have an http-git service in the project

--- a/features/cli/serviceaccount.feature
+++ b/features/cli/serviceaccount.feature
@@ -9,6 +9,7 @@ Feature: ServiceAccount and Policy Managerment
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Could grant admin permission for the service account username to access to its own project
     Given I have a project
     When I create a new application with:
@@ -45,6 +46,7 @@ Feature: ServiceAccount and Policy Managerment
   @singlenode
   @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Could grant admin permission for the service account group to access to its own project
     Given I have a project
     When I run the :new_app client command with:
@@ -86,6 +88,7 @@ Feature: ServiceAccount and Policy Managerment
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: User can get the serviceaccount token via client
     Given I have a project
     When I run the :serviceaccounts_get_token client command with:

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -6,6 +6,7 @@ Feature: Check status via oc status, wait etc
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Show RC info and indicate bad secrets reference in 'oc status'
     Given I have a project
 

--- a/features/cluster_configuration/cluster_logging_operator.feature
+++ b/features/cluster_configuration/cluster_logging_operator.feature
@@ -10,6 +10,7 @@ Feature: cluster logging related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Deploy Logging Via Community Operators
     Given logging service has been installed successfully
 

--- a/features/images/jenkins.feature
+++ b/features/images/jenkins.feature
@@ -102,6 +102,7 @@ Feature: jenkins.feature
     @singlenode
     @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @amd64
     Examples:
       | version |
       | 2       | # @case_id OCP-10980
@@ -115,6 +116,7 @@ Feature: jenkins.feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: new-app/new-build support for pipeline buildconfigs
     Given I have a project
     When I run the :new_app client command with:
@@ -306,6 +308,7 @@ Feature: jenkins.feature
     @upgrade-sanity
     @proxy @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @amd64
     Examples:
       | version |
       | 1       |
@@ -320,6 +323,7 @@ Feature: jenkins.feature
   @upgrade-sanity
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @amd64
   Scenario: Jenkins pipeline build with OpenShift Client Plugin Example
     And I have a project
     When I run the :create client command with:
@@ -369,6 +373,7 @@ Feature: jenkins.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Oauthaccesstoken should be deleted after loging out from Jenkins webconsole
     Given I have a project
     When I run the :new_app client command with:

--- a/features/images/rhel8_images.feature
+++ b/features/images/rhel8_images.feature
@@ -78,6 +78,7 @@ Feature: rhel8images.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: mysql persistent template
     Given I have a project
     When I run the :tag admin command with:
@@ -136,6 +137,7 @@ Feature: rhel8images.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create mysql service from imagestream via oc new-app mysql-rhel8 image
     Given I have a project
     When I run the :new_app client command with:

--- a/features/infrastructure/cluster-capacity.feature
+++ b/features/infrastructure/cluster-capacity.feature
@@ -12,6 +12,7 @@ Feature: cluster-capacity related features
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Cluster capacity image support: Cluster capacity can work well with a simple pod
     Given environment has at least 2 schedulable nodes
     Given I have a project

--- a/features/kata/install_uninstall.feature
+++ b/features/kata/install_uninstall.feature
@@ -20,6 +20,7 @@ Feature: kata related features
   @upgrade-sanity
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: test delete kata installation
     Given I remove kata operator from the namespace
 
@@ -41,6 +42,7 @@ Feature: kata related features
   @gcp-upi @baremetal-upi @azure-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Operator can be installed through web console
     Given the kata-operator is installed using OLM GUI
 

--- a/features/kata/pod.feature
+++ b/features/kata/pod.feature
@@ -7,6 +7,7 @@ Feature: kata and pod related scenarios
   @gcp-upi @baremetal-upi @azure-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Pod using kata runtime can have an initcontainer
     Given I have a project
     And I obtain test data file "kata/OCP-38468/pod_with_init_container.yaml"

--- a/features/kata/smoke_tests.feature
+++ b/features/kata/smoke_tests.feature
@@ -9,6 +9,7 @@ Feature: kata smoke tests
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: [sandboxed containers] Namespace installed by operator
     Given kata container has been installed successfully
     Then the expression should be true> project.name == 'openshift-sandboxed-containers-operator'

--- a/features/logging/cluster_log_forwarder.feature
+++ b/features/logging/cluster_log_forwarder.feature
@@ -555,6 +555,7 @@ Feature: cluster log forwarder features
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Send logs to both external fluentd and internalES
     #Creating secure fluentd receiver
     Given I switch to cluster admin pseudo user

--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -13,6 +13,7 @@ Feature: cluster-logging-operator related test
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: ServiceMonitor Object for collector is deployed along with cluster logging
     Given logging collector name is stored in the :collector_name clipboard
     Given I wait for the "<%= cb.collector_name %>" service_monitor to appear
@@ -93,6 +94,7 @@ Feature: cluster-logging-operator related test
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Fluentd alert rule: FluentdNodeDown
     Given the master version >= "4.2"
     Given I obtain test data file "logging/clusterlogging/example.yaml"
@@ -160,6 +162,7 @@ Feature: cluster-logging-operator related test
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: OpenShift Logging dashboard
     Given I switch to the first user
     And the first user is cluster-admin
@@ -211,6 +214,7 @@ Feature: cluster-logging-operator related test
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Expose more fluentd knobs to support optimizing fluentd for different environments
     Given I obtain test data file "logging/clusterlogging/cl_fluentd-buffer.yaml"
     And I create clusterlogging instance with:
@@ -239,6 +243,7 @@ Feature: cluster-logging-operator related test
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Fluentd optimizing variable changes trigger new deployment
     Given I obtain test data file "logging/clusterlogging/cl_fluentd-buffer_default.yaml"
     And I create clusterlogging instance with:

--- a/features/logging/collector.feature
+++ b/features/logging/collector.feature
@@ -213,6 +213,7 @@ Feature: collector related tests
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: All nodes logs are collected
     Given the master version >= "4.5"
     Given logging collector name is stored in the :collector_name clipboard

--- a/features/logging/elasticsearch.feature
+++ b/features/logging/elasticsearch.feature
@@ -12,6 +12,7 @@ Feature: Elasticsearch related tests
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Elasticsearch using dynamic volumes
     Given default storageclass is stored in the :default_sc clipboard
     Given I obtain test data file "logging/clusterlogging/clusterlogging-storage-template.yaml"

--- a/features/logging/elasticsearch_operator.feature
+++ b/features/logging/elasticsearch_operator.feature
@@ -12,6 +12,7 @@ Feature: elasticsearch-operator related tests
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: ServiceMonitor Object for Elasticsearch is deployed along with the Elasticsearch cluster
     Given I wait for the "monitor-elasticsearch-cluster" service_monitor to appear
     When I perform the HTTP request on the ES pod with labels "es-node-master=true":
@@ -81,6 +82,7 @@ Feature: elasticsearch-operator related tests
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | cluster_setting |
       | transient       | # @case_id OCP-21530
@@ -98,6 +100,7 @@ Feature: elasticsearch-operator related tests
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Additional essential metrics ES dashboard
     Given I switch to the first user
     And the first user is cluster-admin

--- a/features/logging/kibana.feature
+++ b/features/logging/kibana.feature
@@ -70,6 +70,7 @@ Feature: Kibana related features
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Normal User can only view logs out of the projects owned by himself --kibana
     Given I switch to the first user
     And I create a project with non-leading digit name
@@ -127,6 +128,7 @@ Feature: Kibana related features
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: User with cluster-admin role can show logs out of all projects -- kibana
     Given I switch to the first user
     Given I create a project with non-leading digit name
@@ -240,6 +242,7 @@ Feature: Kibana related features
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Logs can be redirected from Webconsole to kibana
     Given I switch to the first user
     Given I create a project with non-leading digit name

--- a/features/logging/logging_acceptance.feature
+++ b/features/logging/logging_acceptance.feature
@@ -12,6 +12,7 @@ Feature: Logging smoke test case
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: One logging acceptance case for all cluster
     # Deploy cluster-logging operator via web console
     Given logging service is removed successfully

--- a/features/logging/permission.feature
+++ b/features/logging/permission.feature
@@ -61,6 +61,7 @@ Feature: permission related test
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Normal User can only view project owned by himself
     Given I switch to the first user
     And evaluation of `user.cached_tokens.first` is stored in the :user_token clipboard
@@ -111,6 +112,7 @@ Feature: permission related test
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: cluster-admin view all projects
     Given I switch to the first user
     Given I create a project with non-leading digit name

--- a/features/machine/autoscaler.feature
+++ b/features/machine/autoscaler.feature
@@ -9,6 +9,7 @@ Feature: Cluster Autoscaler Tests
   @upgrade-sanity
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Cluster should automatically scale up and scale down with clusterautoscaler deployed
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -131,6 +132,7 @@ Feature: Cluster Autoscaler Tests
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Update machineAutoscaler to reference a different MachineSet
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -206,6 +208,7 @@ Feature: Cluster Autoscaler Tests
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Machineautoscaler can be deleted when its referenced machineset does not exist
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user

--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -10,6 +10,7 @@ Feature: Machine features testing
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Machines should be linked to nodes
     Given I have an IPI deployment
     Then the machines should be linked to nodes
@@ -23,6 +24,7 @@ Feature: Machine features testing
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: machine-api clusteroperator should be in Available state
     Given evaluation of `cluster_operator('machine-api').condition(type: 'Available')` is stored in the :co_available clipboard
     Then the expression should be true> cb.co_available["status"]=="True"
@@ -46,6 +48,7 @@ Feature: Machine features testing
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Baremetal clusteroperator should be disabled in any deployment that is not baremetal
     Given evaluation of `cluster_operator('baremetal').condition(type: 'Disabled')` is stored in the :co_disabled clipboard
     Then the expression should be true> cb.co_disabled["status"]=="True"
@@ -59,6 +62,7 @@ Feature: Machine features testing
   @upgrade-sanity
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Scale up and scale down a machineSet
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -97,6 +101,7 @@ Feature: Machine features testing
     @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
     @network-ovnkubernetes @network-openshiftsdn
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | url                                                                          |
       | https://machine-api-operator.openshift-machine-api.svc:8443/metrics          | # @case_id OCP-25652
@@ -111,6 +116,7 @@ Feature: Machine features testing
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Machine should have immutable field providerID and nodeRef
     Given I have an IPI deployment
     Given I store the last provisioned machine in the :machine clipboard
@@ -154,6 +160,7 @@ Feature: Machine features testing
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Verify all machine instance-state should be consistent with their providerStats.instanceState
     Given I have an IPI deployment
     And evaluation of `BushSlicer::Machine.list(user: admin, project: project('openshift-machine-api'))` is stored in the :machines clipboard
@@ -167,6 +174,7 @@ Feature: Machine features testing
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Scaling a machineset with providerSpec.publicIp set to true
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -187,6 +195,7 @@ Feature: Machine features testing
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: [MAO] Reconciling machine taints with nodes
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -304,6 +313,7 @@ Feature: Machine features testing
       | aws       | machineset-clone-29199 | # @case_id OCP-29199
 
     @gcp-ipi
+    @arm64 @amd64
     Examples:
       | iaas_type | machineset_name        |
       | gcp       | machineset-clone-32126 | # @case_id OCP-32126
@@ -316,6 +326,7 @@ Feature: Machine features testing
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Labels specified in a machineset should propagate to nodes
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -386,6 +397,7 @@ Feature: Machine features testing
     @aws-ipi
     @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | name                    | file_name                 | Validation                    |
       | default-valued-32269    | ms_default_values.yaml    | Placement                     | # @case_id OCP-32269
@@ -400,6 +412,7 @@ Feature: Machine features testing
   @gcp-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Implement defaulting machineset values for GCP
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -472,6 +485,7 @@ Feature: Machine features testing
     @azure-ipi
     @network-ovnkubernetes @network-openshiftsdn
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | name                    | file_name               | Validation                |
       | default-valued-33058    | ms_default_values.yaml  | Public IP                 | # @case_id OCP-33058
@@ -483,6 +497,7 @@ Feature: Machine features testing
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Run machine api Controllers using leader election
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -511,6 +526,7 @@ Feature: Machine features testing
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Node labels and Affinity definition in PV should match
     Given I have a project
 
@@ -591,6 +607,7 @@ Feature: Machine features testing
       | default-valued-33380         | <%= cb.template %>                 | <%= cb.diskGiB %> | # @case_id OCP-33380
     @network-ovnkubernetes @network-openshiftsdn
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | name                         | template                           | diskGiB           |
       | default-valued-windows-35421 | openshift-qe-template-windows-2019 | 135               | # @case_id OCP-35421
@@ -601,6 +618,7 @@ Feature: Machine features testing
   @proxy @noproxy @disconnected
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [Azure] Machineset should not be created when publicIP:true in disconnected Azure enviroment
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -688,6 +706,7 @@ Feature: Machine features testing
     @aws-ipi
     @proxy @disconnected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | name                    | file_name                 | Validation                    |
       | default-valued-48463    | ms_default_values.yaml    | Placement                     | # @case_id OCP-48463

--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -8,6 +8,7 @@ Feature: MachineHealthCheck Test Scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Remediation should be applied when the unhealthyCondition 'Ready' is met
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -47,6 +48,7 @@ Feature: MachineHealthCheck Test Scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Create a machinehealthcheck when there is already an unhealthy machine
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -78,6 +80,7 @@ Feature: MachineHealthCheck Test Scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Create multiple MHCs to monitor same machineset
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -111,6 +114,7 @@ Feature: MachineHealthCheck Test Scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Use "maxUnhealthy" to prevent automated remediation
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -163,6 +167,7 @@ Feature: MachineHealthCheck Test Scenarios
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: [MHC] - Machine Node startup timeout should be configurable
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -204,6 +209,7 @@ Feature: MachineHealthCheck Test Scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Remediation should be applied when machine has nodeRef but node is deleted
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -261,6 +267,7 @@ Feature: MachineHealthCheck Test Scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: MHC MaxUnhealthy string value should be checked for '%' symbol
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -300,6 +307,7 @@ Feature: MachineHealthCheck Test Scenarios
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Leverage OpenAPI validation within MHC
     Given I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project
@@ -320,6 +328,7 @@ Feature: MachineHealthCheck Test Scenarios
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: [mhc] timeout field without units(h,m,s) shoud not be allowed to be stored
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user

--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -8,6 +8,7 @@ Feature: Machine misc features testing
   @vsphere-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: PVCs can still be provisioned after the password has been changed vSphere
     Given I have an IPI deployment
     Then I switch to cluster admin pseudo user
@@ -66,6 +67,7 @@ Feature: Machine misc features testing
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Reconciliation of MutatingWebhookConfiguration values should happen
     Given I switch to cluster admin pseudo user
 
@@ -123,6 +125,7 @@ Feature: Machine misc features testing
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: kube-rbac-proxy should not expose tokens, have excessive verbosity
     Given I switch to cluster admin pseudo user
 
@@ -167,6 +170,7 @@ Feature: Machine misc features testing
   @4.11 @4.10 @4.9 @4.8 @4.7
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Report vCenter version to telemetry
     Given I switch to cluster admin pseudo user
     When I perform the GET prometheus rest client with:
@@ -183,6 +187,7 @@ Feature: Machine misc features testing
   @vsphere-ipi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Deattach disk before destroying vm from vsphere
     Given I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project

--- a/features/machine/upi_gcp.feature
+++ b/features/machine/upi_gcp.feature
@@ -8,6 +8,7 @@ Feature: UPI GCP Tests
   @gcp-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: MachineSets in GCP should create Machines in a Shared (XPN) VPC environment
     Given I have an UPI deployment and machinesets are enabled
 
@@ -19,6 +20,7 @@ Feature: UPI GCP Tests
   @gcp-upi
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [GCP] Scaling OCP Cluster on UPI
     Given I have an UPI deployment and machinesets are enabled
     And I switch to cluster admin pseudo user

--- a/features/networking/build.feature
+++ b/features/networking/build.feature
@@ -46,6 +46,7 @@ Feature: Testing the isolation during build scenarios
     @network-openshiftsdn @network-multitenant
     @upgrade-sanity
     @noproxy
+    @arm64 @amd64
     Examples:
       | type   | repo                                                           | strategy       |
       | Docker | https://github.com/zhaozhanqi/ruby-docker-test/#isolation      | dockerStrategy | # @case_id OCP-15741
@@ -119,6 +120,7 @@ Feature: Testing the isolation during build scenarios
     @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
     @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
     @network-openshiftsdn @network-networkpolicy
+    @arm64 @amd64
     Examples:
       | type   | repo                                                           | strategy       |
       | Docker | https://github.com/zhaozhanqi/ruby-docker-test/#isolation      | dockerStrategy | # @case_id OCP-15731

--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -10,6 +10,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: EgressNetworkPolicy will not take effect after delete it
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -54,6 +55,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: Apply different egress network policy in different projects
     Given the env is using multitenant or networkpolicy network
     Given I have a project
@@ -123,6 +125,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: The rules of egress network policy are added in openflow
     Given the env is using multitenant or networkpolicy network
     Given I have a project
@@ -168,6 +171,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: Egress network policy use dnsname with multiple ipv4 addresses
     Given the env is using multitenant or networkpolicy network
     Given I have a project
@@ -203,6 +207,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: Service with a DNS name can not by pass Egressnetworkpolicy with that DNS name
     Given the env is using multitenant or networkpolicy network
     Given I have a project
@@ -264,6 +269,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: Add nodes local IP address to OVS rules for egressnetworkpolicy
     Given the env is using multitenant or networkpolicy network
     Given I have a project
@@ -318,6 +324,7 @@ Feature: Egress-ingress related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: Update different dnsname in same egress network policy
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -357,6 +364,7 @@ Feature: Egress-ingress related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Iptables should be updated with correct endpoints when egress DNS policy was used
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
@@ -411,6 +419,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @noproxy @connected
   @network-ovnkubernetes
+  @arm64 @amd64
   Scenario: [SDN-682] EgressFirewall allows traffic to destination ports
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -451,6 +460,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @noproxy @connected
   @network-ovnkubernetes
+  @arm64 @amd64
   Scenario:  [SDN-682] EgressFirewall rules take effect in order
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -475,6 +485,7 @@ Feature: Egress-ingress related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @noproxy @connected
   @network-ovnkubernetes
+  @arm64 @amd64
   Scenario:  [SDN-682] EgressFirewall policy should not take effect for traffic between pods and pods to service
     Given I have a project
     # Create EgressFirewall policy to deny all outbound traffic
@@ -513,6 +524,7 @@ Feature: Egress-ingress related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @noproxy @connected
   @network-ovnkubernetes
+  @arm64 @amd64
   Scenario: [SDN-682] EgressFirewall policy take effect for multiple port
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -543,6 +555,7 @@ Feature: Egress-ingress related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: EgressNetworkPolicy maxItems is 1000
     Given I have a project
     Given I obtain test data file "networking/egressnetworkpolicy/egressnetworkpolicy_1000.yaml"
@@ -570,6 +583,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @noproxy @connected
   @network-ovnkubernetes
+  @arm64 @amd64
   Scenario: [SDN-1181] EgressFirewall allows traffic to destination dnsName
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -605,6 +619,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @noproxy @connected
   @network-ovnkubernetes
+  @arm64 @amd64
   Scenario: [SDN-1181] EgressFirewall denys traffic to destination dnsName
     Given I have a project
 
@@ -640,6 +655,7 @@ Feature: Egress-ingress related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @noproxy @connected
   @network-ovnkubernetes
+  @arm64 @amd64
   Scenario: [SDN-1181] Edit EgressFirewall should take effect
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -677,6 +693,7 @@ Feature: Egress-ingress related networking scenarios
   @upgrade-sanity
   @noproxy @connected
   @network-ovnkubernetes
+  @arm64 @amd64
   Scenario: [bug1947917] Egress Firewall should reliably apply firewall rules
     Given I have a project
     Given I have a pod-for-ping in the project

--- a/features/networking/egress-ip.feature
+++ b/features/networking/egress-ip.feature
@@ -9,6 +9,7 @@ Feature: Egress IP related features
   @upgrade-sanity
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: Only cluster admin can add/remove egressIPs on hostsubnet
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
@@ -29,6 +30,7 @@ Feature: Egress IP related features
   @upgrade-sanity
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: Only cluster admin can add/remove egressIPs on netnamespaces
     # Try to add the egress ip to the netnamespace with normal user
     Given I have a project
@@ -50,6 +52,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: All the pods egress connection will get out through the egress IP if the egress IP is set to netns and egress node can host the IP
     Given I save ipecho url to the clipboard
     Given I select a random node's host
@@ -109,6 +112,7 @@ Feature: Egress IP related features
   @vsphere-upi @aws-upi
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: The egressIPs will be added to the node's primary NIC when it gets set on hostsubnet and will be removed after gets unset
     # add the egress ip to the hostsubnet
     Given  the valid egress IP is added to the node
@@ -148,6 +152,7 @@ Feature: Egress IP related features
   @vsphere-upi
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Should remove the egressIP from the array if it was not being used
     Given I store a random unused IP address from the reserved range to the clipboard
     And evaluation of `IPAddr.new("<%= cb.subnet_range %>").to_s+"/"+IPAddr.new("<%= cb.subnet_range %>").prefix.to_s` is stored in the :valid_subnet clipboard
@@ -200,6 +205,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: The EgressNetworkPolicy should work well with egressIP
     Given I save ipecho url to the clipboard
     Given the valid egress IP is added to the node
@@ -246,6 +252,7 @@ Feature: Egress IP related features
   @vsphere-upi @aws-upi
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: The related iptables/openflow rules will be removed once the egressIP gets removed from netnamespace
     Given the valid egress IP is added to the node
     And I have a project
@@ -297,6 +304,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: The egressIP should still work fine after the node or network service restarted
     Given I save ipecho url to the clipboard
     Given the valid egress IP is added to the node
@@ -335,6 +343,7 @@ Feature: Egress IP related features
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Invalid egressIP should not be acceptable
     Given I select a random node's host
     Given evaluation of `["fe80::5054:ff:fedd:3698", "a.b.c.d", "10.10.10.-1", "10.0.0.1/64", "10.1.1/24", "A008696"]` is stored in the :ips clipboard
@@ -359,6 +368,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Random outages with egressIP
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
@@ -395,6 +405,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Should be able to access to the service's externalIP with egressIP
     Given I have a project
     Given I store the schedulable nodes in the :nodes clipboard
@@ -452,6 +463,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: The egressIPs should work well when re-using the egressIP which is holding by a deleted project
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
@@ -487,6 +499,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: Add the removed egressIP back to the netnamespace would work well
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
@@ -528,6 +541,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: The pod should be able to access outside with the node source IP after the egressIP removed
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
@@ -577,6 +591,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: Pods will not be affected by the egressIP set on other netnamespace
     Given I save ipecho url to the clipboard
     # create project with pods
@@ -646,6 +661,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: The same egressIP will not be assigned to different netnamespace
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
@@ -690,6 +706,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [sdn-1282] Manually EgressIPs assignments:if a pod is on a node that is hosting an egressIP that pod will always use the egressIP of the node it is on
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
@@ -739,6 +756,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [sdn-1282] Manually EgressIPs assignments: if a pod is not on a node hosting an egressIP it is random which egressIP it will use
     Given I save ipecho url to the clipboard
     Given I store the masters in the :masters clipboard
@@ -789,6 +807,7 @@ Feature: Egress IP related features
   @qeci
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: [SDN-1282] Auto EgressIPs assignments: if a pod is not on a node hosting an egressIP it is random which egressIP it will use
     Given I save ipecho url to the clipboard
     Given I store the masters in the :masters clipboard
@@ -840,6 +859,7 @@ Feature: Egress IP related features
   @qeci
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: [SDN-1282] Auto EgressIPs assignments:if a pod is on a node that is hosting an egressIP that pod will always use the egressIP of the node
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :workers clipboard
@@ -898,6 +918,7 @@ Feature: Egress IP related features
   @qeci
   @noproxy @disconnected @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [Bug 1926662] NodePort works when configuring an EgressIP address
     Given I store the schedulable workers in the :workers clipboard
     And I store the masters in the :masters clipboard

--- a/features/networking/ipv6_dualstack.feature
+++ b/features/networking/ipv6_dualstack.feature
@@ -9,6 +9,7 @@ Feature: ipv6 dual stack cluster test scenarios
   @upgrade-sanity
   @proxy @noproxy @disconnected @connected
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @arm64 @amd64
   Scenario: Project should be in isolation when using multitenant policy for ipv6 dual stack
     # create project and pods
     Given I have a project
@@ -91,6 +92,7 @@ Feature: ipv6 dual stack cluster test scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @arm64 @amd64
   Scenario: ipv6 for nodeport service
     Given I store the workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ipv4 clipboard    

--- a/features/networking/isolation.feature
+++ b/features/networking/isolation.feature
@@ -309,6 +309,7 @@ Feature: networking isolation related scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @upgrade-sanity
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Make the network of given projects be accessible globally
     # Create 3 projects and each contains 1 pod and 1 service
     Given the env is using multitenant network

--- a/features/networking/metrics.feature
+++ b/features/networking/metrics.feature
@@ -9,6 +9,7 @@ Feature: SDN/OVN metrics related networking scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Prometheus should be able to monitor kubeproxy metrics
     Given I switch to cluster admin pseudo user
     And I use the "openshift-sdn" project
@@ -46,6 +47,7 @@ Feature: SDN/OVN metrics related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Should be able to monitor the openshift-sdn related metrics by prometheus
     Given I switch to cluster admin pseudo user
     And I use the "openshift-sdn" project
@@ -84,6 +86,7 @@ Feature: SDN/OVN metrics related networking scenarios
   @singlenode
   @network-ovnkubernetes
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Should be able to monitor various ovnkube-master and ovnkube-node metrics via prometheus
     Given I switch to cluster admin pseudo user
     And I use the "openshift-ovn-kubernetes" project

--- a/features/networking/multicast.feature
+++ b/features/networking/multicast.feature
@@ -10,6 +10,7 @@ Feature: testing multicast scenarios
   @proxy @noproxy @connected
   @network-multitenant
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: pods should be able to subscribe send and receive multicast traffic
     # create some multicast testing pods
     Given I have a project
@@ -98,6 +99,7 @@ Feature: testing multicast scenarios
   @network-multitenant
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: multicast is disabled by default if not annotate the namespace
     # create multicast testing pods in the project and without multicast enable
     Given I have a project
@@ -167,6 +169,7 @@ Feature: testing multicast scenarios
   @network-multitenant
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Same multicast groups can be created in multiple namespace
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -310,6 +313,7 @@ Feature: testing multicast scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: pods in default project should not be able to receive multicast traffic from other namespace
     # create multicast testing pod in one project
     Given I have a project
@@ -392,6 +396,7 @@ Feature: testing multicast scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: pods should be able to join multiple multicast groups at same time  
     # create some multicast testing pods in the project
     Given I have a project
@@ -492,6 +497,7 @@ Feature: testing multicast scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: pods should not be able to receive multicast traffic from other pods in different namespace
     # create some multicast testing pods in one project
     Given I have a project
@@ -573,6 +579,7 @@ Feature: testing multicast scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: pods in default project should be able to receive multicast traffic from other default project pods
     # enable multicast and create testing pods
     Given I switch to cluster admin pseudo user

--- a/features/networking/multus-ipv6.feature
+++ b/features/networking/multus-ipv6.feature
@@ -61,6 +61,7 @@ Feature: Multus-CNI ipv6 related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: IPv6 testing for OCP-31999: Whereabouts should exclude IPv6 ranges
   # Bug https://bugzilla.redhat.com/show_bug.cgi?id=1913062
   # Bug https://bugzilla.redhat.com/show_bug.cgi?id=1917984

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -10,6 +10,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create pods with multus-cni - macvlan bridge mode
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
@@ -77,6 +78,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create pods with multus-cni - macvlan private mode
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
@@ -142,6 +144,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create pods with multus-cni - macvlan vepa mode
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
@@ -208,6 +211,7 @@ Feature: Multus-CNI related scenarios
   @upgrade-sanity
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create pods with multus-cni - host-device
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
@@ -284,6 +288,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create pods with muliple cni plugins via multus-cni - macvlan + macvlan
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
@@ -335,6 +340,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create pods with muliple cni plugins via multus-cni - macvlan + host-device
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
@@ -406,6 +412,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create pods with muliple cni plugins via multus-cni - host-device + host-device
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
@@ -484,6 +491,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create pod with Multus bridge CNI plugin without vlan
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -539,6 +547,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Create pod with Multus bridge CNI plugin and vlan tag
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -586,6 +595,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: CNO manager mavlan configured manually with static
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
@@ -681,6 +691,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: User cannot consume the net-attach-def created in other project which is namespace isolated
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -722,6 +733,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Pods can communicate each other with same vlan tag
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -813,6 +825,7 @@ Feature: Multus-CNI related scenarios
   @upgrade-sanity
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Pods cannot communicate each other with different vlan tag
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -920,6 +933,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: macvlan plugin without master parameter
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -952,6 +966,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Supported runtimeConfig/capability for MAC/IP
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -995,6 +1010,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Multus CNI type bridge with DHCP
     # Make sure that the multus is Running
     Given the multus is enabled on the cluster
@@ -1135,6 +1151,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Assign static IP address using pod annotation
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -1176,6 +1193,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Assign static MAC address using pod annotation
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -1215,6 +1233,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Multus default route overwrite
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -1252,6 +1271,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Multus Telemetry Adds capability to track usage of network attachment definitions
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -1315,6 +1335,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: The multus admission controller should be able to detect that the pod is using net-attach-def in other namespaces when the isolation is enabled
     Given I create 2 new projects
     # Create the net-attach-def via cluster admin
@@ -1351,6 +1372,7 @@ Feature: Multus-CNI related scenarios
   @upgrade-sanity
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Create pod with Multus ipvlan CNI plugin
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -1410,6 +1432,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Dynamic IP address assignment with Whereabouts
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -1473,6 +1496,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Multus custom route change with route override
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -1509,6 +1533,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Multus namespaceIsolation should allow references to CRD in the default namespace
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -1541,6 +1566,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Log pod IP and pod UUID when pod start
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
@@ -1593,6 +1619,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Whereabouts with exclude IP address
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -1735,6 +1762,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: [BZ1944678] Whereabouts IPAM CNI duplicate IP addresses assigned to pods
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -9,6 +9,7 @@ Feature: Operator related networking scenarios
   @upgrade-sanity
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: The clusteroperator should be able to reflect the network operator version corresponding to the OCP version
 
     Given the master version > "3.11"
@@ -27,6 +28,7 @@ Feature: Operator related networking scenarios
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: The clusteroperator should be able to reflect the correct version field post bad network operator config
 
     Given the master version >= "4.1"
@@ -74,6 +76,7 @@ Feature: Operator related networking scenarios
   @upgrade-sanity
   @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Should have a clusteroperator object created under config.openshift.io api group for network-operator
     Given the master version >= "4.1"
     # Check the operator object has version
@@ -179,6 +182,7 @@ Feature: Operator related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Service should not get unidle when config flag is disabled under CNO
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
@@ -265,6 +269,7 @@ Feature: Operator related networking scenarios
   @upgrade-sanity
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Should not allow to change the openshift-sdn config
     #Trying to change network mode to Subnet or any other
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
@@ -300,6 +305,7 @@ Feature: Operator related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: CNO should delete non-relevant resources
     # Make sure that the multus is Running
     Given the multus is enabled on the cluster
@@ -383,6 +389,7 @@ Feature: Operator related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Changing mtu in CNO should not be allowed
     Given the mtu value "1750" is patched in CNO config according to the networkType
     And admin uses the "openshift-network-operator" project

--- a/features/networking/ovn-egress-ip.feature
+++ b/features/networking/ovn-egress-ip.feature
@@ -11,6 +11,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @qeci
   @noproxy @connected
+  @arm64 @amd64
   Scenario: EgressIP works for all pods in the matched namespace when only configure namespaceSelector
     Given I save ipecho url to the clipboard
     Given I select a random node's host
@@ -81,6 +82,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @qeci
   @noproxy @connected
+  @arm64 @amd64
   Scenario: Multiple EgressIP objects can have multiple Egress IPs
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
@@ -154,6 +156,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @qeci
   @noproxy @connected
+  @arm64 @amd64
   Scenario: Multi-project can share same EgressIP
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
@@ -228,6 +231,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @qeci
   @noproxy @connected
+  @arm64 @amd64
   Scenario: Removed matched labels from project will not use EgressIP
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
@@ -284,6 +288,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @qeci
   @noproxy @connected
+  @arm64 @amd64
   Scenario: Removed matched labels from pods will not use EgressIP
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
@@ -348,6 +353,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @qeci
   @noproxy @connected
+  @arm64 @amd64
   Scenario: EgressIP was removed after delete egressIP object
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
@@ -400,6 +406,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @qeci
   @noproxy @connected
+  @arm64 @amd64
   Scenario: After reboot node or reboot OVN services EgressIP still work
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
@@ -462,6 +469,7 @@ Feature: OVN Egress IP related features
   @vsphere-ipi @aws-ipi
   @vsphere-upi @aws-upi
   @noproxy @connected
+  @arm64 @amd64
   Scenario: Warning event will be triggered if apply EgressIP object but no EgressIP nodes
     #Get unused IP as egress ip
     Given I store a random unused IP address from the reserved range to the clipboard
@@ -497,6 +505,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @qeci
   @noproxy @connected
+  @arm64 @amd64
   Scenario: The pod located on different node than EgressIP nodes
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
@@ -550,6 +559,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @qeci
   @noproxy @connected
+  @arm64 @amd64
   Scenario: Deleting EgressIP object and recreating it will work
     Given I save ipecho url to the clipboard
 
@@ -614,6 +624,7 @@ Feature: OVN Egress IP related features
   @vsphere-upi @baremetal-upi
   @network-ovnkubernetes
   @noproxy @connected
+  @arm64 @amd64
   Scenario: An EgressIP object can not have multiple egress IP assignments on the same node
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -647,6 +658,7 @@ Feature: OVN Egress IP related features
   @aws-upi
   @network-ovnkubernetes
   @noproxy @connected
+  @arm64 @amd64
   Scenario: Common user cannot tag the nodes by labelling them as egressIP nodes
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
@@ -669,6 +681,7 @@ Feature: OVN Egress IP related features
   @aws-ipi
   @aws-upi
   @noproxy @connected
+  @arm64 @amd64
   Scenario: Any egress IP can only be assigned to one node only
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -718,6 +731,7 @@ Feature: OVN Egress IP related features
   @vsphere-upi
   @network-ovnkubernetes
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: lr-policy-list and snat should be updated correctly after remove pods
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -830,6 +844,7 @@ Feature: OVN Egress IP related features
   @vsphere-upi
   @network-ovnkubernetes
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: lr-policy-list and snat should be updated correctly after remove egressip objects 
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -924,6 +939,7 @@ Feature: OVN Egress IP related features
   @vsphere-upi
   @qeci
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Traffic is load balanced between egress nodes in OVN cluster
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard

--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -10,6 +10,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Creating a resource in Kube API should be synced to OVN NB db correctly even post NB db crash too
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
@@ -57,6 +58,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: OVN DB should be updated correctly if a resource only exist in Kube API but not in OVN NB db
     Given the env is using "OVNKubernetes" networkType
     Given I register clean-up steps:
@@ -112,6 +114,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: OVN DB should be updated correctly if a resource only exist in NB db but not in Kube API
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
@@ -175,6 +178,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Thrashing ovnkube master IPAM allocator by creating and deleting various pods on a specific node
     Given the env is using "OVNKubernetes" networkType
     And I store all worker nodes to the :nodes clipboard
@@ -203,6 +207,7 @@ Feature: OVN related networking scenarios
   @network-ovnkubernetes
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: ovnkube-masters should allocate pod IP and mac addresses
     Given the env is using "OVNKubernetes" networkType
     And I have a project
@@ -231,6 +236,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Create/delete pods while forcing OVN leader election
   #Test for bug https://bugzilla.redhat.com/show_bug.cgi?id=1781297
     Given the env is using "OVNKubernetes" networkType
@@ -260,6 +266,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Pods and Services should keep running when a new raft leader gets be elected
     Given the env is using "OVNKubernetes" networkType
     Given I store the ovnkube-master "south" leader pod in the clipboard
@@ -305,6 +312,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Traffic flow shouldn't be interrupted when master switches the leader positions
     Given the env is using "OVNKubernetes" networkType
     Given I switch to cluster admin pseudo user
@@ -374,6 +382,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: New raft leader should be elected if existing leader gets deleted or crashed in hybrid/non-hybrid clusters
     Given the env is using "OVNKubernetes" networkType
     Given admin uses the "openshift-ovn-kubernetes" project
@@ -428,6 +437,7 @@ Feature: OVN related networking scenarios
     """
     And admin waits for all pods in the project to become ready up to 120 seconds
 
+    @arm64 @amd64
     Examples:
       | signal |
       | TERM   |
@@ -446,6 +456,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Inducing Split Brain in the OVN HA cluster
     Given admin uses the "openshift-ovn-kubernetes" project
     When I store the ovnkube-master "south" leader pod in the clipboard
@@ -501,6 +512,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Delete all OVN master pods and makes sure leader/follower election converges smoothly
     Given the env is using "OVNKubernetes" networkType
     Given admin uses the "openshift-ovn-kubernetes" project
@@ -528,6 +540,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: OVN handles projects that start with a digit
     Given the env is using "OVNKubernetes" networkType
     Given I create a project with leading digit name
@@ -612,6 +625,7 @@ Feature: OVN related networking scenarios
   @vsphere-ipi @baremetal-ipi
   @proxy @noproxy @connected
   @vsphere-upi @baremetal-upi
+  @arm64 @amd64
   Scenario: Logical Router Policies and Annotations for a given node should be current
     Given the env is using "OVNKubernetes" networkType
     #Find apiVIP address of the cluster

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -8,6 +8,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Should be able to send node to node ESP traffic on IPsec clusters
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -55,6 +56,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Segfault on pluto IKE daemon should result in restarting pluto daemon and corresponding ovn-ipsec pod
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -86,6 +88,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Make sure IPsec SA's are establishing in a transport mode
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -104,6 +107,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Pod created on IPsec cluster should have appropriate MTU size to accomdate IPsec Header
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -127,6 +131,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Delete all ovn-ipsec containers and check if they gets recreated
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -145,6 +150,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: pod to pod traffic on different nodes should be ESP encrypted
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster

--- a/features/networking/ovn_winc.feature
+++ b/features/networking/ovn_winc.feature
@@ -7,6 +7,7 @@ Feature: OVNKubernetes Windows Container related networking scenarios
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @azure-ipi @aws-ipi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Ensure Pods and Service communication across window and linux nodes
     Given the env is using windows nodes
     Given I have a project
@@ -62,6 +63,7 @@ Feature: OVNKubernetes Windows Container related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @upgrade-sanity
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Create Loadbalancer service for a window container
     Given the env is using windows nodes
     Given I have a project

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -9,6 +9,7 @@ Feature: Pod related networking scenarios
   @upgrade-sanity
   @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Pod cannot claim UDP port 4789 on the node as part of a port mapping
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
@@ -33,6 +34,7 @@ Feature: Pod related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @upgrade-sanity
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Container could reach the dns server
     Given I have a project
     Given I obtain test data file "pods/ocp10031/pod.json"
@@ -56,6 +58,7 @@ Feature: Pod related networking scenarios
   @upgrade-sanity
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The openflow list will be cleaned after delete the pods
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -88,6 +91,7 @@ Feature: Pod related networking scenarios
   @upgrade-sanity
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check QoS after creating pod
     Given I have a project
     # setup iperf server to receive the traffic
@@ -153,6 +157,7 @@ Feature: Pod related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: A pod with or without hostnetwork cannot access the MCS port 22623 or 22624 on the master
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard
@@ -191,6 +196,7 @@ Feature: Pod related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: A pod cannot access the MCS port 22623 or 22624 via the SDN/tun0 address of the master
     Given I store the masters in the :masters clipboard
     And the vxlan tunnel address of node "<%= cb.masters[0].name %>" is stored in the :master_tunnel_address clipboard
@@ -214,6 +220,7 @@ Feature: Pod related networking scenarios
   @vsphere-upi @baremetal-upi @azure-upi @aws-upi
   @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: A pod in a namespace with an egress IP cannot access the MCS
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard
@@ -250,6 +257,7 @@ Feature: Pod related networking scenarios
   @upgrade-sanity
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: User cannot access the MCS by creating a service that maps to non-MCS port to port 22623 or 22624 on the IP of a master (via manually-created ep's)
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard
@@ -281,6 +289,7 @@ Feature: Pod related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: ovn pod can be scheduled even if the node taint to unschedule
     Given the env is using "OVNKubernetes" networkType
     And I store all worker nodes to the :nodes clipboard
@@ -332,6 +341,7 @@ Feature: Pod related networking scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: [4.x] Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted
     Given I store the workers in the :nodes clipboard
     And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :node_ip clipboard
@@ -488,6 +498,7 @@ Feature: Pod related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Pod readiness check for OVN
     Given the env is using "OVNKubernetes" networkType
     And OVN is functional on the cluster
@@ -588,6 +599,7 @@ Feature: Pod related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Check the unused ip are released after node reboot
     Given I store the workers in the :workers clipboard
     Given I use the "<%= cb.workers[0].name %>" node

--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -63,6 +63,7 @@ Feature: SCTP related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Expose SCTP ClusterIP Services
     Given I store the ready and schedulable workers in the :workers clipboard
     And I install machineconfigs load-sctp-module
@@ -127,6 +128,7 @@ Feature: SCTP related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Expose SCTP NodePort Services
     Given I store the ready and schedulable workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ip clipboard
@@ -193,6 +195,7 @@ Feature: SCTP related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Networkpolicy allow SCTP Client
     Given I store the ready and schedulable workers in the :workers clipboard
     And I install machineconfigs load-sctp-module

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -47,6 +47,7 @@ Feature: SDN related networking scenarios
   @upgrade-sanity
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: iptables rules will be repaired automatically once it gets destroyed
     # we do not detect incomplete rule removal since ~4.3, BZ-1810316
     # so only test on >= 4.3
@@ -87,6 +88,7 @@ Feature: SDN related networking scenarios
   @upgrade-sanity
   @proxy @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: an empty OPENSHIFT-ADMIN-OUTPUT-RULES chain is created in filter table at startup
     Given the master version >= "3.6"
     Given I have a project
@@ -195,6 +197,7 @@ Feature: SDN related networking scenarios
   @upgrade-sanity
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: should not show "No such device" message when run "ovs-vsctl show" command
     Given I have a project
     And I have a pod-for-ping in the project
@@ -217,6 +220,7 @@ Feature: SDN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: The iptables binary and rules on sdn containers should be the same as host
     Given I select a random node's host
     When I run commands on the host:
@@ -313,6 +317,7 @@ Feature: SDN related networking scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Networking should work on default namespace
   #Test for bug https://bugzilla.redhat.com/show_bug.cgi?id=1800324 and https://bugzilla.redhat.com/show_bug.cgi?id=1796157
     Given I switch to cluster admin pseudo user
@@ -367,6 +372,7 @@ Feature: SDN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Don't write CNI configuration file until ovn-controller has done at least one iteration
     Given the env is using "OVNKubernetes" networkType
     And I store the masters in the :master clipboard
@@ -421,6 +427,7 @@ Feature: SDN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: NetworkManager should consider OVS interfaces as unmanaged
   Given the env is using "OVNKubernetes" networkType
   And I select a random node's host
@@ -489,6 +496,7 @@ Feature: SDN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @arm64 @amd64
   Scenario: Netnamespace should be recreated after deleting it before the project is deleted
     Given the env is using "OpenShiftSDN" networkType
     Given I have a project
@@ -508,6 +516,7 @@ Feature: SDN related networking scenarios
   @vsphere-upi
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: UDP offloads were disabled on vsphere platform
     Given I select a random node's host
     Given the default interface on nodes is stored in the :default_interface clipboard
@@ -526,6 +535,7 @@ Feature: SDN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Disable conntrack for vxlan traffic
     Given the env is using "OpenShiftSDN" networkType
     Given I select a random node's host

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -82,6 +82,7 @@ Feature: Service related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: User cannot access the MCS by creating a LoadBalancer service that points to the MCS
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard
@@ -113,6 +114,7 @@ Feature: Service related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @noproxy @connected
   @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The headless service can publish the pods even if they are not ready
     Given I have a project
     Given I obtain test data file "networking/headless_notreadypod.json"
@@ -143,6 +145,7 @@ Feature: Service related networking scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: externalIP defined in service but no spec.externalIP defined
     Given I have a project
     # Create a service with a externalIP
@@ -161,6 +164,7 @@ Feature: Service related networking scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: externalIP defined in service with set ExternalIP in allowedCIDRs
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
@@ -211,6 +215,7 @@ Feature: Service related networking scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: A rejectedCIDRs inside an allowedCIDRs
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
@@ -265,6 +270,7 @@ Feature: Service related networking scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: externalIP defined in service with set ExternalIP in rejectedCIDRs
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
@@ -302,6 +308,7 @@ Feature: Service related networking scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: An allowedCIDRs inside an rejectedCIDRs
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
@@ -342,6 +349,7 @@ Feature: Service related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Defined Multiple allowedCIDRs
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
@@ -420,6 +428,7 @@ Feature: Service related networking scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Idling/Unidling services on sdn/OVN
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
@@ -497,6 +506,7 @@ Feature: Service related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Taint node with too small MTU value
     Given the default interface on nodes is stored in the :default_interface clipboard
     And the node's MTU value is stored in the :mtu_actual clipboard
@@ -558,6 +568,7 @@ Feature: Service related networking scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: User can expand the nodePort range by patch the serviceNodePortRange in network
     Given I store the workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[0].name %>" is stored in the :worker0_ip clipboard
@@ -616,6 +627,7 @@ Feature: Service related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: The iptables rules for the service should be DNAT or REDIRECT to node after being idled
     Given I have a project
     And evaluation of `project.name` is stored in the :proj_name clipboard
@@ -681,6 +693,7 @@ Feature: Service related networking scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Update externalIP from oc edit svc
     Given I have a project
     And evaluation of `project.name` is stored in the :proj_name clipboard
@@ -750,6 +763,7 @@ Feature: Service related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @connected
   @network-ovnkubernetes
+  @arm64 @amd64
   Scenario: Other node cannot be accessed for nodePort when externalTrafficPolicy is Local
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard
@@ -792,6 +806,7 @@ Feature: Service related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Be able to access the service via the nodeport
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard

--- a/features/networking/sgw-lgw-migration.feature
+++ b/features/networking/sgw-lgw-migration.feature
@@ -9,6 +9,7 @@ Feature: SGW<->LGW migration related scenarios
   @vsphere-ipi
   @noproxy @connected
   @vsphere-upi
+  @amd64
   Scenario: [SDN-2290] SGW <-> LGW migration scenario	for vsphere platform
     Given the env is using "OVNKubernetes" networkType
 
@@ -127,6 +128,7 @@ Feature: SGW<->LGW migration related scenarios
   @network-ovnkubernetes
   @baremetal-upi
   @proxy @noproxy @disconnected @connected
+  @amd64
   Scenario: [SDN-2290] SGW <-> LGW migration scenario	for BM platform
     Given the env is using "OVNKubernetes" networkType
 
@@ -191,6 +193,7 @@ Feature: SGW<->LGW migration related scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @amd64
   Scenario: [SDN-2290] SGW <-> LGW migration scenarios for externalIP	
     Given the env is using "OVNKubernetes" networkType
     ######## Prepare Data Pre Migration ############

--- a/features/networking/sriov.feature
+++ b/features/networking/sriov.feature
@@ -693,6 +693,7 @@ Feature: Sriov related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: dpdk for intel card works well
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/intel-dpdk.yaml"

--- a/features/node/proxy.feature
+++ b/features/node/proxy.feature
@@ -30,6 +30,7 @@ Feature: Node proxy configuration tests
     @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
     @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | file                                                      |
       | /etc/systemd/system/kubelet.service.d/10-default-env.conf | # @case_id OCP-24429

--- a/features/node/seccomp.feature
+++ b/features/node/seccomp.feature
@@ -28,6 +28,7 @@ Feature: Secure Computing Test Scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Using Secure Computing Profiles with Pod Annotations
     # Create custom machine config that contains the seccomp
     Given I switch to cluster admin pseudo user

--- a/features/registry/is.feature
+++ b/features/registry/is.feature
@@ -100,6 +100,7 @@ Feature: Testing imagestream
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Prune images when DC reference to invalid image
     Given I have a project
     Given I enable image-registry default route
@@ -148,6 +149,7 @@ Feature: Testing imagestream
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Do not prune layer of a valid Image due to minimum aging
     Given I have a project
     Given I enable image-registry default route

--- a/features/registry/registry.feature
+++ b/features/registry/registry.feature
@@ -11,6 +11,7 @@ Feature: Testing registry
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Prune images by command oadm_prune_images
     Given cluster role "system:image-pruner" is added to the "first" user
     Given I enable image-registry default route
@@ -49,6 +50,7 @@ Feature: Testing registry
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Copy image to another tag via 'oc image mirror'
     Given I have a project
     Given docker config for default image registry is stored to the :dockercfg_file clipboard
@@ -72,6 +74,7 @@ Feature: Testing registry
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Mirror multiple locations to another registry via 'oc image mirror'
     Given I have a project
     Given docker config for default image registry is stored to the :dockercfg_file clipboard
@@ -97,6 +100,7 @@ Feature: Testing registry
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: Enable must-gather object refs in image-registry cluster
     When I run the :get admin command with:
       | resource      | co             |
@@ -173,6 +177,7 @@ Feature: Testing registry
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check the related log from must-gather tool
     When I run the :delete admin command with:
       | object_type       | co             |
@@ -195,6 +200,7 @@ Feature: Testing registry
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Mirror image to another registry via 'oc image mirror'
     Given I have a project
     Given docker config for default image registry is stored to the :dockercfg_file clipboard
@@ -219,6 +225,7 @@ Feature: Testing registry
   @singlenode
   @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Use node credentials in imagestream import
     Given I have a project
     When I run the :tag client command with:
@@ -255,6 +262,7 @@ Feature: Testing registry
   @upgrade-sanity
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [Disconnect]Import image from a secure registry using node credentials
     Given I have a project
     And evaluation of `image_content_source_policy('image-policy-aosqe').mirror_registry(cached: false)` is stored in the :mirror_registry clipboard
@@ -289,6 +297,7 @@ Feature: Testing registry
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Node secret takes effect when common secret is removed
     Given I have a project
     When I run the :extract admin command with:

--- a/features/registry/remote.feature
+++ b/features/registry/remote.feature
@@ -8,6 +8,7 @@ Feature: remote registry related scenarios
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Support unauthenticated with registry-admin role
     Given I have a project
     Given I find a bearer token of the default service account

--- a/features/rest/webhook.feature
+++ b/features/rest/webhook.feature
@@ -50,6 +50,7 @@ Feature: Webhook REST Related Tests
     @singlenode
     @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | type    | negative1 | negative2   | negative3 | path              | file              | header1        | header2 |
       | generic | GitHub    | ImageChange | github    | generic/testdata/ | push-generic.json |                |         | # @case_id OCP-11693

--- a/features/routing/abrouting.feature
+++ b/features/routing/abrouting.feature
@@ -279,6 +279,7 @@ Feature: Testing abrouting
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Each endpoint gets weight/numberOfEndpoints portion of the requests - unsecure route
     Given I switch to cluster admin pseudo user
     And I use the router project
@@ -366,6 +367,7 @@ Feature: Testing abrouting
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Each endpoint gets weight/numberOfEndpoints portion of the requests - passthrough route
     Given I switch to cluster admin pseudo user
     And I use the router project

--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -9,6 +9,7 @@ Feature: Testing haproxy router
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: haproxy cookies based sticky session for unsecure routes
     #create route and service which has two endpoints
     Given I have a project
@@ -71,6 +72,7 @@ Feature: Testing haproxy router
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: haproxy cookies based sticky session for edge termination routes
     #create route and service which has two endpoints
     Given I have a project
@@ -138,6 +140,7 @@ Feature: Testing haproxy router
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Limit the number of TCP connection per IP in specified time period
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -192,6 +195,7 @@ Feature: Testing haproxy router
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The backend health check interval of unsecure route can be set by annotation
     Given I switch to cluster admin pseudo user
     And I use the router project
@@ -238,6 +242,7 @@ Feature: Testing haproxy router
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The backend health check interval of edge route can be set by annotation
     Given I switch to cluster admin pseudo user
     And I use the router project
@@ -284,6 +289,7 @@ Feature: Testing haproxy router
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set balance leastconn for passthrough routes
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -337,6 +343,7 @@ Feature: Testing haproxy router
   @singlenode
   @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Disable haproxy hash based sticky session for unsecure routes
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -385,6 +392,7 @@ Feature: Testing haproxy router
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: can set cookie name for unsecure routes by annotation
     #create route and service which has two endpoints
     Given the master version >= "3.7"
@@ -435,6 +443,7 @@ Feature: Testing haproxy router
   @singlenode
   @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: can set cookie name for edge routes by annotation
     #create route and service which has two endpoints
     Given the master version >= "3.7"

--- a/features/routing/operator.feature
+++ b/features/routing/operator.feature
@@ -10,6 +10,7 @@ Feature: Testing Ingress Operator related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: set namespaceOwnership of routeAdmission to InterNamespaceAllowed
     Given the master version >= "4.4"
     And I have a project

--- a/features/routing/rate-limit.feature
+++ b/features/routing/rate-limit.feature
@@ -10,6 +10,7 @@ Feature: Testing haproxy rate limit related features
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: limits backend pod max concurrent connections for unsecure, edge, reen route
     Given I switch to cluster admin pseudo user
     And I use the router project

--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -10,6 +10,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Alias will be invalid after removing it
     Given I have a project
     Given I obtain test data file "routing/header-test/dc.json"
@@ -43,6 +44,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Service endpoint can be work well if the mapping pod ip is updated
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
@@ -95,6 +97,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The later route should be HostAlreadyClaimed when there is a same host exist
     Given I have a project
     Given I obtain test data file "routing/unsecure/route_unsecure.json"
@@ -124,6 +127,7 @@ Feature: Testing route
   @singlenode
   @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The path specified in route can work well for edge terminated
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -206,6 +210,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The path specified in route can work well for reencrypt terminated
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -253,6 +258,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Config insecureEdgeTerminationPolicy to Redirect for route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -304,6 +310,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Config insecureEdgeTerminationPolicy to Allow for route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -374,6 +381,7 @@ Feature: Testing route
   @singlenode
   @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Route could NOT be updated after created
     Given I have a project
     Given I obtain test data file "routing/route_withouthost1.json"
@@ -396,6 +404,7 @@ Feature: Testing route
   @singlenode
   @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set insecureEdgeTerminationPolicy to Redirect for passthrough route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -451,6 +460,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set insecureEdgeTerminationPolicy to Redirect and Allow for reencrypt route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -517,6 +527,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The hostname should be converted to available route when met special character
     Given I have a project
     Given I obtain test data file "routing/service_unsecure.yaml"
@@ -562,6 +573,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check the cookie if using secure mode when insecureEdgeTerminationPolicy to Redirect for edge/reencrypt route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -649,6 +661,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @amd64
   Scenario: Use the default destination CA of router if the route does not specify one for reencrypt route
     # since console route is using the reencrypt route without destination CA so we use it to check
     Given I switch to cluster admin pseudo user
@@ -673,6 +686,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Only the host in whitelist could access the route - unsecure route
     Given I have a project
     And I have a header test service in the project
@@ -714,6 +728,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The edge route should support HSTS
     Given the master version >= "3.7"
     And I have a project
@@ -777,6 +792,7 @@ Feature: Testing route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: The reencrypt route should support HSTS
     Given the master version >= "3.7"
     And I have a project

--- a/features/routing/timeout.feature
+++ b/features/routing/timeout.feature
@@ -9,6 +9,7 @@ Feature: Testing timeout route
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Set timeout server for passthough route
     Given I have a project
     Given I obtain test data file "routing/routetimeout/httpbin-pod-2.json"

--- a/features/routing/websocket.feature
+++ b/features/routing/websocket.feature
@@ -9,6 +9,7 @@ Feature: Testing websocket features
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: haproxy router support websocket via unsecure route
     Given I have a project
     Given I obtain test data file "routing/websocket/pod.json"

--- a/features/storage/NoDiskConflict.feature
+++ b/features/storage/NoDiskConflict.feature
@@ -6,6 +6,7 @@ Feature: NoDiskConflict
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: [storage_201] Only one pod with the same persistent volume can be scheduled when NoDiskConflicts policy is enabled
     Given a 5 characters random string of type :dns is stored into the :proj_name clipboard
     When I run the :oadm_new_project admin command with:

--- a/features/storage/cinder.feature
+++ b/features/storage/cinder.feature
@@ -6,6 +6,7 @@ Feature: Cinder Persistent Volume
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Persistent Volume with cinder volume plugin
     Given I have a project
     And I have a 1 GB volume and save volume id in the :vid clipboard

--- a/features/storage/cloud_provider.feature
+++ b/features/storage/cloud_provider.feature
@@ -52,6 +52,7 @@ Feature: kubelet restart and node restart
     @upgrade-sanity
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | platform       |
       | vsphere-volume | # @case_id OCP-13631

--- a/features/storage/csi.feature
+++ b/features/storage/csi.feature
@@ -85,6 +85,7 @@ Feature: CSI testing related feature
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | sc_name      |
       | standard-csi | # @case_id OCP-37572
@@ -169,6 +170,7 @@ Feature: CSI testing related feature
     @qeci
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | sc_name      |
       | standard-csi | # @case_id OCP-37562
@@ -224,6 +226,7 @@ Feature: CSI testing related feature
     @qeci
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | sc_name       | fstype |
       | standard-csi  | xfs    | # @case_id OCP-37560
@@ -276,6 +279,7 @@ Feature: CSI testing related feature
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | sc_name      |
       | standard-csi | # @case_id OCP-37511
@@ -328,6 +332,7 @@ Feature: CSI testing related feature
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | sc_name      | type   | size  |
       | standard-csi | pd-ssd | 1Gi   | # @case_id OCP-37478
@@ -382,6 +387,7 @@ Feature: CSI testing related feature
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | provisioner              | sc_name      | deployment_operator                  | deployment_controller                  | daemonset_node                   |
       | pd.csi.storage.gke.io    | standard-csi | gcp-pd-csi-driver-operator           | gcp-pd-csi-driver-controller           | gcp-pd-csi-driver-node           | # @case_id OCP-37474

--- a/features/storage/csi_clone.feature
+++ b/features/storage/csi_clone.feature
@@ -15,6 +15,7 @@ Feature: CSI clone testing related feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Clone a PVC and verify data consistency
     # Step 1
     Given the master version >= "4.7"
@@ -61,6 +62,7 @@ Feature: CSI clone testing related feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [Cinder CSI Clone] Clone a pvc with capacity greater than original pvc
     Given I have a project
     # Create mypvc-ori with 1Gi size
@@ -115,6 +117,7 @@ Feature: CSI clone testing related feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [Cinder CSI Clone] Clone a pvc with capacity less than original pvc will fail
     Given I have a project
     # Create mypvc-ori with 2Gi size
@@ -168,6 +171,7 @@ Feature: CSI clone testing related feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [Cinder CSI clone] Clone a pvc with block VolumeMode successfully
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -226,6 +230,7 @@ Feature: CSI clone testing related feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [Cinder CSI Clone] Clone a pvc with default storageclass
     Given default storage class is patched to non-default
     And admin clones storage class "my-csi-default" from "standard-csi" with:
@@ -284,6 +289,7 @@ Feature: CSI clone testing related feature
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: [Cinder CSI Clone] Clone a pvc with different storage class is failed
     # Create mypvc-ori with sc1
     Given I have a project

--- a/features/storage/csi_resize.feature
+++ b/features/storage/csi_resize.feature
@@ -56,6 +56,7 @@ Feature: CSI Resizing related feature
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | sc_name      |
       | standard-csi | # @case_id OCP-37559
@@ -91,6 +92,7 @@ Feature: CSI Resizing related feature
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | sc_name |
       | gp2-csi | # @case_id OCP-25809

--- a/features/storage/csi_snapshot.feature
+++ b/features/storage/csi_snapshot.feature
@@ -72,6 +72,7 @@ Feature: Volume snapshot test
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | csi-sc       | csi-vsc      |
       | standard-csi | standard-csi |# @case_id OCP-37568
@@ -144,6 +145,7 @@ Feature: Volume snapshot test
     @qeci
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | csi-sc       | csi-vsc      |
       | standard-csi | standard-csi | # @case_id OCP-37569

--- a/features/storage/dynamic_provisioning.feature
+++ b/features/storage/dynamic_provisioning.feature
@@ -80,6 +80,7 @@ Feature: Dynamic provisioning
     @upgrade-sanity
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | cloud_provider |
       | cinder         | # @case_id OCP-9656

--- a/features/storage/fsType.feature
+++ b/features/storage/fsType.feature
@@ -49,6 +49,7 @@ Feature: testing for parameter fsType
     @upgrade-sanity
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | fsType | type   |
       | ext3   | cinder | # @case_id OCP-10097

--- a/features/storage/hostpath.feature
+++ b/features/storage/hostpath.feature
@@ -52,6 +52,7 @@ Feature: Storage of Hostpath plugin testing
     @upgrade-sanity
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | access_mode   | reclaim_policy | pv_status | step_status |
       | ReadWriteOnce | Retain         | released  | succeed     | # @case_id OCP-9639

--- a/features/storage/negative.feature
+++ b/features/storage/negative.feature
@@ -15,6 +15,7 @@ Feature: negative testing
 
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | dir | file               | error                        |
       | gce | pv-retain-rwx.json | error querying GCE PD volume | # @case_id OCP-10310

--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -10,6 +10,7 @@ Feature: NFS Persistent Volume
   @upgrade-sanity
   @singlenode
   @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Share NFS with multiple pods with ReadWriteMany mode
     Given I have a project
     And I have a NFS service in the project
@@ -62,6 +63,7 @@ Feature: NFS Persistent Volume
   @upgrade-sanity
   @singlenode
   @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Permission denied when nfs pv annotaion is not right
     Given I have a project
     And I have a NFS service in the project

--- a/features/storage/node_operations.feature
+++ b/features/storage/node_operations.feature
@@ -61,6 +61,7 @@ Feature: Node operations test scenarios
 
     @upgrade-sanity
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | cloud_provider |
       | aws-ebs        | # @case_id OCP-15283

--- a/features/storage/persistent_volume.feature
+++ b/features/storage/persistent_volume.feature
@@ -40,6 +40,7 @@ Feature: Persistent Volume Claim binding policies
     @upgrade-sanity
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | accessMode1   | accessMode2   | accessMode3   |
       | ReadOnlyMany  | ReadWriteMany | ReadWriteOnce | # @case_id OCP-9702
@@ -100,6 +101,7 @@ Feature: Persistent Volume Claim binding policies
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | access_mode   |
       | ReadOnlyMany  | # @case_id OCP-26880
@@ -140,6 +142,7 @@ Feature: Persistent Volume Claim binding policies
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | pv_access_mode | pvc_access_mode1 | pvc_access_mode2 |
       | ReadOnlyMany   | ReadWriteMany    | ReadWriteOnce    | # @case_id OCP-26882

--- a/features/storage/pre-bind.feature
+++ b/features/storage/pre-bind.feature
@@ -6,6 +6,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Prebound pv is availabe due to requested pvc status is bound
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -32,6 +33,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Prebound pv is availabe due to mismatched accessmode with requested pvc
     Given I have a project
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
@@ -57,6 +59,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Prebound pvc is pending due to requested pv status is bound
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -82,6 +85,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Prebound PVC is pending due to mismatched accessmode with requested PV
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -106,6 +110,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: Prebound PVC is pending due to mismatched volume size with requested PV
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -130,6 +135,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: PV and PVC bound successfully when pvc created prebound to pv
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -157,6 +163,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @singlenode
   @proxy @noproxy @connected
+  @arm64 @amd64
   Scenario: PV and PVC bound successfully when pv created prebound to pvc
     Given I have a project
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
@@ -199,6 +206,7 @@ Feature: Testing for pv and pvc pre-bind feature
     And the "pv-<%= project.name %>" PV status is :available
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | pre-bind-pvc | pre-bind-pv                |
       | nfsc         | nfspv1-<%= project.name %> | # @case_id OCP-10108

--- a/features/storage/quota.feature
+++ b/features/storage/quota.feature
@@ -9,6 +9,7 @@ Feature: ResourceQuata for storage
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Requested storage can not exceed the namespace's storage quota
     Given I have a project
     And I switch to cluster admin pseudo user
@@ -85,6 +86,7 @@ Feature: ResourceQuata for storage
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Setting quota for a StorageClass
     Given I have a project
     Given admin clones storage class "sc-<%= project.name %>" from ":default" with:

--- a/features/storage/reclaim_policy.feature
+++ b/features/storage/reclaim_policy.feature
@@ -55,6 +55,7 @@ Feature: Persistent Volume reclaim policy tests
     @openstack-upi
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | storage_type         | volume_name | path   | file                |
       | cinder               | volumeID    | cinder | pv-rwx-default.json | # @case_id OCP-9944

--- a/features/storage/regression.feature
+++ b/features/storage/regression.feature
@@ -9,6 +9,7 @@ Feature: Regression testing cases
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: RWO volumes are exclusively mounted on different nodes
     Given I have a project
     Given I store the schedulable workers in the :workers clipboard

--- a/features/storage/security.feature
+++ b/features/storage/security.feature
@@ -124,6 +124,7 @@ Feature: storage security check
     @singlenode
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
     Examples:
       | storage_type         | volume_name | type   |
       | cinder               | volumeID    | cinder | # @case_id OCP-9721
@@ -138,6 +139,7 @@ Feature: storage security check
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: secret volume security check
     Given I have a project
     Given I obtain test data file "storage/secret/secret.yaml"

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -48,6 +48,7 @@ Feature: storageClass related feature
     @azure-upi
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | storage-class-name |
       | managed-premium    | # @case_id OCP-13488
@@ -104,6 +105,7 @@ Feature: storageClass related feature
     @upgrade-sanity
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | provisioner | type        | zone          | is-default | size  |
       | aws-ebs     | gp2         | us-east-1d    | false      | 1Gi   | # @case_id OCP-10160
@@ -178,6 +180,7 @@ Feature: storageClass related feature
     @upgrade-sanity
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | provisioner    |
       | vsphere-volume | # @case_id OCP-24259
@@ -244,6 +247,7 @@ Feature: storageClass related feature
     @aws-upi
     @singlenode
     @proxy @noproxy @connected
+    @arm64 @amd64
     Examples:
       | size  |
       | 4Gi   | # @case_id OCP-10158
@@ -282,6 +286,7 @@ Feature: storageClass related feature
     @aws-upi
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | type | size | errorMessage                  |
       | sc1  | 5Gi  | at least 125 GiB              | # @case_id OCP-10164
@@ -295,6 +300,7 @@ Feature: storageClass related feature
   @aws-upi
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: PVC with storage class won't provisioned pv if no storage class or wrong storage class object
     Given I have a project
     # No sc exists
@@ -323,6 +329,7 @@ Feature: storageClass related feature
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: AWS ebs volume is dynamic provisioned with default storageclass
     Given I have a project
     Given I obtain test data file "storage/ebs/pvc-retain.json"

--- a/features/storage/vsphere.feature
+++ b/features/storage/vsphere.feature
@@ -60,6 +60,7 @@ Feature: vSphere test scenarios
     @upgrade-sanity
     @singlenode
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | disk_format      |
       | thin             | # @case_id OCP-13386
@@ -75,6 +76,7 @@ Feature: vSphere test scenarios
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Dynamically provision a vSphere volume with invalid disk format
     Given I have a project
     Given I obtain test data file "storage/vsphere/storageclass.yml"

--- a/features/upgrade/api_auth/upgrade.feature
+++ b/features/upgrade/api_auth/upgrade.feature
@@ -201,6 +201,7 @@ Feature: apiserver and auth related upgrade check
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Check the default SCCs should not be stomped by CVO - prepare
     Given as admin I successfully merge patch resource "scc/anyuid" with:
       | {"users": ["system:serviceaccount:test-scc:test-scc"]} |
@@ -231,6 +232,7 @@ Feature: apiserver and auth related upgrade check
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Check the default SCCs should not be stomped by CVO
     Given the "kube-apiserver" operator version matches the current cluster version
     And the "openshift-apiserver" operator version matches the current cluster version
@@ -266,6 +268,7 @@ Feature: apiserver and auth related upgrade check
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Upgrade action will cause re-generation of certificates for headless services to include the wildcard subjects - prepare
     Given I switch to the first user
     When I run the :new_project client command with:
@@ -303,6 +306,7 @@ Feature: apiserver and auth related upgrade check
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Upgrade action will cause re-generation of certificates for headless services to include the wildcard subjects
     Given the master version >= "4.8"
     Given I switch to cluster admin pseudo user
@@ -333,6 +337,7 @@ Feature: apiserver and auth related upgrade check
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: kube-apiserver and openshift-apiserver should have zero-disruption upgrade - prepare
     # According to our upgrade workflow, we need an upgrade-prepare and upgrade-check for each scenario.
     # But some of them do not need any prepare steps, which lead to errors "can not find scenarios" in the log.
@@ -351,6 +356,7 @@ Feature: apiserver and auth related upgrade check
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: kube-apiserver and openshift-apiserver should have zero-disruption upgrade
     # This case needs keep running oc commands against servers during upgrade, but our framework does not support
     # So using a workaround: run them in a background script during upgrade CI job and check result here

--- a/features/upgrade/build/build-upgrade.feature
+++ b/features/upgrade/build/build-upgrade.feature
@@ -9,6 +9,7 @@ Feature: build related upgrade check
   @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check docker and sti build works well before and after upgrade - prepare
     Given I switch to the first user
     When I run the :new_project client command with:
@@ -35,6 +36,7 @@ Feature: build related upgrade check
   @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check docker and sti build works well before and after upgrade
     Given I switch to the first user
     When I use the "build-upgrade" project

--- a/features/upgrade/cloudcredential/upgrade.feature
+++ b/features/upgrade/cloudcredential/upgrade.feature
@@ -10,6 +10,7 @@ Feature: CloudCredentialOperator components upgrade tests
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Cluster operator cloud-credential should be available after upgrade - prepare
     Given I switch to cluster admin pseudo user
     #Check cloud-credential version
@@ -38,6 +39,7 @@ Feature: CloudCredentialOperator components upgrade tests
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Cluster operator cloud-credential should be available after upgrade
     # Check cloud-credential operator version after upgraded
     Given the "cloud-credential" operator version matches the current cluster version

--- a/features/upgrade/etcd/upgrade.feature
+++ b/features/upgrade/etcd/upgrade.feature
@@ -10,6 +10,7 @@ Feature: basic verification for upgrade testing
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: etcd-operator and cluster works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "admin/subscription.yaml"
@@ -43,6 +44,7 @@ Feature: basic verification for upgrade testing
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: etcd-operator and cluster works well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "openshift-operators" project
@@ -60,6 +62,7 @@ Feature: basic verification for upgrade testing
   @proxy @disconnected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check etcd image have been udpated to target release value after upgrade
     Given I switch to cluster admin pseudo user
     And I use the "openshift-etcd" project

--- a/features/upgrade/jenkins/upgrade.feature
+++ b/features/upgrade/jenkins/upgrade.feature
@@ -12,6 +12,7 @@ Feature: Jenkins feature upgrade test
   @noproxy @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @amd64
   Scenario: Jenkins feature upgrade test - prepare
     Given I switch to the first user
     When I run the :new_project client command with:
@@ -35,6 +36,7 @@ Feature: Jenkins feature upgrade test
   @noproxy @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @amd64
   Scenario: Jenkins feature upgrade test
     Given I switch to the first user
     When I use the "jenkins-upgrade" project

--- a/features/upgrade/logging/upgrade.feature
+++ b/features/upgrade/logging/upgrade.feature
@@ -13,6 +13,7 @@ Feature: Logging upgrading related features
   @noproxy @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @amd64
   Scenario: Cluster logging checking during cluster upgrade - prepare
     Given I switch to the first user
     Given I have "json" log pod in project "logging-upg-prep-1"
@@ -55,6 +56,7 @@ Feature: Logging upgrading related features
   @noproxy @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @amd64
   Scenario: Cluster logging checking during cluster upgrade
     Given I switch to the first user
     Given I create a project with non-leading digit name

--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -38,6 +38,7 @@ Feature: Machine-api components upgrade tests
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
     @network-ovnkubernetes @network-openshiftsdn
+    @arm64 @amd64
   Examples:
     | cluster_operator           |
     | "machine-api"              | # @case_id OCP-22712
@@ -60,6 +61,7 @@ Feature: Machine-api components upgrade tests
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Cloud-controller-manager cluster operator should be available after upgrade
     Given evaluation of `cluster_operator('cloud-controller-manager').condition(type: 'Available')` is stored in the :co_available clipboard
     Then the expression should be true> cb.co_available["status"]=="True"
@@ -82,6 +84,7 @@ Feature: Machine-api components upgrade tests
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: There should be no pending or firing alerts for machine-api operators - prepare
     Given the expression should be true> "True" == "True"
 
@@ -95,6 +98,7 @@ Feature: Machine-api components upgrade tests
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: There should be no pending or firing alerts for machine-api operators
     Given I switch to cluster admin pseudo user
 
@@ -115,6 +119,7 @@ Feature: Machine-api components upgrade tests
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Scale up and scale down a machineSet after upgrade - prepare
     Given the expression should be true> "True" == "True"
 
@@ -128,6 +133,7 @@ Feature: Machine-api components upgrade tests
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Scale up and scale down a machineSet after upgrade
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -234,6 +240,7 @@ Feature: Machine-api components upgrade tests
     @upgrade
     @network-ovnkubernetes @network-openshiftsdn
     @proxy @noproxy @disconnected @connected
+    @arm64 @amd64
     Examples:
       | iaas_type | machineset_name        | value                   |
       | azure     | machineset-clone-41804 | "spotVMOptions": {}     | # @case_id OCP-41804
@@ -246,6 +253,7 @@ Feature: Machine-api components upgrade tests
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Cluster should automatically scale up and scale down with clusterautoscaler deployed - prepare
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -268,6 +276,7 @@ Feature: Machine-api components upgrade tests
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Cluster should automatically scale up and scale down with clusterautoscaler deployed
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -319,6 +328,7 @@ Feature: Machine-api components upgrade tests
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Registering Components delays should not be more than liveliness probe - prepare 
     Given the expression should be true> "True" == "True"
 
@@ -331,6 +341,7 @@ Feature: Machine-api components upgrade tests
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Registering Components delays should not be more than liveliness probe 
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user

--- a/features/upgrade/monitoring/monitoring-upgrade.feature
+++ b/features/upgrade/monitoring/monitoring-upgrade.feature
@@ -10,6 +10,7 @@ Feature: cluster monitoring related upgrade check
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: upgrade cluster monitoring along with OCP - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "monitoring/upgrade/cm-monitoring-retention.yaml"
@@ -28,6 +29,7 @@ Feature: cluster monitoring related upgrade check
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: upgrade cluster monitoring along with OCP
     Given I switch to cluster admin pseudo user
     And I use the "openshift-monitoring" project

--- a/features/upgrade/node/hpa/upgrade.feature
+++ b/features/upgrade/node/hpa/upgrade.feature
@@ -11,6 +11,7 @@ Feature: basic verification for upgrade testing
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Upgrade - Make sure multiple resources work well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I ensure "node-upgrade" project is deleted
@@ -62,6 +63,7 @@ Feature: basic verification for upgrade testing
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Upgrade - Make sure multiple resources work well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "node-upgrade" project

--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -12,6 +12,7 @@ Feature: Node components upgrade tests
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Make sure nodeConfig is not changed after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :label admin command with:
@@ -61,6 +62,7 @@ Feature: Node components upgrade tests
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Make sure nodeConfig is not changed after upgrade
     Given I switch to cluster admin pseudo user
     When I run the :get admin command with:

--- a/features/upgrade/node/scc.feature
+++ b/features/upgrade/node/scc.feature
@@ -11,6 +11,7 @@ Feature: Seccomp part of SCC policy should be kept and working after upgrade
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Seccomp part of SCC policy should be kept and working after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I obtain test data file "node/scc.yaml"
@@ -29,6 +30,7 @@ Feature: Seccomp part of SCC policy should be kept and working after upgrade
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Seccomp part of SCC policy should be kept and working after upgrade
     Given I switch to cluster admin pseudo user
     Given admin checks that the "seccomp" scc exists

--- a/features/upgrade/olm/upgrade.feature
+++ b/features/upgrade/olm/upgrade.feature
@@ -13,6 +13,7 @@ Feature: OLM related scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: upgrade OLM - prepare
     # Check OLM version
     Given the "operator-lifecycle-manager" operator version matches the current cluster version
@@ -41,6 +42,7 @@ Feature: OLM related scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: upgrade OLM
     # Check OLM version after upgraded
     Given the "operator-lifecycle-manager" operator version matches the current cluster version

--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -10,6 +10,7 @@ Feature: Routing and DNS related scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: ensure ingress works well before and after upgrade - prepare
     # Check console route
     Given I switch to cluster admin pseudo user
@@ -31,6 +32,7 @@ Feature: Routing and DNS related scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: ensure ingress works well before and after upgrade
     # Check console route after upgraded
     Given I switch to cluster admin pseudo user
@@ -51,6 +53,7 @@ Feature: Routing and DNS related scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: ensure DNS works well before and after upgrade - prepare
     # Check service name can be resolvede
     Given I switch to cluster admin pseudo user
@@ -75,6 +78,7 @@ Feature: Routing and DNS related scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: ensure DNS works well before and after upgrade
     # Check service name can be resolvede
     Given I switch to cluster admin pseudo user
@@ -97,6 +101,7 @@ Feature: Routing and DNS related scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: upgrade with running router pods on all worker nodes - prepare
     # Get the number of worker nodes and scale up router pods
     Given I switch to cluster admin pseudo user
@@ -126,6 +131,7 @@ Feature: Routing and DNS related scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: upgrade with running router pods on all worker nodes
     Given I switch to cluster admin pseudo user
     And I store the number of linux worker nodes to the :num_workers clipboard
@@ -147,6 +153,7 @@ Feature: Routing and DNS related scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: upgrade with route shards - prepare
     # Ensure cluster operator ingress is in normal status
     Given I switch to cluster admin pseudo user
@@ -221,6 +228,7 @@ Feature: Routing and DNS related scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: upgrade with route shards
     # Ensure cluster operator ingress is in normal status after upgrade
     Given I switch to cluster admin pseudo user

--- a/features/upgrade/samples_operator/upgrade.feature
+++ b/features/upgrade/samples_operator/upgrade.feature
@@ -36,6 +36,7 @@ Feature: image-registry operator upgrade tests
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: samples/openshift-controller-manager/image-registry operators should be in correct status after upgrade
     Given I switch to cluster admin pseudo user
     # Check cluster operator openshift-samples should be in correct status

--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -9,6 +9,7 @@ Feature: Egress compoment upgrade testing
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @upgrade
+  @arm64 @amd64
   Scenario: Check egressfirewall is functional post upgrade - prepare
     Given I switch to cluster admin pseudo user
     And I run the :new_project client command with:
@@ -53,6 +54,7 @@ Feature: Egress compoment upgrade testing
   @noproxy @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check egressfirewall is functional post upgrade
     Given I switch to cluster admin pseudo user
     And I save egress type to the clipboard
@@ -82,6 +84,7 @@ Feature: Egress compoment upgrade testing
   @qeci
   @upgrade
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Check ovn egressip is functional post upgrade - prepare
     Given I switch to cluster admin pseudo user
     And I save ipecho url to the clipboard
@@ -140,6 +143,7 @@ Feature: Egress compoment upgrade testing
   @qeci
   @upgrade
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Check ovn egressip is functional post upgrade
     Given I save ipecho url to the clipboard
     Given I switch to cluster admin pseudo user
@@ -183,6 +187,7 @@ Feature: Egress compoment upgrade testing
   @upgrade
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Check sdn egressip is functional post upgrade - prepare
     Given I save ipecho url to the clipboard
     Given I switch to cluster admin pseudo user
@@ -254,6 +259,7 @@ Feature: Egress compoment upgrade testing
   @upgrade
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Check sdn egressip is functional post upgrade
     Given I run the :get admin command with:
       | resource      | hostsubnet                                  |

--- a/features/upgrade/sdn/ipsec-upgrade.feature
+++ b/features/upgrade/sdn/ipsec-upgrade.feature
@@ -10,6 +10,7 @@ Feature: IPsec upgrade scenarios
   @network-ovnkubernetes @network-networkpolicy @ipsec
   @upgrade
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Confirm node-node and pod-pod packets are ESP enrypted on IPsec clusters post upgrade - prepare
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -77,6 +78,7 @@ Feature: IPsec upgrade scenarios
   @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @upgrade
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Confirm node-node and pod-pod packets are ESP enrypted on IPsec clusters post upgrade
     Given the IPsec is enabled on the cluster
     Given evaluation of `50` is stored in the :protocol clipboard

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -9,6 +9,7 @@ Feature: SDN compoment upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: network operator should be available after upgrade - prepare
   # According to our upgrade workflow, we need an upgrade-prepare and upgrade-check for each scenario.
   # But some of them do not need any prepare steps, which lead to errors "can not find scenarios" in the log.
@@ -25,6 +26,7 @@ Feature: SDN compoment upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @arm64 @amd64
   Scenario: network operator should be available after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "openshift-network-operator" project
@@ -49,6 +51,7 @@ Feature: SDN compoment upgrade testing
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: Check the networkpolicy works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
@@ -92,6 +95,7 @@ Feature: SDN compoment upgrade testing
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: Check the networkpolicy works well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "policy-upgrade" project
@@ -115,6 +119,7 @@ Feature: SDN compoment upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Check the namespace networkpolicy for an application works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
@@ -207,6 +212,7 @@ Feature: SDN compoment upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Check the namespace networkpolicy for an application works well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "policy-upgrade1" project
@@ -282,6 +288,7 @@ Feature: SDN compoment upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
@@ -373,6 +380,7 @@ Feature: SDN compoment upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade
     Given I switch to cluster admin pseudo user
     When I use the "policy-upgrade3" project
@@ -408,6 +416,7 @@ Feature: SDN compoment upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade - prepare
     Given I switch to cluster admin pseudo user
     And I store the workers in the :nodes clipboard
@@ -442,6 +451,7 @@ Feature: SDN compoment upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade
     Given I switch to cluster admin pseudo user
     And I use the "conntrack-upgrade" project

--- a/features/upgrade/sdn/service-upgrade.feature
+++ b/features/upgrade/sdn/service-upgrade.feature
@@ -10,6 +10,7 @@ Feature: service upgrade scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check the idle service works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
@@ -42,6 +43,7 @@ Feature: service upgrade scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check the idle service works well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "idle-upgrade" project
@@ -72,6 +74,7 @@ Feature: service upgrade scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: Check the nodeport service works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
@@ -113,6 +116,7 @@ Feature: service upgrade scenarios
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
+  @arm64 @amd64
   Scenario: Check the nodeport service works well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "nodeport-upgrade" project

--- a/features/upgrade/security_compliance/fips.feature
+++ b/features/upgrade/security_compliance/fips.feature
@@ -12,6 +12,7 @@ Feature: fips enabled verification for upgrade
   @proxy @noproxy @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: FIPS mode checking command works for a cluster with fip mode on - prepare
     Given fips is enabled
 
@@ -60,6 +61,7 @@ Feature: fips enabled verification for upgrade
   @proxy @noproxy @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: FIPS mode checking command works for a cluster with fip mode on
     Given fips is enabled
 

--- a/features/upgrade/storage/upgrade.feature
+++ b/features/upgrade/storage/upgrade.feature
@@ -11,6 +11,7 @@ Feature: Storage upgrade tests
   @disconnected @connected
   @proxy @noproxy @disconnected @connected
   @upgrade
+  @arm64 @amd64
   Scenario: Cluster operator storage should be in correct status and dynamic provisioning should work well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     # Check cluster operator storage should be in correct status
@@ -84,6 +85,7 @@ Feature: Storage upgrade tests
   @singlenode
   @proxy @noproxy @disconnected @connected
   @upgrade
+  @arm64 @amd64
   Scenario: Cluster operator storage should be in correct status and dynamic provisioning should work well after upgrade
     Given I switch to cluster admin pseudo user
     # Check storage operator version after upgraded
@@ -171,6 +173,7 @@ Feature: Storage upgrade tests
   @disconnected @connected
   @proxy @noproxy @disconnected @connected
   @upgrade
+  @arm64 @amd64
   Scenario: Cluster operator storage should be in correct status after upgrade - prepare
     Given I switch to cluster admin pseudo user
     # Check cluster operator storage should be in correct status
@@ -190,6 +193,7 @@ Feature: Storage upgrade tests
   @singlenode
   @proxy @noproxy @disconnected @connected
   @upgrade
+  @arm64 @amd64
   Scenario: Cluster operator storage should be in correct status after upgrade
     Given I switch to cluster admin pseudo user
     # Check storage operator version after upgraded

--- a/features/upgrade/web/console-upgrade.feature
+++ b/features/upgrade/web/console-upgrade.feature
@@ -13,6 +13,7 @@ Feature: web console related upgrade check
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: check console accessibility - prepare
     Given I switch to the first user
     When I run the :new_project client command with:
@@ -64,6 +65,7 @@ Feature: web console related upgrade check
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: check console accessibility
     Given the first user is cluster-admin
     Given I open admin console in a browser

--- a/features/upgrade/workloads/descheduler-upgrade.feature
+++ b/features/upgrade/workloads/descheduler-upgrade.feature
@@ -48,6 +48,7 @@ Feature: Descheduler major upgrade should work fine
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: [upgrade] - upgrade descheduler from 4.x to 4.y
     Given I switch to cluster admin pseudo user
     And I use the "openshift-kube-descheduler-operator" project

--- a/features/upgrade/workloads/oc-upgrade.feature
+++ b/features/upgrade/workloads/oc-upgrade.feature
@@ -74,6 +74,7 @@ Feature: basic verification for upgrade oc client testing
   @proxy @noproxy @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check some container related oc commands still work for ocp45 after upgrade - prepare
     Given the master version >= "4.5"
     Given I switch to the first user
@@ -95,6 +96,7 @@ Feature: basic verification for upgrade oc client testing
   @proxy @noproxy @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: Check some container related oc commands still work for ocp45 after upgrade
     Given I switch to the first user
     When I use the "workloads-upgrade" project

--- a/features/upgrade/workloads/scheduler-upgrade.feature
+++ b/features/upgrade/workloads/scheduler-upgrade.feature
@@ -12,6 +12,7 @@ Feature: scheduler with custom policy upgrade check
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine - prepare
     Given the "kube-scheduler" operator version matches the current cluster version
     Given the expression should be true> cluster_operator('kube-scheduler').condition(type: 'Progressing')['status'] == "False"
@@ -61,6 +62,7 @@ Feature: scheduler with custom policy upgrade check
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
   Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine
     Given the "kube-scheduler" operator version matches the current cluster version
     Given the expression should be true> cluster_operator('kube-scheduler').condition(type: 'Progressing')['status'] == "False"


### PR DESCRIPTION
This is to support [OCPQE-9784](https://issues.redhat.com//browse/OCPQE-9784), which add tags for amd64/arm64

/cc @aleskandro @YuLi517 @jhou1 @wsun1