### PR TITLE
Changing the mode type log check behavior for ipsec 

### DIFF
--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -91,10 +91,10 @@ Feature: OVNKubernetes IPsec related networking scenarios
     And the IPsec is enabled on the cluster
     Given I select a random node's host
     And I run commands on the host:
-      | grep -i "IPsec SA established transport mode" /var/log/openvswitch/libreswan.log |
+      | ip x s \| grep -i "mode transport" |
     Then the step should succeed
     #We need to make sure some mode is chosen and supported only for now is transport
-    And the output should contain "IPsec SA established transport mode"
+    And the output should contain "mode transport"
 
   # @author anusaxen@redhat.com
   # @case_id OCP-39216


### PR DESCRIPTION
Probably a bad idea to check libreswan logs which is managed mostly upstream. We can rely on `ip transform state /ip x s` utlity to check ipsec mode 
Logs: https://privatebin.corp.redhat.com/?d68fdddf02f8db32#EyVVWiU7jUfGTWDERXeb3YwVYzZyhhVc1CVZrvTFNT6N

Small fix