### PR TITLE
try not to raise Exceptions to avoid premature exit of long testrun t…

### DIFF
--- a/lib/launchers/amz.rb
+++ b/lib/launchers/amz.rb
@@ -164,7 +164,7 @@ module BushSlicer
       logger.info("S3 upload file status: #{res}")
       unless res
         # XXX: don't raise exception to avoid premature exit of long test runs
-        puts "Failed to upload file '#{file}' to #{target}'"
+        logger.error("Failed to upload file '#{file}' to #{target}'")
       end
     end
 

--- a/lib/launchers/amz.rb
+++ b/lib/launchers/amz.rb
@@ -163,7 +163,8 @@ module BushSlicer
       res = s3.bucket(bucket).object(target).upload_file(file, content_type: content_type)
       logger.info("S3 upload file status: #{res}")
       unless res
-        raise "Failed to upload file '#{file}' to #{target}'"
+        # XXX: don't raise exception to avoid premature exit of long test runs
+        puts "Failed to upload file '#{file}' to #{target}'"
       end
     end
 

--- a/lib/launchers/amz.rb
+++ b/lib/launchers/amz.rb
@@ -164,7 +164,7 @@ module BushSlicer
       logger.info("S3 upload file status: #{res}")
       unless res
         # XXX: don't raise exception to avoid premature exit of long test runs
-        logger.error("Failed to upload file '#{file}' to #{target}'")
+        logger.error("Failed to upload file '#{file}' to '#{target}'")
       end
     end
 

--- a/lib/polarshift/test_record.rb
+++ b/lib/polarshift/test_record.rb
@@ -173,9 +173,11 @@ module BushSlicer
       def start_scenario_for!(test_case)
         scenario = self.test_case.scenarios.find { |s| s.match! test_case}
         unless scenario
-          raise "logic error: trying to start Cucumber scenario not part of this test record"
+          puts "logic error: trying to start Cucumber scenario not part of this test record\n"
+          puts "Skipping testcase #{test_case}\n"
+        else
+          scenario.start!
         end
-        scenario.start!
       end
 
       # @param test_case [Cucumber::Core::Test::Case, Cucumber::Events::TestRunFinished]

--- a/lib/polarshift/test_record.rb
+++ b/lib/polarshift/test_record.rb
@@ -173,8 +173,8 @@ module BushSlicer
       def start_scenario_for!(test_case)
         scenario = self.test_case.scenarios.find { |s| s.match! test_case}
         unless scenario
-          puts "logic error: trying to start Cucumber scenario not part of this test record\n"
-          puts "Skipping testcase #{test_case}\n"
+          logger.warn "logic error: trying to start Cucumber scenario not part of this test record"
+          logger.warn "Skipping testcase #{test_case}"
         else
           scenario.start!
         end

--- a/lib/polarshift/test_suite.rb
+++ b/lib/polarshift/test_suite.rb
@@ -108,7 +108,8 @@ module BushSlicer
         if self.current_test_record.start_scenario_for! test_case
           return true
         else
-          raise "logic error: starting test case that is not part of current test record"
+          puts "logic error: starting test case that is not part of current test record\n"
+          #raise "logic error: starting test case that is not part of current test record"
         end
       end
 
@@ -122,7 +123,8 @@ module BushSlicer
       # @param test_case [Cucumber::Events::TestRunFinished]
       def test_case_execute_finish!(event, attach:)
         unless current_test_record
-          raise "Bug in test case management - current test record is not set but we finished scenario '#{event.test_case.name}'"
+          puts "Bug in test case management - current test record is not set but we finished scenario '#{event.test_case.name}'"
+          #raise "Bug in test case management - current test record is not set but we finished scenario '#{event.test_case.name}'"
         end
         test_case_expected?(event.test_case)
         current_test_record.finished!(event, attach: attach)
@@ -147,11 +149,13 @@ module BushSlicer
       # @param test_case [Cucumber::Core::Test::Case]
       def test_case_expected?(test_case)
         unless current_test_record
-         raise "logic error: expected to have current test record but we do not"
+          puts "logic error: expected to have current test record but we do not\n"
+          puts "Skipping testcase due to lacking testrecord for #{test_case}\n"
         end
 
         unless current_test_record.in_progress?(test_case)
-          raise "logic error: test case in progress status confusion"
+          puts "logic error: test case in progress status confusion\n"
+          puts "Skipping testcase due to logic error for #{test_case}\n"
         end
       end
 

--- a/lib/polarshift/test_suite.rb
+++ b/lib/polarshift/test_suite.rb
@@ -108,7 +108,7 @@ module BushSlicer
         if self.current_test_record.start_scenario_for! test_case
           return true
         else
-          puts "logic error: starting test case '#{test_case} that is not part of current test record\n"
+          puts "logic error: starting test case '#{test_case}' that is not part of current test record\n"
           #raise "logic error: starting test case that is not part of current test record"
         end
       end

--- a/lib/polarshift/test_suite.rb
+++ b/lib/polarshift/test_suite.rb
@@ -108,7 +108,7 @@ module BushSlicer
         if self.current_test_record.start_scenario_for! test_case
           return true
         else
-          puts "logic error: starting test case that is not part of current test record\n"
+          puts "logic error: starting test case '#{test_case} that is not part of current test record\n"
           #raise "logic error: starting test case that is not part of current test record"
         end
       end


### PR DESCRIPTION
…o allow tests to continue instead of exiting

Tried with two separate run 20220524-1826 & 20220524-2345 and get the same number of waiting cases w/o seeing premature exit.  We can either wait for more sample runs or merge as is.