### PR TITLE
[hotfix] Add --allowerasing and --skip-broken when dnf install

### DIFF
--- a/tools/install_os_deps.sh
+++ b/tools/install_os_deps.sh
@@ -25,7 +25,7 @@ elif [ "$(os_type)" == "rhel7" ] || [ "$(os_type)" == "centos7" ]; then
     file="deps.yum.RHEL7"
     additional_deps=install_rvm_if_ruby_is_outdated
 elif [ "$(os_type)" == "rhel8" ] || [ "$(os_type)" == "centos8" ]; then
-    cmd="dnf install -y --setopt=skip_missing_names_on_install=False"
+    cmd="dnf install -y --setopt=skip_missing_names_on_install=False --allowerasing --skip-broken"
     file="deps.yum.RHEL8"
     additional_deps=install_rvm_if_ruby_is_outdated
 elif [ "$(os_type)" == "Mac OS X" ]; then


### PR DESCRIPTION
Fix the ci/prow/images failure which block auto merge of PRs.
```
Package zlib-1.2.11-18.el8_5.x86_64 is already installed.
Error: 
 Problem: package zlib-devel-1.2.11-17.el8.x86_64 requires zlib(x86-64) = 1.2.11-17.el8, but none of the providers can be installed
  - cannot install both zlib-1.2.11-17.el8.x86_64 and zlib-1.2.11-18.el8_5.x86_64
  - cannot install the best candidate for the job
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

/cc @jhou1 @JianLi-RH @dis016 @pruan-rht 