### PR TITLE
OCPQE-10360: [hotfix] Use parallel_tests with v3.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,6 @@ gem 'oga' # replacemen for nokogiri when we thought we can workaround it
 # gem 'mongoid'
 # gem 'text-table'
 # gem 'terminal-table'
-gem 'parallel_tests'
+gem 'parallel_tests', '~>3.8.1'
 gem 'slack-ruby-client'
 gem 'ovirt-engine-sdk'


### PR DESCRIPTION
parallel_tests/cucumber upgrade from 3.8.1 to 3.10.0 earlier this week, which break parallel testing of cucushift in Prow CI.
```
$ podman images | grep -E '87042656c28d|1df7752c33ba|08eb6b18522c'
registry.ci.openshift.org/ci/verification-tests          latest      08eb6b18522c  29 hours ago  2.2 GB
<none>                                                   <none>      1df7752c33ba  9 days ago    2.18 GB
<none>                                                   <none>      87042656c28d  3 weeks ago   2.12 GB
#####################################################################################################
$ podman run -it --rm 87042656c28d bash
[root@b4c323c5d657 /]# gem list | grep parallel
parallel (1.22.1)
parallel_tests (3.8.1)
[root@b4c323c5d657 /]# parallel_cucumber -n 2 --verbose-process-command --first-is-1 --type cucumber --serialize-stdout --combine-stderr --prefix-output-with-test-env-number --exec 'export WORKSPACE=/tmp/dir${TEST_ENV_NUMBER}; echo $WORKSPACE'

export WORKSPACE=/tmp/dir${TEST_ENV_NUMBER}; echo $WORKSPACE 2>&1
/tmp/dir1

export WORKSPACE=/tmp/dir${TEST_ENV_NUMBER}; echo $WORKSPACE 2>&1
/tmp/dir2
#####################################################################################################
$ podman run -it --rm 1df7752c33ba bash
[root@d5ca829ea0c3 /]# gem list | grep parallel
parallel (1.22.1)
parallel_tests (3.8.1)
#####################################################################################################
$ podman run -it --rm 08eb6b18522c bash
[root@c54fb1da3c2c /]# gem list | grep parallel
parallel (1.22.1)
parallel_tests (3.10.0)
[root@c54fb1da3c2c /]# parallel_cucumber -n 2 --verbose-process-command --first-is-1 --type cucumber --serialize-stdout --combine-stderr --prefix-output-with-test-env-number --exec 'export WORKSPACE=/tmp/dir${TEST_ENV_NUMBER}; echo $WORKSPACE'
Traceback (most recent call last):
	9: from /usr/share/gems/gems/parallel-1.22.1/lib/parallel.rb:222:in `block (4 levels) in in_threads'
	8: from /usr/share/gems/gems/parallel-1.22.1/lib/parallel.rb:377:in `block in work_in_threads'
	7: from /usr/share/gems/gems/parallel-1.22.1/lib/parallel.rb:597:in `with_instrumentation'
	6: from /usr/share/gems/gems/parallel-1.22.1/lib/parallel.rb:378:in `block (2 levels) in work_in_threads'
	5: from /usr/share/gems/gems/parallel-1.22.1/lib/parallel.rb:587:in `call_with_index'
	4: from /usr/share/gems/gems/parallel_tests-3.10.0/lib/parallel_tests/cli.rb:47:in `block (4 levels) in execute_in_parallel'
	3: from /usr/share/gems/gems/parallel_tests-3.10.0/lib/parallel_tests/cli.rb:361:in `block in execute_command_in_parallel'
	2: from /usr/share/gems/gems/parallel_tests-3.10.0/lib/parallel_tests/test/runner.rb:96:in `execute_command'
	1: from /usr/share/gems/gems/parallel_tests-3.10.0/lib/parallel_tests/test/runner.rb:105:in `execute_command_and_capture_output'
/usr/share/gems/gems/parallel_tests-3.10.0/lib/parallel_tests/test/runner.rb:105:in `popen': No such file or directory - export (Errno::ENOENT)
```

/cc @jhou1 @JianLi-RH @dis016 @pruan-rht 