### PR TITLE
fix OCPQE-7772

### DIFF
--- a/features/logging/kibana.feature
+++ b/features/logging/kibana.feature
@@ -88,7 +88,7 @@ Feature: Kibana related features
     Given I switch to the first user
     When I login to kibana logging web console
     Then the step should succeed
-    Given I have index pattern "*app"
+    Given I have index pattern "app"
     Then the step should succeed
     Given I wait up to 300 seconds for the steps to pass:
     """
@@ -97,7 +97,7 @@ Feature: Kibana related features
     """
     # check the log count, wait for the Kibana console to be loaded
     When I perform the :kibana_find_index_pattern web action with:
-      | index_pattern_name | *app |
+      | index_pattern_name | app* |
     Then the step should succeed
     Given I wait up to 300 seconds for the steps to pass:
     """
@@ -147,10 +147,9 @@ Feature: Kibana related features
     And I wait for the project "<%= cb.proj.name %>" logs to appear in the ES pod
     When I login to kibana logging web console
     Then the step should succeed
-    Given I have index pattern "*app"
+    Given I have index pattern "app"
     Then the step should succeed
-    Given I have index pattern "*infra"
-    Then the step should succeed
+    And I have index pattern "infra"
     Then the step should succeed
     Given I wait up to 180 seconds for the steps to pass:
     """
@@ -159,7 +158,7 @@ Feature: Kibana related features
     """
 
     When I perform the :kibana_find_index_pattern web action with:
-      | index_pattern_name | *app |
+      | index_pattern_name | app* |
     Then the step should succeed
     Given I wait up to 180 seconds for the steps to pass:
     """
@@ -169,12 +168,12 @@ Feature: Kibana related features
     And I run the :kibana_expand_index_patterns web action
     Then the step should succeed
     When I perform the :kibana_click_index web action with:
-      | index_pattern_name | *infra |
+      | index_pattern_name | infra* |
     Then the step should succeed
     Given I wait up to 180 seconds for the steps to pass:
     """
     When I perform the :kibana_find_index_pattern web action with:
-      | index_pattern_name | *infra |
+      | index_pattern_name | infra* |
     Then the step should succeed
     When I run the :check_log_count web action
     Then the step should succeed
@@ -253,7 +252,7 @@ Feature: Kibana related features
     Then the step should succeed
     Given a pod becomes ready with labels:
       | run=centos-logtest,test=centos-logtest |
-    And evaluation of `pod.name` is stored in the :pod_name clipboard 
+    And evaluation of `pod.name` is stored in the :pod_name clipboard
     Given the first user is cluster-admin
     And I use the "openshift-logging" project
     Given I wait for the "app" index to appear in the ES pod with labels "es-node-master=true"
@@ -269,12 +268,12 @@ Feature: Kibana related features
       | project_name | <%= cb.proj_name %> |
       | pod_name     | <%= cb.pod_name %>  |
     Then the step should succeed
-    
+
     When I click the following "a" element:
       | text  | Show in Kibana   |
       | class | co-external-link |
     Then the step should succeed
-    
+
     # This step is to store the redirecting url of new window, does not check anything
     And I wait up to 15 seconds for the steps to pass:
     """
@@ -291,9 +290,9 @@ Feature: Kibana related features
       | idp        | <%= env.idp %>               |
     Then the step should succeed
 
-    Given I have index pattern "*app"
+    Given I have index pattern "app"
     Then the step should succeed
-    Given I have index pattern "*infra"
+    Given I have index pattern "infra"
     Then the step should succeed
     Given I wait up to 180 seconds for the steps to pass:
     """
@@ -302,7 +301,7 @@ Feature: Kibana related features
     """
 
     When I perform the :kibana_find_index_pattern web action with:
-      | index_pattern_name | *app |
+      | index_pattern_name | app* |
     Then the step should succeed
     Given I wait up to 180 seconds for the steps to pass:
     """
@@ -312,12 +311,12 @@ Feature: Kibana related features
     And I run the :kibana_expand_index_patterns web action
     Then the step should succeed
     When I perform the :kibana_click_index web action with:
-      | index_pattern_name | *infra |
+      | index_pattern_name | infra* |
     Then the step should succeed
     Given I wait up to 180 seconds for the steps to pass:
     """
     When I perform the :kibana_find_index_pattern web action with:
-      | index_pattern_name | *infra |
+      | index_pattern_name | infra* |
     Then the step should succeed
     When I run the :check_log_count web action
     Then the step should succeed

--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -1192,9 +1192,9 @@ Given /^I have index pattern #{QUOTED}$/ do | pattern_name |
     unless @result[:success]
       step %Q/I run the :go_to_kibana_management_page web action/
       step %Q/I perform the :create_index_pattern_in_kibana web action with:/, table(%{
-        | index_pattern_name | "#{pattern_name}" |
-       })
-       raise "Failed to create index pattern #{pattern_name}" unless @result[:success]
+        | index_pattern_name | #{pattern_name} |
+      })
+      raise "Failed to create index pattern #{pattern_name}" unless @result[:success]
     end
 end
 

