### PR TITLE
removing skipped_nbctl_daemon metric

### DIFF
--- a/features/networking/metrics.feature
+++ b/features/networking/metrics.feature
@@ -119,7 +119,6 @@ Feature: SDN/OVN metrics related networking scenarios
       | ovnkube_master_ready_duration             |
       | ovnkube_master_resource_update_total      |
       | ovnkube_master_sb_e2e_timestamp           |
-      | ovnkube_master_skipped_nbctl_daemon_total |
     
     When I run the :exec admin command with:
       | n                | openshift-monitoring              |


### PR DESCRIPTION
This is causing failure in recent 4.11 runs as this metric was removed from 4.11. As per checking with dev, this one is really not needed to check in prior releases as well due to low customer importance. So removing this from script. Anyways our script intention is to make sure we are able to curl random metrics and prometheus queries are not broken, which is okay,

@openshift/team-sdn-qe 