### PR TITLE
Fix OCPQE-8117: ServiceUnavailable errors caused by openshift-apiserver not available

### DIFF
--- a/lib/admin_credentials.rb
+++ b/lib/admin_credentials.rb
@@ -61,6 +61,9 @@ module BushSlicer
         # config_str = res[:stdout].gsub(/^(\s*server:)\s.*$/) {
         #   $1 + " " + env.api_endpoint_url
         # }
+        # HACK: save kubeconfig for debug purpose
+        debug_kubeconfig_path = File.join(Host.localhost.workdir, "debug.kubeconfig")
+        File.write(debug_kubeconfig_path, res[:response])
         return accessor_from_kubeconfig(res[:response])
       else
         logger.error(res[:response])
@@ -81,6 +84,9 @@ module BushSlicer
         res = Http.get(url: url, raise_on_error: true)
         config = res[:response]
       end
+      # HACK: save kubeconfig for debug purpose
+      debug_kubeconfig_path = File.join(Host.localhost.workdir, "debug.kubeconfig")
+      File.write(debug_kubeconfig_path, res[:response])
       return accessor_from_kubeconfig(config)
     end
   end


### PR DESCRIPTION
Some resource request related `oc` command errors are caused by openshift-apiserver resourced not available:
```
Error from server (ServiceUnavailable): the server is currently unable to handle the request (get projects.project.openshift.io) 
```
This fix tries to identify all possible executions on resource request and add **debug messages** to help identify the failure.
Issue: https://issues.redhat.com/browse/OCPQE-8117