### PR TITLE
Fixes ldapserver related cases

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -161,9 +161,10 @@ Given /^I have LDAP service in my project$/ do
     # So take the second one since this one can be implemented currently
     ###
     stats = {}
-    step %Q/I run the :run client command with:/, table(%{
-      | name  | ldapserver                                       |
-      | image | quay.io/openshifttest/ldap:multiarch |
+    step 'I obtain test data file "pods/ldapserver.yaml"'
+    step %Q/I run the :create admin command with:/, table(%{
+      | f | ldapserver.yaml      |
+      | n | <%= project.name %>  |
       })
     step %Q/the step should succeed/
     step %Q/a pod becomes ready with labels:/, table(%{

--- a/testdata/pods/ldapserver.yaml
+++ b/testdata/pods/ldapserver.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: ldapserver
+  name: ldapserver
+spec:
+  containers:
+    - image: quay.io/openshifttest/ldap:multiarch
+      imagePullPolicy: IfNotPresent
+      name: ldapserver
+      securityContext:
+        allowPrivilegeEscalation: false
+


### PR DESCRIPTION
This PR changes how the ldapserver pod is run, letting an admin user do that. The PR also makes use of a new yaml resource in the testdata folder for future purposes (e.g., if the image can be rebuilt to run in a more restricted context with precise capabilities).

Some of the currently failing test cases run through this branch [here](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/451402/console).