### PR TITLE
Enable support for BareMetal provider (IPI)

### DIFF
--- a/lib/iaas/iaas.rb
+++ b/lib/iaas/iaas.rb
@@ -20,6 +20,8 @@ module BushSlicer
           return {:type => "vsphere", :provider => nil}
         when "None"
           return {:type => "none", :provider => nil}
+        when "BareMetal"
+          return {:type => "none", :provider => nil}
         else
           raise "The IAAS provider #{provider_name} is currently not supported by test framework!"
         end


### PR DESCRIPTION
The BareMetal provider (set when installing through BM IPI) is currently not supported.

This PR set it as for BareMetal UPI installations with `none` as type and no `provider` object. Further changes could be needed after testing is unblocked by this enablement.

Link to a failed case due to the missing provider: http://10.14.89.4:3000/url/generate?key=logs/2022/05/24/23:11:56/OCP-43338_Allow_ETCD_Ciphers_customization