### PR TITLE
openstack launcher - add a function to map network id to name

### DIFF
--- a/lib/launchers/openstack.rb
+++ b/lib/launchers/openstack.rb
@@ -732,6 +732,14 @@ module BushSlicer
       end
     end
 
+    def network_id_to_name(network_id)
+      network = floating_ip_networks.find { |n| n["id"] == network_id }
+      unless network
+        raise "could not find network for id #{network_id} in current tenant."
+      end
+      return network["name"]
+    end
+
     def allocate_floating_ip(network_name, reuse: true, designator: nil)
       network = floating_ip_networks.find { |n| n["name"] == network_name }
       unless network


### PR DESCRIPTION
This is needed by https://gitlab.cee.redhat.com/aosqe/flexy-templates/-/merge_requests/1149