### PR TITLE
OCPQE-9923: Fix apiVersion

### DIFF
--- a/testdata/build/ruby20rhel7-template-sti.json
+++ b/testdata/build/ruby20rhel7-template-sti.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "metadata": {
     "name": "ruby-helloworld-sample",
     "creationTimestamp": null,


### PR DESCRIPTION
```
        Given I obtain test data file "build/ruby20rhel7-template-sti.json"                                                                                # features/step_definitions/file.rb:1
        And I process and create "ruby20rhel7-template-sti.json"                                                                                           # features/step_definitions/cli.rb:131
      
      STDERR:
      error: failed to read input object (not a Template?): resource mapping not found for name: "ruby-helloworld-sample" namespace: "" from "ruby20rhel7-template-sti.json": no matches for kind "Template" in version "v1"
      ensure CRDs are installed first
```

/cc @jitendar-singh @jhou1 @JianLi-RH @dis016 @pruan-rht 