### PR TITLE
fix getting nodes internalIP

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -999,10 +999,10 @@ Given /^the Internal IP(v6)? of node "([^"]*)" is stored in the#{OPT_SYM} clipbo
     if v6
       step %Q/I run command on the node's ovnkube pod:/, table("| ip | -6 | route | show | default |")
     else
-      inf_address = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.status.addresses[0].address}")
+      inf_address = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.status.addresses[?(@.type==\"InternalIP\")].address}")
     end
   when "OpenShiftSDN"
-    inf_address = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.status.addresses[0].address}")
+    inf_address = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.status.addresses[?(@.type==\"InternalIP\")].address}")
   else
     logger.info "unknown networkType"
     skip_this_scenario

--- a/features/upgrade/sdn/externalIP-upgrade.feature
+++ b/features/upgrade/sdn/externalIP-upgrade.feature
@@ -40,7 +40,7 @@ Feature: SDN externalIP compoment upgrade testing
     Then the step should succeed
     Given a pod becomes ready with labels:
       | name=externalip-pod    |
-    And evaluation of `pod(1).name` is stored in the :pod1name clipboard
+    And evaluation of `pod.name` is stored in the :pod1name clipboard
 
     # Curl externalIP:portnumber should pass
     When I execute on the "<%= cb.pod1name %>" pod:


### PR DESCRIPTION
Resovle ticket https://issues.redhat.com/browse/OCPQE-10460 
The issue failed due to PR https://github.com/openshift/verification-tests/pull/2862/files.

In Azure cluster, .status.addresses[0].address is not the IP address, but hostname, that cause the case failing.

```
status:
  addresses:
  - address: huirwang-0531a-r44mf-master-0
    type: Hostname
  - address: 10.0.0.6
    type: InternalIP
```

Secondly as in PR https://github.com/openshift/verification-tests/pull/2862/files changed the way to get the IP address, no need to get sdn pod, so the test pod index here also changed. 
```
-    step %Q/I run command on the node's sdn pod:/, table("| ip | -4 | route | show | default |")
+   inf_address = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.status.addresses[0].address}")
```

Test log:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4435/console

/cc @openshift/team-sdn-qe 