### PR TITLE
condition check fix for unmanaged infs on OCP

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -442,11 +442,11 @@ Feature: SDN related networking scenarios
   # And veths ovs interfaces also needs to be unmanaged
   And I run commands on the host:
     | nmcli device \| grep ethernet \| grep -c unmanaged |
-  And evaluation of `@result[:response].split("\n")[0]` is stored in the :no_of_unmanaged_veths clipboard
+  And evaluation of `@result[:response].split("\n")[0]` is stored in the :no_of_unmanaged_infs clipboard
   And I run commands on the host:
     | nmcli \| grep veth \| wc -l |
   And evaluation of `@result[:response].split("\n")[0]` is stored in the :no_of_veths clipboard
-  Then the expression should be true> cb.no_of_unmanaged_veths >=cb.no_of_veths
+  Then the expression should be true> cb.no_of_unmanaged_infs >=cb.no_of_veths
 
   # @author huirwang@redhat.com
   # @case_id OCP-29299

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -446,7 +446,7 @@ Feature: SDN related networking scenarios
   And I run commands on the host:
     | nmcli \| grep veth \| wc -l |
   And evaluation of `@result[:response].split("\n")[0]` is stored in the :no_of_veths clipboard
-  Then the expression should be true> cb.no_of_veths == cb.no_of_unmanaged_veths
+  Then the expression should be true> cb.no_of_unmanaged_veths >=cb.no_of_veths
 
   # @author huirwang@redhat.com
   # @case_id OCP-29299


### PR DESCRIPTION
Seems like this usually fails on platforms having mellanox card as they tend do more unmanaged infs like

```
ens4f0v4: unmanaged "Mellanox MT27800" ethernet (mlx5_core), 8E:A7:7F:D1:D7:2D, hw, mtu 1500 
ens4f0v5: unmanaged "Mellanox MT27800" ethernet (mlx5_core), 46:CD:4A:77:48:CC, hw, mtu 1500 
ens4f0v6: unmanaged "Mellanox MT27800" ethernet (mlx5_core), 0A:1B:D7:23:BF:A4, hw, mtu 1500 
```

We want to make sure veths are unmanaged and 'br-int' `geneve` and `tunnel` too. Changed condition 
to satisfy the test on all platforms

@openshift/team-sdn-qe 