### PR TITLE
 remove ovnkube_master_resource_update_total metircs

### DIFF
--- a/features/networking/metrics.feature
+++ b/features/networking/metrics.feature
@@ -120,7 +120,6 @@ Feature: SDN/OVN metrics related networking scenarios
       | ovnkube_master_nb_e2e_timestamp           |
       | ovnkube_master_pod_creation_latency       |
       | ovnkube_master_ready_duration             |
-      | ovnkube_master_resource_update_total      |
       | ovnkube_master_sb_e2e_timestamp           |
     
     When I run the :exec admin command with:


### PR DESCRIPTION

from logs, no this one.  

https://s3.upshift.redhat.com/cucushift-html-logs/logs/2022/05/30/16%3A43%3A11/Should_be_able_to_monitor_various_ovnkube-master_and_ovnkube-node_metrics_via_prometheus?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20220531%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20220531T075805Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=5acec5bd099907dbb50740765914eb2da2b5dd5d9024f0d700fec6898876769b

and also not found this in document https://docs.google.com/document/d/1BAsjLOpAeSyIq2UcyukPK7PgKCqgAKuHcz3962DtoUo/edit#heading=h.vjtgfgyrg60f

So remove this one. @anuragthehatter please help double confirm. 