### PR TITLE
Fix string validation and image location (docker->quay)

### DIFF
--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -47,7 +47,7 @@ Feature: Machine misc features testing
 
    Then I get project events
    And the output should match:
-     | Failed to provision volume with StorageClass "thin": ServerFaultCode: Cannot complete login |
+     | Failed to provision volume with StorageClass "thin": Credentials not found|
 
    Then I run the :replace admin command with:
       | _tool | oc                           |

--- a/testdata/cloud/misc/nginx-pod.yaml
+++ b/testdata/cloud/misc/nginx-pod.yaml
@@ -8,7 +8,7 @@ spec:
   containers:
     -
       name: "myfrontend"
-      image: "nginx"
+      image: "quay.io/openshifttest/nginx-alpine@sha256:f266733786efb10c4353d4b44ada6f22434e983d22f0975d20803f1817d38f56"
       ports:
         -
           containerPort: 80


### PR DESCRIPTION
@jhou1 @sunzhaohua2 @huali9 PTAL . 
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/444887/console

Raised this to fix -- https://issues.redhat.com/browse/OCPQE-7384 , we found it many times.
 