### PR TITLE
Mark build api tests as flaky

### DIFF
--- a/features/build/stibuild.feature
+++ b/features/build/stibuild.feature
@@ -144,6 +144,7 @@ Feature: stibuild.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-42159
+  @flaky
   @4.11 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi

--- a/features/images/jenkins.feature
+++ b/features/images/jenkins.feature
@@ -96,6 +96,7 @@ Feature: jenkins.feature
       | jenkins=slave |
     Given the "openshift-jee-sample-1" build completes
 
+    @flaky
     @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
     @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
     @upgrade-sanity


### PR DESCRIPTION
The following cases are marked `@flaky` because nearly 100% of the time they are failing. For proof refer to [this job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci_monitor/job/testcases_analyze/54/console)

/assign @liangxia 