### PR TITLE
Remove special char from Scenario name and sync tags

### DIFF
--- a/features/upgrade/storage/upgrade.feature
+++ b/features/upgrade/storage/upgrade.feature
@@ -396,8 +396,10 @@ Feature: Storage upgrade tests
   @aws-ipi
   @aws-upi
   @singlenode
-  @connected
-  Scenario: [AWS-EBS-CSI] [Snapshot operator] should work well before and after upgrade of a cluster - prepare
+  @proxy @noproxy @disconnected @connected
+  @upgrade
+  @network-ovnkubernetes @network-openshiftsdn
+  Scenario: AWS-EBS-CSI Snapshot operator should work well before and after upgrade of a cluster - prepare
     Given I switch to cluster admin pseudo user
     Given the master version >= "4.7"
 
@@ -496,7 +498,7 @@ Feature: Storage upgrade tests
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: [AWS-EBS-CSI] [Snapshot operator] should work well before and after upgrade of a cluster
+  Scenario: AWS-EBS-CSI Snapshot operator should work well before and after upgrade of a cluster
     Given I switch to cluster admin pseudo user
     Given the master version >= "4.7"
 

--- a/features/upgrade/workloads/descheduler-upgrade.feature
+++ b/features/upgrade/workloads/descheduler-upgrade.feature
@@ -8,7 +8,11 @@ Feature: Descheduler major upgrade should work fine
   @4.11 @4.10 @4.9 @4.8 @4.7
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
-  Scenario: [upgrade] - upgrade descheduler from 4.x to 4.y - prepare
+  @upgrade
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy @disconnected @connected
+  @arm64 @amd64
+  Scenario: upgrade - upgrade descheduler from 4.x to 4.y - prepare
     Given I switch to cluster admin pseudo user
     Given I store master major version in the clipboard
     Given kubedescheduler operator has been installed successfully
@@ -49,7 +53,7 @@ Feature: Descheduler major upgrade should work fine
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @arm64 @amd64
-  Scenario: [upgrade] - upgrade descheduler from 4.x to 4.y
+  Scenario: upgrade - upgrade descheduler from 4.x to 4.y
     Given I switch to cluster admin pseudo user
     And I use the "openshift-kube-descheduler-operator" project
     Given I store master major version in the clipboard


### PR DESCRIPTION
The `[]` are special character in regexp, remove them from the scenario name so that  several tools rely on regexp works.

Will sync the scenario name change back to Polarion after PR merge.

/cc @ropatil010 @duanwei33 @kasturinarra @jhou1 @JianLi-RH @dis016 @pruan-rht 