--- a/features/upgrade/logging/upgrade.feature
+++ b/features/upgrade/logging/upgrade.feature
@@ -30,8 +30,8 @@ Feature: Logging upgrading related features
 
     Given I switch to the first user
     When I login to kibana logging web console
-    Given I have index pattern "*app"
-    Then I can display the pod logs of the "logging-upg-prep-1" project under the "*app" pattern in kibana
+    Given I have index pattern "app"
+    Then I can display the pod logs of the "logging-upg-prep-1" project under the "app*" pattern in kibana
     Then I close the current browser
     Given I run the :policy_add_role_to_group client command with:
       | group_name | project-group-share |
@@ -39,8 +39,8 @@ Feature: Logging upgrading related features
     Then the step should succeed
     Given I switch to the second user
     Given I login to kibana logging web console
-    Given I have index pattern "*app"
-    Then I can display the pod logs of the "logging-upg-prep-share" project under the "*app" pattern in kibana
+    Given I have index pattern "app"
+    Then I can display the pod logs of the "logging-upg-prep-share" project under the "app*" pattern in kibana
     Then I close the current browser
 
   # @case_id OCP-22911
@@ -71,11 +71,11 @@ Feature: Logging upgrading related features
     # check if kibana console is accessible
     Given I switch to the first user
     When I login to kibana logging web console
-    Then I can display the pod logs of the "logging-upg-prep-1" project under the "*app" pattern in kibana
+    Then I can display the pod logs of the "logging-upg-prep-1" project under the "app*" pattern in kibana
     Then I close the current browser
     Given I switch to the second user
     When I login to kibana logging web console
-    Then I can display the pod logs of the "logging-upg-prep-share" project under the "*app" pattern in kibana
+    Then I can display the pod logs of the "logging-upg-prep-share" project under the "app*" pattern in kibana
     Then I close the current browser
 
     # upgrade logging if needed
@@ -92,11 +92,11 @@ Feature: Logging upgrading related features
     # check if kibana console is accessible
     Given I switch to the first user
     When I login to kibana logging web console
-    Then I can display the pod logs of the "logging-upg-prep-1" project under the "*app" pattern in kibana
+    Then I can display the pod logs of the "logging-upg-prep-1" project under the "app*" pattern in kibana
     Then I close the current browser
     Given I switch to the second user
     When I login to kibana logging web console
-    Then I can display the pod logs of the "logging-upg-prep-share" project under the "*app" pattern in kibana
+    Then I can display the pod logs of the "logging-upg-prep-share" project under the "app*" pattern in kibana
     Then I close the current browser
     Given I switch to the first user
     Then the "<%= cb.proj1 %>" project is deleted

--- a/lib/rules/web/admin_console/4.10/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.10/logging_kibana.xyaml
@@ -111,11 +111,17 @@ set_index_patter_name:
   elements:
   - selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: clear
+    op: click
     timeout: 30
-  - selector:
+  scripts:
+  - command: |
+      document.querySelector("input[name='indexPattern']").value = '<index_pattern_name>';
+      return document.querySelector("input[name='indexPattern']").value == '<index_pattern_name>';
+    expect_result: true
+  element:
+    selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: send_keys <index_pattern_name>
+    op: send_keys "*"
 
 click_create_index_pattern_go_to_step2_button:
   element:

--- a/lib/rules/web/admin_console/4.11/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.11/logging_kibana.xyaml
@@ -111,11 +111,17 @@ set_index_patter_name:
   elements:
   - selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: clear
+    op: click
     timeout: 30
-  - selector:
+  scripts:
+  - command: |
+      document.querySelector("input[name='indexPattern']").value = '<index_pattern_name>';
+      return document.querySelector("input[name='indexPattern']").value == '<index_pattern_name>';
+    expect_result: true
+  element:
+    selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: send_keys <index_pattern_name>
+    op: send_keys "*"
 
 click_create_index_pattern_go_to_step2_button:
   element:

--- a/lib/rules/web/admin_console/4.5/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.5/logging_kibana.xyaml
@@ -45,7 +45,7 @@ check_kibana_status:
       xpath: //div[@id="createStatusPageReact"]
     missing: true
     timeout: 30
-  
+
 create_index_pattern_in_kibana:
   action:
     if_element:
@@ -60,7 +60,7 @@ create_index_pattern:
       selector:
         xpath: //a[@data-test-subj="indexPatternLink"]
       timeout: 30
