### PR TITLE
Hot fix for outdated apiVersion in test files for scc-review cases OCP-9552, OCP-9553

### DIFF
--- a/features/cli/policy.feature
+++ b/features/cli/policy.feature
@@ -463,31 +463,16 @@ Feature: change the policy of user/service account
     Then the step should succeed
     And the output should not match:
       | .*default.*restricted |
-    Given I obtain test data file "authorization/scc/PodSecurityPolicyReview.json"
+    # Test explicit serviceaccount
     Given I run the :policy_scc_review client command with:
-      | f | PodSecurityPolicyReview.json |
-      | n | <%= project.name %>                                                                            |
-    Then the step should succeed
-    And the output should not match:
-      | .*default.*restricted |
-    Given I obtain test data file "authorization/scc/PodSecurityPolicyReview.json"
-    Given I run the :policy_scc_review client command with:
-      | serviceaccount | default                                                                                        |
+      | serviceaccount | default                      |
       | f              | PodSecurityPolicyReview.json |
-    Then the step should succeed
-    And the output should not match:
-      | .*default.*restricted |
-    Given I obtain test data file "authorization/scc/PodSecurityPolicyReview.json"
-    Given I run the :policy_scc_review client command with:
-      | serviceaccount | default                                                                                        |
-      | f              | PodSecurityPolicyReview.json |
-      | n              | <%= project.name %>                                                                            |
+      | n              | <%= project.name %>          |
     Then the step should succeed
     And the output should not match:
       | .*default.*restricted |
     Given SCC "restricted" is added to the "default" service account
-    Given I obtain test data file "authorization/scc/PodSecurityPolicyReview.json"
-    And I wait for the steps to pass:
+    Then I wait for the steps to pass:
     """
     Given I run the :policy_scc_review client command with:
       | f | PodSecurityPolicyReview.json |
@@ -495,31 +480,12 @@ Feature: change the policy of user/service account
     And the output should match:
       | .*default.*restricted |
     """
-    Given I obtain test data file "authorization/scc/PodSecurityPolicyReview.json"
-    And I wait for the steps to pass:
-    """
+
+    # Test explicit serviceaccount
     Given I run the :policy_scc_review client command with:
-      | f | PodSecurityPolicyReview.json |
-      | n | <%= project.name %>                                                                            |
-    Then the step should succeed
-    And the output should match:
-      | .*default.*restricted |
-    """
-    Given I obtain test data file "authorization/scc/PodSecurityPolicyReview.json"
-    And I wait for the steps to pass:
-    """
-    Given I run the :policy_scc_review client command with:
-      | serviceaccount | default                                                                                        |
+      | serviceaccount | default                      |
       | f              | PodSecurityPolicyReview.json |
-    Then the step should succeed
-    And the output should match:
-      | .*default.*restricted |
-    """
-    Given I obtain test data file "authorization/scc/PodSecurityPolicyReview.json"
-    Given I run the :policy_scc_review client command with:
-      | serviceaccount | default                                                                                        |
-      | f              | PodSecurityPolicyReview.json |
-      | n              | <%= project.name %>                                                                            |
+      | n              | <%= project.name %>          |
     Then the step should succeed
     And the output should match:
       | .*default.*restricted |
@@ -535,34 +501,19 @@ Feature: change the policy of user/service account
   Scenario: User can know whether the PodSpec he's describing will actually be allowed by the current SCC rules via CLI
     Given I have a project
     Given I obtain test data file "authorization/scc/PodSecurityPolicySubjectReview.json"
+    # If user is specified but not groups, it is interpreted as "what if the user
+    # is not a member of any groups", see "oc policy scc-subject-review -h"
     Given I run the :policy_scc_subject_review client command with:
-      | user | <%= user.name %>                                                                                      |
+      | user | <%= user.name %>                    |
       | f    | PodSecurityPolicySubjectReview.json |
     Then the step should succeed
     And the output should not match:
       | .*restricted |
-    Given I obtain test data file "authorization/scc/PodSecurityPolicySubjectReview.json"
     Given I run the :policy_scc_subject_review client command with:
-      | user | <%= user.name %>                                                                                      |
-      | f    | PodSecurityPolicySubjectReview.json |
-      | n    | <%= project.name %>                                                                                   |
-    Then the step should succeed
-    And the output should not match:
-      | .*restricted |
-    Given I obtain test data file "authorization/scc/PodSecurityPolicySubjectReview.json"
-    Given I run the :policy_scc_subject_review client command with:
-      | user  | <%= user.name %>                                                                                      |
-      | group | system:authenticated                                                                                  |
+      | user  | <%= user.name %>                    |
+      | group | system:authenticated                |
       | f     | PodSecurityPolicySubjectReview.json |
-    Then the step should succeed
-    And the output should match:
-      | .*restricted |
-    Given I obtain test data file "authorization/scc/PodSecurityPolicySubjectReview.json"
-    Given I run the :policy_scc_subject_review client command with:
-      | user  | <%= user.name %>                                                                                      |
-      | group | system:authenticated                                                                                  |
-      | f     | PodSecurityPolicySubjectReview.json |
-      | n     | <%= project.name %>                                                                                   |
+      | n     | <%= project.name %>                 |
     Then the step should succeed
     And the output should match:
       | .*restricted |

--- a/testdata/authorization/scc/PodSecurityPolicyReview.json
+++ b/testdata/authorization/scc/PodSecurityPolicyReview.json
@@ -1,6 +1,6 @@
 {
     "kind": "PodSecurityPolicyReview",
-    "apiVersion": "v1",
+    "apiVersion": "security.openshift.io/v1",
     "metadata": {
         "name": "pspsr"
     },

--- a/testdata/authorization/scc/PodSecurityPolicySubjectReview.json
+++ b/testdata/authorization/scc/PodSecurityPolicySubjectReview.json
@@ -1,6 +1,6 @@
 {
     "kind": "PodSecurityPolicySubjectReview",
-    "apiVersion": "v1",
+    "apiVersion": "security.openshift.io/v1",
     "metadata": {
         "name": "pspsr"
     },


### PR DESCRIPTION
Failure to be fixed: see [logs here](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2022/04/21/14%3A07%3A34/User_can_know_which_serviceaccount_and_SA_groups_can_create_the_podspec_against_the_curre_1852026995?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20220425%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20220425T031821Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=0863762dc03d1ce31288e688920dbc81eb99a4c0aeda9d07a5375ce7f5a3f98d):
```
resource mapping not found for name: "" namespace: "" from "PodSecurityPolicyReview.json": no matches for kind "PodSecurityPolicyReview" in version "v1"
```
The failures are same category as https://github.com/openshift/cucushift/pull/9106, to avoid duplicate typing, please read the first comment in https://github.com/openshift/cucushift/pull/9106 to understand background.
Pass log: /job/ocp-common/job/Runner/404192/console
Self review done.
@y4sht @redHatGong, please help review, thx.