### PR TITLE
Fix RuntimeError "could not find locations for case IDs"

### DIFF
--- a/features/networking/egress-ip.feature
+++ b/features/networking/egress-ip.feature
@@ -954,7 +954,7 @@ Feature: Egress IP related features
       | Hello OpenShift! |
 
   # @author huirwang@redhat.com
-  # @case_id OCP-46637 
+  # @case_id OCP-46637
   @admin
   @destructive
   @4.10 @4.9

--- a/features/storage/csi_resize.feature
+++ b/features/storage/csi_resize.feature
@@ -177,4 +177,4 @@ Feature: CSI Resizing related feature
 
     Examples:
       | sc_name     |
-      | managed-csi | # @case_id OCP-41452 
+      | managed-csi | # @case_id OCP-41452

--- a/lib/gherkin_parse.rb
+++ b/lib/gherkin_parse.rb
@@ -91,7 +91,7 @@ module BushSlicer
               raise "invalid line following #{id_found} comment: #{line}"
             end
           else
-            id_matcher = line.match(case_id_re(*case_ids))
+            id_matcher = line.rstrip.match(case_id_re(*case_ids))
             if id_matcher
               id_found = id_matcher[2]
               pre_tag = id_matcher[1]


### PR DESCRIPTION
If test case ID suffix with whitespaces, we will get below error when running ` tools/polarshift.rb update-automation`
```
[verification-tests]# tools/polarshift.rb update-automation --no-wait OCP-46637
Traceback (most recent call last):
	8: from tools/polarshift.rb:553:in `<main>'
	7: from tools/polarshift.rb:270:in `run'
	6: from /usr/share/gems/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
	5: from /usr/share/gems/gems/commander-4.6.0/lib/commander/runner.rb:58:in `run!'
	4: from /usr/share/gems/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
	3: from /usr/share/gems/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
	2: from /usr/share/gems/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
	1: from tools/polarshift.rb:64:in `block (2 levels) in run'
/verification-tests/lib/gherkin_parse.rb:118:in `locations_for': could not find locations for case IDs: OCP-46637 (RuntimeError)
```

The PR remove whitespaces from test case IDs, and also fix the logic so that extra whitespaces will not cause RuntimeError

/cc @jhou1 @JianLi-RH @dis016 @pruan-rht 