### PR TITLE
fix OCP-33894

### DIFF
--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -258,14 +258,17 @@ Feature: cluster-logging-operator related test
     And evaluation of `File.read("fluent.conf")` is stored in the :fluent_conf clipboard
     And the expression should be true> (cb.fluent_conf).include? "flush_mode interval"
     When I run the :patch client command with:
-      | resource      | clusterlogging                                                              |
-      | resource_name | instance                                                                    |
-      | p             | {"spec": {"forwarder": {"fluentd": {"buffer": {"flushMode":"lazy"}}}}}      |
-      | type          | merge                                                                       |
+      | resource      | clusterlogging                                                         |
+      | resource_name | instance                                                               |
+      | p             | {"spec": {"forwarder": {"fluentd": {"buffer": {"flushMode":"lazy"}}}}} |
+      | type          | merge                                                                  |
     Then the step should succeed
+    Given I wait up to 120 seconds for the steps to pass:
+    """
     When I run the :extract admin command with:
       | resource  | configmap/<%= cb.collector_name %> |
       | confirm   | true                               |
     Then the step should succeed
-    And evaluation of `File.read("fluent.conf")` is stored in the :fluent_conf clipboard
-    Given the expression should be true> (cb.fluent_conf).include? "flush_mode lazy"
+    Given evaluation of `File.read("fluent.conf")` is stored in the :fluent_conf clipboard
+    Then the expression should be true> (cb.fluent_conf).include? "flush_mode lazy"
+    """

--- a/testdata/logging/clusterlogging/cl_fluentd-buffer.yaml
+++ b/testdata/logging/clusterlogging/cl_fluentd-buffer.yaml
@@ -1,27 +1,16 @@
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
-metadata: 
+metadata:
   name: instance
   namespace: openshift-logging
-spec: 
-  collection: 
-    logs: 
-      fluentd:
-        resources: 
-          limits: 
-            cpu: 250m
-            memory: 1Gi
-          requests: 
-            cpu: 250m
-            memory: 1Gi
+spec:
+  collection:
+    logs:
+      fluentd: {}
       type: fluentd
-  curation: 
-    curator: 
-      schedule: "*/10 * * * *"
-    type: curator
-  forwarder: 
-    fluentd: 
-      buffer: 
+  forwarder:
+    fluentd:
+      buffer:
         chunkLimitSize: 1m
         flushAtShutdown: true
         flushInterval: 5s
@@ -32,20 +21,20 @@ spec:
         retryType: exponential_backoff
         retryWait: 1s
         totalLimitSize: 32m
-  logStore: 
-    elasticsearch: 
-      nodeCount: 2
+  logStore:
+    elasticsearch:
+      nodeCount: 1
       redundancyPolicy: ZeroRedundancy
-      resources: 
-        limits: 
-          memory: 2Gi
-        requests: 
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
           cpu: 100m
           memory: 1Gi
       storage: {}
     type: elasticsearch
   managementState: Managed
-  visualization: 
-    kibana: 
+  visualization:
+    kibana:
       replicas: 1
     type: kibana

--- a/testdata/logging/clusterlogging/cl_fluentd-buffer_Invalid.yaml
+++ b/testdata/logging/clusterlogging/cl_fluentd-buffer_Invalid.yaml
@@ -1,27 +1,16 @@
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
-metadata: 
+metadata:
   name: instance
   namespace: openshift-logging
-spec: 
-  collection: 
-    logs: 
-      fluentd:
-        resources: 
-          limits: 
-            cpu: 250m
-            memory: 1Gi
-          requests: 
-            cpu: 250m
-            memory: 1Gi
+spec:
+  collection:
+    logs:
+      fluentd: {}
       type: fluentd
-  curation: 
-    curator: 
-      schedule: "*/10 * * * *"
-    type: curator
-  forwarder: 
-    fluentd: 
-      buffer: 
+  forwarder:
+    fluentd:
+      buffer:
         totalLimitSize: 1
         chunkLimitSize: 1
         flushMode: ""
@@ -32,20 +21,20 @@ spec:
         retryWait: x
         retryMaxInterval: x
         overflowAction: x
-  logStore: 
-    elasticsearch: 
+  logStore:
+    elasticsearch:
       nodeCount: 1
       redundancyPolicy: ZeroRedundancy
-      resources: 
-        limits: 
-          memory: 2Gi
-        requests: 
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
           cpu: 100m
           memory: 1Gi
       storage: {}
     type: elasticsearch
   managementState: Managed
-  visualization: 
-    kibana: 
+  visualization:
+    kibana:
       replicas: 1
     type: kibana

--- a/testdata/logging/clusterlogging/cl_fluentd-buffer_default.yaml
+++ b/testdata/logging/clusterlogging/cl_fluentd-buffer_default.yaml
@@ -1,41 +1,30 @@
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
-metadata: 
+metadata:
   name: instance
   namespace: openshift-logging
-spec: 
-  collection: 
-    logs: 
-      fluentd:
-        resources: 
-          limits: 
-            cpu: 250m
-            memory: 1Gi
-          requests: 
-            cpu: 250m
-            memory: 1Gi
+spec:
+  collection:
+    logs:
+      fluentd: {}
       type: fluentd
-  curation: 
-    curator: 
-      schedule: "*/10 * * * *"
-    type: curator
-  forwarder: 
-    fluentd: 
-      buffer: {} 
-  logStore: 
-    elasticsearch: 
-      nodeCount: 2
+  forwarder:
+    fluentd:
+      buffer: {}
+  logStore:
+    elasticsearch:
+      nodeCount: 1
       redundancyPolicy: ZeroRedundancy
-      resources: 
-        limits: 
-          memory: 2Gi
-        requests: 
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
           cpu: 100m
           memory: 1Gi
       storage: {}
     type: elasticsearch
   managementState: Managed
-  visualization: 
-    kibana: 
+  visualization:
+    kibana:
       replicas: 1
     type: kibana


### PR DESCRIPTION
Fix failure:
```
06-07 13:08:37.768      Given the expression should be true> (cb.fluent_conf).include? "flush_mode lazy"      # features/step_definitions/common.rb:141
06-07 13:08:37.769        [05:08:37] INFO> singular expression detected skipping left & right operand eval() ...
06-07 13:08:37.769        expression returned non-positive status: false (RuntimeError)
06-07 13:08:37.769        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/common.rb:168:in `/^(?:the )?expression should be true> (.+)$/'
06-07 13:08:37.769        features/logging/cluster_logging_operator.feature:271:in `the expression should be true> (cb.fluent_conf).include? "flush_mode lazy"'
```