### PR TITLE
Sync upgrade tags from check to prepare for sample operator

### DIFF
--- a/features/upgrade/samples_operator/upgrade.feature
+++ b/features/upgrade/samples_operator/upgrade.feature
@@ -8,7 +8,10 @@ Feature: image-registry operator upgrade tests
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode
-  @disconnected @connected
+  @proxy @noproxy @disconnected @connected
+  @upgrade
+  @network-ovnkubernetes @network-openshiftsdn
+  @arm64 @amd64
   Scenario: samples/openshift-controller-manager/image-registry operators should be in correct status after upgrade - prepare
     Given I switch to cluster admin pseudo user
     # Check cluster operator openshift-samples should be in correct status


### PR DESCRIPTION
Fixed a bug in the sync-tags script, which previously use `/` for address part in command sed, now replaced with `#`.
Since the scenario line contains multiple `/` which breaks the script, the scenario is missed at previous batch tag sync.

/cc @xiuwang @jhou1 @JianLi-RH @dis016 @pruan-rht 