### PR TITLE
Add support for dualstack cluster for OCP-44315

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1550,29 +1550,25 @@ Given /^the egressfirewall policy is applied to the "(.+?)" namespace$/ do | pro
   ensure_admin_tagged
   network_operator = BushSlicer::NetworkOperator.new(name: "cluster", env: env)
   network_type = network_operator.network_type(user: admin)
+  policy_file = ''
   case network_type
   when "OVNKubernetes"
     step "I save cluster type to the clipboard"
     if cb.cluster_type == "dualstack"
-      @result = admin.cli_exec(:create, n: project_name , f: "#{BushSlicer::HOME}/testdata/networking/ovn-egressfirewall/limit_policy_dualstack.json")
-      unless @result[:success]
-        raise "Failed to apply the egressfirewall policy to specified namespace."
-      end
+      policy_file = "networking/ovn-egressfirewall/limit_policy_dualstack.json"
     elsif cb.cluster_type == "ipv4single"
-      @result = admin.cli_exec(:create, n: project_name , f: "#{BushSlicer::HOME}/testdata/networking/ovn-egressfirewall/limit_policy.json")
-      unless @result[:success]
-        raise "Failed to apply the egressfirewall policy to specified namespace."
-      end
+      policy_file = "networking/ovn-egressfirewall/limit_policy.json"
     else
       skip_this_scenario
     end
   when "OpenShiftSDN"
-    @result = admin.cli_exec(:create, n: project_name , f: "#{BushSlicer::HOME}/testdata/networking/egressnetworkpolicy/limit_policy.json")
-    unless @result[:success]
-      raise "Failed to apply the egressnetworkpolicy to specified namespace."
-    end
+    policy_file = "networking/egressnetworkpolicy/limit_policy.json"
   else
     raise "unknown network_type"
+  end
+  @result = admin.cli_exec(:create, n: project_name , f: "#{BushSlicer::HOME}/testdata/#{policy_file}")
+  unless @result[:success]
+    raise "Failed to apply the egressnetworkpolicy to specified namespace."
   end
   logger.info "The egressfirewall type is applied."
 end

--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -29,11 +29,7 @@ Feature: Egress compoment upgrade testing
     Then the step should succeed
     And the output should contain "redhat.com"
 
-    Given I save egress data file directory to the clipboard
-    Given I obtain test data file "networking/<%= cb.cb_egress_directory %>/limit_policy.json"
-    When I run the :create admin command with:
-      | f | limit_policy.json   |
-      | n | <%= project.name %> |
+    Given the egressfirewall policy is applied to the "egressfw-upgrade1" namespace
     Then the step should succeed
 
     And I wait up to 10 seconds for the steps to pass:
@@ -41,7 +37,6 @@ Feature: Egress compoment upgrade testing
     When I execute on the "<%= cb.pod1 %>" pod:
       | curl | -I | --connect-timeout | 5 | redhat.com |
     Then the step should fail
-    And the output should contain "timed out"
     """
 
   # @author huirwang@redhat.com
@@ -67,13 +62,13 @@ Feature: Egress compoment upgrade testing
     And the output should contain:
       | 0.0.0.0/0 |
     Given I use the "egressfw-upgrade1" project
+
     Given status becomes :running of 1 pod labeled:
       | name=test-pods |
     And evaluation of `pod(0).name` is stored in the :pod1 clipboard
     When I execute on the "<%= cb.pod1 %>" pod:
       | curl | -I | --connect-timeout | 5 | redhat.com |
     Then the step should fail
-    And the output should contain "timed out"
 
   # @author huirwang@redhat.com
   @admin

--- a/testdata/networking/ovn-egressfirewall/limit_policy_dualstack.json
+++ b/testdata/networking/ovn-egressfirewall/limit_policy_dualstack.json
@@ -1,0 +1,23 @@
+{
+  "kind": "EgressFirewall",
+  "apiVersion": "k8s.ovn.org/v1",
+  "metadata": {
+    "name": "default"
+  },
+  "spec": {
+    "egress": [
+      {
+        "type": "Deny",
+        "to": {
+          "cidrSelector": "0.0.0.0/0"
+        }
+      },
+      {
+        "type": "Deny",
+        "to": {
+          "cidrSelector": "::/0"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Resolved  https://issues.redhat.com/browse/OCPQE-9910, add support for dualstack cluster for case OCP-44315.

dualstack cluster log:
PreUpgrade:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4235/console
PostUpgrade:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4236/console
ovn log:
PreUpgrade: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4237/console
PostUpgrade:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4238/console
sdn log:
PreUpgrade: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4239/console
PostUpgrade:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4240/console

/cc @openshift/team-sdn-qe 