### PR TITLE
IPv6 coverage for couple of more node related cases

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -445,13 +445,13 @@ Feature: Pod related networking scenarios
     #Pod should be accesible via node ip and host port from its home node
     Given I use the "<%= cb.workers[0].name %>" node
     And I run commands on the host:
-      | curl <%= cb.worker0_ip %>:9500 |
+      | curl --connect-timeout 5 [<%= cb.worker0_ip %>]:9500 |
     Then the output should contain:
       | Hello OpenShift |
     #Pod should be accesible via node ip and host port from another node as well. Remember worker0 is home node for that pod
     Given I use the "<%= cb.workers[1].name %>" node
     And I run commands on the host:
-      | curl <%= cb.worker0_ip %>:9500 |
+      | curl --connect-timeout 5 [<%= cb.worker0_ip %>]:9500 |
     Then the output should contain:
       | Hello OpenShift |
 

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -591,13 +591,13 @@ Feature: Service related networking scenarios
       | name=hello-pod |
     Given I use the "<%= cb.workers[0].name %>" node
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.worker0_ip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.worker0_ip %>]:<%= cb.port %> |
     Then the step should succeed
     And the output should contain:
       | Hello OpenShift! |
     Given I ensure "hello-pod" service is deleted
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.worker0_ip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.worker0_ip %>]:<%= cb.port %> |
     And the output should contain:
       | Connection refused |      
 

--- a/features/networking/sgw-lgw-migration.feature
+++ b/features/networking/sgw-lgw-migration.feature
@@ -175,18 +175,18 @@ Feature: SGW<->LGW migration related scenarios
     #OCP-47087 - [bug_1903408]Other node cannot be accessed for nodePort when externalTrafficPolicy is Local	
     Given I use the "<%= cb.masters[1].name %>" node
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.hostip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.hostip %>]:<%= cb.port %> |
     Then the step should succeed
     And the output should contain:
       | Hello OpenShift! |
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.master0_ip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.master0_ip %>]:<%= cb.port %> |
     Then the step should fail
     And the output should not contain:
       | Hello OpenShift! |
     Given I ensure "hello-pod" service is deleted
     When I run commands on the host:
-      | curl --connect-timeout 5 <%= cb.hostip %>:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.hostip %>]:<%= cb.port %> |
     Then the step should fail
 
   # @author weliang@redhat.com

--- a/testdata/networking/pod-for-ping-with-hostport.yml
+++ b/testdata/networking/pod-for-ping-with-hostport.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: hello-pod
-    image: quay.io/openshifttest/hello-openshift@sha256:eb47fdebd0f2cc0c130228ca972f15eb2858b425a3df15f10f7bb519f60f0c96
+    image: quay.io/openshifttest/hello-sdn@sha256:2af5b5ec480f05fda7e9b278023ba04724a3dd53a296afcd8c13f220dec52197
     ports:
     - hostPort: 9500
       containerPort: 8080


### PR DESCRIPTION
Noticed pod hosport image doesn't had our right sdn image path linked. Fixed that. That is being used in OCP-25294 which only had versions coverage until 4.4, strange. I manually added later versions to that. And verified it works.

Make couple of more nodeport case IPv6/IPv4 compatible with braces logic.

PTAL @openshift/team-sdn-qe 
Logs: https://privatebin.corp.redhat.com/?d68737f2c8635330#HwK5zX8MNmF1vEWYKjd53qGYjonvsxXECFXaP5rV2cb9