-    ref: click_create_index_pattern_button   
+    ref: click_create_index_pattern_button
   action: set_index_pattern_name
   action: click_create_index_pattern_go_to_step2_button
   action: create_index_pattern_time_field_select
@@ -98,7 +98,7 @@ click_kibana_index_patterns:
     selector:
       xpath: //span[@class="euiSideNavItemButton__label" and contains(., "Index Patterns")]
     timeout: 30
-    op: click 
+    op: click
 
 click_create_index_pattern_button:
   element:
@@ -108,14 +108,20 @@ click_create_index_pattern_button:
     op: click
 
 set_index_patter_name:
-  elements: 
+  elements:
   - selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: clear
+    op: click
     timeout: 30
-  - selector:
+  scripts:
+  - command: |
+      document.querySelector("input[name='indexPattern']").value = '<index_pattern_name>';
+      return document.querySelector("input[name='indexPattern']").value == '<index_pattern_name>';
+    expect_result: true
+  element:
+    selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: send_keys <index_pattern_name>
+    op: send_keys "*"
 
 click_create_index_pattern_go_to_step2_button:
   element:

--- a/lib/rules/web/admin_console/4.6/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.6/logging_kibana.xyaml
@@ -45,7 +45,7 @@ check_kibana_status:
       xpath: //div[@id="createStatusPageReact"]
     missing: true
     timeout: 30
-  
+
 create_index_pattern_in_kibana:
   action:
     if_element:
@@ -60,7 +60,7 @@ create_index_pattern:
       selector:
         xpath: //a[@data-test-subj="indexPatternLink"]
       timeout: 30
-    ref: click_create_index_pattern_button   
+    ref: click_create_index_pattern_button
   action: set_index_patter_name
   action: click_create_index_pattern_go_to_step2_button
   action: create_index_pattern_time_field_select
@@ -111,11 +111,17 @@ set_index_patter_name:
   elements:
   - selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: clear
+    op: click
     timeout: 30
-  - selector:
+  scripts:
+  - command: |
+      document.querySelector("input[name='indexPattern']").value = '<index_pattern_name>';
+      return document.querySelector("input[name='indexPattern']").value == '<index_pattern_name>';
+    expect_result: true
+  element:
+    selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: send_keys <index_pattern_name>
+    op: send_keys "*"
 
 click_create_index_pattern_go_to_step2_button:
   element:

--- a/lib/rules/web/admin_console/4.7/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.7/logging_kibana.xyaml
@@ -111,11 +111,17 @@ set_index_patter_name:
   elements:
   - selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: clear
+    op: click
     timeout: 30
-  - selector:
+  scripts:
+  - command: |
+      document.querySelector("input[name='indexPattern']").value = '<index_pattern_name>';
+      return document.querySelector("input[name='indexPattern']").value == '<index_pattern_name>';
+    expect_result: true
+  element:
+    selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: send_keys <index_pattern_name>
+    op: send_keys "*"
 
 click_create_index_pattern_go_to_step2_button:
   element:

--- a/lib/rules/web/admin_console/4.8/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.8/logging_kibana.xyaml
@@ -111,11 +111,17 @@ set_index_patter_name:
   elements:
   - selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: clear
+    op: click
     timeout: 30
-  - selector:
+  scripts:
+  - command: |
+      document.querySelector("input[name='indexPattern']").value = '<index_pattern_name>';
+      return document.querySelector("input[name='indexPattern']").value == '<index_pattern_name>';
+    expect_result: true
+  element:
+    selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: send_keys <index_pattern_name>
+    op: send_keys "*"
 
 click_create_index_pattern_go_to_step2_button:
   element:

--- a/lib/rules/web/admin_console/4.9/logging_kibana.xyaml
+++ b/lib/rules/web/admin_console/4.9/logging_kibana.xyaml
@@ -111,11 +111,17 @@ set_index_patter_name:
   elements:
   - selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: clear
+    op: click
     timeout: 30
-  - selector:
+  scripts:
+  - command: |
+      document.querySelector("input[name='indexPattern']").value = '<index_pattern_name>';
+      return document.querySelector("input[name='indexPattern']").value == '<index_pattern_name>';
+    expect_result: true
+  element:
+    selector:
       xpath: //input[@type="text" and @name="indexPattern"]
-    op: send_keys <index_pattern_name>
+    op: send_keys "*"
 
 click_create_index_pattern_go_to_step2_button:
   element:


### PR DESCRIPTION
To fix https://issues.redhat.com/browse/OCPQE-7772, do below steps to create an index pattern:
1. running Javascript to set the index pattern name, for example: `app`
2. using `send_keys` to add `*` to the index pattern name, then the index pattern name will be `app*`
The reason why don't use Javascript to set the index pattern to `app*` is: if set index pattern name to `app*`, the button `Next step` is not enabled, then the step will fail. Adding `*` by `send_keys` will enable this button. 