### PR TITLE
Add a new rule(oc create token) to fix issue in OCPQE-10552

### DIFF
--- a/lib/cli_executor.rb
+++ b/lib/cli_executor.rb
@@ -11,6 +11,7 @@ module BushSlicer
     RULES_DIR = File.expand_path(HOME + "/lib/rules/cli")
     LOGIN_TIMEOUT = 20 # seconds
     CENSOR_LOGS = [
+      'create_token',
       'serviceaccounts_get_token',
       'whoami',
     ]

--- a/lib/local_process.rb
+++ b/lib/local_process.rb
@@ -15,11 +15,10 @@ module BushSlicer
       'oc exec .*--d?creds',  # oc exec -- skopeo copy --dcreds username:****
                               # oc exec -- skopeo inspect --tls-verify=false --creds username:****
       'oc rsh .*bearer',      # oc rsh elasticsearch-* -- curl "Authorization: Bearer ***"
-      'oc login .*--token',   # oc login --token=***
-                              # oc login --token ***
       'oc login .*-p',        # oc login --passwordr= ***
                               # oc login --password ***
                               # oc login -p ***
+      '--token',              # any commands with --token
     ]
 
     attr_reader :pid

--- a/lib/rules/cli/4.5.yaml
+++ b/lib/rules/cli/4.5.yaml
@@ -317,6 +317,10 @@
     :tcp: --tcp=<value>
 :create_serviceaccount:
   :cmd: oc create serviceaccount <serviceaccount_name>
+:create_token:
+  :cmd: oc create token
+  :options:
+    :serviceaccount: <value>
 :create_user:
   :cmd: oc create user <username>
   :options:


### PR DESCRIPTION
Fix issue PR Link: https://github.com/openshift/cucushift/pull/9174
There is a new command in 4.11 version: oc create token, So a new rule needs to be added to help to fix [OCPQE-10552](https://issues.redhat.com/browse/OCPQE-10552)
Self review is done, please help CR, thanks a lot. @xingxingxia @y4sht 
Test Runner:  **/job/ocp-common/job/Runner/460020/console**
Passed Log:
**06-07 19:50:41.870  1 scenario (1 passed)
06-07 19:50:41.870  24 steps (24 passed)
06-07 19:50:41.870  0m28.816s**
