### PR TITLE
IPv6 improvements for nodeport and hard delay for gw migration

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -786,23 +786,23 @@ Feature: Service related networking scenarios
     Given I use the "<%= cb.masters[1].name %>" node
     #It should work because its external traffic from another node and destination node has a backend pod on it (ETP=local respected)
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.hostip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.hostip %>]:<%= cb.port %>|
     Then the step should succeed
     And the output should contain:
       | Hello OpenShift! |
     #It should NOT work because its external traffic from another node and destination node DOES NOT have a backend pod on it (ETP=local respected)
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.master0_ip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.master0_ip %>]:<%= cb.port %> |
     And the output should contain:
       | Connection refused |
     #It should work like ETP=cluster because its not external traffic, its within the node (ETP=local shouldn't be respected and its like ETP=cluster behaviour) 
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.master1_ip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.master1_ip %>]:<%= cb.port %> |
     And the output should contain:
       | Hello OpenShift! |
     Given I ensure "hello-pod" service is deleted
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.hostip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.hostip %>]:<%= cb.port %> |
     And the output should contain:
       | Connection refused |
 
@@ -834,17 +834,17 @@ Feature: Service related networking scenarios
 
     Given I use the "<%= cb.masters[1].name %>" node
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.hostip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.hostip %>]:<%= cb.port %> |
     Then the step should succeed
     And the output should contain:
       | Hello OpenShift! |
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.master0_ip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.master0_ip %>]:<%= cb.port %> |
     Then the step should succeed 
     And the output should contain:
       | Hello OpenShift! |
     Given I ensure "hello-pod" service is deleted
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.hostip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.hostip %>]:<%= cb.port %> |
     And the output should contain:
       | Connection refused |      

--- a/features/networking/sgw-lgw-migration.feature
+++ b/features/networking/sgw-lgw-migration.feature
@@ -18,6 +18,7 @@ Feature: SGW<->LGW migration related scenarios
     #OCP-47087 - [bug_1903408]Other node cannot be accessed for nodePort when externalTrafficPolicy is Local	
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard
+    And the Internal IP of node "<%= cb.masters[1].name %>" is stored in the :master1_ip clipboard
     And evaluation of `rand(30000..32767)` is stored in the :port clipboard
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -97,6 +98,11 @@ Feature: SGW<->LGW migration related scenarios
       | curl --connect-timeout 5 <%= cb.master0_ip %>:<%= cb.port %> |
     Then the step should fail
     And the output should not contain:
+      | Hello OpenShift! |
+    When I run commands on the host:
+      | curl --connect-timeout 5 <%= cb.master1_ip %>:<%= cb.port %> |
+    Then the step should succeed
+    And the output should contain:
       | Hello OpenShift! |
     Given I use the "<%= cb.proj1 %>" project
     Given I ensure "hello-pod" service is deleted

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1480,9 +1480,9 @@ Given /^I switch the ovn gateway mode on this cluster$/ do
     @result = admin.cli_exec(:patch, resource: "network.operator", resource_name: "cluster", p: "{\"spec\":{\"defaultNetwork\":{\"ovnKubernetesConfig\":{\"gatewayConfig\":{\"routingViaHost\": true}}}}}", type: "merge")
   end
   raise "Failed to patch network operator for gateway mode" unless @result[:success]
-  # Sometimes CNO starts rolling out changes after few seconds have passed (gap). During that gap, if we check rollout status it would always be a pass from previous rollout result.Its not a bug.
-  # Keeping a 30 seconds harcoded time before we make following instruction (oc rollout status) worthy
-  step "30 seconds have passed"
+  logger.info "Waiting upto 30 sec for network operator to change status to Progressing as a result of patch"
+  @result = admin.cli_exec(:wait, resource: "co", resource_name: "network", for: "condition=PROGRESSING=True", timeout: "30s")
+  raise "Patch was successful but CNO didn't change status to Progressing" unless @result[:success]
   @result = admin.cli_exec(:rollout_status, resource: "daemonset", name: "ovnkube-master", n: "openshift-ovn-kubernetes")
   raise "Failed to rollout masters" unless @result[:success]
 end

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -997,25 +997,25 @@ Given /^the Internal IP(v6)? of node "([^"]*)" is stored in the#{OPT_SYM} clipbo
   case network_type
   when "OVNKubernetes"
     if v6
-       step %Q/I run command on the node's ovnkube pod:/, table("| ip | -6 | route | show | default |")
+      step %Q/I run command on the node's ovnkube pod:/, table("| ip | -6 | route | show | default |")
     else
-       inf_address = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.status.addresses[0].address}")
+      inf_address = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.status.addresses[0].address}")
     end
   when "OpenShiftSDN"
-       inf_address = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.status.addresses[0].address}")
+    inf_address = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.status.addresses[0].address}")
   else
     logger.info "unknown networkType"
     skip_this_scenario
   end
   # OVN uses `br-ex` and `-` is not a word char, so we have to split on whitespace
-    if v6
-       def_inf = @result[:response].split("\n").first.split[4]
-       logger.info "The node's default interface is #{def_inf}"
-       @result = host.exec_admin("ip -6 -brief addr show #{def_inf}")
-       cb[cb_ipaddr]=@result[:response].match(/([a-f0-9:]+:+)+[a-f0-9]+/)[0]
-    else
-       cb[cb_ipaddr]=inf_address[:response]
-    end
+  if v6
+    def_inf = @result[:response].split("\n").first.split[4]
+    logger.info "The node's default interface is #{def_inf}"
+    @result = host.exec_admin("ip -6 -brief addr show #{def_inf}")
+    cb[cb_ipaddr]=@result[:response].match(/([a-f0-9:]+:+)+[a-f0-9]+/)[0]
+  else
+    cb[cb_ipaddr]=inf_address[:response]
+  end
   logger.info "The Internal IP of node is stored in the #{cb_ipaddr} clipboard."
 end
 


### PR DESCRIPTION
- Nodeport cases compatibility with IPv6 single stack (we discussed it on slack last week). This is failing on single stack IPv6

- 30 seconds hard wait added in gateway migration tests (comment added on why)

- A step is added into nodeport scenario to align with https://github.com/openshift/verification-tests/blob/master/features/networking/service.feature#L799. It was added an an improvement post customer bug so keeping aligned in both scenarios

@openshift/team-sdn-qe PTAL