### PR TITLE
Resolve 10087

### DIFF
--- a/features/upgrade/sdn/externalIP-upgrade.feature
+++ b/features/upgrade/sdn/externalIP-upgrade.feature
@@ -61,14 +61,8 @@ Feature: SDN externalIP compoment upgrade testing
   Scenario: Check the externalIP works well after upgrade
     Given I switch to cluster admin pseudo user
     # Get the external ip from  service
-    When I run the :get client command with:
-      | resource      | service                         |
-      | resource_name | service-unsecure                |
-      | n             | externalip-upgrade              |
-      | o             | jsonpath={.spec.externalIPs[0]} |
-    Then the step should succeed
-    And evaluation of `@result[:response]` is stored in the :hostip clipboard
     When I use the "externalip-upgrade" project
+    And evaluation of `service('service-unsecure').raw_resource(cached: true).dig('spec','externalIPs')[0]` is stored in the :hostip clipboard
     Given a pod becomes ready with labels:
       | name=externalip-pod    |
     And evaluation of `pod(0).name` is stored in the :pod1name clipboard

--- a/features/upgrade/sdn/externalIP-upgrade.feature
+++ b/features/upgrade/sdn/externalIP-upgrade.feature
@@ -60,12 +60,18 @@ Feature: SDN externalIP compoment upgrade testing
   @proxy @noproxy @disconnected @connected
   Scenario: Check the externalIP works well after upgrade
     Given I switch to cluster admin pseudo user
-    Given I store the schedulable nodes in the :nodes clipboard
-    And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :hostip clipboard
+    # Get the external ip from  service
+    When I run the :get client command with:
+      | resource      | service                         |
+      | resource_name | service-unsecure                |
+      | n             | externalip-upgrade              |
+      | o             | jsonpath={.spec.externalIPs[0]} |
+    Then the step should succeed
+    And evaluation of `@result[:response]` is stored in the :hostip clipboard
     When I use the "externalip-upgrade" project
     Given a pod becomes ready with labels:
       | name=externalip-pod    |
-    And evaluation of `pod(1).name` is stored in the :pod1name clipboard
+    And evaluation of `pod(0).name` is stored in the :pod1name clipboard
 
     # Curl externalIP:portnumber should pass
     When I execute on the "<%= cb.pod1name %>" pod:

--- a/features/upgrade/sdn/externalIP-upgrade.feature
+++ b/features/upgrade/sdn/externalIP-upgrade.feature
@@ -62,10 +62,10 @@ Feature: SDN externalIP compoment upgrade testing
     Given I switch to cluster admin pseudo user
     # Get the external ip from  service
     When I use the "externalip-upgrade" project
-    And evaluation of `service('service-unsecure').raw_resource(cached: true).dig('spec','externalIPs')[0]` is stored in the :hostip clipboard
+    And evaluation of `service('service-unsecure').raw_resource.dig('spec','externalIPs')[0]` is stored in the :hostip clipboard
     Given a pod becomes ready with labels:
       | name=externalip-pod    |
-    And evaluation of `pod(0).name` is stored in the :pod1name clipboard
+    And evaluation of `pod.name` is stored in the :pod1name clipboard
 
     # Curl externalIP:portnumber should pass
     When I execute on the "<%= cb.pod1name %>" pod:


### PR DESCRIPTION
Will Resolve ticket https://issues.redhat.com/browse/OCPQE-10087

The case failed after upgrade because it was trying to get the external IP from nodes[0]'s internal IP, however, after upgrades, the nodes[0] might not the same node as before upgrade.
Fixed it by getting externalIP from service directly.

Test log: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4397/console

/cc @openshift/team-sdn-qe  