### PR TITLE
Add case ID to scenario name

### DIFF
--- a/features/admin/pod.feature
+++ b/features/admin/pod.feature
@@ -10,7 +10,7 @@ Feature: pod related features
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Endpoints should update in time and no delay
+  Scenario: OCP-15808 Endpoints should update in time and no delay
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
     When I run the :create client command with:
@@ -25,7 +25,7 @@ Feature: pod related features
   @admin
   @destructive
   @inactive
-  Scenario: Existing pods will not be affected when node is unschedulable
+  Scenario: OCP-10598 Existing pods will not be affected when node is unschedulable
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift/origin/master/examples/hello-openshift/hello-pod.json |
@@ -55,7 +55,7 @@ Feature: pod related features
   @admin
   @destructive
   @inactive
-  Scenario: New pods creation will be disabled on unschedulable nodes
+  Scenario: OCP-11116 New pods creation will be disabled on unschedulable nodes
     Given I have a project
     Given I store the schedulable nodes in the :nodes clipboard
     Given node schedulable status should be restored after scenario
@@ -83,7 +83,7 @@ Feature: pod related features
   @admin
   @destructive
   @inactive
-  Scenario: Recovering an unschedulable node
+  Scenario: OCP-11466 Recovering an unschedulable node
     Given I have a project
     Given I run the :patch admin command with:
       | resource | namespace |
@@ -110,7 +110,7 @@ Feature: pod related features
   # @case_id OCP-11752
   @admin
   @inactive
-  Scenario: Pod will not be copied to nodes which does not match it's node selector
+  Scenario: OCP-11752 Pod will not be copied to nodes which does not match it's node selector
     Given I have a project
     Given I run the :patch admin command with:
       | resource | namespace |
@@ -149,7 +149,7 @@ Feature: pod related features
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Pods will still be created by DaemonSet when nodes are SchedulingDisabled
+  Scenario: OCP-11925 Pods will still be created by DaemonSet when nodes are SchedulingDisabled
     Given I have a project
     Given I store the schedulable workers in the :nodes clipboard
     Given node schedulable status should be restored after scenario
@@ -186,7 +186,7 @@ Feature: pod related features
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: When node labels change, DaemonSet will add pods to newly matching nodes and delete pods from not-matching nodes
+  Scenario: OCP-12047 When node labels change, DaemonSet will add pods to newly matching nodes and delete pods from not-matching nodes
     Given I have a project
     Given I run the :patch admin command with:
       | resource | namespace |
@@ -240,7 +240,7 @@ Feature: pod related features
   @admin
   @destructive
   @inactive
-  Scenario: Secret is valid after node reboot
+  Scenario: OCP-12338 Secret is valid after node reboot
     Given I have a project
     Given I run the :patch admin command with:
       | resource | namespace |

--- a/features/admin/project.feature
+++ b/features/admin/project.feature
@@ -11,7 +11,7 @@ Feature: project permissions
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Pod creation should fail when pod's node selector conflicts with project node selector
+  Scenario: OCP-11717 Pod creation should fail when pod's node selector conflicts with project node selector
     Given a 5 characters random string of type :dns is stored into the :proj_name clipboard
     When I run the :oadm_new_project admin command with:
       | project_name  | <%= cb.proj_name %> |
@@ -35,7 +35,7 @@ Feature: project permissions
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: The job and HPA should be deleted when project has been deleted
+  Scenario: OCP-10736 The job and HPA should be deleted when project has been deleted
     Given I have a project
     Given I obtain test data file "hpa/hpa.yaml"
     When I run the :create client command with:

--- a/features/admin/quota.feature
+++ b/features/admin/quota.feature
@@ -55,7 +55,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The quota usage should NOT be incremented if Requests and Limits aren't specified
+  Scenario: OCP-12292 The quota usage should NOT be incremented if Requests and Limits aren't specified
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
     When I run the :create admin command with:
@@ -95,7 +95,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The quota usage should NOT be incremented if Requests > Limits
+  Scenario: OCP-12256 The quota usage should NOT be incremented if Requests > Limits
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
     When I run the :create admin command with:
@@ -139,7 +139,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The quota usage should NOT be incremented if Requests = Limits but exceeding hard quota
+  Scenario: OCP-12206 The quota usage should NOT be incremented if Requests = Limits but exceeding hard quota
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
     When I run the :create admin command with:
@@ -172,7 +172,7 @@ Feature: Quota related scenarios
   # @case_id OCP-11566
   @admin
   @inactive
-  Scenario: The quota status is calculated ASAP when editing its quota spec
+  Scenario: OCP-11566 The quota status is calculated ASAP when editing its quota spec
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
     When I run the :create admin command with:
@@ -236,7 +236,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check BestEffort scope of resourcequota
+  Scenario: OCP-10801 Check BestEffort scope of resourcequota
     Given I have a project
     Given I obtain test data file "quota/quota-besteffort.yaml"
     When I run the :create admin command with:
@@ -297,7 +297,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check NotBestEffort scope of resourcequota
+  Scenario: OCP-11251 Check NotBestEffort scope of resourcequota
     Given I have a project
     Given I obtain test data file "quota/quota-notbesteffort.yaml"
     When I run the :create admin command with:
@@ -378,7 +378,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check NotTerminating scope of resourcequota
+  Scenario: OCP-11568 Check NotTerminating scope of resourcequota
     Given I have a project
     Given I obtain test data file "quota/quota-notterminating.yaml"
     When I run the :create admin command with:
@@ -453,7 +453,7 @@ Feature: Quota related scenarios
   # @case_id OCP-11780
   @admin
   @inactive
-  Scenario: Check Terminating scope of resourcequota
+  Scenario: OCP-11780 Check Terminating scope of resourcequota
     Given I have a project
     Given I obtain test data file "quota/quota-terminating.yaml"
     When I run the :create admin command with:
@@ -544,7 +544,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Could create quota if existing resources exceed to the hard quota but prevent to create further resources
+  Scenario: OCP-10706 Could create quota if existing resources exceed to the hard quota but prevent to create further resources
     Given I have a project
     Given I obtain test data file "quota/quota_template.yaml"
     When I run the :new_app admin command with:
@@ -616,7 +616,7 @@ Feature: Quota related scenarios
   # @case_id OCP-11779
   @admin
   @inactive
-  Scenario: The usage for cpu/mem/pod counts are fixed up ASAP if delete a pod
+  Scenario: OCP-11779 The usage for cpu/mem/pod counts are fixed up ASAP if delete a pod
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
     When I run the :create admin command with:
@@ -680,7 +680,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Quota events for compute resource failures shouldn't be redundant
+  Scenario: OCP-10033 Quota events for compute resource failures shouldn't be redundant
     Given I have a project
     Given I obtain test data file "templates/ocp10033/quota.yaml"
     When I run the :create admin command with:
@@ -707,7 +707,7 @@ Feature: Quota related scenarios
   # @case_id OCP-11247
   @admin
   @inactive
-  Scenario: The current quota usage is calculated ASAP when adding a quota
+  Scenario: OCP-11247 The current quota usage is calculated ASAP when adding a quota
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
     When I run the :create admin command with:
@@ -760,7 +760,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The quota usage should be incremented if Requests = Limits and in the range of hard quota but exceed the real node available resources
+  Scenario: OCP-11927 The quota usage should be incremented if Requests = Limits and in the range of hard quota but exceed the real node available resources
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
     When I run the :create admin command with:
@@ -808,7 +808,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The quota usage should be released when pod completed
+  Scenario: OCP-10945 The quota usage should be released when pod completed
     Given I have a project
     When I run the :create_quota admin command with:
       | name | myquota                    |
@@ -853,7 +853,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Quota with BestEffort and NotBestEffort scope
+  Scenario: OCP-11983 Quota with BestEffort and NotBestEffort scope
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | quota-besteffort     |
@@ -912,7 +912,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Quota with Terminating and NotTerminating scope
+  Scenario: OCP-12086 Quota with Terminating and NotTerminating scope
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | quota-terminating |
@@ -980,7 +980,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Quota combined scopes
+  Scenario: OCP-11348 Quota combined scopes
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | quota-notbesteffortandnotterminating |
@@ -1080,7 +1080,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Quota scope conflict BestEffort and NotBestEffort
+  Scenario: OCP-11636 Quota scope conflict BestEffort and NotBestEffort
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | quota-besteffortnot      |
@@ -1101,7 +1101,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Quota scope conflict Terminating and NotTerminating
+  Scenario: OCP-11827 Quota scope conflict Terminating and NotTerminating
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | quota-terminatingnot       |
@@ -1122,7 +1122,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Negative test for requests.storage of quota
+  Scenario: OCP-11000 Negative test for requests.storage of quota
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | my-quota             |
@@ -1174,7 +1174,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Annotation selector supports special characters
+  Scenario: OCP-10283 Annotation selector supports special characters
     Given I have a project
     Given admin ensures "crq-<%= project.name %>" cluster_resource_quota is deleted after scenario
     When I run the :create_clusterresourcequota admin command with:
@@ -1210,7 +1210,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Quota requests.storage with PVC existing
+  Scenario: OCP-11660 Quota requests.storage with PVC existing
     Given I have a project
     Given I obtain test data file "storage/nfs/claim-rox.json"
     When I run the :create client command with:
@@ -1268,7 +1268,7 @@ Feature: Quota related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Prevent creating further PVC if existing PVC exceeds the quota of requests.storage
+  Scenario: OCP-11389 Prevent creating further PVC if existing PVC exceeds the quota of requests.storage
     Given I have a project
     # Only quota requests.storage < 5Gi
     When I run the :create_quota admin command with:

--- a/features/admin/scc.feature
+++ b/features/admin/scc.feature
@@ -10,7 +10,7 @@ Feature: SCC policy related scenarios
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: deployment hook volume inheritance with hostPath volume
+  Scenario: OCP-11762 deployment hook volume inheritance with hostPath volume
     Given I have a project
     # Create hostdir pod again with new SCC
     Given I obtain test data file "authorization/scc/ocp11762/scc_hostdir.yaml"
@@ -45,7 +45,7 @@ Feature: SCC policy related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create or update scc with illegal capability name should fail with prompt message
+  Scenario: OCP-11775 Create or update scc with illegal capability name should fail with prompt message
     Given I have a project
     Given cluster role "cluster-admin" is added to the "first" user
     Given admin ensures "scc-<%= project.name %>" scc is deleted after scenario

--- a/features/admin/scheduler.feature
+++ b/features/admin/scheduler.feature
@@ -9,7 +9,7 @@ Feature: Scheduler related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: When no scheduler name is supplied, the pod is automatically scheduled using the default-scheduler
+  Scenario: OCP-14582 When no scheduler name is supplied, the pod is automatically scheduled using the default-scheduler
     Given I have a project
     Given I obtain test data file "scheduler/multiple-schedulers/pod-no-scheduler.yaml"
     When I run the :create client command with:

--- a/features/build/buildconfig.feature
+++ b/features/build/buildconfig.feature
@@ -3,7 +3,7 @@ Feature: buildconfig.feature
   # @author wzheng@redhat.com
   # @case_id OCP-12121
   @inactive
-  Scenario: Start build from buildConfig/build
+  Scenario: OCP-12121 Start build from buildConfig/build
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/ruby:latest |
@@ -24,7 +24,7 @@ Feature: buildconfig.feature
 
   # @author haowang@redhat.com
   # @case_id OCP-10667
-  Scenario: Rebuild image when the underlying image changed for Docker build
+  Scenario: OCP-10667 Rebuild image when the underlying image changed for Docker build
     Given I have a project
     When I run the :new_build client command with:
       | D    | FROM quay.io/openshifttest/base-alpine@sha256:0b379877aba876774e0043ea5ba41b0c574825ab910d32b43c05926fab4eea22\nRUN echo "hello" |
@@ -42,7 +42,7 @@ Feature: buildconfig.feature
 
   # @author dyan@redhat.com
   # @case_id OCP-12020
-  Scenario: Trigger chain builds from a image update
+  Scenario: OCP-12020 Trigger chain builds from a image update
     Given I have a project
     When I run the :new_build client command with:
       | app_repo     | registry.redhat.io/rhscl/ruby-27-rhel7:latest~https://github.com/openshift/ruby-hello-world.git |
@@ -105,7 +105,7 @@ Feature: buildconfig.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Using secret to pull a docker image which be used as source input
+  Scenario: OCP-12057 Using secret to pull a docker image which be used as source input
     Given I have a project
     When I run the :create_secret client command with:
      | name        | pull                                                                            |

--- a/features/build/buildlogic.feature
+++ b/features/build/buildlogic.feature
@@ -10,7 +10,7 @@ Feature: buildlogic.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Build with specified Dockerfile via new-build -D
+  Scenario: OCP-11545 Build with specified Dockerfile via new-build -D
     Given I have a project
     When I run the :new_build client command with:
       | D    | FROM quay.io/openshifttest/base-alpine@sha256:0b379877aba876774e0043ea5ba41b0c574825ab910d32b43c05926fab4eea22\nRUN echo "hello" |
@@ -22,7 +22,7 @@ Feature: buildlogic.feature
 
   # @author xiazhao@redhat.com
   # @case_id OCP-11170
-  Scenario: Result image will be tried to push after multi-build
+  Scenario: OCP-11170 Result image will be tried to push after multi-build
     Given I have a project
     Given I obtain test data file "image/language-image-templates/php-55-rhel7-stibuild.json"
     When I run the :new_app client command with:
@@ -47,7 +47,7 @@ Feature: buildlogic.feature
 
   # @author gpei@redhat.com
   # @case_id OCP-11767
-  Scenario: Create build without output
+  Scenario: OCP-11767 Create build without output
     Given I have a project
     When I run the :new_build client command with:
       | app_repo  | openshift/ruby~https://github.com/openshift/ruby-hello-world.git |
@@ -68,7 +68,7 @@ Feature: buildlogic.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create new build config use dockerfile with source repo
+  Scenario: OCP-10799 Create new build config use dockerfile with source repo
     Given I have a project
     When I run the :new_build client command with:
       | app_repo | https://github.com/openshift/ruby-hello-world   |
@@ -130,7 +130,7 @@ Feature: buildlogic.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Build with specified Dockerfile to image with same image name via new-build
+  Scenario: OCP-10745 Build with specified Dockerfile to image with same image name via new-build
     Given I have a project
     When I run the :new_build client command with:
       | D  | FROM quay.io/openshifttest/centos@sha256:285bc3161133ec01d8ca8680cd746eecbfdbc1faa6313bd863151c4b26d7e5a5 |
@@ -173,7 +173,7 @@ Feature: buildlogic.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Build from private git repo with/without ssh key
+  Scenario: OCP-11720 Build from private git repo with/without ssh key
     Given I have a project
     And I have an ssh-git service in the project
     And the "secret" file is created with the following lines:
@@ -224,7 +224,7 @@ Feature: buildlogic.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create new-app from private git repo with ssh key
+  Scenario: OCP-11896 Create new-app from private git repo with ssh key
     Given I have a project
     When I run the :new_app client command with:
       | image_stream   | openshift/perl:latest                            |
@@ -267,7 +267,7 @@ Feature: buildlogic.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check s2i build substatus and times
+  Scenario: OCP-13683 Check s2i build substatus and times
     Given I have a project
     Given I obtain test data file "build/application-template-stibuild.json"
     When I run the :new_app client command with:
@@ -295,7 +295,7 @@ Feature: buildlogic.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check docker build substatus and times
+  Scenario: OCP-13684 Check docker build substatus and times
     Given I have a project
     Given I obtain test data file "build/application-template-dockerbuild.json"
     When I run the :new_app client command with:
@@ -314,7 +314,7 @@ Feature: buildlogic.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-13914
-  Scenario: Prune old builds automaticly
+  Scenario: OCP-13914 Prune old builds automaticly
     #Should prune completed builds based on the successfulBuildsHistoryLimit setting
     Given I have a project
     When I run the :new_build client command with:
@@ -341,7 +341,7 @@ Feature: buildlogic.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-24154
-  Scenario: Should prune canceled builds based on the failedBuildsHistoryLimit setting
+  Scenario: OCP-24154 Should prune canceled builds based on the failedBuildsHistoryLimit setting
     Given I have a project
     When I run the :new_app client command with:
       | template | rails-postgresql-example |
@@ -374,7 +374,7 @@ Feature: buildlogic.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-24155
-  Scenario: Should prune failed builds based on the failedBuildsHistoryLimit setting
+  Scenario: OCP-24155 Should prune failed builds based on the failedBuildsHistoryLimit setting
     Given I have a project
     When I run the :new_app client command with:
       | template | rails-postgresql-example                                         |
@@ -399,7 +399,7 @@ Feature: buildlogic.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-24156
-  Scenario: Should prune errored builds based on the failedBuildsHistoryLimit setting
+  Scenario: OCP-24156 Should prune errored builds based on the failedBuildsHistoryLimit setting
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift/origin/master/test/extended/testdata/builds/build-pruning/errored-build-config.yaml |
@@ -421,7 +421,7 @@ Feature: buildlogic.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-24158
-  Scenario: Should prune builds after a buildConfig change
+  Scenario: OCP-24158 Should prune builds after a buildConfig change
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | ruby                                              |
@@ -466,7 +466,7 @@ Feature: buildlogic.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-24159
-  Scenario: Buildconfigs should have a default history limit set when created via the group api
+  Scenario: OCP-24159 Buildconfigs should have a default history limit set when created via the group api
     Given I have a project
     When I run the :new_build client command with:
       | app_repo | https://github.com/openshift/ruby-hello-world.git |
@@ -490,7 +490,7 @@ Feature: buildlogic.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Pipeline build can be pruned automatically
+  Scenario: OCP-19133 Pipeline build can be pruned automatically
     Given I have a project
     And I have a jenkins v2 application
     When I run the :new_app client command with:
@@ -548,7 +548,7 @@ Feature: buildlogic.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Mirroring built image doesn't degrade scheme2 ,keep consistent SHA's
+  Scenario: OCP-40366 Mirroring built image doesn't degrade scheme2 ,keep consistent SHA's
     Given I have a project
     Given I save a htpasswd registry auth to the :combine_dockercfg clipboard
     And default image registry route is stored in the :integrated_reg_host clipboard

--- a/features/build/dockerbuild.feature
+++ b/features/build/dockerbuild.feature
@@ -1,4 +1,5 @@
 Feature: dockerbuild.feature
+
   # @author wzheng@redhat.com
   # @case_id OCP-12115
   @smoke
@@ -10,7 +11,7 @@ Feature: dockerbuild.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Docker build with both SourceURI and context dir
+  Scenario: OCP-12115 Docker build with both SourceURI and context dir
     Given I have a project
     Given I obtain test data file "build/ruby20rhel7-context-docker.json"
     When I run the :create client command with:
@@ -38,7 +39,7 @@ Feature: dockerbuild.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Docker build with dockerImage with specified tag
+  Scenario: OCP-30854 Docker build with dockerImage with specified tag
     Given I have a project
     When I run the :new_app client command with:
       | docker_image | quay.io/openshifttest/ruby-27:multiarch |
@@ -78,7 +79,7 @@ Feature: dockerbuild.feature
 
   # @author dyan@redhat.com
   # @case_id OCP-13083
-  Scenario: Docker build using Dockerfile with 'FROM scratch'
+  Scenario: OCP-13083 Docker build using Dockerfile with 'FROM scratch'
     Given I have a project
     When I run the :new_build client command with:
       | D  | FROM scratch\nENV NUM 1 |
@@ -103,7 +104,7 @@ Feature: dockerbuild.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Add ARGs in docker build
+  Scenario: OCP-12855 Add ARGs in docker build
     Given I have a project
     When I run the :new_build client command with:
       | code         | http://github.com/openshift/ruby-hello-world.git |
@@ -148,7 +149,7 @@ Feature: dockerbuild.feature
   # @author wzheng@redhat.com
   # @case_id OCP-18501
   @inactive
-  Scenario: Support additional EXPOSE values in new-app
+  Scenario: OCP-18501 Support additional EXPOSE values in new-app
     Given I have a project
     When I run the :new_app client command with:
       | code | https://github.com/openshift-qe/oc_newapp_expose |
@@ -167,7 +168,7 @@ Feature: dockerbuild.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Mount source secret to builder container- dockerstrategy
+  Scenario: OCP-42157 Mount source secret to builder container- dockerstrategy
     Given I have a project
     When I run the :create_secret client command with:
       | secret_type  | generic            |
@@ -209,7 +210,7 @@ Feature: dockerbuild.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Mount source configmap to builder container- dockerstrategy
+  Scenario: OCP-42158 Mount source configmap to builder container- dockerstrategy
     Given I have a project
     When I run the :create_configmap client command with:
       | name         | myconfig  |
@@ -250,7 +251,7 @@ Feature: dockerbuild.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Mount multi paths to builder container
+  Scenario: OCP-42184 Mount multi paths to builder container
     Given I have a project
     When I run the :create_secret client command with:
       | secret_type  | generic            |
@@ -293,7 +294,7 @@ Feature: dockerbuild.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Can't add relative path for mount path
+  Scenario: OCP-42185 Can't add relative path for mount path
     Given I have a project
     When I run the :create_secret client command with:
       | secret_type  | generic            |
@@ -332,7 +333,7 @@ Feature: dockerbuild.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Mount source name must be unique
+  Scenario: OCP-42529 Mount source name must be unique
     Given I have a project
     When I run the :create_secret client command with:
       | secret_type  | generic            |

--- a/features/build/env.feature
+++ b/features/build/env.feature
@@ -8,7 +8,7 @@ Feature: env.feature
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Can set env vars on buildconfig with new-app --env and --env-file
+  Scenario: OCP-11543 Can set env vars on buildconfig with new-app --env and --env-file
     Given I have a project
     When I run the :new_app client command with:
       | app_repo | ruby:latest~https://github.com/openshift/ruby-hello-world |
@@ -84,7 +84,7 @@ Feature: env.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Can set env vars on buildconfig with new-app --env and --env-file test
+  Scenario: OCP-31247 Can set env vars on buildconfig with new-app --env and --env-file test
     Given I have a project
     When I run the :new_app client command with:
       | app_repo | ruby:latest~https://github.com/openshift/ruby-hello-world |

--- a/features/build/metrics.feature
+++ b/features/build/metrics.feature
@@ -11,7 +11,7 @@ Feature: Builds and samples related metrics test
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Alerts on imagestream import retries
+  Scenario: OCP-33220 Alerts on imagestream import retries
     When as admin I successfully merge patch resource "config.samples.operator.openshift.io/cluster" with:
       | {"spec":{"samplesRegistry":"registry.unconnected.redhat.com"}} |
     And I register clean-up steps:
@@ -73,7 +73,7 @@ Feature: Builds and samples related metrics test
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check build metrics
+  Scenario: OCP-33722 Check build metrics
     Given I have a project
     When I run the :new_app client command with:
       | template | cakephp-mysql-example |
@@ -160,7 +160,7 @@ Feature: Builds and samples related metrics test
   @proxy @noproxy @connected
   @4.6
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Adding metric for registry v1 protocol imports
+  Scenario: OCP-33770 Adding metric for registry v1 protocol imports
     Given I have a project
     #Importing a image with regsitry v1 api
     When I run the :import_image client command with:
@@ -202,7 +202,7 @@ Feature: Builds and samples related metrics test
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Monitoring, Alerting, and Degraded Status Reporting-Samples-operator
+  Scenario: OCP-25598 Monitoring, Alerting, and Degraded Status Reporting-Samples-operator
     When as admin I successfully merge patch resource "config.samples.operator.openshift.io/cluster" with:
       | {"spec":{"samplesRegistry":"registry.unconnected.redhat.com"}} |
     And I register clean-up steps:

--- a/features/build/stibuild.feature
+++ b/features/build/stibuild.feature
@@ -1,4 +1,5 @@
 Feature: stibuild.feature
+
   # @author xiuwang@redhat.com
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Trigger s2i/docker/custom build using additional imagestream
@@ -54,7 +55,7 @@ Feature: stibuild.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: STI build with dockerImage with specified tag
+  Scenario: OCP-30858 STI build with dockerImage with specified tag
     Given I have a project
     When I run the :new_app client command with:
       | docker_image | quay.io/openshifttest/ruby-27:multiarch   |
@@ -96,7 +97,7 @@ Feature: stibuild.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create app with template eap73-basic-s2i with jbosseap rhel7 image
+  Scenario: OCP-22596 Create app with template eap73-basic-s2i with jbosseap rhel7 image
     Given I have a project
     When I run the :new_app client command with:
       | template | eap73-basic-s2i |
@@ -120,7 +121,7 @@ Feature: stibuild.feature
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Test s2i build in disconnect cluster
+  Scenario: OCP-28891 Test s2i build in disconnect cluster
     Given I have a project
     When I have an http-git service in the project
     And I run the :set_env client command with:
@@ -153,7 +154,7 @@ Feature: stibuild.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Mount source secret and configmap to builder container- sourcestrategy
+  Scenario: OCP-42159 Mount source secret and configmap to builder container- sourcestrategy
     Given I have a project
     When I run the :create_secret client command with:
       | secret_type  | generic            |

--- a/features/cli/allinone-volume.feature
+++ b/features/cli/allinone-volume.feature
@@ -10,7 +10,7 @@ Feature: All in one volume
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Project secrets, configmap and downward API into the same volume with normal keys and path
+  Scenario: OCP-11683 Project secrets, configmap and downward API into the same volume with normal keys and path
     Given I have a project
     Given I obtain test data file "pods/allinone-volume/configmap.yaml"
     When I run the :create client command with:

--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -3,7 +3,7 @@ Feature: build 'apps' with CLI
   # @author cryan@redhat.com
   # @case_id OCP-11132
   @inactive
-  Scenario: Create a build config based on the provided image and source code
+  Scenario: OCP-11132 Create a build config based on the provided image and source code
     Given I have a project
     When I run the :new_build client command with:
       | code         | https://github.com/openshift/ruby-hello-world |
@@ -77,7 +77,7 @@ Feature: build 'apps' with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create a build config based on the source code in the current git repository
+  Scenario: OCP-11133 Create a build config based on the source code in the current git repository
     Given I have a project
     And I git clone the repo "https://github.com/openshift/ruby-hello-world.git"
     When I run the :new_build client command with:
@@ -146,7 +146,7 @@ Feature: build 'apps' with CLI
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create applications only with multiple db images
+  Scenario: OCP-11139 Create applications only with multiple db images
     Given I create a new project
     When I run the :new_app client command with:
       | image_stream      | openshift/mysql                                      |
@@ -190,7 +190,7 @@ Feature: build 'apps' with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Add multiple source inputs
+  Scenario: OCP-11227 Add multiple source inputs
     Given I have a project
     Given I obtain test data file "templates/ocp11227/ruby22rhel7-template-sti.json"
     When I run the :new_app client command with:
@@ -223,7 +223,7 @@ Feature: build 'apps' with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Add a image with multiple paths as source input
+  Scenario: OCP-10771 Add a image with multiple paths as source input
     Given I have a project
     Given I obtain test data file "templates/ocp10771/ruby22rhel7-template-sti.json"
     When I run the :new_app client command with:
@@ -249,7 +249,7 @@ Feature: build 'apps' with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Using a docker image as source input using new-build cmd
+  Scenario: OCP-11943 Using a docker image as source input using new-build cmd
     Given I have a project
     When I run the :tag client command with:
       | source | quay.io/openshifttest/python:3.6 |
@@ -318,7 +318,7 @@ Feature: build 'apps' with CLI
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Cannot create secret from local file and with same name via oc new-build
+  Scenario: OCP-11776 Cannot create secret from local file and with same name via oc new-build
     Given I have a project
     Given I obtain test data file "secrets/testsecret1.json"
     When I run the :create client command with:
@@ -353,7 +353,7 @@ Feature: build 'apps' with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Using a docker image as source input for docker build
+  Scenario: OCP-11552 Using a docker image as source input for docker build
     Given I have a project
     Given I obtain test data file "templates/ocp11552/ruby22rhel7-template-docker.json"
     When I run the :new_app client command with:
@@ -417,7 +417,7 @@ Feature: build 'apps' with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Change runpolicy to SerialLatestOnly build
+  Scenario: OCP-11582 Change runpolicy to SerialLatestOnly build
     Given I have a project
     When I run the :new_build client command with:
       | code         | https://github.com/openshift/ruby-hello-world |
@@ -721,7 +721,7 @@ Feature: build 'apps' with CLI
   @proxy
   @4.10 @4.9
   @inactive
-  Scenario: Simple error message return when no value followed with oc build-logs
+  Scenario: OCP-10944 Simple error message return when no value followed with oc build-logs
     Given I have a project
     When I run the :logs client command with:
       | resource_name | |
@@ -755,7 +755,7 @@ Feature: build 'apps' with CLI
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Handle build naming collisions
+  Scenario: OCP-11023 Handle build naming collisions
     Given I have a project
     When I run the :new_build client command with:
       | app_repo     | https://github.com/openshift/ruby-hello-world.git |
@@ -787,7 +787,7 @@ Feature: build 'apps' with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: io.openshift.build.commit.ref displays correctly in build reference on imagestreamtag if building from git branch reference
+  Scenario: OCP-17523 io.openshift.build.commit.ref displays correctly in build reference on imagestreamtag if building from git branch reference
     Given I have a project
     When I run the :new_app client command with:
       | app_repo | quay.io/openshifttest/ruby-27:multiarch~https://github.com/openshift/ruby-hello-world#config |
@@ -811,7 +811,7 @@ Feature: build 'apps' with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Insert configmap when create a buildconfig
+  Scenario: OCP-19631 Insert configmap when create a buildconfig
     Given I have a project
     Given a "configmap.test" file is created with the following lines:
     """
@@ -950,7 +950,7 @@ Feature: build 'apps' with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Allow using a configmap as an input to a docker build
+  Scenario: OCP-18962 Allow using a configmap as an input to a docker build
     Given I have a project
     Given a "configmap1.test" file is created with the following lines:
     """

--- a/features/cli/configmap.feature
+++ b/features/cli/configmap.feature
@@ -11,7 +11,7 @@ Feature: configMap
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Consume ConfigMap in environment variables
+  Scenario: OCP-10805 Consume ConfigMap in environment variables
     Given I have a project
     Given I obtain test data file "configmap/configmap.yaml"
     When I run the :create client command with:
@@ -52,7 +52,7 @@ Feature: configMap
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Consume ConfigMap via volume plugin
+  Scenario: OCP-11255 Consume ConfigMap via volume plugin
     Given I have a project
     Given I obtain test data file "configmap/configmap.yaml"
     When I run the :create client command with:
@@ -101,7 +101,7 @@ Feature: configMap
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Perform CRUD operations against a ConfigMap resource
+  Scenario: OCP-11572 Perform CRUD operations against a ConfigMap resource
     Given I have a project
     Given I obtain test data file "configmap/configmap-example.yaml"
     When I run the :create client command with:
@@ -143,7 +143,7 @@ Feature: configMap
   # @case_id OCP-9882
   @smoke
   @inactive
-  Scenario: Set command-line arguments with ConfigMap
+  Scenario: OCP-9882 Set command-line arguments with ConfigMap
     Given I have a project
     Given I obtain test data file "configmap/configmap.yaml"
     When I run the :create client command with:
@@ -175,7 +175,7 @@ Feature: configMap
   # @author chezhang@redhat.com
   # @case_id OCP-9884
   @inactive
-  Scenario: Configuring redis using ConfigMap
+  Scenario: OCP-9884 Configuring redis using ConfigMap
     Given I have a project
     Given a "redis-config" file is created with the following lines:
     """
@@ -212,7 +212,7 @@ Feature: configMap
   # @case_id OCP-9880
   @smoke
   @inactive
-  Scenario: Create ConfigMap from file
+  Scenario: OCP-9880 Create ConfigMap from file
     Given I have a project
     Given I create the "configmap-test" directory
     Given a "configmap-test/game.properties" file is created with the following lines:
@@ -306,7 +306,7 @@ Feature: configMap
   # @author chezhang@redhat.com
   # @case_id OCP-9881
   @inactive
-  Scenario: Create ConfigMap from literal values
+  Scenario: OCP-9881 Create ConfigMap from literal values
     Given I have a project
     When I run the :create_configmap client command with:
       | name         | special-config     |
@@ -330,7 +330,7 @@ Feature: configMap
   # @author chezhang@redhat.com
   # @case_id OCP-9879
   @inactive
-  Scenario: Create ConfigMap from directories
+  Scenario: OCP-9879 Create ConfigMap from directories
     Given I have a project
     Given I create the "configmap-test" directory
     Given a "configmap-test/game.properties" file is created with the following lines:
@@ -381,7 +381,7 @@ Feature: configMap
   # @author xiuli@redhat.com
   # @case_id OCP-16721
   @inactive
-  Scenario: Changes to ConfigMap should be auto-updated into container
+  Scenario: OCP-16721 Changes to ConfigMap should be auto-updated into container
     Given I have a project
     Given I obtain test data file "configmap/configmap.json"
     When I run the :create client command with:

--- a/features/cli/create.feature
+++ b/features/cli/create.feature
@@ -13,7 +13,7 @@ Feature: creating 'apps' with CLI
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Process with special FSGroup id can be ran when using RunAsAny as the RunAsGroupStrategy
+  Scenario: OCP-11761 Process with special FSGroup id can be ran when using RunAsAny as the RunAsGroupStrategy
     Given I have a project
     Given I obtain test data file "pods/pod_with_special_fsGroup.json"
     When I run the :create client command with:
@@ -38,7 +38,7 @@ Feature: creating 'apps' with CLI
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Create an application from source code
+  Scenario: OCP-12399 Create an application from source code
     Given I have a project
     When I git clone the repo "https://github.com/openshift/ruby-hello-world"
     Then the step should succeed
@@ -162,7 +162,7 @@ Feature: creating 'apps' with CLI
   @singlenode
   @proxy @noproxy @connected
   @arm64 @amd64
-  Scenario: 4.x Could not create any context in non-existent project
+  Scenario: OCP-22515 4.x Could not create any context in non-existent project
     Given I create a new application with:
       | docker image | openshift/ruby-20-centos7~https://github.com/openshift/ruby-hello-world |
       | name         | myapp          |
@@ -202,7 +202,7 @@ Feature: creating 'apps' with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create an application from source code test
+  Scenario: OCP-31250 Create an application from source code test
     Given I have a project
     When I git clone the repo "https://github.com/openshift/ruby-hello-world"
     Then the step should succeed

--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -9,7 +9,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Restart a failed deployment by oc deploy
+  Scenario: OCP-12543 Restart a failed deployment by oc deploy
     Given I have a project
     Given I obtain test data file "deployment/dc-with-pre-mid-post.yaml"
     When I run the :create client command with:
@@ -47,7 +47,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Manually make deployment
+  Scenario: OCP-10643 Manually make deployment
     Given I have a project
     Given I obtain test data file "deployment/manual.json"
     When I run the :create client command with:
@@ -92,7 +92,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: CLI rollback output to file
+  Scenario: OCP-11695 CLI rollback output to file
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
     When I run the :create client command with:
@@ -198,7 +198,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: CLI rollback with one component
+  Scenario: OCP-11877 CLI rollback with one component
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
     When I run the :create client command with:
@@ -248,7 +248,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Can't stop a deployment in Failed status
+  Scenario: OCP-12133 Can't stop a deployment in Failed status
     Given I have a project
     Given I obtain test data file "deployment/test-stop-failed-deployment.json"
     When I run the :create client command with:
@@ -289,7 +289,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Stop a "Running" deployment
+  Scenario: OCP-12246 Stop a "Running" deployment
     Given I have a project
     Given I obtain test data file "deployment/dc-with-pre-mid-post.yaml"
     When I run the :create client command with:
@@ -320,7 +320,7 @@ Feature: deployment related features
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Rollback via CLI when previous version failed
+  Scenario: OCP-10648 Rollback via CLI when previous version failed
     Given I have a project
     When I run the :create_deploymentconfig client command with:
       | image | quay.io/openshifttest/hello-openshift@sha256:eb47fdebd0f2cc0c130228ca972f15eb2858b425a3df15f10f7bb519f60f0c96 |
@@ -350,7 +350,7 @@ Feature: deployment related features
   # @author pruan@redhat.com
   # @case_id OCP-12528
   @inactive
-  Scenario: Make multiple deployment by oc deploy
+  Scenario: OCP-12528 Make multiple deployment by oc deploy
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
     And I run the :create client command with:
@@ -373,7 +373,7 @@ Feature: deployment related features
   # @author xiaocwan@redhat.com
   # @case_id OCP-10717
   @inactive
-  Scenario: View the logs of the latest deployment
+  Scenario: OCP-10717 View the logs of the latest deployment
     # check deploy log when deploying
     Given I have a project
     When I run the :run client command with:
@@ -405,7 +405,7 @@ Feature: deployment related features
   @proxy @noproxy @connected
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
-  Scenario: A/B Deployment
+  Scenario: OCP-9563 A/B Deployment
     Given I have a project
     When I run the :new_app client command with:
       | docker_image | quay.io/openshifttest/deployment-example@sha256:9e0a0cd621fcb46b3439cb8979a0467dfaadb934215e8544193741aae2454668 |
@@ -469,7 +469,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Blue-Green Deployment
+  Scenario: OCP-9566 Blue-Green Deployment
     Given I have a project
     When I run the :new_app client command with:
       | docker_image | quay.io/openshifttest/deployment-example:v1-multiarch |
@@ -502,7 +502,7 @@ Feature: deployment related features
   # @author pruan@redhat.com
   # @case_id OCP-12532
   @inactive
-  Scenario: Manually start deployment by oc deploy
+  Scenario: OCP-12532 Manually start deployment by oc deploy
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
     When I run the :create client command with:
@@ -517,7 +517,7 @@ Feature: deployment related features
   # @author yinzhou@redhat.com
   # @case_id OCP-12468
   @inactive
-  Scenario: Pre and post deployment hooks
+  Scenario: OCP-12468 Pre and post deployment hooks
     Given I have a project
     Given I obtain test data file "deployment/testhook.json"
     When I run the :create client command with:
@@ -539,7 +539,7 @@ Feature: deployment related features
   # @author yinzhou@redhat.com
   # @case_id OCP-10724
   @inactive
-  Scenario: deployment hook volume inheritance that volume name was null
+  Scenario: OCP-10724 deployment hook volume inheritance that volume name was null
     Given I have a project
     Given I obtain test data file "deployment/ocp10724/hooks-null-volume.json"
     When I run the :create client command with:
@@ -551,7 +551,7 @@ Feature: deployment related features
   # @case_id OCP-9567
   @smoke
   @inactive
-  Scenario: Recreate deployment strategy
+  Scenario: OCP-9567 Recreate deployment strategy
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift/origin/master/examples/deployment/recreate-example.yaml |
@@ -580,7 +580,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: start deployment when the latest deployment is completed
+  Scenario: OCP-11939 start deployment when the latest deployment is completed
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
     And I run the :create client command with:
@@ -597,7 +597,7 @@ Feature: deployment related features
   # @author pruan@redhat.com
   # @case_id OCP-12056
   @inactive
-  Scenario: Manual scale dc will update the deploymentconfig's replicas
+  Scenario: OCP-12056 Manual scale dc will update the deploymentconfig's replicas
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
     And I run the :create client command with:
@@ -623,7 +623,7 @@ Feature: deployment related features
   # @author pruan@redhat.com
   # @case_id OCP-10728
   @inactive
-  Scenario: Inline deployer hook logs
+  Scenario: OCP-10728 Inline deployer hook logs
     Given I have a project
     Given I obtain test data file "deployment/Inline-logs.json"
     And I run the :create client command with:
@@ -648,7 +648,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Start new deployment when deployment running
+  Scenario: OCP-11769 Start new deployment when deployment running
     Given I have a project
     Given I obtain test data file "deployment/dc-with-pre-mid-post.yaml"
     When I run the :create client command with:
@@ -675,7 +675,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: When the latest deployment failed auto rollback to the active deployment
+  Scenario: OCP-12151 When the latest deployment failed auto rollback to the active deployment
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
     When I run the :create client command with:
@@ -732,7 +732,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: DeploymentConfig should allow valid value of resource requirements
+  Scenario: OCP-10617 DeploymentConfig should allow valid value of resource requirements
     Given I have a project
     Given I obtain test data file "quota/limits.yaml"
     When I run the :create admin command with:
@@ -775,7 +775,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Scale up when deployment running
+  Scenario: OCP-11221 Scale up when deployment running
     Given I have a project
     When I run the :create_deploymentconfig client command with:
       | image | quay.io/openshifttest/deployment-example@sha256:9e0a0cd621fcb46b3439cb8979a0467dfaadb934215e8544193741aae2454668 |
@@ -797,7 +797,7 @@ Feature: deployment related features
   # @author qwang@redhat.com
   # @case_id OCP-12356
   @inactive
-  Scenario: configchange triggers deploy automatically
+  Scenario: OCP-12356 configchange triggers deploy automatically
     Given I have a project
     Given I obtain test data file "deployment/deployment1.json"
     When I run the :create client command with:
@@ -827,7 +827,7 @@ Feature: deployment related features
   # @author yinzhou@redhat.com
   # @case_id OCP-11326
   @smoke
-  Scenario: Support verbs of Deployment in OpenShift
+  Scenario: OCP-11326 Support verbs of Deployment in OpenShift
     Given I have a project
     Given I obtain test data file "deployment/extensions/deployment.yaml"
     When I run the :create client command with:
@@ -906,7 +906,7 @@ Feature: deployment related features
   # @case_id OCP-10902
   @smoke
   @inactive
-  Scenario: Auto cleanup old RCs
+  Scenario: OCP-10902 Auto cleanup old RCs
     Given I have a project
     Given I obtain test data file "deployment/ocp10902/history-limit-dc.yaml"
     When I run the :create client command with:
@@ -947,7 +947,7 @@ Feature: deployment related features
   @singlenode
   @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Trigger info is retained for deployment caused by image changes 37 new feature
+  Scenario: OCP-16443 Trigger info is retained for deployment caused by image changes 37 new feature
     Given the master version >= "3.7"
     Given I have a project
     When I process and create "https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/application-template-stibuild.json"
@@ -970,7 +970,7 @@ Feature: deployment related features
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: A/B Deployment for OCP 4.5 or greater
+  Scenario: OCP-31200 A/B Deployment for OCP 4.5 or greater
     Given the master version >= "4.5"
     Given I have a project
     When I run the :new_app client command with:

--- a/features/cli/deployment.feature
+++ b/features/cli/deployment.feature
@@ -2,7 +2,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11421
-  Scenario: Add perma-failed - Deplyment succeed after change pod template by edit deployment
+  Scenario: OCP-11421 Add perma-failed - Deplyment succeed after change pod template by edit deployment
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-1.yaml"
     When I run the :create client command with:
@@ -76,7 +76,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11046
-  Scenario: Add perma-failed - Deployment failed after pausing and resuming
+  Scenario: OCP-11046 Add perma-failed - Deployment failed after pausing and resuming
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-1.yaml"
     When I run the :create client command with:
@@ -169,7 +169,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11681
-  Scenario: Add perma-failed - Failing deployment can be rolled back successful
+  Scenario: OCP-11681 Add perma-failed - Failing deployment can be rolled back successful
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-3.yaml"
     When I run the :create client command with:
@@ -268,7 +268,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-12110
-  Scenario: Add perma-failed - Rolling back to a failing deployment revision
+  Scenario: OCP-12110 Add perma-failed - Rolling back to a failing deployment revision
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-3.yaml"
     When I run the :create client command with:
@@ -375,7 +375,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11865
-  Scenario: Add perma-failed - Make a change outside pod template for failing deployment
+  Scenario: OCP-11865 Add perma-failed - Make a change outside pod template for failing deployment
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-1.yaml"
     When I run the :create client command with:
@@ -467,7 +467,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-12009
-  Scenario: Add perma-failed - Negative value test of progressDeadlineSeconds in failing deployment
+  Scenario: OCP-12009 Add perma-failed - Negative value test of progressDeadlineSeconds in failing deployment
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-2.yaml"
     When I run the :create client command with:

--- a/features/cli/downwardapi.feature
+++ b/features/cli/downwardapi.feature
@@ -10,7 +10,7 @@ Feature: Downward API
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Pods can get IPs via downward API under race condition
+  Scenario: OCP-10707 Pods can get IPs via downward API under race condition
     Given I have a project
     Given I obtain test data file "downwardapi/ocp10707/pod-downwardapi-env.yaml"
     When I run the :create client command with:
@@ -32,7 +32,7 @@ Feature: Downward API
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: downward api pod name and pod namespace as env variables
+  Scenario: OCP-10628 downward api pod name and pod namespace as env variables
     Given I have a project
     Given I obtain test data file "downwardapi/ocp10628/downward-example.yaml"
     When I run the :create client command with:
@@ -57,7 +57,7 @@ Feature: Downward API
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Container consume infomation from the downward API using a volume plugin
+  Scenario: OCP-10708 Container consume infomation from the downward API using a volume plugin
     Given I have a project
     Given I obtain test data file "downwardapi/pod-dapi-volume.yaml"
     When I run the :create client command with:
@@ -124,7 +124,7 @@ Feature: Downward API
   # @case_id OCP-11977
   @admin
   @inactive
-  Scenario: Using resources downward API via volume plugin should be compatible with metadata downward API
+  Scenario: OCP-11977 Using resources downward API via volume plugin should be compatible with metadata downward API
     Given I have a project
     Given I obtain test data file "downwardapi/dapi-resources-metadata-volume-pod.yaml"
     When I run the :create client command with:
@@ -210,7 +210,7 @@ Feature: Downward API
   # @case_id OCP-11618
   @admin
   @inactive
-  Scenario: Could expose resouces limits and requests via volume plugin from Downward APIs with magics keys
+  Scenario: OCP-11618 Could expose resouces limits and requests via volume plugin from Downward APIs with magics keys
     Given I have a project
     Given I obtain test data file "downwardapi/dapi-resources-volume-magic-keys-pod.yaml"
     When I run the :create client command with:
@@ -264,7 +264,7 @@ Feature: Downward API
   # @case_id OCP-11816
   @admin
   @inactive
-  Scenario: Using resources downward API via ENV should be compatible with metadata downward API
+  Scenario: OCP-11816 Using resources downward API via ENV should be compatible with metadata downward API
     Given I have a project
     Given I obtain test data file "downwardapi/dapi-resources-metadata-env-pod.yaml"
     When I run the :create client command with:

--- a/features/cli/event.feature
+++ b/features/cli/event.feature
@@ -7,7 +7,7 @@ Feature: Event related scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: check event compressed in kube
+  Scenario: OCP-10751 check event compressed in kube
     Given I have a project
     Given I obtain test data file "quota/quota_template.yaml"
     When I run the :new_app admin command with:
@@ -54,7 +54,7 @@ Feature: Event related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-10750
   @inactive
-  Scenario: Check normal and warning information for kubernetes events
+  Scenario: OCP-10750 Check normal and warning information for kubernetes events
     Given I have a project
     Given I obtain test data file "pods/hello-pod.json"
     When I run the :create client command with:
@@ -98,7 +98,7 @@ Feature: Event related scenarios
   # @author dma@redhat.com
   # @case_id OCP-10208
   @inactive
-  Scenario: Event should show full failed reason when readiness probe failed
+  Scenario: OCP-10208 Event should show full failed reason when readiness probe failed
     Given I have a project
     Given I obtain test data file "pods/ocp10208/readiness-probe-exec.yaml"
     When I run the :create client command with:

--- a/features/cli/hpa.feature
+++ b/features/cli/hpa.feature
@@ -10,7 +10,7 @@ Feature: hpa scale
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: HPA shouldn't scale up target if the replicas of dc is 0
+  Scenario: OCP-10931 HPA shouldn't scale up target if the replicas of dc is 0
     Given I have a project
     Given I obtain test data file "hpa/dc-hello-openshift.yaml"
     When I run the :create client command with:
@@ -54,7 +54,7 @@ Feature: hpa scale
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: HPA shouldn't scale up target if the replicas of rc is 0
+  Scenario: OCP-11338 HPA shouldn't scale up target if the replicas of rc is 0
     Given I have a project
     Given I obtain test data file "hpa/rc-hello-openshift.yaml"
     When I run the :create client command with:
@@ -96,7 +96,7 @@ Feature: hpa scale
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Creates autoscaler for replication controller by oc autoscale
+  Scenario: OCP-11259 Creates autoscaler for replication controller by oc autoscale
     Given I have a project
     Given I obtain test data file "hpa/rc-hello-openshift.yaml"
     When I run the :create client command with:
@@ -144,7 +144,7 @@ Feature: hpa scale
 
   # @author chezhang@redhat.com
   # @case_id OCP-11576
-  Scenario: Creates autoscaler for replication controller with invalid value
+  Scenario: OCP-11576 Creates autoscaler for replication controller with invalid value
     Given I have a project
     Given I obtain test data file "hpa/rc-hello-openshift.yaml"
     When I run the :create client command with:

--- a/features/cli/job.feature
+++ b/features/cli/job.feature
@@ -9,7 +9,7 @@ Feature: job.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create job with multiple completions
+  Scenario: OCP-11206 Create job with multiple completions
     Given I have a project
     Given I obtain test data file "templates/ocp11206/job.yaml"
     When I run the :create client command with:
@@ -60,7 +60,7 @@ Feature: job.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create job with pod parallelism
+  Scenario: OCP-11539 Create job with pod parallelism
     Given I have a project
     Given I obtain test data file "job/job_with_0_activeDeadlineSeconds.yaml"
     When I run oc create over "job_with_0_activeDeadlineSeconds.yaml" replacing paths:
@@ -156,7 +156,7 @@ Feature: job.feature
   # @author qwang@redhat.com
   # @case_id OCP-9948
   @inactive
-  Scenario: Create job with activeDeadlineSeconds
+  Scenario: OCP-9948 Create job with activeDeadlineSeconds
     Given I have a project
     Given I obtain test data file "job/job_with_lessthan_runtime_activeDeadlineSeconds.yaml"
     When I run the :create client command with:
@@ -184,7 +184,7 @@ Feature: job.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Specifying your own pod selector for job
+  Scenario: OCP-9952 Specifying your own pod selector for job
     Given I have a project
     Given I obtain test data file "job/job-manualselector.yaml"
     When I run the :create client command with:
@@ -204,7 +204,7 @@ Feature: job.feature
   # @author qwang@redhat.com
   # @case_id OCP-10734
   @inactive
-  Scenario: Create job with different pod restartPolicy
+  Scenario: OCP-10734 Create job with different pod restartPolicy
     Given I have a project
     Given I obtain test data file "job/job-restartpolicy.yaml"
     # Create job without restartPolicy
@@ -318,7 +318,7 @@ Feature: job.feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Create job with specific deadline
+  Scenario: OCP-10781 Create job with specific deadline
     Given I have a project
     Given I obtain test data file "job/job_with_0_activeDeadlineSeconds.yaml"
     When I run the :create client command with:
@@ -378,7 +378,7 @@ Feature: job.feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: User can schedule a Cronjob execution with cron format time
+  Scenario: OCP-17515 User can schedule a Cronjob execution with cron format time
     Given I have a project
     When I run the :create_cronjob client command with:
        | name             | sj3       |

--- a/features/cli/limits.feature
+++ b/features/cli/limits.feature
@@ -102,7 +102,7 @@ Feature: limit range related scenarios:
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Limit range does not allow min > defaultRequest
+  Scenario: OCP-12250 Limit range does not allow min > defaultRequest
     Given I have a project
     Given I obtain test data file "limits/ocp12250/limit.yaml"
     When I run the :create admin command with:
@@ -125,7 +125,7 @@ Feature: limit range related scenarios:
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Limit range does not allow defaultRequest > default
+  Scenario: OCP-11918 Limit range does not allow defaultRequest > default
     Given I have a project
     Given I obtain test data file "limits/ocp11918/limit.yaml"
     When I run the :create admin command with:
@@ -148,7 +148,7 @@ Feature: limit range related scenarios:
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Limit range does not allow defaultRequest > max
+  Scenario: OCP-12043 Limit range does not allow defaultRequest > max
     Given I have a project
     Given I obtain test data file "limits/ocp12043/limit.yaml"
     When I run the :create admin command with:
@@ -171,7 +171,7 @@ Feature: limit range related scenarios:
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Limit range does not allow maxLimitRequestRatio > Limit/Request
+  Scenario: OCP-12139 Limit range does not allow maxLimitRequestRatio > Limit/Request
     Given I have a project
     Given I obtain test data file "limits/ocp12139/limit.yaml"
     When I run the :create admin command with:
@@ -203,7 +203,7 @@ Feature: limit range related scenarios:
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Limit range with all values set with proper values
+  Scenario: OCP-12315 Limit range with all values set with proper values
     Given I have a project
     Given I obtain test data file "limits/ocp12315/limit.yaml"
     When I run the :create admin command with:

--- a/features/cli/oc_delete.feature
+++ b/features/cli/oc_delete.feature
@@ -10,7 +10,7 @@ Feature: oc_delete.feature
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Gracefully delete a pod with '--grace-period' option
+  Scenario: OCP-11184 Gracefully delete a pod with '--grace-period' option
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/10.json"
     When I run the :create client command with:
@@ -60,7 +60,7 @@ Feature: oc_delete.feature
   # @bug_id 1277101
   @admin
   @inactive
-  Scenario: The namespace will not be deleted until all pods gracefully terminate
+  Scenario: OCP-12048 The namespace will not be deleted until all pods gracefully terminate
     Given I have a project
     And evaluation of `project.name` is stored in the :prj1 clipboard
     Given I obtain test data file "pods/graceful-delete/40.json"
@@ -94,7 +94,7 @@ Feature: oc_delete.feature
   # @author cryan@redhat.com
   # @case_id OCP-10705
   @inactive
-  Scenario: Default termination grace period is 30s if it's not set
+  Scenario: OCP-10705 Default termination grace period is 30s if it's not set
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/default.json"
     When I run the :create client command with:
@@ -129,7 +129,7 @@ Feature: oc_delete.feature
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Verify pod is gracefully deleted when DeletionGracePeriodSeconds is specified.
+  Scenario: OCP-12144 Verify pod is gracefully deleted when DeletionGracePeriodSeconds is specified.
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/10.json"
     When I run the :create client command with:
@@ -162,7 +162,7 @@ Feature: oc_delete.feature
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Pod should be immediately deleted if TerminationGracePeriodSeconds is 0
+  Scenario: OCP-11526 Pod should be immediately deleted if TerminationGracePeriodSeconds is 0
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/0.json"
     When I run the :create client command with:

--- a/features/cli/oc_env.feature
+++ b/features/cli/oc_env.feature
@@ -11,7 +11,7 @@ Feature: oc_env.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set environment variables when creating application using non-DeploymentConfig template
+  Scenario: OCP-11032 Set environment variables when creating application using non-DeploymentConfig template
     Given I have a project
     When I run the :new_app client command with:
       | template | cakephp-mysql-example |

--- a/features/cli/oc_expose.feature
+++ b/features/cli/oc_expose.feature
@@ -10,7 +10,7 @@ Feature: oc_expose.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Access app througth secure service and regenerate service serving certs if it about to expire
+  Scenario: OCP-10873 Access app througth secure service and regenerate service serving certs if it about to expire
     Given the master version >= "3.3"
     Given I have a project
     Given I obtain test data file "deployment/OCP-10873/svc.json"

--- a/features/cli/oc_help.feature
+++ b/features/cli/oc_help.feature
@@ -3,7 +3,7 @@ Feature: oc related features
   # @author chezhang@redhat.com
   # @case_id OCP-11565
   @inactive
-  Scenario: kubectl secret subcommand - help
+  Scenario: OCP-11565 kubectl secret subcommand - help
     Given I have a project
     When I run the :create_secret client command with:
       | secret_type | |
@@ -87,7 +87,7 @@ Feature: oc related features
   # @author chezhang@redhat.com
   # @case_id OCP-10812
   @inactive
-  Scenario: Check `oc autoscale` help info
+  Scenario: OCP-10812 Check `oc autoscale` help info
     Given I have a project
     When I run the :autoscale client command with:
       | name  | :false |

--- a/features/cli/oc_idle.feature
+++ b/features/cli/oc_idle.feature
@@ -10,7 +10,7 @@ Feature: oc idle
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: CLI - Idle all the service in the same project
+  Scenario: OCP-11633 CLI - Idle all the service in the same project
     Given I have a project
     Given I obtain test data file "rc/idle-rc-1.yaml"
     When I run the :create client command with:
@@ -61,7 +61,7 @@ Feature: oc idle
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: CLI - Idle service by label
+  Scenario: OCP-11980 CLI - Idle service by label
     Given I have a project
     Given I obtain test data file "rc/idle-rc-2.yaml"
     When I run the :create client command with:
@@ -105,7 +105,7 @@ Feature: oc idle
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: CLI - Idle service from file
+  Scenario: OCP-12085 CLI - Idle service from file
     Given I have a project
     Given I obtain test data file "rc/idle-rc-2.yaml"
     When I run the :create client command with:
@@ -154,7 +154,7 @@ Feature: oc idle
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: CLI - Idle service with dry-run
+  Scenario: OCP-12169 CLI - Idle service with dry-run
     Given I have a project
     Given I obtain test data file "rc/idle-rc-2.yaml"
     When I run the :create client command with:
@@ -190,7 +190,7 @@ Feature: oc idle
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Idling service with dc
+  Scenario: OCP-10941 Idling service with dc
     Given I have a project
     Given I obtain test data file "rc/idling-echo-server.yaml"
     When I run the :create client command with:
@@ -260,7 +260,7 @@ Feature: oc idle
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Idling service with rc
+  Scenario: OCP-11345 Idling service with rc
     Given I have a project
     Given I obtain test data file "rc/idle-rc-2.yaml"
     When I run the :create client command with:

--- a/features/cli/oc_import_image.feature
+++ b/features/cli/oc_import_image.feature
@@ -1,4 +1,5 @@
 Feature: oc import-image related feature
+
   # @author chaoyang@redhat.com
   # @case_id OCP-10585
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
@@ -9,7 +10,7 @@ Feature: oc import-image related feature
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Do not create tags for ImageStream if image repository does not have tags
+  Scenario: OCP-10585 Do not create tags for ImageStream if image repository does not have tags
     When I have a project
     Given I obtain test data file "image-streams/is_without_tags.json"
     And I run the :create client command with:
@@ -34,7 +35,7 @@ Feature: oc import-image related feature
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Could not import the tag when reference is true
+  Scenario: OCP-10721 Could not import the tag when reference is true
     Given I have a project
     Given I obtain test data file "image-streams/ocp10721.json"
     When I run the :create client command with:
@@ -52,7 +53,7 @@ Feature: oc import-image related feature
   # @author wjiang@redhat.com
   # @case_id OCP-11760
   @inactive
-  Scenario: Import Image when spec.DockerImageRepository not defined
+  Scenario: OCP-11760 Import Image when spec.DockerImageRepository not defined
     Given I have a project
     Given I obtain test data file "image-streams/ocp11760.json"
     When I run the :create client command with:
@@ -73,7 +74,7 @@ Feature: oc import-image related feature
   # @case_id OCP-12052
   @smoke
   @inactive
-  Scenario: Import image when spec.DockerImageRepository with some tags defined when Kind==DockerImage
+  Scenario: OCP-12052 Import image when spec.DockerImageRepository with some tags defined when Kind==DockerImage
     Given I have a project
     Given I obtain test data file "image-streams/ocp12052.json"
     When I run the :create client command with:
@@ -98,7 +99,7 @@ Feature: oc import-image related feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Tags should be added to ImageStream if image repository is from an external docker registry
+  Scenario: OCP-11089 Tags should be added to ImageStream if image repository is from an external docker registry
     Given I have a project
     Given I obtain test data file "image-streams/external.json"
     When I run the :create client command with:
@@ -126,7 +127,7 @@ Feature: oc import-image related feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Allow imagestream request deployment config triggers by different mode('TagreferencePolicy':source/local)
+  Scenario: OCP-12765 Allow imagestream request deployment config triggers by different mode('TagreferencePolicy':source/local)
     Given I have a project
     When I run the :tag client command with:
       | source_type | docker                                                |
@@ -195,7 +196,7 @@ Feature: oc import-image related feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Allow imagestream request build config triggers by different mode('TagreferencePolicy':source/local)
+  Scenario: OCP-12766 Allow imagestream request build config triggers by different mode('TagreferencePolicy':source/local)
     Given I have a project
     When I run the :import_image client command with:
       | from       | registry.redhat.io/rhscl/ruby-26-rhel7:latest |

--- a/features/cli/oc_patch_apply.feature
+++ b/features/cli/oc_patch_apply.feature
@@ -11,7 +11,7 @@ Feature: oc patch/apply related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: oc patch can update one or more fields of rescource
+  Scenario: OCP-10696 oc patch can update one or more fields of rescource
     Given I have a project
     And I run the :create_deploymentconfig client command with:
       | name  | hello                                               |

--- a/features/cli/oc_portforward.feature
+++ b/features/cli/oc_portforward.feature
@@ -10,7 +10,7 @@ Feature: oc_portforward.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Forward multi local ports to a pod
+  Scenario: OCP-11195 Forward multi local ports to a pod
     Given I have a project
     And evaluation of `rand(5000..7999)` is stored in the :porta clipboard
     And evaluation of `rand(5000..7999)` is stored in the :portb clipboard

--- a/features/cli/oc_process.feature
+++ b/features/cli/oc_process.feature
@@ -11,7 +11,7 @@ Feature: oc_process.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Supply oc new-app parameter list+env vars via a file
+  Scenario: OCP-11044 Supply oc new-app parameter list+env vars via a file
     Given I have a project
     Given a "test1.env" file is created with the following lines:
     """

--- a/features/cli/oc_registry.feature
+++ b/features/cli/oc_registry.feature
@@ -9,7 +9,7 @@ Feature: oc registry command scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check function of oc registry command
+  Scenario: OCP-21926 Check function of oc registry command
     Given I have a project
     When I run the :registry_info client command with:
       | internal | true |

--- a/features/cli/oc_secrets.feature
+++ b/features/cli/oc_secrets.feature
@@ -5,7 +5,7 @@ Feature: oc_secrets.feature
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy
-  Scenario: Add secrets to serviceaccount via oc secrets add
+  Scenario: OCP-12600 Add secrets to serviceaccount via oc secrets add
     Given I have a project
     When I run the :secrets client command with:
       | action | new        |
@@ -63,7 +63,7 @@ Feature: oc_secrets.feature
   @singlenode
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Project admin can process local directory or files and convert it to kubernetes secret
+  Scenario: OCP-10631 Project admin can process local directory or files and convert it to kubernetes secret
     Given I have a project
     When the "tmpfoo" file is created with the following lines:
       | somecontent |
@@ -113,7 +113,7 @@ Feature: oc_secrets.feature
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
-  Scenario: Check name requirements for oc secret
+  Scenario: OCP-11900 Check name requirements for oc secret
     Given I have a project
     And I run the :get client command with:
       | resource      | project |

--- a/features/cli/oc_set_build_hook.feature
+++ b/features/cli/oc_set_build_hook.feature
@@ -12,7 +12,7 @@ Feature: oc_set_build_hook
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set post-build-commit on buildconfig via oc set build-hook
+  Scenario: OCP-11602 Set post-build-commit on buildconfig via oc set build-hook
     Given I have a project
     When I process and create "https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json"
     Then the step should succeed

--- a/features/cli/oc_set_deployment_hook.feature
+++ b/features/cli/oc_set_deployment_hook.feature
@@ -11,7 +11,7 @@ Feature: set deployment-hook/build-hook with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set pre/mid/post deployment hooks on deployment config via oc set deployment-hook
+  Scenario: OCP-11805 Set pre/mid/post deployment hooks on deployment config via oc set deployment-hook
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json |
@@ -102,7 +102,7 @@ Feature: set deployment-hook/build-hook with CLI
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set invalid pre/mid/post deployment hooks on deployment config via oc set deployment-hook
+  Scenario: OCP-11298 Set invalid pre/mid/post deployment hooks on deployment config via oc set deployment-hook
     Given I have a project
     When I run the :new_app client command with:
       | template | rails-postgresql-example |

--- a/features/cli/oc_set_env.feature
+++ b/features/cli/oc_set_env.feature
@@ -10,7 +10,7 @@ Feature: oc_set_env.feature
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Set environment variables for resources using oc set env
+  Scenario: OCP-11248 Set environment variables for resources using oc set env
     Given I have a project
     Given I obtain test data file "build/application-template-stibuild.json"
     When I run the :new_app client command with:
@@ -72,7 +72,7 @@ Feature: oc_set_env.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Remove environment variables for resources using oc set env
+  Scenario: OCP-10798 Remove environment variables for resources using oc set env
     Given I have a project
     Given I obtain test data file "build/application-template-stibuild.json"
     When I run the :new_app client command with:

--- a/features/cli/oc_set_probe.feature
+++ b/features/cli/oc_set_probe.feature
@@ -3,7 +3,7 @@ Feature: oc_set_probe.feature
   # @author dyan@redhat.com
   # @case_id OCP-9870
   @inactive
-  Scenario: Set a probe to open a TCP socket
+  Scenario: OCP-9870 Set a probe to open a TCP socket
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mysql:latest |
@@ -61,7 +61,7 @@ Feature: oc_set_probe.feature
   # @author dyan@redhat.com
   # @case_id OCP-9871
   @inactive
-  Scenario: Set a probe over HTTPS/HTTP
+  Scenario: OCP-9871 Set a probe over HTTPS/HTTP
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mysql:latest |
@@ -107,7 +107,7 @@ Feature: oc_set_probe.feature
   # @author dyan@redhat.com
   # @case_id OCP-9872
   @inactive
-  Scenario: Set an exec action probe
+  Scenario: OCP-9872 Set an exec action probe
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mysql:latest |
@@ -156,7 +156,7 @@ Feature: oc_set_probe.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set a probe to open a TCP socket test
+  Scenario: OCP-31241 Set a probe to open a TCP socket test
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mysql:latest |
@@ -220,7 +220,7 @@ Feature: oc_set_probe.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set a probe over HTTPS/HTTP test
+  Scenario: OCP-31245 Set a probe over HTTPS/HTTP test
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mysql:latest |
@@ -273,7 +273,7 @@ Feature: oc_set_probe.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set an exec action probe test
+  Scenario: OCP-31246 Set an exec action probe test
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mysql:latest |

--- a/features/cli/oc_volume.feature
+++ b/features/cli/oc_volume.feature
@@ -12,7 +12,7 @@ Feature: oc_volume.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create a pod that consumes the secret in a volume
+  Scenario: OCP-12194 Create a pod that consumes the secret in a volume
     Given I have a project
     Given I obtain test data file "pods/allinone-volume/secret.yaml"
     Given I run the :create client command with:
@@ -60,7 +60,7 @@ Feature: oc_volume.feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Add secret volume to dc and rc
+  Scenario: OCP-11906 Add secret volume to dc and rc
     Given I have a project
     When I run the :new_app_as_dc client command with:
       | docker_image | quay.io/openshifttest/hello-openshift@sha256:b1aabe8c8272f750ce757b6c4263a2712796297511e0c6df79144ee188933623 |

--- a/features/cli/pod.feature
+++ b/features/cli/pod.feature
@@ -3,7 +3,7 @@ Feature: pods related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-11218
   @inactive
-  Scenario: kubectl describe pod should show qos tier info when pod without limits and request info
+  Scenario: OCP-11218 kubectl describe pod should show qos tier info when pod without limits and request info
     Given I have a project
     Given I obtain test data file "pods/hello-pod.json"
     When I run the :create client command with:
@@ -28,7 +28,7 @@ Feature: pods related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: kubectl describe pod should show qos tier info
+  Scenario: OCP-11527 kubectl describe pod should show qos tier info
     Given I have a project
     Given I obtain test data file "quota/pod-notbesteffort.yaml"
     When I run the :create client command with:
@@ -63,7 +63,7 @@ Feature: pods related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-10729
   @inactive
-  Scenario: Implement supplemental groups for pod
+  Scenario: OCP-10729 Implement supplemental groups for pod
     Given I have a project
     Given I obtain test data file "pods/ocp10729/pod-supplementalGroups.yaml"
     When I run the :create client command with:
@@ -113,7 +113,7 @@ Feature: pods related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Pod should be immediately deleted if it's not scheduled even if graceful termination period is set
+  Scenario: OCP-11753 Pod should be immediately deleted if it's not scheduled even if graceful termination period is set
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/10.json"
     When I run the :create client command with:
@@ -131,7 +131,7 @@ Feature: pods related scenarios
   # @case_id OCP-10813
   # @bug_id 1324396
   @inactive
-  Scenario: Update ActiveDeadlineSeconds for pod
+  Scenario: OCP-10813 Update ActiveDeadlineSeconds for pod
     Given I have a project
     Given I obtain test data file "pods/ocp10813/hello-pod.json"
     When I run the :create client command with:
@@ -172,7 +172,7 @@ Feature: pods related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: /dev/shm can be automatically shared among all of a pod's containers
+  Scenario: OCP-11055 /dev/shm can be automatically shared among all of a pod's containers
     Given I have a project
     Given I obtain test data file "pods/pod_with_two_containers.json"
     When I run the :create client command with:
@@ -231,7 +231,7 @@ Feature: pods related scenarios
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: 4.0 Oauth provider info should be consumed in a pod
+  Scenario: OCP-22283 4.0 Oauth provider info should be consumed in a pod
     Given I have a project
     When I run the :new_app client command with:
       | docker_image | aosqe/ruby-ex |

--- a/features/cli/policy.feature
+++ b/features/cli/policy.feature
@@ -10,7 +10,7 @@ Feature: change the policy of user/service account
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: User can view ,add, remove and modify roleBinding via admin role user
+  Scenario: OCP-11074 User can view ,add, remove and modify roleBinding via admin role user
     Given I have a project
     When I run the :get client command with:
       | resource      | rolebinding |
@@ -65,7 +65,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Could get projects for new role which has permission to get projects
+  Scenario: OCP-12430 Could get projects for new role which has permission to get projects
     Given an 8 characters random string of type :dns is stored into the :random clipboard
     And admin ensures "clusterrole-12430-<%= cb.random %>" cluster_role is deleted after scenario
     Given I obtain test data file "authorization/policy/clustergetproject.json"
@@ -89,7 +89,7 @@ Feature: change the policy of user/service account
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: User can view, add , modify and delete specific role to/from new added project via admin role user
+  Scenario: OCP-11442 User can view, add , modify and delete specific role to/from new added project via admin role user
     Given I have a project
     Given I obtain test data file "authorization/policy/projectviewservice.json"
     When I run the :create client command with:
@@ -147,7 +147,7 @@ Feature: change the policy of user/service account
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: DaemonSet only support Always restartPolicy
+  Scenario: OCP-10211 DaemonSet only support Always restartPolicy
     Given I have a project
     Given cluster role "sudoer" is added to the "first" user
     Given I obtain test data file "daemon/daemonset-negtive-onfailure.yaml"
@@ -178,7 +178,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Basic user could not get deeper storageclass object info
+  Scenario: OCP-10447 Basic user could not get deeper storageclass object info
     Given I have a project
     When I run the :get client command with:
       | resource | storageclass |
@@ -228,7 +228,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: User with role storage-admin can check deeper storageclass object info
+  Scenario: OCP-10448 User with role storage-admin can check deeper storageclass object info
     Given I have a project
     And admin ensures "sc-<%= project.name %>" storageclasses is deleted after scenario
     Given cluster role "storage-admin" is added to the "first" user
@@ -291,7 +291,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: User with role storage-admin can check deeper pv object info
+  Scenario: OCP-10466 User with role storage-admin can check deeper pv object info
     Given I have a project
     And admin ensures "pv-<%= project.name %>" pv is deleted after scenario
     Given cluster role "storage-admin" is added to the "first" user
@@ -355,7 +355,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: User with role storage-admin can get pvc object info
+  Scenario: OCP-10467 User with role storage-admin can get pvc object info
     Given I have a project
     And evaluation of `project.name` is stored in the :project clipboard
 
@@ -403,7 +403,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Basic user could not get pv object info
+  Scenario: OCP-10465 Basic user could not get pv object info
     Given I have a project
     Then I run the :get client command with:
       | resource | pv |
@@ -430,7 +430,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: User can know if he can create podspec against the current scc rules via CLI
+  Scenario: OCP-9551 User can know if he can create podspec against the current scc rules via CLI
     Given I have a project
     Given I obtain test data file "authorization/scc/PodSecurityPolicySubjectReview_privileged_false.json"
     Given I run the :policy_scc_subject_review client command with:
@@ -468,7 +468,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: User can know which serviceaccount and SA groups can create the podspec against the current sccs by CLI
+  Scenario: OCP-9552 User can know which serviceaccount and SA groups can create the podspec against the current sccs by CLI
     Given I have a project
     Given I obtain test data file "authorization/scc/PodSecurityPolicyReview.json"
     Given I run the :policy_scc_review client command with:
@@ -512,7 +512,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: User can know whether the PodSpec he's describing will actually be allowed by the current SCC rules via CLI
+  Scenario: OCP-9553 User can know whether the PodSpec he's describing will actually be allowed by the current SCC rules via CLI
     Given I have a project
     Given I obtain test data file "authorization/scc/PodSecurityPolicySubjectReview.json"
     # If user is specified but not groups, it is interpreted as "what if the user

--- a/features/cli/projects.feature
+++ b/features/cli/projects.feature
@@ -11,7 +11,7 @@ Feature: projects related features via cli
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Could delete all resources when delete the project
+  Scenario: OCP-11887 Could delete all resources when delete the project
     Given a 5 characters random string of type :dns is stored into the :prj_name clipboard
     When I run the :new_project client command with:
       | project_name | <%= cb.prj_name %> |
@@ -83,7 +83,7 @@ Feature: projects related features via cli
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: User can get node selector from a project
+  Scenario: OCP-12193 User can get node selector from a project
     Given  an 8 character random string of type :dns is stored into the :oadmproj1 clipboard
     Given  an 8 character random string of type :dns is stored into the :oadmproj2 clipboard
     When admin creates a project with:
@@ -117,7 +117,7 @@ Feature: projects related features via cli
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Could remove user and group from the current project
+  Scenario: OCP-12561 Could remove user and group from the current project
     Given I have a project
     When I run the :oadm_policy_add_role_to_user client command with:
       | role_name        | admin                              |
@@ -160,7 +160,7 @@ Feature: projects related features via cli
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Process with default FSGroup id can be ran when using the default MustRunAs as the RunAsGroupStrategy
+  Scenario: OCP-11201 Process with default FSGroup id can be ran when using the default MustRunAs as the RunAsGroupStrategy
     Given I have a project
     Given I obtain test data file "pods/hello-pod.json"
     When I run the :create client command with:

--- a/features/cli/replica_set.feature
+++ b/features/cli/replica_set.feature
@@ -3,7 +3,7 @@ Feature: replicaSet related tests
   # @author pruan@redhat.com
   # @case_id OCP-10917
   @smoke
-  Scenario: Support endpoints of RS in OpenShift
+  Scenario: OCP-10917 Support endpoints of RS in OpenShift
     Given I have a project
     Given I obtain test data file "replicaSet/ocp10917/rs_endpoints.yaml"
     When I run the :create client command with:

--- a/features/cli/resources.feature
+++ b/features/cli/resources.feature
@@ -10,7 +10,7 @@ Feature: resouces related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Return description of resources with cli describe
+  Scenario: OCP-11882 Return description of resources with cli describe
     Given I have a project
     And I create a new application with:
       | file     | https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/application-template-stibuild.json |

--- a/features/cli/rolling_deploy.feature
+++ b/features/cli/rolling_deploy.feature
@@ -3,7 +3,7 @@ Feature: rolling deployment related scenarios
   # @author pruan@redhat.com
   # @case_id OCP-12359
   @inactive
-  Scenario: Rolling-update pods with default value for maxSurge/maxUnavailable
+  Scenario: OCP-12359 Rolling-update pods with default value for maxSurge/maxUnavailable
     Given I have a project
     Given I obtain test data file "deployment/rolling.json"
     When I run the :create client command with:

--- a/features/cli/route.feature
+++ b/features/cli/route.feature
@@ -11,7 +11,7 @@ Feature: route related features via cli
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Expose routes from services
+  Scenario: OCP-10629 Expose routes from services
     Given I have a project
     When I run the :new_app client command with:
       | code | https://github.com/sclorg/s2i-perl-container |
@@ -44,7 +44,7 @@ Feature: route related features via cli
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Be unable to add an existed alias name for service
+  Scenario: OCP-12022 Be unable to add an existed alias name for service
     Given I have a project
     Given I obtain test data file "routing/unsecure/route_unsecure.json"
     When I run the :create client command with:

--- a/features/cli/rsh.feature
+++ b/features/cli/rsh.feature
@@ -10,7 +10,7 @@ Feature: rsh.feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check oc rsh for simpler access to a remote shell
+  Scenario: OCP-10658 Check oc rsh for simpler access to a remote shell
     Given I have a project
     Then evaluation of `project.name` is stored in the :proj_name clipboard
     Given I obtain test data file "pods/pod_with_two_containers.json"

--- a/features/cli/scale.feature
+++ b/features/cli/scale.feature
@@ -4,7 +4,7 @@ Feature: scaling related scenarios
   # @case_id OCP-10626
   @proxy
   @inactive
-  Scenario: Scale replicas via replicationcontrollers and deploymentconfig
+  Scenario: OCP-10626 Scale replicas via replicationcontrollers and deploymentconfig
     Given I have a project
     And I create a new application with:
       | image_stream | openshift/perl:5.26                          |

--- a/features/cli/secrets.feature
+++ b/features/cli/secrets.feature
@@ -9,7 +9,7 @@ Feature: secrets related scenarios
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: deployment hook volume inheritance --with secret volume
+  Scenario: OCP-10725 deployment hook volume inheritance --with secret volume
     Given I have a project
     And I run the :create_secret client command with:
       | secret_type | generic    |
@@ -44,7 +44,7 @@ Feature: secrets related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Pods do not have access to each other's secrets in the same namespace
+  Scenario: OCP-12281 Pods do not have access to each other's secrets in the same namespace
     Given I have a project
     Given I obtain test data file "secrets/ocp12281/first-secret.json"
     When I run the :create client command with:
@@ -97,7 +97,7 @@ Feature: secrets related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Pods do not have access to each other's secrets with the same secret name in different namespaces
+  Scenario: OCP-12310 Pods do not have access to each other's secrets with the same secret name in different namespaces
     Given I have a project
     Given evaluation of `project.name` is stored in the :project0 clipboard
     Given I obtain test data file "secrets/secret1.json"
@@ -196,7 +196,7 @@ Feature: secrets related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Consume the same Secrets as environment variables in multiple pods
+  Scenario: OCP-10814 Consume the same Secrets as environment variables in multiple pods
     Given I have a project
     Given I obtain test data file "secrets/secret.yaml"
     When I run the :create client command with:
@@ -254,7 +254,7 @@ Feature: secrets related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Using Secrets as Environment Variables
+  Scenario: OCP-11260 Using Secrets as Environment Variables
     Given I have a project
     Given I obtain test data file "secrets/secret.yaml"
     When I run the :create client command with:
@@ -284,7 +284,7 @@ Feature: secrets related scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
-  Scenario: Secret volume should update when secret is updated
+  Scenario: OCP-11311 Secret volume should update when secret is updated
     Given I have a project
     Given I obtain test data file "secrets/secret1.json"
     When I run the :create client command with:
@@ -327,7 +327,7 @@ Feature: secrets related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Mapping specified secret volume should update when secret is updated
+  Scenario: OCP-10899 Mapping specified secret volume should update when secret is updated
     Given I have a project
     Given I obtain test data file "secrets/secret1.json"
     When I run the :create client command with:
@@ -367,7 +367,7 @@ Feature: secrets related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Allow specifying secret data using strings and images
+  Scenario: OCP-10569 Allow specifying secret data using strings and images
     Given I have a project
     Given I obtain test data file "secrets/secret-datastring-image.json"
     When I run the :create client command with:
@@ -421,7 +421,7 @@ Feature: secrets related scenarios
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: oc new-app to gather git creds
+  Scenario: OCP-10982 oc new-app to gather git creds
     Given I have a project
     When I have an http-git service in the project
     And I run the :set_env client command with:
@@ -501,7 +501,7 @@ Feature: secrets related scenarios
 
   # @author xiuwang@redhat.com
   # @case_id OCP-12838
-  Scenario: Use build source secret based on annotation on Secret --http
+  Scenario: OCP-12838 Use build source secret based on annotation on Secret --http
     Given I have a project
     When I have an http-git service in the project
     And I run the :set_env client command with:

--- a/features/cli/serviceaccount.feature
+++ b/features/cli/serviceaccount.feature
@@ -10,7 +10,7 @@ Feature: ServiceAccount and Policy Managerment
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Could grant admin permission for the service account username to access to its own project
+  Scenario: OCP-10642 Could grant admin permission for the service account username to access to its own project
     Given I have a project
     When I create a new application with:
       | image_stream | ruby         |
@@ -47,7 +47,7 @@ Feature: ServiceAccount and Policy Managerment
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Could grant admin permission for the service account group to access to its own project
+  Scenario: OCP-11494 Could grant admin permission for the service account group to access to its own project
     Given I have a project
     When I run the :new_app client command with:
       | app_repo | quay.io/openshifttest/hello-openshift:multiarch |
@@ -90,7 +90,7 @@ Feature: ServiceAccount and Policy Managerment
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: User can get the serviceaccount token via client
+  Scenario: OCP-11249 User can get the serviceaccount token via client
     Given I have a project
     When I run the :serviceaccounts_get_token client command with:
       |serviceaccount_name| default|

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -7,7 +7,7 @@ Feature: Check status via oc status, wait etc
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Show RC info and indicate bad secrets reference in 'oc status'
+  Scenario: OCP-11147 Show RC info and indicate bad secrets reference in 'oc status'
     Given I have a project
 
     # Check standalone RC info is dispalyed in oc status output

--- a/features/cluster_configuration/autoscaling.feature
+++ b/features/cluster_configuration/autoscaling.feature
@@ -1,4 +1,5 @@
 Feature: auto scaling related scenarios
+
   @admin
   @destructive
   Scenario: setup autoscaling

--- a/features/cluster_configuration/cluster_logging_operator.feature
+++ b/features/cluster_configuration/cluster_logging_operator.feature
@@ -1,4 +1,5 @@
 Feature: cluster logging related scenarios
+
   # @author pruan@redhat.com
   # @case_id OCP-21311
   @admin
@@ -11,6 +12,6 @@ Feature: cluster logging related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Deploy Logging Via Community Operators
+  Scenario: OCP-21311 Deploy Logging Via Community Operators
     Given logging service has been installed successfully
 

--- a/features/cluster_configuration/create_index_catalog.feature
+++ b/features/cluster_configuration/create_index_catalog.feature
@@ -1,4 +1,5 @@
 Feature: create index catalog
+
   # based on https://gitlab.cee.redhat.com/aosqe/aosqe-tools/-/blob/master/app_registry_tools/create_index_catalogsource.sh
   @admin
   @destructive

--- a/features/cluster_configuration/csi.feature
+++ b/features/cluster_configuration/csi.feature
@@ -1,4 +1,5 @@
 Feature: Enable CSI in OCP cluster
+
   # @author piqin@redhat.com
   @admin
   @destructive

--- a/features/cluster_configuration/localstorage.feature
+++ b/features/cluster_configuration/localstorage.feature
@@ -1,4 +1,5 @@
 Feature: Deploy LocalVolume provisoner in OCP cluster
+
   # @author piqin@redhat.com
   @admin
   @destructive

--- a/features/cluster_configuration/snapshot.feature
+++ b/features/cluster_configuration/snapshot.feature
@@ -1,4 +1,5 @@
 Feature: Enable volume snapshot on the cluster
+
   # @author lxia@redhat.com
   @admin
   @destructive

--- a/features/images/rhel8_images.feature
+++ b/features/images/rhel8_images.feature
@@ -7,7 +7,7 @@ Feature: rhel8images.feature
   @singlenode
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Using new-app cmd to create app with ruby rhel8 image
+  Scenario: OCP-22950 Using new-app cmd to create app with ruby rhel8 image
     Given I have a project
     When I run the :tag admin command with:
       | source           | registry.redhat.io/rhel8/ruby-25:latest |
@@ -45,7 +45,7 @@ Feature: rhel8images.feature
   # @case_id OCP-22953
   @admin
   @inactive
-  Scenario: Enable hot deploy for ruby app with ruby rhel8 image
+  Scenario: OCP-22953 Enable hot deploy for ruby app with ruby rhel8 image
     Given I have a project
     When I run the :tag admin command with:
       | source           | registry.redhat.io/rhel8/ruby-25:latest |
@@ -79,7 +79,7 @@ Feature: rhel8images.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: mysql persistent template
+  Scenario: OCP-22595 mysql persistent template
     Given I have a project
     When I run the :tag admin command with:
       | source           | registry.redhat.io/rhel8/mysql-80:latest |
@@ -138,7 +138,7 @@ Feature: rhel8images.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create mysql service from imagestream via oc new-app mysql-rhel8 image
+  Scenario: OCP-22958 Create mysql service from imagestream via oc new-app mysql-rhel8 image
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mysql:latest |
@@ -180,7 +180,7 @@ Feature: rhel8images.feature
   # @case_id OCP-31249
   @admin
   @inactive
-  Scenario: Using new-app cmd to create app with ruby rhel8 image test
+  Scenario: OCP-31249 Using new-app cmd to create app with ruby rhel8 image test
     Given I have a project
     When I run the :tag admin command with:
       | source           | registry.redhat.io/rhel8/ruby-25:latest |

--- a/features/infrastructure/cluster-capacity.feature
+++ b/features/infrastructure/cluster-capacity.feature
@@ -13,7 +13,7 @@ Feature: cluster-capacity related features
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Cluster capacity image support: Cluster capacity can work well with a simple pod
+  Scenario: OCP-14799 Cluster capacity image support: Cluster capacity can work well with a simple pod
     Given environment has at least 2 schedulable nodes
     Given I have a project
     Given I create the serviceaccount "cluster-capacity-sa"

--- a/features/infrastructure/scheduler.feature
+++ b/features/infrastructure/scheduler.feature
@@ -4,7 +4,7 @@ Feature: Scheduler predicates and priority test suites
   # @case_id OCP-12467
   @admin
   @inactive
-  Scenario: Fixed predicates rules testing - MatchNodeSelector
+  Scenario: OCP-12467 Fixed predicates rules testing - MatchNodeSelector
     Given I have a project
     Given I obtain test data file "scheduler/pod_with_nodeselector.json"
     Given I run the :create client command with:

--- a/features/kata/install_uninstall.feature
+++ b/features/kata/install_uninstall.feature
@@ -1,11 +1,12 @@
 Feature: kata related features
+
   # @author pruan@redhat.com
   # @case_id OCP-36508
   @admin
   @destructive
   @flaky
   @inactive
-  Scenario: kata container operator installation
+  Scenario: OCP-36508 kata container operator installation
     Given kata container has been installed successfully in the "openshift-sandboxed-containers-operator" project
     And I verify kata container runtime is installed into a worker node
 
@@ -21,7 +22,7 @@ Feature: kata related features
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: test delete kata installation
+  Scenario: OCP-36509 test delete kata installation
     Given I remove kata operator from the namespace
 
 
@@ -43,7 +44,7 @@ Feature: kata related features
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Operator can be installed through web console
+  Scenario: OCP-39344 Operator can be installed through web console
     Given the kata-operator is installed using OLM GUI
 
   # @author pruan@redhat.com
@@ -52,7 +53,7 @@ Feature: kata related features
   @destructive
   @flaky
   @inactive
-  Scenario: kata operator can be installed via CLI with OLM for OCP>=4.8
+  Scenario: OCP-39499 kata operator can be installed via CLI with OLM for OCP>=4.8
     Given the kata-operator is installed using OLM CLI
 
   # @author pruan@redhat.com
@@ -65,7 +66,7 @@ Feature: kata related features
   @gcp-upi @baremetal-upi @azure-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: install kata, verify pod has kata runtime followed by uninstall kata from cluster
+  Scenario: OCP-41813 install kata, verify pod has kata runtime followed by uninstall kata from cluster
     Given the kata-operator is installed using OLM CLI
     And I verify kata container runtime is installed into a worker node
     And I ensure "<%= project.name %>" project is deleted

--- a/features/kata/pod.feature
+++ b/features/kata/pod.feature
@@ -1,4 +1,5 @@
 Feature: kata and pod related scenarios
+
   # @author pruan@redhat.com
   # @case_id OCP-38468
   @4.11 @4.10 @4.9 @4.8 @4.7
@@ -8,7 +9,7 @@ Feature: kata and pod related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Pod using kata runtime can have an initcontainer
+  Scenario: OCP-38468 Pod using kata runtime can have an initcontainer
     Given I have a project
     And I obtain test data file "kata/OCP-38468/pod_with_init_container.yaml"
     And I run the :create client command with:

--- a/features/kata/smoke_tests.feature
+++ b/features/kata/smoke_tests.feature
@@ -1,4 +1,5 @@
 Feature: kata smoke tests
+
   # @author pruan@redhat.com
   # @case_id OCP-41263
   @admin
@@ -10,6 +11,6 @@ Feature: kata smoke tests
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Namespace installed by operator
+  Scenario: OCP-41263 Namespace installed by operator
     Given kata container has been installed successfully
     Then the expression should be true> project.name == 'openshift-sandboxed-containers-operator'

--- a/features/logging/cluster_log_forwarder.feature
+++ b/features/logging/cluster_log_forwarder.feature
@@ -12,7 +12,7 @@ Feature: cluster log forwarder features
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: ClusterLogForwarder `default` behavior testing
+  Scenario: OCP-25989 ClusterLogForwarder `default` behavior testing
     Given the master version >= "4.6"
     # create project to generate logs
     Given I switch to the first user
@@ -144,7 +144,7 @@ Feature: cluster log forwarder features
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous
-  Scenario: ClusterLogForwarder: Forward logs to fluentd as insecure
+  Scenario: OCP-29843 ClusterLogForwarder: Forward logs to fluentd as insecure
     Given I switch to the first user
     And I have a project
     And evaluation of `project` is stored in the :fluentd_proj clipboard
@@ -316,7 +316,7 @@ Feature: cluster log forwarder features
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Forward logs to remote-syslog - config error
+  Scenario: OCP-33627 Forward logs to remote-syslog - config error
     Given the master version >= "4.6"
     Given I switch to cluster admin pseudo user
     And I use the "openshift-logging" project
@@ -395,7 +395,7 @@ Feature: cluster log forwarder features
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Forward logs to different kafka topics
+  Scenario: OCP-32697 Forward logs to different kafka topics
     Given I switch to the first user
     And I create a project with non-leading digit name
     And evaluation of `project` is stored in the :kafka_project clipboard
@@ -444,7 +444,7 @@ Feature: cluster log forwarder features
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Fluentd continues to ship logs even when one of multiple destination is down
+  Scenario: OCP-32628 Fluentd continues to ship logs even when one of multiple destination is down
     # create project to generate logs
     Given I switch to the first user
     Given I create a project with non-leading digit name
@@ -558,7 +558,7 @@ Feature: cluster log forwarder features
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Send logs to both external fluentd and internalES
+  Scenario: OCP-39786 Send logs to both external fluentd and internalES
     #Creating secure fluentd receiver
     Given I switch to cluster admin pseudo user
     Given fluentd receiver is deployed as secure with server_auth_share enabled in the "openshift-logging" project

--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -14,7 +14,7 @@ Feature: cluster-logging-operator related test
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: ServiceMonitor Object for collector is deployed along with cluster logging
+  Scenario: OCP-21333 ServiceMonitor Object for collector is deployed along with cluster logging
     Given logging collector name is stored in the :collector_name clipboard
     Given I wait for the "<%= cb.collector_name %>" service_monitor to appear
     And the expression should be true> service_monitor("<%= cb.collector_name %>").service_monitor_endpoint_spec(port: "metrics").path == "/metrics"
@@ -37,7 +37,7 @@ Feature: cluster-logging-operator related test
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
-  Scenario: Scale Elasticsearch nodes by nodeCount 2->3->4 in clusterlogging
+  Scenario: OCP-22492 Scale Elasticsearch nodes by nodeCount 2->3->4 in clusterlogging
     Given I obtain test data file "logging/clusterlogging/scalebase.yaml"
     Given I create clusterlogging instance with:
       | remove_logging_pods | true           |
@@ -95,7 +95,7 @@ Feature: cluster-logging-operator related test
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Fluentd alert rule: FluentdNodeDown
+  Scenario: OCP-23738 Fluentd alert rule: FluentdNodeDown
     Given the master version >= "4.2"
     Given I obtain test data file "logging/clusterlogging/example.yaml"
     Given I create clusterlogging instance with:
@@ -127,7 +127,7 @@ Feature: cluster-logging-operator related test
   @admin
   @destructive
   @inactive
-  Scenario: CLO should generate Elasticsearch Index Management
+  Scenario: OCP-28131 CLO should generate Elasticsearch Index Management
     Given I obtain test data file "logging/clusterlogging/example_indexmanagement.yaml"
     Given I create clusterlogging instance with:
       | remove_logging_pods | true                         |
@@ -163,7 +163,7 @@ Feature: cluster-logging-operator related test
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: OpenShift Logging dashboard
+  Scenario: OCP-33721 OpenShift Logging dashboard
     Given I switch to the first user
     And the first user is cluster-admin
     And I open admin console in a browser
@@ -193,7 +193,7 @@ Feature: cluster-logging-operator related test
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Expose more fluentd knobs to support optimizing fluentd for different environments - Invalid Values
+  Scenario: OCP-33868 Expose more fluentd knobs to support optimizing fluentd for different environments - Invalid Values
     Given I register clean-up steps:
     """
     Given I delete the clusterlogging instance
@@ -215,7 +215,7 @@ Feature: cluster-logging-operator related test
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Expose more fluentd knobs to support optimizing fluentd for different environments
+  Scenario: OCP-33793 Expose more fluentd knobs to support optimizing fluentd for different environments
     Given I obtain test data file "logging/clusterlogging/cl_fluentd-buffer.yaml"
     And I create clusterlogging instance with:
       | remove_logging_pods | true                   |
@@ -244,7 +244,7 @@ Feature: cluster-logging-operator related test
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Fluentd optimizing variable changes trigger new deployment
+  Scenario: OCP-33894 Fluentd optimizing variable changes trigger new deployment
     Given I obtain test data file "logging/clusterlogging/cl_fluentd-buffer_default.yaml"
     And I create clusterlogging instance with:
       | remove_logging_pods | true                           |

--- a/features/logging/collector.feature
+++ b/features/logging/collector.feature
@@ -10,7 +10,7 @@ Feature: collector related tests
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: All nodes logs are sent to Elasticsearch
+  Scenario: OCP-25767 All nodes logs are sent to Elasticsearch
     Given the master version == "4.1"
     Given evaluation of `cluster_logging('instance').fluentd_ready_pods.map(&:ip)` is stored in the :collector_pod_ips clipboard
     #A workaround to https://bugzilla.redhat.com/show_bug.cgi?id=1776594
@@ -54,7 +54,7 @@ Feature: collector related tests
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
-  Scenario: All nodes logs had sent logs to Elasticsearch
+  Scenario: OCP-24837 All nodes logs had sent logs to Elasticsearch
     Given the master version >= "4.2"
     Given evaluation of `cluster_logging('instance').collection_type` is stored in the :collection_type clipboard
     Given <%= daemon_set(cb.collection_type).replica_counters[:desired] %> pods become ready with labels:
@@ -129,7 +129,7 @@ Feature: collector related tests
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
-  Scenario: The Container logs metadata check
+  Scenario: OCP-18147 The Container logs metadata check
     Given the master version == "4.1"
     Given I switch to the first user
     Given I create a project with non-leading digit name
@@ -171,7 +171,7 @@ Feature: collector related tests
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: The container logs metadata check
+  Scenario: OCP-25768 The container logs metadata check
     Given the master version >= "4.2"
     Given I switch to the first user
     Given I create a project with non-leading digit name
@@ -214,7 +214,7 @@ Feature: collector related tests
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: All nodes logs are collected
+  Scenario: OCP-30084 All nodes logs are collected
     Given the master version >= "4.5"
     Given logging collector name is stored in the :collector_name clipboard
     Given <%= daemon_set(cb.collector_name).replica_counters[:desired] %> pods become ready with labels:
@@ -259,7 +259,7 @@ Feature: collector related tests
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: Fluentd should write it's own logs to stdout and exclude them from collection
+  Scenario: OCP-32197 Fluentd should write it's own logs to stdout and exclude them from collection
     Given I obtain test data file "logging/clusterlogging/example.yaml"
     When I create clusterlogging instance with:
       | remove_logging_pods | true         |

--- a/features/logging/elasticsearch.feature
+++ b/features/logging/elasticsearch.feature
@@ -13,7 +13,7 @@ Feature: Elasticsearch related tests
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Elasticsearch using dynamic volumes
+  Scenario: OCP-22050 Elasticsearch using dynamic volumes
     Given default storageclass is stored in the :default_sc clipboard
     Given I obtain test data file "logging/clusterlogging/clusterlogging-storage-template.yaml"
     Given I create clusterlogging instance with:
@@ -54,7 +54,7 @@ Feature: Elasticsearch related tests
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Elasticsearch6 new data modle indices
+  Scenario: OCP-30776 Elasticsearch6 new data modle indices
     Given I switch to the first user
     And I create a project with non-leading digit name
     And evaluation of `project` is stored in the :proj clipboard
@@ -88,7 +88,7 @@ Feature: Elasticsearch related tests
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: Elasticsearch retention policy testing
+  Scenario: OCP-28140 Elasticsearch retention policy testing
     Given I switch to the first user
     And I create a project with non-leading digit name
     And evaluation of `project` is stored in the :proj clipboard

--- a/features/logging/elasticsearch_operator.feature
+++ b/features/logging/elasticsearch_operator.feature
@@ -13,7 +13,7 @@ Feature: elasticsearch-operator related tests
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: ServiceMonitor Object for Elasticsearch is deployed along with the Elasticsearch cluster
+  Scenario: OCP-21332 ServiceMonitor Object for Elasticsearch is deployed along with the Elasticsearch cluster
     Given I wait for the "monitor-elasticsearch-cluster" service_monitor to appear
     When I perform the HTTP request on the ES pod with labels "es-node-master=true":
       | relative_url | _prometheus/metrics |
@@ -101,7 +101,7 @@ Feature: elasticsearch-operator related tests
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Additional essential metrics ES dashboard
+  Scenario: OCP-33883 Additional essential metrics ES dashboard
     Given I switch to the first user
     And the first user is cluster-admin
     And I open admin console in a browser

--- a/features/logging/kibana.feature
+++ b/features/logging/kibana.feature
@@ -11,7 +11,7 @@ Feature: Kibana related features
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: Show logs on Kibana web console according to different user role
+  Scenario: OCP-25599 Show logs on Kibana web console according to different user role
     Given I switch to the first user
     Given I create a project with non-leading digit name
     Given evaluation of `project` is stored in the :proj clipboard
@@ -71,7 +71,7 @@ Feature: Kibana related features
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Normal User can only view logs out of the projects owned by himself --kibana
+  Scenario: OCP-30362 Normal User can only view logs out of the projects owned by himself --kibana
     Given I switch to the first user
     And I create a project with non-leading digit name
     And evaluation of `project` is stored in the :proj clipboard
@@ -129,7 +129,7 @@ Feature: Kibana related features
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: User with cluster-admin role can show logs out of all projects -- kibana
+  Scenario: OCP-30361 User with cluster-admin role can show logs out of all projects -- kibana
     Given I switch to the first user
     Given I create a project with non-leading digit name
     Given evaluation of `project` is stored in the :proj clipboard
@@ -190,7 +190,7 @@ Feature: Kibana related features
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: Kibana logout function should log off user
+  Scenario: OCP-32002 Kibana logout function should log off user
     Given the master version < "4.5"
     Given I switch to the first user
     Given I create a project with non-leading digit name
@@ -242,7 +242,7 @@ Feature: Kibana related features
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Logs can be redirected from Webconsole to kibana
+  Scenario: OCP-30343 Logs can be redirected from Webconsole to kibana
     Given I switch to the first user
     Given I create a project with non-leading digit name
     Given evaluation of `project.name` is stored in the :proj_name clipboard

--- a/features/logging/logging_acceptance.feature
+++ b/features/logging/logging_acceptance.feature
@@ -13,7 +13,7 @@ Feature: Logging smoke test case
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: One logging acceptance case for all cluster
+  Scenario: OCP-37508 One logging acceptance case for all cluster
     Given logging operators are installed successfully
     # create a pod to generate some logs
     Given I switch to the second user

--- a/features/logging/permission.feature
+++ b/features/logging/permission.feature
@@ -10,7 +10,7 @@ Feature: permission related test
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: BZ1446217 View the project mapping index as different roles
+  Scenario: OCP-25364 BZ1446217 View the project mapping index as different roles
     Given I switch to the first user
     Given I create a project with non-leading digit name
     And evaluation of `project` is stored in the :project clipboard
@@ -62,7 +62,7 @@ Feature: permission related test
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Normal User can only view project owned by himself
+  Scenario: OCP-30356 Normal User can only view project owned by himself
     Given I switch to the first user
     And evaluation of `user.cached_tokens.first` is stored in the :user_token clipboard
     Given I create a project with non-leading digit name
@@ -113,7 +113,7 @@ Feature: permission related test
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: cluster-admin view all projects
+  Scenario: OCP-30359 cluster-admin view all projects
     Given I switch to the first user
     Given I create a project with non-leading digit name
     And evaluation of `project` is stored in the :proj clipboard

--- a/features/machine/autoscaler.feature
+++ b/features/machine/autoscaler.feature
@@ -10,7 +10,7 @@ Feature: Cluster Autoscaler Tests
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Cluster should automatically scale up and scale down with clusterautoscaler deployed
+  Scenario: OCP-28108 Cluster should automatically scale up and scale down with clusterautoscaler deployed
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -75,7 +75,7 @@ Feature: Cluster Autoscaler Tests
   # @case_id OCP-21516
   @admin
   @destructive
-  Scenario: Cao listens and deploys cluster-autoscaler based on ClusterAutoscaler resource
+  Scenario: OCP-21516 Cao listens and deploys cluster-autoscaler based on ClusterAutoscaler resource
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -92,7 +92,7 @@ Feature: Cluster Autoscaler Tests
   # @case_id OCP-21517
   @admin
   @destructive
-  Scenario: CAO listens and annotations machineSets based on MachineAutoscaler resource
+  Scenario: OCP-21517 CAO listens and annotations machineSets based on MachineAutoscaler resource
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -133,7 +133,7 @@ Feature: Cluster Autoscaler Tests
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Update machineAutoscaler to reference a different MachineSet
+  Scenario: OCP-22102 Update machineAutoscaler to reference a different MachineSet
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -209,7 +209,7 @@ Feature: Cluster Autoscaler Tests
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Machineautoscaler can be deleted when its referenced machineset does not exist
+  Scenario: OCP-23745 Machineautoscaler can be deleted when its referenced machineset does not exist
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project

--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -11,7 +11,7 @@ Feature: Machine features testing
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Machines should be linked to nodes
+  Scenario: OCP-21196 Machines should be linked to nodes
     Given I have an IPI deployment
     Then the machines should be linked to nodes
 
@@ -25,7 +25,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: machine-api clusteroperator should be in Available state
+  Scenario: OCP-22115 machine-api clusteroperator should be in Available state
     Given evaluation of `cluster_operator('machine-api').condition(type: 'Available')` is stored in the :co_available clipboard
     Then the expression should be true> cb.co_available["status"]=="True"
 
@@ -49,7 +49,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Baremetal clusteroperator should be disabled in any deployment that is not baremetal
+  Scenario: OCP-37706 Baremetal clusteroperator should be disabled in any deployment that is not baremetal
     Given evaluation of `cluster_operator('baremetal').condition(type: 'Disabled')` is stored in the :co_disabled clipboard
     Then the expression should be true> cb.co_disabled["status"]=="True"
 
@@ -63,7 +63,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Scale up and scale down a machineSet
+  Scenario: OCP-25436 Scale up and scale down a machineSet
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -117,7 +117,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Machine should have immutable field providerID and nodeRef
+  Scenario: OCP-25608 Machine should have immutable field providerID and nodeRef
     Given I have an IPI deployment
     Given I store the last provisioned machine in the :machine clipboard
     And evaluation of `machine_machine_openshift_io(cb.machine).node_name` is stored in the :nodeRef_name clipboard
@@ -161,7 +161,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Verify all machine instance-state should be consistent with their providerStats.instanceState
+  Scenario: OCP-27627 Verify all machine instance-state should be consistent with their providerStats.instanceState
     Given I have an IPI deployment
     And evaluation of `BushSlicer::MachineMachineOpenshiftIo.list(user: admin, project: project('openshift-machine-api'))` is stored in the :machines clipboard
     Then the expression should be true> cb.machines.select{|m|m.instance_state == m.annotation_instance_state}.count == cb.machines.count
@@ -175,7 +175,7 @@ Feature: Machine features testing
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Scaling a machineset with providerSpec.publicIp set to true
+  Scenario: OCP-27609 Scaling a machineset with providerSpec.publicIp set to true
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -196,7 +196,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Reconciling machine taints with nodes
+  Scenario: OCP-24363 Reconciling machine taints with nodes
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -327,7 +327,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Labels specified in a machineset should propagate to nodes
+  Scenario: OCP-32620 Labels specified in a machineset should propagate to nodes
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -413,7 +413,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Implement defaulting machineset values for GCP
+  Scenario: OCP-33056 Implement defaulting machineset values for GCP
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -498,7 +498,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Run machine api Controllers using leader election
+  Scenario: OCP-33455 Run machine api Controllers using leader election
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -527,7 +527,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Node labels and Affinity definition in PV should match
+  Scenario: OCP-34718 Node labels and Affinity definition in PV should match
     Given I have a project
 
     # Create a pvc
@@ -619,7 +619,7 @@ Feature: Machine features testing
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Machineset should not be created when publicIP:true in disconnected Azure enviroment
+  Scenario: OCP-36489 Machineset should not be created when publicIP:true in disconnected Azure enviroment
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project
@@ -642,7 +642,7 @@ Feature: Machine features testing
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: Operator cloud-controller-manager should not show empty version
+  Scenario: OCP-47658 Operator cloud-controller-manager should not show empty version
     Given I switch to cluster admin pseudo user
     Then evaluation of `cluster_operator('cloud-controller-manager').versions` is stored in the :versions clipboard
     And the expression should be true> cb.versions[0].include? "4"
@@ -656,7 +656,7 @@ Feature: Machine features testing
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: Baremetal clusteroperator should be enabled in vsphere and osp 
+  Scenario: OCP-47989 Baremetal clusteroperator should be enabled in vsphere and osp 
     Given evaluation of `cluster_operator('baremetal').condition(type: 'Disabled')` is stored in the :co_disabled clipboard
     Then the expression should be true> cb.co_disabled["status"]=="False"
 

--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -9,7 +9,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Remediation should be applied when the unhealthyCondition 'Ready' is met
+  Scenario: OCP-25897 Remediation should be applied when the unhealthyCondition 'Ready' is met
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -49,7 +49,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Create a machinehealthcheck when there is already an unhealthy machine
+  Scenario: OCP-26311 Create a machinehealthcheck when there is already an unhealthy machine
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -81,7 +81,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Create multiple MHCs to monitor same machineset
+  Scenario: OCP-25734 Create multiple MHCs to monitor same machineset
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -115,7 +115,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Use "maxUnhealthy" to prevent automated remediation
+  Scenario: OCP-25691 Use "maxUnhealthy" to prevent automated remediation
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -168,7 +168,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Machine Node startup timeout should be configurable
+  Scenario: OCP-28718 Machine Node startup timeout should be configurable
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project
@@ -210,7 +210,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Remediation should be applied when machine has nodeRef but node is deleted
+  Scenario: OCP-25727 Remediation should be applied when machine has nodeRef but node is deleted
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -236,7 +236,7 @@ Feature: MachineHealthCheck Test Scenarios
   @admin
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: MaxUnhealthy should not allow malformed values
+  Scenario: OCP-29857 MaxUnhealthy should not allow malformed values
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project
@@ -268,7 +268,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: MHC MaxUnhealthy string value should be checked for '%' symbol
+  Scenario: OCP-28859 MHC MaxUnhealthy string value should be checked for '%' symbol
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -308,7 +308,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Leverage OpenAPI validation within MHC
+  Scenario: OCP-33714 Leverage OpenAPI validation within MHC
     Given I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project
 
@@ -329,7 +329,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: timeout field without units(h,m,s) shoud not be allowed to be stored
+  Scenario: OCP-34095 timeout field without units(h,m,s) shoud not be allowed to be stored
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project

--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -9,7 +9,7 @@ Feature: Machine misc features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: PVCs can still be provisioned after the password has been changed vSphere
+  Scenario: OCP-34940 PVCs can still be provisioned after the password has been changed vSphere
     Given I have an IPI deployment
     Then I switch to cluster admin pseudo user
 
@@ -68,7 +68,7 @@ Feature: Machine misc features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Reconciliation of MutatingWebhookConfiguration values should happen
+  Scenario: OCP-35454 Reconciliation of MutatingWebhookConfiguration values should happen
     Given I switch to cluster admin pseudo user
 
     Given I use the "openshift-cluster-version" project
@@ -126,7 +126,7 @@ Feature: Machine misc features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: kube-rbac-proxy should not expose tokens, have excessive verbosity
+  Scenario: OCP-37744 kube-rbac-proxy should not expose tokens, have excessive verbosity
     Given I switch to cluster admin pseudo user
 
     Given I use the "openshift-machine-api" project
@@ -171,7 +171,7 @@ Feature: Machine misc features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Report vCenter version to telemetry
+  Scenario: OCP-37180 Report vCenter version to telemetry
     Given I switch to cluster admin pseudo user
     When I perform the GET prometheus rest client with:
       | path  | /api/v1/query?                         |
@@ -188,7 +188,7 @@ Feature: Machine misc features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Deattach disk before destroying vm from vsphere
+  Scenario: OCP-40665 Deattach disk before destroying vm from vsphere
     Given I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project
     And I clone a machineset and name it "machineset-clone-40665"

--- a/features/machine/upi_gcp.feature
+++ b/features/machine/upi_gcp.feature
@@ -9,7 +9,7 @@ Feature: UPI GCP Tests
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: MachineSets in GCP should create Machines in a Shared (XPN) VPC environment
+  Scenario: OCP-34697 MachineSets in GCP should create Machines in a Shared (XPN) VPC environment
     Given I have an UPI deployment and machinesets are enabled
 
   # @author zhsun@redhat.com
@@ -21,7 +21,7 @@ Feature: UPI GCP Tests
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: GCP Scaling OCP Cluster on UPI
+  Scenario: OCP-25034 GCP Scaling OCP Cluster on UPI
     Given I have an UPI deployment and machinesets are enabled
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project

--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -11,7 +11,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: EgressNetworkPolicy will not take effect after delete it
+  Scenario: OCP-11639 EgressNetworkPolicy will not take effect after delete it
     Given I have a project
     Given I have a pod-for-ping in the project
     Given I save egress data file directory to the clipboard
@@ -56,7 +56,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: Apply different egress network policy in different projects
+  Scenario: OCP-13502 Apply different egress network policy in different projects
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -126,7 +126,7 @@ Feature: Egress-ingress related networking scenarios
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: The rules of egress network policy are added in openflow
+  Scenario: OCP-13507 The rules of egress network policy are added in openflow
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -172,7 +172,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: Egress network policy use dnsname with multiple ipv4 addresses
+  Scenario: OCP-13509 Egress network policy use dnsname with multiple ipv4 addresses
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -208,7 +208,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: Service with a DNS name can not by pass Egressnetworkpolicy with that DNS name
+  Scenario: OCP-15005 Service with a DNS name can not by pass Egressnetworkpolicy with that DNS name
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -270,7 +270,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: Add nodes local IP address to OVS rules for egressnetworkpolicy
+  Scenario: OCP-15017 Add nodes local IP address to OVS rules for egressnetworkpolicy
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -325,7 +325,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: Update different dnsname in same egress network policy
+  Scenario: OCP-13506 Update different dnsname in same egress network policy
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -365,7 +365,7 @@ Feature: Egress-ingress related networking scenarios
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Iptables should be updated with correct endpoints when egress DNS policy was used
+  Scenario: OCP-19615 Iptables should be updated with correct endpoints when egress DNS policy was used
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
     When I run oc create over "list_for_pods.json" replacing paths:
@@ -420,7 +420,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
-  Scenario: EgressFirewall allows traffic to destination ports
+  Scenario: OCP-33530 EgressFirewall allows traffic to destination ports
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -461,7 +461,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
-  Scenario: EgressFirewall rules take effect in order
+  Scenario: OCP-33531 EgressFirewall rules take effect in order
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -486,7 +486,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
-  Scenario: EgressFirewall policy should not take effect for traffic between pods and pods to service
+  Scenario: OCP-33539 EgressFirewall policy should not take effect for traffic between pods and pods to service
     Given I have a project
     # Create EgressFirewall policy to deny all outbound traffic
     When I obtain test data file "networking/ovn-egressfirewall/limit_policy.json"
@@ -525,7 +525,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
-  Scenario: EgressFirewall policy take effect for multiple port
+  Scenario: OCP-33565 EgressFirewall policy take effect for multiple port
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -556,7 +556,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: EgressNetworkPolicy maxItems is 1000
+  Scenario: OCP-35341 EgressNetworkPolicy maxItems is 1000
     Given I have a project
     Given I obtain test data file "networking/egressnetworkpolicy/egressnetworkpolicy_1000.yaml"
     When I run the :create admin command with:
@@ -584,7 +584,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
-  Scenario: EgressFirewall allows traffic to destination dnsName
+  Scenario: OCP-37491 EgressFirewall allows traffic to destination dnsName
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -620,7 +620,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
-  Scenario: EgressFirewall denys traffic to destination dnsName
+  Scenario: OCP-37495 EgressFirewall denys traffic to destination dnsName
     Given I have a project
 
     When I obtain test data file "networking/ovn-egressfirewall/egressfirewall-policy4.yaml"
@@ -656,7 +656,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
-  Scenario: Edit EgressFirewall should take effect
+  Scenario: OCP-37496 Edit EgressFirewall should take effect
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -694,7 +694,7 @@ Feature: Egress-ingress related networking scenarios
   @noproxy @connected
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
-  Scenario: bug1947917 Egress Firewall should reliably apply firewall rules
+  Scenario: OCP-41179 bug1947917 Egress Firewall should reliably apply firewall rules
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -733,7 +733,7 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn	
   @singlenode
   @proxy @noproxy @disconnected @connected
-  Scenario: bug2000057 No segmentation error occurs in ovnkube-master after egressfirewall resource that references a DNS name is deleted
+  Scenario: OCP-44940 bug2000057 No segmentation error occurs in ovnkube-master after egressfirewall resource that references a DNS name is deleted
     Given the env is using "OVNKubernetes" networkType
     And I have a project
     Given I obtain test data file "networking/list_for_pods.json"

--- a/features/networking/egress-ip.feature
+++ b/features/networking/egress-ip.feature
@@ -10,7 +10,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: Only cluster admin can add/remove egressIPs on hostsubnet
+  Scenario: OCP-15465 Only cluster admin can add/remove egressIPs on hostsubnet
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
 
@@ -31,7 +31,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: Only cluster admin can add/remove egressIPs on netnamespaces
+  Scenario: OCP-15466 Only cluster admin can add/remove egressIPs on netnamespaces
     # Try to add the egress ip to the netnamespace with normal user
     Given I have a project
     And evaluation of `project.name` is stored in the :project clipboard
@@ -53,7 +53,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: All the pods egress connection will get out through the egress IP if the egress IP is set to netns and egress node can host the IP
+  Scenario: OCP-15471 All the pods egress connection will get out through the egress IP if the egress IP is set to netns and egress node can host the IP
     Given I save ipecho url to the clipboard
     Given I select a random node's host
     # create project with pods
@@ -113,7 +113,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: The egressIPs will be added to the node's primary NIC when it gets set on hostsubnet and will be removed after gets unset
+  Scenario: OCP-15472 The egressIPs will be added to the node's primary NIC when it gets set on hostsubnet and will be removed after gets unset
     # add the egress ip to the hostsubnet
     Given  the valid egress IP is added to the node
     And evaluation of `node.name` is stored in the :egress_node clipboard
@@ -153,7 +153,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Should remove the egressIP from the array if it was not being used
+  Scenario: OCP-21812 Should remove the egressIP from the array if it was not being used
     Given I store a random unused IP address from the reserved range to the clipboard
     And evaluation of `IPAddr.new("<%= cb.subnet_range %>").to_s+"/"+IPAddr.new("<%= cb.subnet_range %>").prefix.to_s` is stored in the :valid_subnet clipboard
 
@@ -206,7 +206,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: The EgressNetworkPolicy should work well with egressIP
+  Scenario: OCP-15992 The EgressNetworkPolicy should work well with egressIP
     Given I save ipecho url to the clipboard
     Given the valid egress IP is added to the node
     And I have a project
@@ -253,7 +253,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: The related iptables/openflow rules will be removed once the egressIP gets removed from netnamespace
+  Scenario: OCP-15473 The related iptables/openflow rules will be removed once the egressIP gets removed from netnamespace
     Given the valid egress IP is added to the node
     And I have a project
 
@@ -305,7 +305,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: The egressIP should still work fine after the node or network service restarted
+  Scenario: OCP-19973 The egressIP should still work fine after the node or network service restarted
     Given I save ipecho url to the clipboard
     Given the valid egress IP is added to the node
     And I have a project
@@ -344,7 +344,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Invalid egressIP should not be acceptable
+  Scenario: OCP-15998 Invalid egressIP should not be acceptable
     Given I select a random node's host
     Given evaluation of `["fe80::5054:ff:fedd:3698", "a.b.c.d", "10.10.10.-1", "10.0.0.1/64", "10.1.1/24", "A008696"]` is stored in the :ips clipboard
     And I repeat the following steps for each :ip in cb.ips:
@@ -369,7 +369,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Random outages with egressIP
+  Scenario: OCP-25694 Random outages with egressIP
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
     And I have a project
@@ -406,7 +406,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Should be able to access to the service's externalIP with egressIP
+  Scenario: OCP-25640 Should be able to access to the service's externalIP with egressIP
     Given I have a project
     Given I store the schedulable nodes in the :nodes clipboard
     And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :hostip clipboard
@@ -465,7 +465,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: The egressIPs should work well when re-using the egressIP which is holding by a deleted project
+  Scenario: OCP-18316 The egressIPs should work well when re-using the egressIP which is holding by a deleted project
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
@@ -501,7 +501,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: Add the removed egressIP back to the netnamespace would work well
+  Scenario: OCP-18315 Add the removed egressIP back to the netnamespace would work well
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
@@ -543,7 +543,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: The pod should be able to access outside with the node source IP after the egressIP removed
+  Scenario: OCP-19785 The pod should be able to access outside with the node source IP after the egressIP removed
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
@@ -593,7 +593,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: Pods will not be affected by the egressIP set on other netnamespace
+  Scenario: OCP-15989 Pods will not be affected by the egressIP set on other netnamespace
     Given I save ipecho url to the clipboard
     # create project with pods
     Given I have a project
@@ -626,7 +626,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
-  Scenario: The egressIP will be unavailable if it was set to multiple hostsubnets
+  Scenario: OCP-15987 The egressIP will be unavailable if it was set to multiple hostsubnets
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
     Given as admin I successfully merge patch resource "hostsubnet/<%= cb.nodes[1].name %>" with:
@@ -663,7 +663,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: The same egressIP will not be assigned to different netnamespace
+  Scenario: OCP-18586 The same egressIP will not be assigned to different netnamespace
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     Given I store a random unused IP address from the reserved range to the clipboard
@@ -708,7 +708,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Manually EgressIPs assignments:if a pod is on a node that is hosting an egressIP that pod will always use the egressIP of the node it is on
+  Scenario: OCP-40928 Manually EgressIPs assignments:if a pod is on a node that is hosting an egressIP that pod will always use the egressIP of the node it is on
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     Given I store a random unused IP address from the reserved range to the clipboard
@@ -758,7 +758,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Manually EgressIPs assignments: if a pod is not on a node hosting an egressIP it is random which egressIP it will use
+  Scenario: OCP-40933 Manually EgressIPs assignments: if a pod is not on a node hosting an egressIP it is random which egressIP it will use
     Given I save ipecho url to the clipboard
     Given I store the masters in the :masters clipboard
     Given I store the schedulable workers in the :workers clipboard
@@ -809,7 +809,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Auto EgressIPs assignments: if a pod is not on a node hosting an egressIP it is random which egressIP it will use
+  Scenario: OCP-40957 Auto EgressIPs assignments: if a pod is not on a node hosting an egressIP it is random which egressIP it will use
     Given I save ipecho url to the clipboard
     Given I store the masters in the :masters clipboard
     Given I store the schedulable workers in the :workers clipboard
@@ -861,7 +861,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Auto EgressIPs assignments:if a pod is on a node that is hosting an egressIP that pod will always use the egressIP of the node
+  Scenario: OCP-40956 Auto EgressIPs assignments:if a pod is on a node that is hosting an egressIP that pod will always use the egressIP of the node
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :workers clipboard
     Given I store a random unused IP address from the reserved range to the clipboard
@@ -920,7 +920,7 @@ Feature: Egress IP related features
   @noproxy @disconnected @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Bug1926662 NodePort works when configuring an EgressIP address
+  Scenario: OCP-46244 Bug1926662 NodePort works when configuring an EgressIP address
     Given I store the schedulable workers in the :workers clipboard
     And I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.workers[0].name %>" is stored in the :worker0_ip clipboard
@@ -962,7 +962,7 @@ Feature: Egress IP related features
   @vsphere-ipi
   @vsphere-upi
   @qeci
-  Scenario: Bug2024880 EgressIP should work when configuring networkpolicy
+  Scenario: OCP-46637 Bug2024880 EgressIP should work when configuring networkpolicy
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :workers clipboard
     And the valid egress IP is added to the "<%= cb.workers[0].name %>" node

--- a/features/networking/ib-sriov.feature
+++ b/features/networking/ib-sriov.feature
@@ -68,7 +68,7 @@ Feature: Sriov IB related scenarios
   # @case_id OCP-33852
   @destructive
   @admin
-  Scenario: Set the infiniband-guid for pod
+  Scenario: OCP-33852 Set the infiniband-guid for pod
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/ib/cx6/cx6-ib.yaml"
     Given I create sriov resource with following:

--- a/features/networking/ipv6_dualstack.feature
+++ b/features/networking/ipv6_dualstack.feature
@@ -10,7 +10,7 @@ Feature: ipv6 dual stack cluster test scenarios
   @proxy @noproxy @disconnected @connected
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @heterogeneous @arm64 @amd64
-  Scenario: Project should be in isolation when using multitenant policy for ipv6 dual stack
+  Scenario: OCP-40581 Project should be in isolation when using multitenant policy for ipv6 dual stack
     # create project and pods
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -93,7 +93,7 @@ Feature: ipv6 dual stack cluster test scenarios
   @proxy @noproxy @disconnected @connected
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @heterogeneous @arm64 @amd64
-  Scenario: ipv6 for nodeport service
+  Scenario: OCP-46816 ipv6 for nodeport service
     Given I store the workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ipv4 clipboard    
     And the Internal IPv6 of node "<%= cb.workers[0].name %>" is stored in the :worker0_ipv6 clipboard

--- a/features/networking/isolation.feature
+++ b/features/networking/isolation.feature
@@ -3,7 +3,7 @@ Feature: networking isolation related scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-9565
   @admin
-  Scenario: The pods in default namespace can communicate with all the other pods
+  Scenario: OCP-9565 The pods in default namespace can communicate with all the other pods
     Given I have a project
     And evaluation of `project.name` is stored in the :u1p1 clipboard
     Given I obtain test data file "networking/list_for_pods.json"
@@ -147,7 +147,7 @@ Feature: networking isolation related scenarios
   # @case_id OCP-9641
   @admin
   @network-multitenant
-  Scenario: Make the network of given project be accessible to other projects
+  Scenario: OCP-9641 Make the network of given project be accessible to other projects
     # Create 3 projects and each contains 1 pod and 1 service
     Given the env is using multitenant network
     Given I have a project
@@ -310,7 +310,7 @@ Feature: networking isolation related scenarios
   @upgrade-sanity
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Make the network of given projects be accessible globally
+  Scenario: OCP-12659 Make the network of given projects be accessible globally
     # Create 3 projects and each contains 1 pod and 1 service
     Given the env is using multitenant network
     Given I have a project
@@ -441,7 +441,7 @@ Feature: networking isolation related scenarios
   # @case_id OCP-9646
   @admin
   @network-multitenant
-  Scenario: Isolate the network for the project which already make network global
+  Scenario: OCP-9646 Isolate the network for the project which already make network global
     Given the env is using multitenant network
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard

--- a/features/networking/metrics.feature
+++ b/features/networking/metrics.feature
@@ -10,7 +10,7 @@ Feature: SDN/OVN metrics related networking scenarios
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Prometheus should be able to monitor kubeproxy metrics
+  Scenario: OCP-28519 Prometheus should be able to monitor kubeproxy metrics
     Given I switch to cluster admin pseudo user
     And I use the "openshift-sdn" project
     And evaluation of `endpoints('sdn').subsets.first.addresses.first.ip.to_s` is stored in the :metrics_ep_ip clipboard
@@ -48,7 +48,7 @@ Feature: SDN/OVN metrics related networking scenarios
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Should be able to monitor the openshift-sdn related metrics by prometheus
+  Scenario: OCP-16016 Should be able to monitor the openshift-sdn related metrics by prometheus
     Given I switch to cluster admin pseudo user
     And I use the "openshift-sdn" project
     And evaluation of `endpoints('sdn').subsets.first.addresses.first.ip.to_s` is stored in the :metrics_ep_ip clipboard
@@ -87,7 +87,7 @@ Feature: SDN/OVN metrics related networking scenarios
   @network-ovnkubernetes
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Should be able to monitor various ovnkube-master and ovnkube-node metrics via prometheus
+  Scenario: OCP-37704 Should be able to monitor various ovnkube-master and ovnkube-node metrics via prometheus
     Given I switch to cluster admin pseudo user
     And I use the "openshift-ovn-kubernetes" project
     And evaluation of `endpoints('ovn-kubernetes-master').subsets.first.addresses.first.ip.to_s` is stored in the :ovn_master_metrics_ep_ip clipboard

--- a/features/networking/multicast.feature
+++ b/features/networking/multicast.feature
@@ -11,7 +11,7 @@ Feature: testing multicast scenarios
   @network-multitenant
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
-  Scenario: pods should be able to subscribe send and receive multicast traffic
+  Scenario: OCP-12926 pods should be able to subscribe send and receive multicast traffic
     # create some multicast testing pods
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -100,7 +100,7 @@ Feature: testing multicast scenarios
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: multicast is disabled by default if not annotate the namespace
+  Scenario: OCP-12977 multicast is disabled by default if not annotate the namespace
     # create multicast testing pods in the project and without multicast enable
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -170,7 +170,7 @@ Feature: testing multicast scenarios
   @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Same multicast groups can be created in multiple namespace
+  Scenario: OCP-12930 Same multicast groups can be created in multiple namespace
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
     Given I obtain test data file "networking/multicast-rc.json"
@@ -314,7 +314,7 @@ Feature: testing multicast scenarios
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: pods in default project should not be able to receive multicast traffic from other namespace
+  Scenario: OCP-12931 pods in default project should not be able to receive multicast traffic from other namespace
     # create multicast testing pod in one project
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -397,7 +397,7 @@ Feature: testing multicast scenarios
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: pods should be able to join multiple multicast groups at same time  
+  Scenario: OCP-12928 pods should be able to join multiple multicast groups at same time  
     # create some multicast testing pods in the project
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -498,7 +498,7 @@ Feature: testing multicast scenarios
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: pods should not be able to receive multicast traffic from other pods in different namespace
+  Scenario: OCP-12929 pods should not be able to receive multicast traffic from other pods in different namespace
     # create some multicast testing pods in one project
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -580,7 +580,7 @@ Feature: testing multicast scenarios
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: pods in default project should be able to receive multicast traffic from other default project pods
+  Scenario: OCP-12966 pods in default project should be able to receive multicast traffic from other default project pods
     # enable multicast and create testing pods
     Given I switch to cluster admin pseudo user
     And I use the "default" project

--- a/features/networking/multus-ipv6.feature
+++ b/features/networking/multus-ipv6.feature
@@ -4,7 +4,7 @@ Feature: Multus-CNI ipv6 related scenarios
   # @case_id OCP-28968
   @admin
   @inactive
-  Scenario: IPv6 testing for OCP-21151: Create pods with multus-cni - macvlan bridge mode
+  Scenario: OCP-28968 IPv6 testing for OCP-21151: Create pods with multus-cni - macvlan bridge mode
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
     And the multus is enabled on the cluster
@@ -62,7 +62,7 @@ Feature: Multus-CNI ipv6 related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: IPv6 testing for OCP-31999: Whereabouts should exclude IPv6 ranges
+  Scenario: OCP-38521 IPv6 testing for OCP-31999: Whereabouts should exclude IPv6 ranges
   # Bug https://bugzilla.redhat.com/show_bug.cgi?id=1913062
   # Bug https://bugzilla.redhat.com/show_bug.cgi?id=1917984
   # Make sure that the multus is enabled
@@ -135,7 +135,7 @@ Feature: Multus-CNI ipv6 related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: Whereabouts IPv6 should be calculated if first hextet of IPv6 has leading zeros	
+  Scenario: OCP-44941 Whereabouts IPv6 should be calculated if first hextet of IPv6 has leading zeros	
   # Bug https://bugzilla.redhat.com/show_bug.cgi?id=1919048
   # Make sure that the multus is enabled
     Given the master version >= "4.6"

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -11,7 +11,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create pods with multus-cni - macvlan bridge mode
+  Scenario: OCP-21151 Create pods with multus-cni - macvlan bridge mode
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
     And the multus is enabled on the cluster
@@ -79,7 +79,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create pods with multus-cni - macvlan private mode
+  Scenario: OCP-21489 Create pods with multus-cni - macvlan private mode
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
     And the multus is enabled on the cluster
@@ -145,7 +145,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create pods with multus-cni - macvlan vepa mode
+  Scenario: OCP-21496 Create pods with multus-cni - macvlan vepa mode
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
     And the multus is enabled on the cluster
@@ -212,7 +212,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create pods with multus-cni - host-device
+  Scenario: OCP-21853 Create pods with multus-cni - host-device
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
     And the multus is enabled on the cluster
@@ -289,7 +289,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create pods with muliple cni plugins via multus-cni - macvlan + macvlan
+  Scenario: OCP-21854 Create pods with muliple cni plugins via multus-cni - macvlan + macvlan
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
     And the multus is enabled on the cluster
@@ -341,7 +341,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create pods with muliple cni plugins via multus-cni - macvlan + host-device
+  Scenario: OCP-21855 Create pods with muliple cni plugins via multus-cni - macvlan + host-device
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
     And the multus is enabled on the cluster
@@ -413,7 +413,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create pods with muliple cni plugins via multus-cni - host-device + host-device
+  Scenario: OCP-21859 Create pods with muliple cni plugins via multus-cni - host-device + host-device
     # Make sure that the multus is enabled
     Given the master version >= "4.1"
     And the multus is enabled on the cluster
@@ -492,7 +492,7 @@ Feature: Multus-CNI related scenarios
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create pod with Multus bridge CNI plugin without vlan
+  Scenario: OCP-24488 Create pod with Multus bridge CNI plugin without vlan
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
@@ -548,7 +548,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Create pod with Multus bridge CNI plugin and vlan tag
+  Scenario: OCP-24489 Create pod with Multus bridge CNI plugin and vlan tag
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
@@ -596,7 +596,7 @@ Feature: Multus-CNI related scenarios
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: CNO manager mavlan configured manually with static
+  Scenario: OCP-24467 CNO manager mavlan configured manually with static
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
     Given the default interface on nodes is stored in the :default_interface clipboard
@@ -637,7 +637,7 @@ Feature: Multus-CNI related scenarios
   # @author anusaxen@redhat.com
   # @case_id OCP-21946
   @admin
-  Scenario: The multus admission controller should be able to detect the syntax issue in the net-attach-def
+  Scenario: OCP-21946 The multus admission controller should be able to detect the syntax issue in the net-attach-def
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin and simulating syntax errors
@@ -664,7 +664,7 @@ Feature: Multus-CNI related scenarios
   # @author anusaxen@redhat.com
   # @case_id OCP-21949
   @admin
-  Scenario: The multus admission controller should be able to detect the issue in the pod template
+  Scenario: OCP-21949 The multus admission controller should be able to detect the issue in the pod template
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
@@ -692,7 +692,7 @@ Feature: Multus-CNI related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: User cannot consume the net-attach-def created in other project which is namespace isolated
+  Scenario: OCP-21793 User cannot consume the net-attach-def created in other project which is namespace isolated
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     Given I have a project
@@ -734,7 +734,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Pods can communicate each other with same vlan tag
+  Scenario: OCP-24490 Pods can communicate each other with same vlan tag
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
@@ -826,7 +826,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Pods cannot communicate each other with different vlan tag
+  Scenario: OCP-24491 Pods cannot communicate each other with different vlan tag
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
@@ -934,7 +934,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: macvlan plugin without master parameter
+  Scenario: OCP-24607 macvlan plugin without master parameter
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def without master pmtr via cluster admin
@@ -967,7 +967,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Supported runtimeConfig/capability for MAC/IP
+  Scenario: OCP-25676 Supported runtimeConfig/capability for MAC/IP
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
 
@@ -1011,7 +1011,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Multus CNI type bridge with DHCP
+  Scenario: OCP-24465 Multus CNI type bridge with DHCP
     # Make sure that the multus is Running
     Given the multus is enabled on the cluster
     Given the default interface on nodes is stored in the :default_interface clipboard
@@ -1070,7 +1070,7 @@ Feature: Multus-CNI related scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @upgrade-sanity
   @inactive
-  Scenario: CNO manager macvlan configured manually with DHCP
+  Scenario: OCP-24466 CNO manager macvlan configured manually with DHCP
     Given the multus is enabled on the cluster
     And I store the masters in the :master clipboard
     And I store all worker nodes to the :worker clipboard
@@ -1152,7 +1152,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Assign static IP address using pod annotation
+  Scenario: OCP-25909 Assign static IP address using pod annotation
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
 
@@ -1194,7 +1194,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Assign static MAC address using pod annotation
+  Scenario: OCP-25910 Assign static MAC address using pod annotation
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
@@ -1234,7 +1234,7 @@ Feature: Multus-CNI related scenarios
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Multus default route overwrite
+  Scenario: OCP-25915 Multus default route overwrite
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
@@ -1272,7 +1272,7 @@ Feature: Multus-CNI related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Multus Telemetry Adds capability to track usage of network attachment definitions
+  Scenario: OCP-25917 Multus Telemetry Adds capability to track usage of network attachment definitions
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     Given I switch to cluster admin pseudo user
@@ -1336,7 +1336,7 @@ Feature: Multus-CNI related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: The multus admission controller should be able to detect that the pod is using net-attach-def in other namespaces when the isolation is enabled
+  Scenario: OCP-22504 The multus admission controller should be able to detect that the pod is using net-attach-def in other namespaces when the isolation is enabled
     Given I create 2 new projects
     # Create the net-attach-def via cluster admin
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
@@ -1373,7 +1373,7 @@ Feature: Multus-CNI related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Create pod with Multus ipvlan CNI plugin
+  Scenario: OCP-24492 Create pod with Multus ipvlan CNI plugin
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     And the default interface on nodes is stored in the :default_interface clipboard
@@ -1433,7 +1433,7 @@ Feature: Multus-CNI related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Dynamic IP address assignment with Whereabouts
+  Scenario: OCP-28633 Dynamic IP address assignment with Whereabouts
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     Given the default interface on nodes is stored in the :default_interface clipboard
@@ -1497,7 +1497,7 @@ Feature: Multus-CNI related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Multus custom route change with route override
+  Scenario: OCP-28518 Multus custom route change with route override
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
@@ -1534,7 +1534,7 @@ Feature: Multus-CNI related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Multus namespaceIsolation should allow references to CRD in the default namespace
+  Scenario: OCP-30054 Multus namespaceIsolation should allow references to CRD in the default namespace
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def in default namespace via cluster admin
@@ -1567,7 +1567,7 @@ Feature: Multus-CNI related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Log pod IP and pod UUID when pod start
+  Scenario: OCP-29742 Log pod IP and pod UUID when pod start
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
     # Create the net-attach-def via cluster admin
@@ -1620,7 +1620,7 @@ Feature: Multus-CNI related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Whereabouts with exclude IP address
+  Scenario: OCP-31999 Whereabouts with exclude IP address
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
@@ -1683,7 +1683,7 @@ Feature: Multus-CNI related scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: Additional network IPAM should support changes in range and overlapping ranges
+  Scenario: OCP-33579 Additional network IPAM should support changes in range and overlapping ranges
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def with whereabouts-shortrange
@@ -1763,7 +1763,7 @@ Feature: Multus-CNI related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: BZ1944678 Whereabouts IPAM CNI duplicate IP addresses assigned to pods
+  Scenario: OCP-41789 BZ1944678 Whereabouts IPAM CNI duplicate IP addresses assigned to pods
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
     # Create the net-attach-def via cluster admin
@@ -1822,7 +1822,7 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: BZ1897431 CIDR support for additional network attachment with the bridge CNI plug-in
+  Scenario: OCP-46116 BZ1897431 CIDR support for additional network attachment with the bridge CNI plug-in
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
     Given the default interface on nodes is stored in the :default_interface clipboard

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -10,7 +10,7 @@ Feature: Operator related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: The clusteroperator should be able to reflect the network operator version corresponding to the OCP version
+  Scenario: OCP-22704 The clusteroperator should be able to reflect the network operator version corresponding to the OCP version
 
     Given the master version > "3.11"
     #Getting OCP version
@@ -29,7 +29,7 @@ Feature: Operator related networking scenarios
   @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: The clusteroperator should be able to reflect the correct version field post bad network operator config
+  Scenario: OCP-22706 The clusteroperator should be able to reflect the correct version field post bad network operator config
 
     Given the master version >= "4.1"
     #Getting OCP version
@@ -77,7 +77,7 @@ Feature: Operator related networking scenarios
   @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Should have a clusteroperator object created under config.openshift.io api group for network-operator
+  Scenario: OCP-22201 Should have a clusteroperator object created under config.openshift.io api group for network-operator
     Given the master version >= "4.1"
     # Check the operator object has version
     Given the expression should be true> cluster_operator('network').versions.length > 0
@@ -91,7 +91,7 @@ Feature: Operator related networking scenarios
   # @case_id OCP-22419
   @admin
   @destructive
-  Scenario: The clusteroperator should be able to reflect the realtime status of the network when the config has problem
+  Scenario: OCP-22419 The clusteroperator should be able to reflect the realtime status of the network when the config has problem
     Given the master version >= "4.1"
     # Check that the operator is not Degraded
     Given the expression should be true> cluster_operator('network').condition(type: 'Degraded')['status'] == "False"
@@ -143,7 +143,7 @@ Feature: Operator related networking scenarios
   # @case_id OCP-22202
   @admin
   @destructive
-  Scenario: The clusteroperator should be able to reflect the realtime status of the network when a new node added
+  Scenario: OCP-22202 The clusteroperator should be able to reflect the realtime status of the network when a new node added
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
@@ -183,7 +183,7 @@ Feature: Operator related networking scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Service should not get unidle when config flag is disabled under CNO
+  Scenario: OCP-24918 Service should not get unidle when config flag is disabled under CNO
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
     When I run the :create client command with:
@@ -270,7 +270,7 @@ Feature: Operator related networking scenarios
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Should not allow to change the openshift-sdn config
+  Scenario: OCP-21574 Should not allow to change the openshift-sdn config
     #Trying to change network mode to Subnet or any other
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec": {"defaultNetwork": {"openshiftSDNConfig": {"mode": "Subnet"}}}} |
@@ -306,7 +306,7 @@ Feature: Operator related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: CNO should delete non-relevant resources
+  Scenario: OCP-25856 CNO should delete non-relevant resources
     # Make sure that the multus is Running
     Given the multus is enabled on the cluster
     Given the default interface on nodes is stored in the :default_interface clipboard
@@ -390,7 +390,7 @@ Feature: Operator related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Changing mtu in CNO should not be allowed
+  Scenario: OCP-27333 Changing mtu in CNO should not be allowed
     Given the mtu value "1750" is patched in CNO config according to the networkType
     And admin uses the "openshift-network-operator" project
     When I run the :get admin command with:

--- a/features/networking/ovn-egress-ip.feature
+++ b/features/networking/ovn-egress-ip.feature
@@ -12,7 +12,7 @@ Feature: OVN Egress IP related features
   @qeci
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: EgressIP works for all pods in the matched namespace when only configure namespaceSelector
+  Scenario: OCP-33618 EgressIP works for all pods in the matched namespace when only configure namespaceSelector
     Given I save ipecho url to the clipboard
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
@@ -83,7 +83,7 @@ Feature: OVN Egress IP related features
   @qeci
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Multiple EgressIP objects can have multiple Egress IPs
+  Scenario: OCP-33723 Multiple EgressIP objects can have multiple Egress IPs
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -157,7 +157,7 @@ Feature: OVN Egress IP related features
   @qeci
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Multi-project can share same EgressIP
+  Scenario: OCP-33641 Multi-project can share same EgressIP
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -232,7 +232,7 @@ Feature: OVN Egress IP related features
   @qeci
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Removed matched labels from project will not use EgressIP
+  Scenario: OCP-33699 Removed matched labels from project will not use EgressIP
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -289,7 +289,7 @@ Feature: OVN Egress IP related features
   @qeci
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Removed matched labels from pods will not use EgressIP
+  Scenario: OCP-33700 Removed matched labels from pods will not use EgressIP
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -354,7 +354,7 @@ Feature: OVN Egress IP related features
   @qeci
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: EgressIP was removed after delete egressIP object
+  Scenario: OCP-33631 EgressIP was removed after delete egressIP object
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -407,7 +407,7 @@ Feature: OVN Egress IP related features
   @qeci
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: After reboot node or reboot OVN services EgressIP still work
+  Scenario: OCP-33704 After reboot node or reboot OVN services EgressIP still work
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -470,7 +470,7 @@ Feature: OVN Egress IP related features
   @vsphere-upi @aws-upi
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Warning event will be triggered if apply EgressIP object but no EgressIP nodes
+  Scenario: OCP-34938 Warning event will be triggered if apply EgressIP object but no EgressIP nodes
     #Get unused IP as egress ip
     Given I store a random unused IP address from the reserved range to the clipboard
 
@@ -506,7 +506,7 @@ Feature: OVN Egress IP related features
   @qeci
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: The pod located on different node than EgressIP nodes
+  Scenario: OCP-33706 The pod located on different node than EgressIP nodes
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -560,7 +560,7 @@ Feature: OVN Egress IP related features
   @qeci
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Deleting EgressIP object and recreating it will work
+  Scenario: OCP-33718 Deleting EgressIP object and recreating it will work
     Given I save ipecho url to the clipboard
 
     #Get unused IP as egress ip
@@ -625,7 +625,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: An EgressIP object can not have multiple egress IP assignments on the same node
+  Scenario: OCP-33710 An EgressIP object can not have multiple egress IP assignments on the same node
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
 
@@ -659,7 +659,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Common user cannot tag the nodes by labelling them as egressIP nodes
+  Scenario: OCP-33617 Common user cannot tag the nodes by labelling them as egressIP nodes
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
 
@@ -682,7 +682,7 @@ Feature: OVN Egress IP related features
   @aws-upi
   @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Any egress IP can only be assigned to one node only
+  Scenario: OCP-33719 Any egress IP can only be assigned to one node only
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
     And label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[1].name %>" node
@@ -732,7 +732,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: lr-policy-list and snat should be updated correctly after remove pods
+  Scenario: OCP-44250 lr-policy-list and snat should be updated correctly after remove pods
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
 
@@ -845,7 +845,7 @@ Feature: OVN Egress IP related features
   @network-ovnkubernetes
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: lr-policy-list and snat should be updated correctly after remove egressip objects 
+  Scenario: OCP-44251 lr-policy-list and snat should be updated correctly after remove egressip objects 
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
 
@@ -940,7 +940,7 @@ Feature: OVN Egress IP related features
   @qeci
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Traffic is load balanced between egress nodes in OVN cluster
+  Scenario: OCP-42925 Traffic is load balanced between egress nodes in OVN cluster
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node

--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -11,7 +11,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Creating a resource in Kube API should be synced to OVN NB db correctly even post NB db crash too
+  Scenario: OCP-29954 Creating a resource in Kube API should be synced to OVN NB db correctly even post NB db crash too
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
     And I obtain test data file "networking/list_for_pods.json"
@@ -59,7 +59,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: OVN DB should be updated correctly if a resource only exist in Kube API but not in OVN NB db
+  Scenario: OCP-30055 OVN DB should be updated correctly if a resource only exist in Kube API but not in OVN NB db
     Given the env is using "OVNKubernetes" networkType
     Given I register clean-up steps:
     """
@@ -115,7 +115,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: OVN DB should be updated correctly if a resource only exist in NB db but not in Kube API
+  Scenario: OCP-30057 OVN DB should be updated correctly if a resource only exist in NB db but not in Kube API
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
     And evaluation of `project.name` is stored in the :hello_pod_project clipboard
@@ -179,7 +179,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Thrashing ovnkube master IPAM allocator by creating and deleting various pods on a specific node
+  Scenario: OCP-32205 Thrashing ovnkube master IPAM allocator by creating and deleting various pods on a specific node
     Given the env is using "OVNKubernetes" networkType
     And I store all worker nodes to the :nodes clipboard
     And I have a project
@@ -208,7 +208,7 @@ Feature: OVN related networking scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: ovnkube-masters should allocate pod IP and mac addresses
+  Scenario: OCP-32184 ovnkube-masters should allocate pod IP and mac addresses
     Given the env is using "OVNKubernetes" networkType
     And I have a project
     Given I have a pod-for-ping in the project
@@ -237,7 +237,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Create/delete pods while forcing OVN leader election
+  Scenario: OCP-28936 Create/delete pods while forcing OVN leader election
   #Test for bug https://bugzilla.redhat.com/show_bug.cgi?id=1781297
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
@@ -267,7 +267,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Pods and Services should keep running when a new raft leader gets be elected
+  Scenario: OCP-26092 Pods and Services should keep running when a new raft leader gets be elected
     Given the env is using "OVNKubernetes" networkType
     Given I store the ovnkube-master "south" leader pod in the clipboard
     Given I have a project
@@ -313,7 +313,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Traffic flow shouldn't be interrupted when master switches the leader positions
+  Scenario: OCP-26139 Traffic flow shouldn't be interrupted when master switches the leader positions
     Given the env is using "OVNKubernetes" networkType
     Given I switch to cluster admin pseudo user
     Given admin creates a project
@@ -383,7 +383,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: New raft leader should be elected if existing leader gets deleted or crashed in hybrid/non-hybrid clusters
+  Scenario: OCP-26089 New raft leader should be elected if existing leader gets deleted or crashed in hybrid/non-hybrid clusters
     Given the env is using "OVNKubernetes" networkType
     Given admin uses the "openshift-ovn-kubernetes" project
     When I store the ovnkube-master "north" leader pod in the clipboard
@@ -457,7 +457,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Inducing Split Brain in the OVN HA cluster
+  Scenario: OCP-26138 Inducing Split Brain in the OVN HA cluster
     Given admin uses the "openshift-ovn-kubernetes" project
     When I store the ovnkube-master "south" leader pod in the clipboard
     Then the step should succeed
@@ -516,7 +516,7 @@ Feature: OVN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Delete all OVN master pods and makes sure leader/follower election converges smoothly
+  Scenario: OCP-26140 Delete all OVN master pods and makes sure leader/follower election converges smoothly
     Given the env is using "OVNKubernetes" networkType
     Given admin uses the "openshift-ovn-kubernetes" project
     When I store the ovnkube-master "north" leader pod in the clipboard
@@ -544,7 +544,7 @@ Feature: OVN related networking scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: OVN handles projects that start with a digit
+  Scenario: OCP-37031 OVN handles projects that start with a digit
     Given the env is using "OVNKubernetes" networkType
     Given I create a project with leading digit name
     And I obtain test data file "networking/list_for_pods.json"
@@ -566,7 +566,7 @@ Feature: OVN related networking scenarios
   @destructive
   @4.10 @4.9
   @inactive
-  Scenario: Should no intermittent packet drop from pod to pod after change hostname
+  Scenario: OCP-38132 Should no intermittent packet drop from pod to pod after change hostname
     Given I store the schedulable workers in the :nodes clipboard
     Given admin uses the "openshift-ovn-kubernetes" project
     And I store the hostname from external ids in the :original_hostname clipboard on the "<%= cb.nodes[0].name %>" node
@@ -629,7 +629,7 @@ Feature: OVN related networking scenarios
   @proxy @noproxy @connected
   @vsphere-upi @baremetal-upi
   @heterogeneous @arm64 @amd64
-  Scenario: Logical Router Policies and Annotations for a given node should be current
+  Scenario: OCP-46285 Logical Router Policies and Annotations for a given node should be current
     Given the env is using "OVNKubernetes" networkType
     #Find apiVIP address of the cluster
     When I run the :get admin command with:

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -9,7 +9,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Should be able to send node to node ESP traffic on IPsec clusters
+  Scenario: OCP-38846 Should be able to send node to node ESP traffic on IPsec clusters
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
     Given I store all worker nodes to the :workers clipboard
@@ -57,7 +57,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Segfault on pluto IKE daemon should result in restarting pluto daemon and corresponding ovn-ipsec pod
+  Scenario: OCP-38845 Segfault on pluto IKE daemon should result in restarting pluto daemon and corresponding ovn-ipsec pod
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
     Given I store all worker nodes to the :workers clipboard
@@ -89,7 +89,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Make sure IPsec SA's are establishing in a transport mode
+  Scenario: OCP-37591 Make sure IPsec SA's are establishing in a transport mode
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
     Given I select a random node's host
@@ -108,7 +108,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Pod created on IPsec cluster should have appropriate MTU size to accomdate IPsec Header
+  Scenario: OCP-39216 Pod created on IPsec cluster should have appropriate MTU size to accomdate IPsec Header
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
     Given the default interface on nodes is stored in the :default_interface clipboard
@@ -132,7 +132,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Delete all ovn-ipsec containers and check if they gets recreated
+  Scenario: OCP-37590 Delete all ovn-ipsec containers and check if they gets recreated
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
     When I run the :delete admin command with:
@@ -151,7 +151,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: pod to pod traffic on different nodes should be ESP encrypted
+  Scenario: OCP-37392 pod to pod traffic on different nodes should be ESP encrypted
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
     Given I store all worker nodes to the :workers clipboard
@@ -200,7 +200,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @destructive
   @inactive
   @network-ovnkubernetes @ipsec
-  Scenario: Allow enablement/disablement ipsec at runtime
+  Scenario: OCP-40569 Allow enablement/disablement ipsec at runtime
     Given the env is using "OVNKubernetes" networkType
     Given I store all worker nodes to the :workers clipboard
     Given the default interface on nodes is stored in the :default_interface clipboard

--- a/features/networking/ovn_winc.feature
+++ b/features/networking/ovn_winc.feature
@@ -8,7 +8,7 @@ Feature: OVNKubernetes Windows Container related networking scenarios
   @azure-ipi @aws-ipi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Ensure Pods and Service communication across window and linux nodes
+  Scenario: OCP-26360 Ensure Pods and Service communication across window and linux nodes
     Given the env is using windows nodes
     Given I have a project
     And I obtain test data file "networking/list_for_pods.json"
@@ -64,7 +64,7 @@ Feature: OVNKubernetes Windows Container related networking scenarios
   @upgrade-sanity
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Create Loadbalancer service for a window container
+  Scenario: OCP-37519 Create Loadbalancer service for a window container
     Given the env is using windows nodes
     Given I have a project
     And I have a pod-for-ping in the project

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -10,7 +10,7 @@ Feature: Pod related networking scenarios
   @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Pod cannot claim UDP port 4789 on the node as part of a port mapping
+  Scenario: OCP-9747 Pod cannot claim UDP port 4789 on the node as part of a port mapping
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I obtain test data file "networking/pod_with_udp_port_4789.json"
@@ -35,7 +35,7 @@ Feature: Pod related networking scenarios
   @upgrade-sanity
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Container could reach the dns server
+  Scenario: OCP-10031 Container could reach the dns server
     Given I have a project
     Given I obtain test data file "pods/ocp10031/pod.json"
     When I run the :create client command with:
@@ -59,7 +59,7 @@ Feature: Pod related networking scenarios
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The openflow list will be cleaned after delete the pods
+  Scenario: OCP-14986 The openflow list will be cleaned after delete the pods
     Given I have a project
     Given I have a pod-for-ping in the project
     Then evaluation of `pod.node_name` is stored in the :node_name clipboard
@@ -94,7 +94,7 @@ Feature: Pod related networking scenarios
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check QoS after creating pod
+  Scenario: OCP-10817 Check QoS after creating pod
     Given I have a project
     # setup iperf server to receive the traffic
     Given I obtain test data file "networking/egress-ingress/qos/iperf-server.json"
@@ -158,7 +158,7 @@ Feature: Pod related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: A pod with or without hostnetwork cannot access the MCS port 22623 or 22624 on the master
+  Scenario: OCP-23890 A pod with or without hostnetwork cannot access the MCS port 22623 or 22624 on the master
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard
     Given I select a random node's host
@@ -197,7 +197,7 @@ Feature: Pod related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: A pod cannot access the MCS port 22623 or 22624 via the SDN/tun0 address of the master
+  Scenario: OCP-23891 A pod cannot access the MCS port 22623 or 22624 via the SDN/tun0 address of the master
     Given I store the masters in the :masters clipboard
     And the vxlan tunnel address of node "<%= cb.masters[0].name %>" is stored in the :master_tunnel_address clipboard
     Given I select a random node's host
@@ -221,7 +221,7 @@ Feature: Pod related networking scenarios
   @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: A pod in a namespace with an egress IP cannot access the MCS
+  Scenario: OCP-23893 A pod in a namespace with an egress IP cannot access the MCS
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard
     Given I select a random node's host
@@ -258,7 +258,7 @@ Feature: Pod related networking scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: User cannot access the MCS by creating a service that maps to non-MCS port to port 22623 or 22624 on the IP of a master (via manually-created ep's)
+  Scenario: OCP-23894 User cannot access the MCS by creating a service that maps to non-MCS port to port 22623 or 22624 on the IP of a master (via manually-created ep's)
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard
     Given I have a project
@@ -290,7 +290,7 @@ Feature: Pod related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: ovn pod can be scheduled even if the node taint to unschedule
+  Scenario: OCP-21846 ovn pod can be scheduled even if the node taint to unschedule
     Given the env is using "OVNKubernetes" networkType
     And I store all worker nodes to the :nodes clipboard
     #Tainting all worker nodes to NoSchedule
@@ -342,7 +342,7 @@ Feature: Pod related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: 4.x Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted
+  Scenario: OCP-26822 4.x Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted
     Given I store the workers in the :nodes clipboard
     And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :node_ip clipboard
     Given I have a project
@@ -430,7 +430,7 @@ Feature: Pod related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: Pod should be accesible via node ip and host port
+  Scenario: OCP-25294 Pod should be accesible via node ip and host port
     Given I store the workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[0].name %>" is stored in the :worker0_ip clipboard
     And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ip clipboard
@@ -461,7 +461,7 @@ Feature: Pod related networking scenarios
   @destructive
   @inactive
   @network-ovnkubernetes
-  Scenario: Make sure the route to ovn tunnel for Node's Pod CIDR gets created in both hybrid/non-hybrid mode
+  Scenario: OCP-26373 Make sure the route to ovn tunnel for Node's Pod CIDR gets created in both hybrid/non-hybrid mode
   Given the env is using "OVNKubernetes" networkType
   And I select a random node's host
   And the vxlan tunnel name of node "<%= node.name %>" is stored in the :tunnel_inf_name clipboard
@@ -499,7 +499,7 @@ Feature: Pod related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Pod readiness check for OVN
+  Scenario: OCP-26014 Pod readiness check for OVN
     Given the env is using "OVNKubernetes" networkType
     And OVN is functional on the cluster
     Given I switch to cluster admin pseudo user
@@ -539,7 +539,7 @@ Feature: Pod related networking scenarios
   @admin
   @destructive
   @inactive
-  Scenario: xt_u32 kernel module functionality check from NET_ADMIN pods
+  Scenario: OCP-33413 xt_u32 kernel module functionality check from NET_ADMIN pods
     Given I have a project
     And I have a pod-for-ping in the project
     Then evaluation of `pod.name` is stored in the :client_pod clipboard
@@ -600,7 +600,7 @@ Feature: Pod related networking scenarios
   @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Check the unused ip are released after node reboot
+  Scenario: OCP-22034 Check the unused ip are released after node reboot
     Given I store the workers in the :workers clipboard
     Given I use the "<%= cb.workers[0].name %>" node
     And I run commands on the host:
@@ -619,7 +619,7 @@ Feature: Pod related networking scenarios
   @long-duration
   @admin
   @destructive
-  Scenario: Pod stuck in container creating - failed to run CNI IPAM ADD: failed to allocate for range 0: no IP addresses available in range set
+  Scenario: OCP-41666 Pod stuck in container creating - failed to run CNI IPAM ADD: failed to allocate for range 0: no IP addresses available in range set
     Given I switch to cluster admin pseudo user
     When I run the :label admin command with:
       | resource  | machineconfigpool         |

--- a/features/networking/ptp_operator.feature
+++ b/features/networking/ptp_operator.feature
@@ -6,7 +6,7 @@ Feature: PTP related scenarios
   @stage-only
   @4.10 @4.9 @4.6
   @proxy @noproxy @disconnected @connected
-  Scenario: ptp operator can be deployed successfully
+  Scenario: OCP-25940 ptp operator can be deployed successfully
     Given I switch to cluster admin pseudo user
     And I use the "openshift-ptp" project
     #check ptp related pods are ready in openshift-ptp projects
@@ -19,7 +19,7 @@ Feature: PTP related scenarios
   # @case_id OCP-25738
   @admin
   @destructive
-  Scenario: Linuxptp run as slave can sync to master
+  Scenario: OCP-25738 Linuxptp run as slave can sync to master
     Given the ptp operator is running well
     Given I switch to the first user
     Given I store the nodes in the clipboard
@@ -53,7 +53,7 @@ Feature: PTP related scenarios
   # @case_id OCP-25740
   @admin
   @destructive
-  Scenario: Linuxptp runs in transparent udp4 mode
+  Scenario: OCP-25740 Linuxptp runs in transparent udp4 mode
     Given the ptp operator is running well
     Given I switch to the first user
     And I store the nodes in the clipboard
@@ -93,7 +93,7 @@ Feature: PTP related scenarios
   @admin
   @destructive
   @4.10 @4.9
-  Scenario: PTP operator starts linuxptp daemon based on nodeSelector configured in default PtpOperatorConfig CRD
+  Scenario: OCP-26187 PTP operator starts linuxptp daemon based on nodeSelector configured in default PtpOperatorConfig CRD
     Given the ptp operator is running well
     And I use the "openshift-ptp" project
     Given as admin I successfully merge patch resource "ptpoperatorconfigs.ptp.openshift.io/default" with:

--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -5,7 +5,7 @@ Feature: SCTP related scenarios
   @admin
   @destructive
   @4.10 @4.9
-  Scenario: Establish pod to pod SCTP connections
+  Scenario: OCP-28757 Establish pod to pod SCTP connections
     Given I store the ready and schedulable workers in the :workers clipboard
     And I install machineconfigs load-sctp-module
     And I have a project
@@ -64,7 +64,7 @@ Feature: SCTP related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Expose SCTP ClusterIP Services
+  Scenario: OCP-28758 Expose SCTP ClusterIP Services
     Given I store the ready and schedulable workers in the :workers clipboard
     And I install machineconfigs load-sctp-module
     And I have a project
@@ -129,7 +129,7 @@ Feature: SCTP related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Expose SCTP NodePort Services
+  Scenario: OCP-28759 Expose SCTP NodePort Services
     Given I store the ready and schedulable workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ip clipboard
     Given I install machineconfigs load-sctp-module
@@ -196,7 +196,7 @@ Feature: SCTP related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Networkpolicy allow SCTP Client
+  Scenario: OCP-29645 Networkpolicy allow SCTP Client
     Given I store the ready and schedulable workers in the :workers clipboard
     And I install machineconfigs load-sctp-module
     And I have a project

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -8,7 +8,7 @@ Feature: SDN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy
-  Scenario: kubelet proxy could change to userspace mode
+  Scenario: OCP-10025 kubelet proxy could change to userspace mode
     Given the env is using one of the listed network plugins:
       | subnet      |
       | multitenant |
@@ -48,7 +48,7 @@ Feature: SDN related networking scenarios
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: iptables rules will be repaired automatically once it gets destroyed
+  Scenario: OCP-11286 iptables rules will be repaired automatically once it gets destroyed
     # we do not detect incomplete rule removal since ~4.3, BZ-1810316
     # so only test on >= 4.3
     Given the master version >= "4.3"
@@ -89,7 +89,7 @@ Feature: SDN related networking scenarios
   @proxy @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: an empty OPENSHIFT-ADMIN-OUTPUT-RULES chain is created in filter table at startup
+  Scenario: OCP-13847 an empty OPENSHIFT-ADMIN-OUTPUT-RULES chain is created in filter table at startup
     Given the master version >= "3.6"
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -107,7 +107,7 @@ Feature: SDN related networking scenarios
   @admin
   @destructive
   @inactive
-  Scenario: net.ipv4.ip_forward should be always enabled on node service startup
+  Scenario: OCP-15251 net.ipv4.ip_forward should be always enabled on node service startup
     Given I select a random node's host
     And the node service is verified
     And the node network is verified
@@ -141,7 +141,7 @@ Feature: SDN related networking scenarios
   @admin
   @destructive
   @inactive
-  Scenario: The openflow list will be cleaned after deleted the node
+  Scenario: OCP-14985 The openflow list will be cleaned after deleted the node
     Given the env is using "OpenShiftSDN" networkType
     Given environment has at least 2 schedulable nodes
     And I store the schedulable workers in the :nodes clipboard
@@ -198,7 +198,7 @@ Feature: SDN related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: should not show "No such device" message when run "ovs-vsctl show" command
+  Scenario: OCP-18535 should not show "No such device" message when run "ovs-vsctl show" command
     Given I have a project
     And I have a pod-for-ping in the project
     And evaluation of `pod.node_name` is stored in the :node_name clipboard
@@ -221,7 +221,7 @@ Feature: SDN related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: The iptables binary and rules on sdn containers should be the same as host
+  Scenario: OCP-23543 The iptables binary and rules on sdn containers should be the same as host
     Given I select a random node's host
     When I run commands on the host:
       | iptables-save --version |
@@ -253,7 +253,7 @@ Feature: SDN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: ovs-vswitchd process must be running on all ovs pods
+  Scenario: OCP-25707 ovs-vswitchd process must be running on all ovs pods
     Given I switch to cluster admin pseudo user
     When I run cmds on all ovs pods:
       | pgrep | ovs-vswitchd |
@@ -269,7 +269,7 @@ Feature: SDN related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-openshiftsdn
-  Scenario: Killing ovs process should not put sdn and ovs pods in bad shape
+  Scenario: OCP-25706 Killing ovs process should not put sdn and ovs pods in bad shape
     Given I have a project
     And evaluation of `project.name` is stored in the :usr_project clipboard
     Given I obtain test data file "networking/list_for_pods.json"
@@ -318,7 +318,7 @@ Feature: SDN related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Networking should work on default namespace
+  Scenario: OCP-27655 Networking should work on default namespace
   #Test for bug https://bugzilla.redhat.com/show_bug.cgi?id=1800324 and https://bugzilla.redhat.com/show_bug.cgi?id=1796157
     Given I switch to cluster admin pseudo user
     And I use the "default" project
@@ -373,7 +373,7 @@ Feature: SDN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Don't write CNI configuration file until ovn-controller has done at least one iteration
+  Scenario: OCP-25787 Don't write CNI configuration file until ovn-controller has done at least one iteration
     Given the env is using "OVNKubernetes" networkType
     And I store the masters in the :master clipboard
     And I store "<%= cb.master[0].name %>" node's corresponding default networkType pod name in the :ovnkube_pod clipboard
@@ -428,7 +428,7 @@ Feature: SDN related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: NetworkManager should consider OVS interfaces as unmanaged
+  Scenario: OCP-25933 NetworkManager should consider OVS interfaces as unmanaged
   Given the env is using "OVNKubernetes" networkType
   And I select a random node's host
   And the vxlan tunnel name of node "<%= node.name %>" is stored in the :tunnel_inf_name clipboard
@@ -457,7 +457,7 @@ Feature: SDN related networking scenarios
   @baremetal-upi
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  Scenario: Without allow the migration operation, migration cannot be executed
+  Scenario: OCP-29299 Without allow the migration operation, migration cannot be executed
     When I run the :annotate client command with:
        | resource     | network.operator.openshift.io                       |
        | resourcename | cluster                                             |
@@ -497,7 +497,7 @@ Feature: SDN related networking scenarios
   @proxy @noproxy @disconnected @connected
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
-  Scenario: Netnamespace should be recreated after deleting it before the project is deleted
+  Scenario: OCP-36287 Netnamespace should be recreated after deleting it before the project is deleted
     Given the env is using "OpenShiftSDN" networkType
     Given I have a project
     And admin checks that the "<%= project.name %>" net_namespace exists
@@ -517,7 +517,7 @@ Feature: SDN related networking scenarios
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: UDP offloads were disabled on vsphere platform
+  Scenario: OCP-41132 UDP offloads were disabled on vsphere platform
     Given I select a random node's host
     Given the default interface on nodes is stored in the :default_interface clipboard
     And I run commands on the host:
@@ -536,7 +536,7 @@ Feature: SDN related networking scenarios
   @proxy @noproxy @disconnected @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Disable conntrack for vxlan traffic
+  Scenario: OCP-43146 Disable conntrack for vxlan traffic
     Given the env is using "OpenShiftSDN" networkType
     Given I select a random node's host
     And I run commands on the host:

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -4,7 +4,7 @@ Feature: Service related networking scenarios
   # @case_id OCP-9604
   @admin
   @network-multitenant
-  Scenario: tenants can access their own services
+  Scenario: OCP-9604 tenants can access their own services
     # create pod and service in project1
     Given the env is using multitenant network
     Given I have a project
@@ -48,7 +48,7 @@ Feature: Service related networking scenarios
   @admin
   @inactive
   @network-multitenant
-  Scenario: The openflow list will be cleaned after delete the services
+  Scenario: OCP-15032 The openflow list will be cleaned after delete the services
     Given the env is using one of the listed network plugins:
       | subnet      |
       | multitenant |
@@ -83,7 +83,7 @@ Feature: Service related networking scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: User cannot access the MCS by creating a LoadBalancer service that points to the MCS
+  Scenario: OCP-23895 User cannot access the MCS by creating a LoadBalancer service that points to the MCS
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard
     Given I select a random node's host
@@ -115,7 +115,7 @@ Feature: Service related networking scenarios
   @noproxy @connected
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The headless service can publish the pods even if they are not ready
+  Scenario: OCP-21814 The headless service can publish the pods even if they are not ready
     Given I have a project
     Given I obtain test data file "networking/headless_notreadypod.json"
     When I run the :create client command with:
@@ -146,7 +146,7 @@ Feature: Service related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: externalIP defined in service but no spec.externalIP defined
+  Scenario: OCP-24668 externalIP defined in service but no spec.externalIP defined
     Given I have a project
     # Create a service with a externalIP
     Given I obtain test data file "networking/externalip_service1.json"
@@ -165,7 +165,7 @@ Feature: Service related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: externalIP defined in service with set ExternalIP in allowedCIDRs
+  Scenario: OCP-24669 externalIP defined in service with set ExternalIP in allowedCIDRs
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I store the schedulable nodes in the :nodes clipboard
@@ -216,7 +216,7 @@ Feature: Service related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: A rejectedCIDRs inside an allowedCIDRs
+  Scenario: OCP-24692 A rejectedCIDRs inside an allowedCIDRs
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["22.2.2.0/24"],"rejectedCIDRs":["22.2.2.0/25"]}}}} |
@@ -271,7 +271,7 @@ Feature: Service related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: externalIP defined in service with set ExternalIP in rejectedCIDRs
+  Scenario: OCP-24670 externalIP defined in service with set ExternalIP in rejectedCIDRs
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I store the schedulable nodes in the :nodes clipboard
@@ -309,7 +309,7 @@ Feature: Service related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: An allowedCIDRs inside an rejectedCIDRs
+  Scenario: OCP-24739 An allowedCIDRs inside an rejectedCIDRs
     # Create additional network through CNO
     Given as admin I successfully merge patch resource "networks.config.openshift.io/cluster" with:
       | {"spec":{"externalIP":{"policy":{"allowedCIDRs":["22.2.2.0/25"],"rejectedCIDRs":["22.2.2.0/24"]}}}} |
@@ -350,7 +350,7 @@ Feature: Service related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Defined Multiple allowedCIDRs
+  Scenario: OCP-24691 Defined Multiple allowedCIDRs
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I store the schedulable nodes in the :nodes clipboard
@@ -429,7 +429,7 @@ Feature: Service related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Idling/Unidling services on sdn/OVN
+  Scenario: OCP-26035 Idling/Unidling services on sdn/OVN
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
     When I run the :create client command with:
@@ -458,7 +458,7 @@ Feature: Service related networking scenarios
   # @author huirwang@redhat.com
   # @case_id OCP-11645
   @inactive
-  Scenario: Create loadbalancer service
+  Scenario: OCP-11645 Create loadbalancer service
     Given I have a project
     Given I obtain test data file "networking/ping_for_pod_containerPort.json"
     When I run the :create client command with:
@@ -507,7 +507,7 @@ Feature: Service related networking scenarios
   @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Taint node with too small MTU value
+  Scenario: OCP-24694 Taint node with too small MTU value
     Given the default interface on nodes is stored in the :default_interface clipboard
     And the node's MTU value is stored in the :mtu_actual clipboard
     And the node's active nmcli connection is stored in the :nmcli_active_con_uuid clipboard
@@ -569,7 +569,7 @@ Feature: Service related networking scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: User can expand the nodePort range by patch the serviceNodePortRange in network
+  Scenario: OCP-33848 User can expand the nodePort range by patch the serviceNodePortRange in network
     Given I store the workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[0].name %>" is stored in the :worker0_ip clipboard
     Given I have a project
@@ -610,7 +610,7 @@ Feature: Service related networking scenarios
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: User cannot decrease the nodePort range in post action
+  Scenario: OCP-33850 User cannot decrease the nodePort range in post action
     When I run the :patch admin command with:
       | resource      | networks.config.openshift.io                     |
       | resource_name | cluster                                          |
@@ -628,7 +628,7 @@ Feature: Service related networking scenarios
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: The iptables rules for the service should be DNAT or REDIRECT to node after being idled
+  Scenario: OCP-10216 The iptables rules for the service should be DNAT or REDIRECT to node after being idled
     Given I have a project
     And evaluation of `project.name` is stored in the :proj_name clipboard
     Given I obtain test data file "networking/list_for_pods.json"
@@ -694,7 +694,7 @@ Feature: Service related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Update externalIP from oc edit svc
+  Scenario: OCP-43493 Update externalIP from oc edit svc
     Given I have a project
     And evaluation of `project.name` is stored in the :proj_name clipboard
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
@@ -764,7 +764,7 @@ Feature: Service related networking scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
-  Scenario: Other node cannot be accessed for nodePort when externalTrafficPolicy is Local
+  Scenario: OCP-47087 Other node cannot be accessed for nodePort when externalTrafficPolicy is Local
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard
     And the Internal IP of node "<%= cb.masters[1].name %>" is stored in the :master1_ip clipboard
@@ -815,7 +815,7 @@ Feature: Service related networking scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Be able to access the service via the nodeport
+  Scenario: OCP-10770 Be able to access the service via the nodeport
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard
     And evaluation of `rand(30000..32767)` is stored in the :port clipboard

--- a/features/networking/sgw-lgw-migration.feature
+++ b/features/networking/sgw-lgw-migration.feature
@@ -1,4 +1,5 @@
 Feature: SGW<->LGW migration related scenarios
+
   
   # @author anusaxen@redhat.com
   # @case_id OCP-47561
@@ -10,7 +11,7 @@ Feature: SGW<->LGW migration related scenarios
   @noproxy @connected
   @vsphere-upi
   @amd64
-  Scenario: SGW <-> LGW migration scenario for vsphere platform
+  Scenario: OCP-47561 SGW <-> LGW migration scenario for vsphere platform
     Given the env is using "OVNKubernetes" networkType
 
     ######## Prepare Data Pre Migration for multiple use cases############
@@ -135,7 +136,7 @@ Feature: SGW<->LGW migration related scenarios
   @baremetal-upi
   @proxy @noproxy @disconnected @connected
   @amd64
-  Scenario: SGW <-> LGW migration scenario for BM platform
+  Scenario: OCP-47641 SGW <-> LGW migration scenario for BM platform
     Given the env is using "OVNKubernetes" networkType
 
     ######## Prepare Data Pre Migration for multiple use cases############
@@ -206,7 +207,7 @@ Feature: SGW<->LGW migration related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @amd64
-  Scenario: SGW <-> LGW migration scenarios for externalIP
+  Scenario: OCP-48066 SGW <-> LGW migration scenarios for externalIP
     Given the env is using "OVNKubernetes" networkType
     ######## Prepare Data Pre Migration ############
     #OCP-24669 - externalIP defined in service with set ExternalIP in allowedCIDRs

--- a/features/networking/sriov.feature
+++ b/features/networking/sriov.feature
@@ -7,7 +7,7 @@ Feature: Sriov related scenarios
   @4.10 @4.9 @4.6
   @singlenode
   @proxy @noproxy @disconnected @connected
-  Scenario: sriov operator can be setup and running well
+  Scenario: OCP-29944 sriov operator can be setup and running well
     Given I switch to cluster admin pseudo user
     And I use the "openshift-sriov-network-operator" project
     And all existing pods are ready with labels:
@@ -24,7 +24,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-24702
   @destructive
   @admin
-  Scenario: netdevice VF for XXV710 can be worked well when sriovnetworknodepolicies is created for rhcos node
+  Scenario: OCP-24702 netdevice VF for XXV710 can be worked well when sriovnetworknodepolicies is created for rhcos node
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/intel-netdevice.yaml"
     Given I create sriov resource with following:
@@ -74,7 +74,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-21364
   @destructive
   @admin
-  Scenario: Create pod with sriov-cni plugin and macvlan on the same interface
+  Scenario: OCP-21364 Create pod with sriov-cni plugin and macvlan on the same interface
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/intel-netdevice.yaml"
     Given I create sriov resource with following:
@@ -134,7 +134,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-24713
   @destructive
   @admin
-  Scenario: NAD can be also updated when networknamespace is change
+  Scenario: OCP-24713 NAD can be also updated when networknamespace is change
     Given the sriov operator is running well
     Given I switch to the first user
     And I have a project
@@ -215,7 +215,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-24780
   @destructive
   @admin
-  Scenario: NAD will be deleted too when sriovnetwork is deleted
+  Scenario: OCP-24780 NAD will be deleted too when sriovnetwork is deleted
     Given the sriov operator is running well
     Given I switch to the first user
     And I have a project
@@ -236,7 +236,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-25287
   @destructive
   @admin
-  Scenario: NAD should be able to restore by sriov operator when it was deleted
+  Scenario: OCP-25287 NAD should be able to restore by sriov operator when it was deleted
     Given the sriov operator is running well
     Given I switch to the first user
     And I have a project
@@ -264,7 +264,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-25790
   @admin
   @destructive
-  Scenario: SR-IOV network config daemon can be set by nodeselector
+  Scenario: OCP-25790 SR-IOV network config daemon can be set by nodeselector
     Given the sriov operator is running well
     And all existing pods are ready with labels:
       | app=sriov-network-config-daemon |
@@ -278,7 +278,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-26134
   @destructive
   @admin
-  Scenario: sriov can be shown in Metrics and telemetry
+  Scenario: OCP-26134 sriov can be shown in Metrics and telemetry
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/mlx278-netdevice.yaml"
     Given I create sriov resource with following:
@@ -363,7 +363,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-33454
   @destructive
   @admin
-  Scenario: VF mac can be set with container mac address
+  Scenario: OCP-33454 VF mac can be set with container mac address
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/mlx278-netdevice.yaml"
     Given I create sriov resource with following:
@@ -460,7 +460,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-25835
   @destructive
   @admin
-  Scenario: SR-IOV resource injector should not overwrite the request memory and cpu
+  Scenario: OCP-25835 SR-IOV resource injector should not overwrite the request memory and cpu
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/mlx278-netdevice.yaml"
     Given I create sriov resource with following:
@@ -528,7 +528,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-28076
   @destructive
   @admin
-  Scenario: vf range should be correct if create sriovnetworkpolicy without pfNames
+  Scenario: OCP-28076 vf range should be correct if create sriovnetworkpolicy without pfNames
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/intel-netdevice-without-pf.yaml"
     Given I create sriov resource with following:
@@ -559,7 +559,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-30268
   @destructive
   @admin
-  Scenario: user can set the loglevel for sriov config daemon
+  Scenario: OCP-30268 user can set the loglevel for sriov config daemon
     Given the sriov operator is running well
     Given sriov config daemon is ready
     Given I patch the sriov logs to "0"
@@ -583,7 +583,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-30277
   @destructive
   @admin
-  Scenario: Loglevel value should be explain in CRD
+  Scenario: OCP-30277 Loglevel value should be explain in CRD
     Given the sriov operator is running well
     When I run the :explain client command with:
       | resource | sriovoperatorconfigs.spec.logLevel |
@@ -594,7 +594,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-32642
   @destructive
   @admin
-  Scenario: MTU can be set according to policy is specified
+  Scenario: OCP-32642 MTU can be set according to policy is specified
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/mlx278-netdevice.yaml"
     Given I create sriov resource with following:
@@ -664,7 +664,7 @@ Feature: Sriov related scenarios
   @destructive
   @admin
   @inactive
-  Scenario: sriov-device-plugin can be scheduled on any node
+  Scenario: OCP-34092 sriov-device-plugin can be scheduled on any node
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/mlx278-netdevice.yaml"
     Given I create sriov resource with following:
@@ -694,7 +694,7 @@ Feature: Sriov related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: dpdk for intel card works well
+  Scenario: OCP-25321 dpdk for intel card works well
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/intel-dpdk.yaml"
     Given I create sriov resource with following:
@@ -748,7 +748,7 @@ Feature: Sriov related scenarios
   # @case_id OCP-37458
   @destructive
   @admin
-  Scenario: user can disable drain node by DisableDrain
+  Scenario: OCP-37458 user can disable drain node by DisableDrain
     Given the sriov operator is running well
     #disable drain node by DisableDrain
     #When I run the :patch admin command with:

--- a/features/node/node.feature
+++ b/features/node/node.feature
@@ -4,7 +4,7 @@ Feature: Node management
   # @case_id OCP-11084
   @admin
   @inactive
-  Scenario: admin can get nodes
+  Scenario: OCP-11084 admin can get nodes
     Given I have a project
     When I run the :get admin command with:
       |resource|nodes|

--- a/features/node/nto.feature
+++ b/features/node/nto.feature
@@ -4,7 +4,7 @@ Feature: Node Tuning Operator related scenarios
   # @case_id OCP-27491
   @admin
   @destructive
-  Scenario: Node tuning operator: tuning is working - add profile
+  Scenario: OCP-27491 Node tuning operator: tuning is working - add profile
     # Cleaning after test if some step failed
     Given admin ensures "nf-conntrack-max" tuned is deleted from the "openshift-cluster-node-tuning-operator" project after scenario
     And I obtain test data file "pods/hello-pod.json"

--- a/features/node/seccomp.feature
+++ b/features/node/seccomp.feature
@@ -3,7 +3,7 @@ Feature: Secure Computing Test Scenarios
   # @author wmeng@redhat.com
   # @case_id OCP-10483
   @inactive
-  Scenario: seccomp=unconfined used by default
+  Scenario: OCP-10483 seccomp=unconfined used by default
     Given I have a project
     Given I obtain test data file "pods/hello-pod.json"
     When I run the :create client command with:
@@ -29,7 +29,7 @@ Feature: Secure Computing Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Using Secure Computing Profiles with Pod Annotations
+  Scenario: OCP-32065 Using Secure Computing Profiles with Pod Annotations
     # Create custom machine config that contains the seccomp
     Given I switch to cluster admin pseudo user
     And I obtain test data file "node/machineconfig_nostat.yaml"

--- a/features/online/accountant.feature
+++ b/features/online/accountant.feature
@@ -2,7 +2,7 @@ Feature: ONLY Accountant console related feature's scripts in this file
 
   # @author xiaocwan@redhat.com
   # @case_id OCP-12754
-  Scenario: Cancel and resume service - UI
+  Scenario: OCP-12754 Cancel and resume service - UI
     Given I open accountant console in a browser
     When I run the :click_to_change_plan web action
     Then the step should succeed
@@ -23,7 +23,7 @@ Feature: ONLY Accountant console related feature's scripts in this file
   # @author yuwan@redhat.com
   # @case_id OCP-12758
   # @note this scenario requires a user who have pro cluster(1) left to resigster
-  Scenario: an existed Red Hat account's contact details can be pre-populated to accountant profile during registration
+  Scenario: OCP-12758 an existed Red Hat account's contact details can be pre-populated to accountant profile during registration
     Given I open accountant console in a browser
     When I run the :go_to_register_pro_cluster_page web action
     Then the step should succeed

--- a/features/online/build.feature
+++ b/features/online/build.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE related feature's scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-9781
-  Scenario: cli disables Docker builds and custom builds and allow only sti builds
+  Scenario: OCP-9781 cli disables Docker builds and custom builds and allow only sti builds
     Given I have a project
     When I run the :new_build client command with:
       | app_repo | centos/ruby-22-centos7~https://github.com/openshift/ruby-hello-world.git |

--- a/features/online/check_link.feature
+++ b/features/online/check_link.feature
@@ -2,7 +2,7 @@ Feature: Check links in Openshift
 
   # @author yasun@redhat.com
   # @case_id OCP-9873
-  Scenario: Check the CLI download links on web page
+  Scenario: OCP-9873 Check the CLI download links on web page
     When I run the :version client command
     Then the step should succeed
     And evaluation of `@result[:props][:openshift_server_version]` is stored in the :server_version clipboard

--- a/features/online/create.feature
+++ b/features/online/create.feature
@@ -38,7 +38,7 @@ Feature: ONLY ONLINE Create related feature's scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-10270
-  Scenario: Create Laravel application with a MySQL database using default template laravel-mysql-example
+  Scenario: OCP-10270 Create Laravel application with a MySQL database using default template laravel-mysql-example
     Given I have a project
     Then I run the :new_app client command with:
       | template | laravel-mysql-persistent |
@@ -52,7 +52,7 @@ Feature: ONLY ONLINE Create related feature's scripts in this file
 
   # @author yuwan@redhat.com
   # @case_id OCP-12687
-  Scenario: PyPi index can be used to providing dependencies for django-psql-example template
+  Scenario: OCP-12687 PyPi index can be used to providing dependencies for django-psql-example template
     Given I have a project
     When I run the :new_app client command with:
       | template | django-psql-persistent                                               |

--- a/features/online/deploy.feature
+++ b/features/online/deploy.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Deployment related scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-10075
-  Scenario: OSO Starter Specify resource constraints for standalone dc and rc in web console with project limits already set
+  Scenario: OCP-10075 OSO Starter Specify resource constraints for standalone dc and rc in web console with project limits already set
     Given I have a project
     Given I obtain test data file "deployment/dc-with-two-containers.yaml"
     When I run the :create client command with:
@@ -150,7 +150,7 @@ Feature: ONLY ONLINE Deployment related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-14969
-  Scenario: OSO Pro Specify resource constraints for standalone dc and rc in web console with project limits already set
+  Scenario: OCP-14969 OSO Pro Specify resource constraints for standalone dc and rc in web console with project limits already set
     Given I have a project
     Given I obtain test data file "deployment/dc-with-two-containers.yaml"
     When I run the :create client command with:

--- a/features/online/fuse.feature
+++ b/features/online/fuse.feature
@@ -3,7 +3,7 @@ Feature: ONLY Fuse Plan related scripts in this file
   # @author yuwan@redhat.com
   # @case_id OCP-20439
   # @note this scenario requires a user who have pro cluster(1) left to resigster
-  Scenario: an existed Red Hat account's contact details can be pre-populated to accountant profile during registration - Fuse
+  Scenario: OCP-20439 an existed Red Hat account's contact details can be pre-populated to accountant profile during registration - Fuse
     Given I open accountant console in a browser
     When I run the :go_to_register_fuse_profile_page web action
     Then the step should succeed

--- a/features/online/images.feature
+++ b/features/online/images.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Images related scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-11614
-  Scenario: Create mongo resources with persistent template for mongodb-32-rhel7 images
+  Scenario: OCP-11614 Create mongo resources with persistent template for mongodb-32-rhel7 images
     Given I have a project
     Then I run the :new_app client command with:
       | template | mongodb-persistent           |
@@ -23,7 +23,7 @@ Feature: ONLY ONLINE Images related scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-10144
-  Scenario: Add env variables to postgresql-95-rhel7 image
+  Scenario: OCP-10144 Add env variables to postgresql-95-rhel7 image
     Given I have a project
     When I run the :new_app client command with:
       | name  | psql                           |
@@ -65,7 +65,7 @@ Feature: ONLY ONLINE Images related scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-10147
-  Scenario: Verify Mariadb can be connected after admin and user password are changed and re-deployment for persistent storage - marialdb-101-rhel7
+  Scenario: OCP-10147 Verify Mariadb can be connected after admin and user password are changed and re-deployment for persistent storage - marialdb-101-rhel7
     Given I have a project
     Given I obtain test data file "templates/ocp10147/mariadb-persistent.json"
     And I run the :new_app client command with:
@@ -113,7 +113,7 @@ Feature: ONLY ONLINE Images related scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-12681
-  Scenario: mem based auto-tuning mariadb
+  Scenario: OCP-12681 mem based auto-tuning mariadb
     Given I have a project
     When I run the :new_app client command with:
       | name  | mariadb                  |

--- a/features/online/imagestreams.feature
+++ b/features/online/imagestreams.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Imagestreams related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-10509
-  Scenario: Check Online Pro default images
+  Scenario: OCP-10509 Check Online Pro default images
     When I run the :get client command with:
       | resource      | imagestreamtag  |
       | n             | openshift       |
@@ -81,7 +81,7 @@ Feature: ONLY ONLINE Imagestreams related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-17285
-  Scenario: Check Online Starter default images
+  Scenario: OCP-17285 Check Online Starter default images
     When I run the :get client command with:
       | resource      | imagestreamtag  |
       | n             | openshift       |

--- a/features/online/infra.feature
+++ b/features/online/infra.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Infra related scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-10142
-  Scenario: User cannot deploy a pod to an infra node
+  Scenario: OCP-10142 User cannot deploy a pod to an infra node
     Given I have a project
     Given I obtain test data file "pods/ocp10142/pod_nodeSelector_infra.yaml"
     When I run the :create client command with:
@@ -13,7 +13,7 @@ Feature: ONLY ONLINE Infra related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-11230
-  Scenario: Specify runtime duration of run-once pods globally in master config
+  Scenario: OCP-11230 Specify runtime duration of run-once pods globally in master config
     Given I have a project
     When I run the :run client command with:
       | name    | run-once-pod     |

--- a/features/online/metrics.feature
+++ b/features/online/metrics.feature
@@ -2,7 +2,7 @@ Feature: Online metrics related tests
 
   # @author pruan@redhat.com
   # @case_id OCP-15214
-  Scenario: Ordinary user could view CPU,memory, network metrics statistics on pod page of openshift web console
+  Scenario: OCP-15214 Ordinary user could view CPU,memory, network metrics statistics on pod page of openshift web console
     Given I have a project
     Given I login via web console
     When I run the :create client command with:

--- a/features/online/notification.feature
+++ b/features/online/notification.feature
@@ -2,7 +2,7 @@ Feature: Online "Notification" related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-12870
-  Scenario: Notification UI should correctly display in web console
+  Scenario: OCP-12870 Notification UI should correctly display in web console
     Given I have a project
     When I perform the :check_notification_message web console action with:
       | project_name | <%= project.name %> |
@@ -12,7 +12,7 @@ Feature: Online "Notification" related scripts in this file
   # @author bingli@redhat.com
   # @case_id OCP-10334
   @inactive
-  Scenario: Enable/Disable online notification in web console - UI
+  Scenario: OCP-10334 Enable/Disable online notification in web console - UI
     Given I have a project
     When I perform the :goto_notification_page web console action with:
       | project_name | <%= project.name %> |

--- a/features/online/projects.feature
+++ b/features/online/projects.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Projects related feature's scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-12547
-  Scenario: Should use and show the existing projects after the user login
+  Scenario: OCP-12547 Should use and show the existing projects after the user login
     Given I create a new project
     When I run the :login client command with:
       | server   | <%= env.api_endpoint_url %>         |
@@ -45,7 +45,7 @@ Feature: ONLY ONLINE Projects related feature's scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-14100
-  Scenario: Should use and show the existing projects after the user login - starter
+  Scenario: OCP-14100 Should use and show the existing projects after the user login - starter
     When I run the :login client command with:
       | server   | <%= env.api_endpoint_url %>         |
       | token    | <%= user.cached_tokens.first %>  |
@@ -65,7 +65,7 @@ Feature: ONLY ONLINE Projects related feature's scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-13073
-  Scenario: a new paid-user can not create muti-projects exceed the selected plan limitation
+  Scenario: OCP-13073 a new paid-user can not create muti-projects exceed the selected plan limitation
     Given I run the steps <%= user.plan.max_projects %> times:
     """
       Given I create a new project

--- a/features/online/quota.feature
+++ b/features/online/quota.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Quota related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-12700
-  Scenario: CRUD operation to the resource quota as project owner
+  Scenario: OCP-12700 CRUD operation to the resource quota as project owner
     Given I have a project
     When I run the :describe client command with:
       | resource | rolebinding   |
@@ -72,7 +72,7 @@ Feature: ONLY ONLINE Quota related scripts in this file
 
   # @author yuwei@redhat.com
   # @case_id OCP-10291
-  Scenario: Can not create resource exceed the hard quota in appliedclusterresourcequota
+  Scenario: OCP-10291 Can not create resource exceed the hard quota in appliedclusterresourcequota
     Given I have a project
     And evaluation of `BushSlicer::AppliedClusterResourceQuota.list(user: user, project: project)` is stored in the :acrq clipboard
     And evaluation of `cb.acrq.find{|o|o.name.end_with?("-compute")}` is stored in the :memory_crq clipboard

--- a/features/online/rolebindingrestriction.feature
+++ b/features/online/rolebindingrestriction.feature
@@ -71,7 +71,7 @@ Feature: rolebindingrestriction.feature
 
   # @author zhaliu@redhat.com
   # @case_id OCP-13798
-  Scenario: After the project is deleted the rolebindingrestriction will be deleted too
+  Scenario: OCP-13798 After the project is deleted the rolebindingrestriction will be deleted too
     Given I have a project
     And evaluation of `project.name` is stored in the :project_name clipboard
     When I run the :get client command with:

--- a/features/online/route.feature
+++ b/features/online/route.feature
@@ -2,7 +2,7 @@ Feature: Route test in online environments
 
   # @author zhaliu@redhat.com
   # @case_id OCP-16320
-  Scenario: Custom hostname is prohibited for passthrough terminated route
+  Scenario: OCP-16320 Custom hostname is prohibited for passthrough terminated route
     Given I have a project
     Given I obtain test data file "routing/passthrough/service_secure.json"
     When I run the :create client command with:
@@ -22,7 +22,7 @@ Feature: Route test in online environments
 
   # @author zhaliu@redhat.com
   # @case_id OCP-16318
-  Scenario: Custom hostname is prohibited for unsecure route
+  Scenario: OCP-16318 Custom hostname is prohibited for unsecure route
     Given I have a project
     Given I obtain test data file "routing/caddy-docker.json"
     When I run the :create client command with:
@@ -48,7 +48,7 @@ Feature: Route test in online environments
 
   # @author zhaliu@redhat.com
   # @case_id OCP-16319
-  Scenario: Custom hostname and cert are prohibited for edge terminated route
+  Scenario: OCP-16319 Custom hostname and cert are prohibited for edge terminated route
     Given I have a project
     Given I obtain test data file "routing/caddy-docker.json"
     When I run the :create client command with:
@@ -94,7 +94,7 @@ Feature: Route test in online environments
 
   # @author zhaliu@redhat.com
   # @case_id OCP-16321
-  Scenario: Custom hostname and cert are prohibited for reencrypt terminated route
+  Scenario: OCP-16321 Custom hostname and cert are prohibited for reencrypt terminated route
     Given I have a project
     Given I obtain test data file "routing/reencrypt/reencrypt-without-all-cert.yaml"
     When I run the :create client command with:

--- a/features/online/storage.feature
+++ b/features/online/storage.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Storage related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-9967
-  Scenario: Delete pod with mounting error
+  Scenario: OCP-9967 Delete pod with mounting error
     Given I have a project
     Given I obtain test data file "online/pod_volumetest.json"
     When I run the :create client command with:
@@ -36,7 +36,7 @@ Feature: ONLY ONLINE Storage related scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-9809
-  Scenario: Pod should not create directories within /var/lib/docker/volumes/ on nodes
+  Scenario: OCP-9809 Pod should not create directories within /var/lib/docker/volumes/ on nodes
     Given I have a project
     Given I obtain test data file "online/pod_volumetest.json"
     When I run the :create client command with:
@@ -59,7 +59,7 @@ Feature: ONLY ONLINE Storage related scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-13108
-  Scenario: Basic user could not get pv object info
+  Scenario: OCP-13108 Basic user could not get pv object info
     Given I have a project
     Given I obtain test data file "storage/ebs/claim.json"
     When I run oc create over "claim.json" replacing paths:
@@ -100,7 +100,7 @@ Feature: ONLY ONLINE Storage related scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-9923
-  Scenario: Claim requesting to get the maximum capacity
+  Scenario: OCP-9923 Claim requesting to get the maximum capacity
     Given I have a project
     Given I obtain test data file "online/dynamic_persistent_volumes/pvc-equal.yaml"
     When I run the :create client command with:
@@ -157,7 +157,7 @@ Feature: ONLY ONLINE Storage related scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-9792
-  Scenario: Volume emptyDir is limited in the Pod in online openshift
+  Scenario: OCP-9792 Volume emptyDir is limited in the Pod in online openshift
     Given I have a project
     And evaluation of `project.mcs(user: user)` is stored in the :proj_selinux_options clipboard
     And evaluation of `project.supplemental_groups(user: user).begin` is stored in the :supplemental_groups clipboard

--- a/features/registry/is.feature
+++ b/features/registry/is.feature
@@ -8,7 +8,7 @@ Feature: Testing imagestream
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
-  Scenario: Should prune the extenal image correctly
+  Scenario: OCP-13895 Should prune the extenal image correctly
     Given default registry service ip is stored in the :registry_hostname clipboard
     Given I have a project
     And I have a skopeo pod in the project
@@ -101,7 +101,7 @@ Feature: Testing imagestream
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Prune images when DC reference to invalid image
+  Scenario: OCP-19196 Prune images when DC reference to invalid image
     Given I have a project
     Given I enable image-registry default route
     Given default image registry route is stored in the :registry_hostname clipboard
@@ -150,7 +150,7 @@ Feature: Testing imagestream
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Do not prune layer of a valid Image due to minimum aging
+  Scenario: OCP-16495 Do not prune layer of a valid Image due to minimum aging
     Given I have a project
     Given I enable image-registry default route
     Given default image registry route is stored in the :registry_hostname clipboard

--- a/features/registry/registry.feature
+++ b/features/registry/registry.feature
@@ -12,7 +12,7 @@ Feature: Testing registry
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Prune images by command oadm_prune_images
+  Scenario: OCP-12400 Prune images by command oadm_prune_images
     Given cluster role "system:image-pruner" is added to the "first" user
     Given I enable image-registry default route
     Given default image registry route is stored in the :registry_ip clipboard
@@ -51,7 +51,7 @@ Feature: Testing registry
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Copy image to another tag via 'oc image mirror'
+  Scenario: OCP-18994 Copy image to another tag via 'oc image mirror'
     Given I have a project
     Given docker config for default image registry is stored to the :dockercfg_file clipboard
     Then I run the :image_mirror client command with:
@@ -75,7 +75,7 @@ Feature: Testing registry
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Mirror multiple locations to another registry via 'oc image mirror'
+  Scenario: OCP-18998 Mirror multiple locations to another registry via 'oc image mirror'
     Given I have a project
     Given docker config for default image registry is stored to the :dockercfg_file clipboard
     Then I run the :image_mirror client command with:
@@ -101,7 +101,7 @@ Feature: Testing registry
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  Scenario: Enable must-gather object refs in image-registry cluster
+  Scenario: OCP-23030 Enable must-gather object refs in image-registry cluster
     When I run the :get admin command with:
       | resource      | co             |
       | resource_name | image-registry |
@@ -178,7 +178,7 @@ Feature: Testing registry
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check the related log from must-gather tool
+  Scenario: OCP-23063 Check the related log from must-gather tool
     When I run the :delete admin command with:
       | object_type       | co             |
       | object_name_or_id | image-registry |
@@ -201,7 +201,7 @@ Feature: Testing registry
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Mirror image to another registry via 'oc image mirror'
+  Scenario: OCP-18995 Mirror image to another registry via 'oc image mirror'
     Given I have a project
     Given docker config for default image registry is stored to the :dockercfg_file clipboard
     Then I run the :image_mirror client command with:
@@ -226,7 +226,7 @@ Feature: Testing registry
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Use node credentials in imagestream import
+  Scenario: OCP-29696 Use node credentials in imagestream import
     Given I have a project
     When I run the :tag client command with:
       | source           | registry.redhat.io/rhel8/mysql-80:latest |
@@ -263,7 +263,7 @@ Feature: Testing registry
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Disconnect Import image from a secure registry using node credentials
+  Scenario: OCP-29693 Disconnect Import image from a secure registry using node credentials
     Given I have a project
     And evaluation of `image_content_source_policy('image-policy-aosqe').mirror_registry(cached: false)` is stored in the :mirror_registry clipboard
     When I run the :tag client command with:
@@ -298,7 +298,7 @@ Feature: Testing registry
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Node secret takes effect when common secret is removed
+  Scenario: OCP-29706 Node secret takes effect when common secret is removed
     Given I have a project
     When I run the :extract admin command with:
       | resource  | secret/pull-secret |

--- a/features/routing/abrouting.feature
+++ b/features/routing/abrouting.feature
@@ -3,7 +3,7 @@ Feature: Testing abrouting
   # @author yadu@redhat.com
   # @case_id OCP-12076
   @admin
-  Scenario: Set backends weight for unsecure route
+  Scenario: OCP-12076 Set backends weight for unsecure route
     Given I switch to cluster admin pseudo user
     And I use the router project
     Given all default router pods become ready
@@ -85,7 +85,7 @@ Feature: Testing abrouting
   # @author yadu@redhat.com
   # @case_id OCP-11970
   @admin
-  Scenario: Set backends weight for reencrypt route
+  Scenario: OCP-11970 Set backends weight for reencrypt route
     Given I switch to cluster admin pseudo user
     And I use the router project
     Given all default router pods become ready
@@ -183,7 +183,7 @@ Feature: Testing abrouting
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
-  Scenario: The edge route with multiple service will set load balance policy to RoundRobin by default
+  Scenario: OCP-13519 The edge route with multiple service will set load balance policy to RoundRobin by default
     #Create pod/service/route
     Given I have a project
     Given I obtain test data file "routing/abrouting/abtest-websrv1.yaml"
@@ -280,7 +280,7 @@ Feature: Testing abrouting
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Each endpoint gets weight/numberOfEndpoints portion of the requests - unsecure route
+  Scenario: OCP-15910 Each endpoint gets weight/numberOfEndpoints portion of the requests - unsecure route
     Given I switch to cluster admin pseudo user
     And I use the router project
     Given all default router pods become ready
@@ -368,7 +368,7 @@ Feature: Testing abrouting
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Each endpoint gets weight/numberOfEndpoints portion of the requests - passthrough route
+  Scenario: OCP-15994 Each endpoint gets weight/numberOfEndpoints portion of the requests - passthrough route
     Given I switch to cluster admin pseudo user
     And I use the router project
     Given all default router pods become ready

--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -1,4 +1,5 @@
 Feature: Testing haproxy router
+
   # @author hongli@redhat.com
   # @case_id OCP-11903
   @smoke
@@ -10,7 +11,7 @@ Feature: Testing haproxy router
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: haproxy cookies based sticky session for unsecure routes
+  Scenario: OCP-11903 haproxy cookies based sticky session for unsecure routes
     #create route and service which has two endpoints
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -73,7 +74,7 @@ Feature: Testing haproxy router
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: haproxy cookies based sticky session for edge termination routes
+  Scenario: OCP-11130 haproxy cookies based sticky session for edge termination routes
     #create route and service which has two endpoints
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -141,7 +142,7 @@ Feature: Testing haproxy router
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Limit the number of TCP connection per IP in specified time period
+  Scenario: OCP-11619 Limit the number of TCP connection per IP in specified time period
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
@@ -196,7 +197,7 @@ Feature: Testing haproxy router
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The backend health check interval of unsecure route can be set by annotation
+  Scenario: OCP-15044 The backend health check interval of unsecure route can be set by annotation
     Given I switch to cluster admin pseudo user
     And I use the router project
     Given all default router pods become ready
@@ -243,7 +244,7 @@ Feature: Testing haproxy router
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The backend health check interval of edge route can be set by annotation
+  Scenario: OCP-15049 The backend health check interval of edge route can be set by annotation
     Given I switch to cluster admin pseudo user
     And I use the router project
     Given all default router pods become ready
@@ -290,7 +291,7 @@ Feature: Testing haproxy router
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set balance leastconn for passthrough routes
+  Scenario: OCP-10043 Set balance leastconn for passthrough routes
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
@@ -344,7 +345,7 @@ Feature: Testing haproxy router
   @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Disable haproxy hash based sticky session for unsecure routes
+  Scenario: OCP-11679 Disable haproxy hash based sticky session for unsecure routes
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
@@ -393,7 +394,7 @@ Feature: Testing haproxy router
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: can set cookie name for unsecure routes by annotation
+  Scenario: OCP-15872 can set cookie name for unsecure routes by annotation
     #create route and service which has two endpoints
     Given the master version >= "3.7"
     Given I have a project
@@ -444,7 +445,7 @@ Feature: Testing haproxy router
   @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: can set cookie name for edge routes by annotation
+  Scenario: OCP-15873 can set cookie name for edge routes by annotation
     #create route and service which has two endpoints
     Given the master version >= "3.7"
     Given I have a project

--- a/features/routing/idle.feature
+++ b/features/routing/idle.feature
@@ -2,7 +2,7 @@ Feature: idle service related scenarios
 
   # @author hongli@redhat.com
   # @case_id OCP-10935
-  Scenario: Pod can be changed to un-idle when there is unsecure or edge or passthrough route coming
+  Scenario: OCP-10935 Pod can be changed to un-idle when there is unsecure or edge or passthrough route coming
     Given I have a project
     Given I obtain test data file "routing/web-server-rc.yaml"
     When I run the :create client command with:
@@ -97,7 +97,7 @@ Feature: idle service related scenarios
 
   # @author hongli@redhat.com
   # @case_id OCP-13837
-  Scenario: Pod can be changed to un-idle when there is reencrypt route coming
+  Scenario: OCP-13837 Pod can be changed to un-idle when there is reencrypt route coming
     Given I have a project
     Given I obtain test data file "routing/web-server-rc.yaml"
     When I run the :create client command with:

--- a/features/routing/operator.feature
+++ b/features/routing/operator.feature
@@ -11,7 +11,7 @@ Feature: Testing Ingress Operator related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: set namespaceOwnership of routeAdmission to InterNamespaceAllowed
+  Scenario: OCP-27594 set namespaceOwnership of routeAdmission to InterNamespaceAllowed
     Given the master version >= "4.4"
     And I have a project
     And I store default router subdomain in the :subdomain clipboard

--- a/features/routing/rate-limit.feature
+++ b/features/routing/rate-limit.feature
@@ -11,7 +11,7 @@ Feature: Testing haproxy rate limit related features
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: limits backend pod max concurrent connections for unsecure, edge, reen route
+  Scenario: OCP-18482 limits backend pod max concurrent connections for unsecure, edge, reen route
     Given I switch to cluster admin pseudo user
     And I use the router project
     Given all default router pods become ready

--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -11,7 +11,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Alias will be invalid after removing it
+  Scenario: OCP-12122 Alias will be invalid after removing it
     Given I have a project
     Given I obtain test data file "routing/header-test/dc.json"
     When I run the :create client command with:
@@ -45,7 +45,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Service endpoint can be work well if the mapping pod ip is updated
+  Scenario: OCP-10660 Service endpoint can be work well if the mapping pod ip is updated
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
     When I run oc create over "list_for_pods.json" replacing paths:
@@ -98,7 +98,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The later route should be HostAlreadyClaimed when there is a same host exist
+  Scenario: OCP-12652 The later route should be HostAlreadyClaimed when there is a same host exist
     Given I have a project
     Given I obtain test data file "routing/unsecure/route_unsecure.json"
     When I run the :create client command with:
@@ -128,7 +128,7 @@ Feature: Testing route
   @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The path specified in route can work well for edge terminated
+  Scenario: OCP-12562 The path specified in route can work well for edge terminated
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
@@ -211,7 +211,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The path specified in route can work well for reencrypt terminated
+  Scenario: OCP-12564 The path specified in route can work well for reencrypt terminated
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
@@ -259,7 +259,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Config insecureEdgeTerminationPolicy to Redirect for route
+  Scenario: OCP-9651 Config insecureEdgeTerminationPolicy to Redirect for route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
@@ -311,7 +311,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Config insecureEdgeTerminationPolicy to Allow for route
+  Scenario: OCP-9650 Config insecureEdgeTerminationPolicy to Allow for route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
@@ -382,7 +382,7 @@ Feature: Testing route
   @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Route could NOT be updated after created
+  Scenario: OCP-10024 Route could NOT be updated after created
     Given I have a project
     Given I obtain test data file "routing/route_withouthost1.json"
     When I run the :create client command with:
@@ -405,7 +405,7 @@ Feature: Testing route
   @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set insecureEdgeTerminationPolicy to Redirect for passthrough route
+  Scenario: OCP-11036 Set insecureEdgeTerminationPolicy to Redirect for passthrough route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
@@ -461,7 +461,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set insecureEdgeTerminationPolicy to Redirect and Allow for reencrypt route
+  Scenario: OCP-13839 Set insecureEdgeTerminationPolicy to Redirect and Allow for reencrypt route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
@@ -528,7 +528,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The hostname should be converted to available route when met special character
+  Scenario: OCP-13248 The hostname should be converted to available route when met special character
     Given I have a project
     Given I obtain test data file "routing/service_unsecure.yaml"
     When I run the :create client command with:
@@ -574,7 +574,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Check the cookie if using secure mode when insecureEdgeTerminationPolicy to Redirect for edge/reencrypt route
+  Scenario: OCP-13753 Check the cookie if using secure mode when insecureEdgeTerminationPolicy to Redirect for edge/reencrypt route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
     When I run the :create client command with:
@@ -662,7 +662,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @amd64
-  Scenario: Use the default destination CA of router if the route does not specify one for reencrypt route
+  Scenario: OCP-14059 Use the default destination CA of router if the route does not specify one for reencrypt route
     # since console route is using the reencrypt route without destination CA so we use it to check
     Given I switch to cluster admin pseudo user
     And I use the "openshift-console" project
@@ -687,7 +687,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Only the host in whitelist could access the route - unsecure route
+  Scenario: OCP-14678 Only the host in whitelist could access the route - unsecure route
     Given I have a project
     And I have a header test service in the project
     And evaluation of `"haproxy.router.openshift.io/ip_whitelist=#{cb.req_headers["x-forwarded-for"]}"` is stored in the :my_whitelist clipboard
@@ -729,7 +729,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The edge route should support HSTS
+  Scenario: OCP-15976 The edge route should support HSTS
     Given the master version >= "3.7"
     And I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -793,7 +793,7 @@ Feature: Testing route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: The reencrypt route should support HSTS
+  Scenario: OCP-16368 The reencrypt route should support HSTS
     Given the master version >= "3.7"
     And I have a project
 

--- a/features/routing/timeout.feature
+++ b/features/routing/timeout.feature
@@ -10,7 +10,7 @@ Feature: Testing timeout route
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Set timeout server for passthough route
+  Scenario: OCP-11635 Set timeout server for passthough route
     Given I have a project
     Given I obtain test data file "routing/routetimeout/httpbin-pod-2.json"
     When I run the :create client command with:

--- a/features/routing/websocket.feature
+++ b/features/routing/websocket.feature
@@ -10,7 +10,7 @@ Feature: Testing websocket features
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: haproxy router support websocket via unsecure route
+  Scenario: OCP-17145 haproxy router support websocket via unsecure route
     Given I have a project
     Given I obtain test data file "routing/websocket/pod.json"
     When I run the :create client command with:

--- a/features/service_catalog_tsb/tsb.feature
+++ b/features/service_catalog_tsb/tsb.feature
@@ -4,7 +4,7 @@ Feature: Template service broker related features
   # @case_id OCP-21690
   @admin
   @inactive
-  Scenario: Clusterserviceclass and clusterserviceplan of templateinstance were created
+  Scenario: OCP-21690 Clusterserviceclass and clusterserviceplan of templateinstance were created
     Given admin checks that the "template-service-broker" cluster_service_broker exists
     When I run the :get client command with:
       | resource | clusterserviceplan                                                      |

--- a/features/storage/NoDiskConflict.feature
+++ b/features/storage/NoDiskConflict.feature
@@ -7,7 +7,7 @@ Feature: NoDiskConflict
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Only one pod with the same persistent volume can be scheduled when NoDiskConflicts policy is enabled
+  Scenario: OCP-9929 Only one pod with the same persistent volume can be scheduled when NoDiskConflicts policy is enabled
     Given a 5 characters random string of type :dns is stored into the :proj_name clipboard
     When I run the :oadm_new_project admin command with:
       | project_name  | <%= cb.proj_name %>                 |

--- a/features/storage/cinder.feature
+++ b/features/storage/cinder.feature
@@ -7,7 +7,7 @@ Feature: Cinder Persistent Volume
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Persistent Volume with cinder volume plugin
+  Scenario: OCP-9643 Persistent Volume with cinder volume plugin
     Given I have a project
     And I have a 1 GB volume and save volume id in the :vid clipboard
 

--- a/features/storage/csi.feature
+++ b/features/storage/csi.feature
@@ -5,7 +5,7 @@ Feature: CSI testing related feature
   @admin
   @stage-only
   @proxy @noproxy @connected
-  Scenario: CSI images checking in stage and prod env
+  Scenario: OCP-30787 CSI images checking in stage and prod env
     Given the master version >= "4.4"
     Given I switch to cluster admin pseudo user
     Given admin uses the "csihostpath" project
@@ -20,7 +20,7 @@ Feature: CSI testing related feature
   @admin
   @stage-only
   @proxy @noproxy @connected
-  Scenario: CSI images checking in stage env in OCP4.3
+  Scenario: OCP-31345 CSI images checking in stage env in OCP4.3
     Given the master version == "4.3"
     Given I switch to cluster admin pseudo user
     Given admin uses the "csihostpath" project
@@ -32,7 +32,7 @@ Feature: CSI testing related feature
   @admin
   @stage-only
   @proxy @noproxy @connected
-  Scenario: CSI images checking in stage env in OCP4.2
+  Scenario: OCP-31346 CSI images checking in stage env in OCP4.2
     Given the master version == "4.2"
     Given I switch to cluster admin pseudo user
     Given admin uses the "csihostpath" project

--- a/features/storage/csi_clone.feature
+++ b/features/storage/csi_clone.feature
@@ -1,4 +1,5 @@
 Feature: CSI clone testing related feature
+
   """
   This test can only work on a Cluster which has CSI driver deployed, OSP has csi deploy by default from 4.7. 
   From 4.7, OSP CSI driver was installed by default. Its storage class name is standard-csi.
@@ -16,7 +17,7 @@ Feature: CSI clone testing related feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Clone a PVC and verify data consistency
+  Scenario: OCP-27615 Clone a PVC and verify data consistency
     # Step 1
     Given the master version >= "4.7"
     Given I have a project
@@ -63,7 +64,7 @@ Feature: CSI clone testing related feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Cinder CSI Clone Clone a pvc with capacity greater than original pvc
+  Scenario: OCP-27689 Cinder CSI Clone Clone a pvc with capacity greater than original pvc
     Given I have a project
     # Create mypvc-ori with 1Gi size
     Given I obtain test data file "storage/misc/pvc.json"
@@ -118,7 +119,7 @@ Feature: CSI clone testing related feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Cinder CSI Clone Clone a pvc with capacity less than original pvc will fail
+  Scenario: OCP-27690 Cinder CSI Clone Clone a pvc with capacity less than original pvc will fail
     Given I have a project
     # Create mypvc-ori with 2Gi size
     Given I obtain test data file "storage/misc/pvc.json"
@@ -172,7 +173,7 @@ Feature: CSI clone testing related feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Cinder CSI clone Clone a pvc with block VolumeMode successfully
+  Scenario: OCP-30315 Cinder CSI clone Clone a pvc with block VolumeMode successfully
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
     When I create a dynamic pvc from "pvc.json" replacing paths:
@@ -231,7 +232,7 @@ Feature: CSI clone testing related feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Cinder CSI Clone Clone a pvc with default storageclass
+  Scenario: OCP-27617 Cinder CSI Clone Clone a pvc with default storageclass
     Given default storage class is patched to non-default
     And admin clones storage class "my-csi-default" from "standard-csi" with:
       | ["metadata"]["name"] | my-csi-default |
@@ -290,7 +291,7 @@ Feature: CSI clone testing related feature
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  Scenario: Cinder CSI Clone Clone a pvc with different storage class is failed
+  Scenario: OCP-27686 Cinder CSI Clone Clone a pvc with different storage class is failed
     # Create mypvc-ori with sc1
     Given I have a project
     When admin clones storage class "sc-<%= project.name %>-1" from "standard-csi" with:

--- a/features/storage/csi_resize.feature
+++ b/features/storage/csi_resize.feature
@@ -1,4 +1,5 @@
 Feature: CSI Resizing related feature
+
   # @author chaoyang@redhat.com
   @admin
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6

--- a/features/storage/local-storage-operator.feature
+++ b/features/storage/local-storage-operator.feature
@@ -4,7 +4,7 @@ Feature: local-storage-operator related features
   # @case_id OCP-24493
   @admin
   @inactive
-  Scenario: Operator local-storage exist in OperatorHub
+  Scenario: OCP-24493 Operator local-storage exist in OperatorHub
     Given I switch to cluster admin pseudo user
     And admin uses the "openshift-marketplace" project
     And the expression should be true> opsrc("redhat-operators").packages&.include? "local-storage-operator"

--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -11,7 +11,7 @@ Feature: NFS Persistent Volume
   @singlenode
   @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Share NFS with multiple pods with ReadWriteMany mode
+  Scenario: OCP-9572 Share NFS with multiple pods with ReadWriteMany mode
     Given I have a project
     And I have a NFS service in the project
 
@@ -64,7 +64,7 @@ Feature: NFS Persistent Volume
   @singlenode
   @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Permission denied when nfs pv annotaion is not right
+  Scenario: OCP-10281 Permission denied when nfs pv annotaion is not right
     Given I have a project
     And I have a NFS service in the project
     When I execute on the pod:

--- a/features/storage/persistent_volume.feature
+++ b/features/storage/persistent_volume.feature
@@ -50,7 +50,7 @@ Feature: Persistent Volume Claim binding policies
   # @author yinzhou@redhat.com
   # @case_id OCP-11933
   @inactive
-  Scenario: deployment hook volume inheritance -- with persistentvolumeclaim Volume
+  Scenario: OCP-11933 deployment hook volume inheritance -- with persistentvolumeclaim Volume
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
     When I create a dynamic pvc from "pvc.json" replacing paths:

--- a/features/storage/pre-bind.feature
+++ b/features/storage/pre-bind.feature
@@ -7,7 +7,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Prebound pv is availabe due to requested pvc status is bound
+  Scenario: OCP-10107 Prebound pv is availabe due to requested pvc status is bound
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
     Given admin creates a PV from "nfs.json" where:
@@ -34,7 +34,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Prebound pv is availabe due to mismatched accessmode with requested pvc
+  Scenario: OCP-10109 Prebound pv is availabe due to mismatched accessmode with requested pvc
     Given I have a project
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
     Given admin creates a PV from "preboundpv-rwo.yaml" where:
@@ -60,7 +60,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Prebound pvc is pending due to requested pv status is bound
+  Scenario: OCP-10111 Prebound pvc is pending due to requested pv status is bound
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
     Given admin creates a PV from "nfs.json" where:
@@ -86,7 +86,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Prebound PVC is pending due to mismatched accessmode with requested PV
+  Scenario: OCP-10113 Prebound PVC is pending due to mismatched accessmode with requested PV
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
     Given admin creates a PV from "nfs.json" where:
@@ -111,7 +111,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Prebound PVC is pending due to mismatched volume size with requested PV
+  Scenario: OCP-10114 Prebound PVC is pending due to mismatched volume size with requested PV
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
     Given admin creates a PV from "nfs.json" where:
@@ -136,7 +136,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: PV and PVC bound successfully when pvc created prebound to pv
+  Scenario: OCP-9941 PV and PVC bound successfully when pvc created prebound to pv
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
     Given admin creates a PV from "nfs.json" where:
@@ -164,7 +164,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
-  Scenario: PV and PVC bound successfully when pv created prebound to pvc
+  Scenario: OCP-9940 PV and PVC bound successfully when pv created prebound to pvc
     Given I have a project
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
     Given admin creates a PV from "preboundpv-rwo.yaml" where:

--- a/features/storage/quota.feature
+++ b/features/storage/quota.feature
@@ -10,7 +10,7 @@ Feature: ResourceQuata for storage
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Requested storage can not exceed the namespace's storage quota
+  Scenario: OCP-14173 Requested storage can not exceed the namespace's storage quota
     Given I have a project
     And I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
@@ -87,7 +87,7 @@ Feature: ResourceQuata for storage
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Setting quota for a StorageClass
+  Scenario: OCP-14382 Setting quota for a StorageClass
     Given I have a project
     Given admin clones storage class "sc-<%= project.name %>" from ":default" with:
       | ["volumeBindingMode"] | Immediate |

--- a/features/storage/reclaim_policy.feature
+++ b/features/storage/reclaim_policy.feature
@@ -1,4 +1,5 @@
 Feature: Persistent Volume reclaim policy tests
+
   # @author lxia@redhat.com
   @admin
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6

--- a/features/storage/regression.feature
+++ b/features/storage/regression.feature
@@ -10,7 +10,7 @@ Feature: Regression testing cases
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: RWO volumes are exclusively mounted on different nodes
+  Scenario: OCP-16485 RWO volumes are exclusively mounted on different nodes
     Given I have a project
     Given I store the schedulable workers in the :workers clipboard
 

--- a/features/storage/security.feature
+++ b/features/storage/security.feature
@@ -140,7 +140,7 @@ Feature: storage security check
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: secret volume security check
+  Scenario: OCP-9709 secret volume security check
     Given I have a project
     Given I obtain test data file "storage/secret/secret.yaml"
     When I run the :create client command with:

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -301,7 +301,7 @@ Feature: storageClass related feature
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: PVC with storage class won't provisioned pv if no storage class or wrong storage class object
+  Scenario: OCP-10159 PVC with storage class won't provisioned pv if no storage class or wrong storage class object
     Given I have a project
     # No sc exists
     Given I obtain test data file "storage/misc/pvc.json"
@@ -330,7 +330,7 @@ Feature: storageClass related feature
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: AWS ebs volume is dynamic provisioned with default storageclass
+  Scenario: OCP-10228 AWS ebs volume is dynamic provisioned with default storageclass
     Given I have a project
     Given I obtain test data file "storage/ebs/pvc-retain.json"
     When I run oc create over "pvc-retain.json" replacing paths:

--- a/features/storage/storage_object_in_use_protection.feature
+++ b/features/storage/storage_object_in_use_protection.feature
@@ -2,7 +2,7 @@ Feature: Storage object in use protection
 
   # @author lxia@redhat.com
   # @case_id OCP-17253
-  Scenario: Delete pvc which is not in active use by pod should be deleted immediately
+  Scenario: OCP-17253 Delete pvc which is not in active use by pod should be deleted immediately
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
     When I create a dynamic pvc from "pvc.json" replacing paths:
@@ -13,7 +13,7 @@ Feature: Storage object in use protection
 
   # @author lxia@redhat.com
   # @case_id OCP-17254
-  Scenario: Delete pvc which is in active use by pod should postpone deletion
+  Scenario: OCP-17254 Delete pvc which is in active use by pod should postpone deletion
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
     When I create a dynamic pvc from "pvc.json" replacing paths:
@@ -51,7 +51,7 @@ Feature: Storage object in use protection
   # @author lxia@redhat.com
   # @case_id OCP-18796
   @admin
-  Scenario: Delete pv which is bind with pvc should postpone deletion
+  Scenario: OCP-18796 Delete pv which is bind with pvc should postpone deletion
     Given I have a project
     Given I obtain test data file "storage/nfs/auto/pv-template.json"
     When admin creates a PV from "pv-template.json" where:

--- a/features/storage/vsphere.feature
+++ b/features/storage/vsphere.feature
@@ -77,7 +77,7 @@ Feature: vSphere test scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Dynamically provision a vSphere volume with invalid disk format
+  Scenario: OCP-13389 Dynamically provision a vSphere volume with invalid disk format
     Given I have a project
     Given I obtain test data file "storage/vsphere/storageclass.yml"
     When admin creates a StorageClass from "storageclass.yml" where:

--- a/features/svc-catalog_asb/asb.feature
+++ b/features/svc-catalog_asb/asb.feature
@@ -78,7 +78,7 @@ Feature: Ansible-service-broker related scenarios
   # @case_id OCP-15354
   @admin
   @inactive
-  Scenario: Check multiple broker support for service catalog
+  Scenario: OCP-15354 Check multiple broker support for service catalog
     Given admin checks that the "ansible-service-broker" cluster_service_broker exists
     And admin checks that the "template-service-broker" cluster_service_broker exists
 

--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -5,7 +5,7 @@ Feature: Service-catalog related scenarios
   @admin
   @destructive
   @inactive
-  Scenario: service-catalog walkthrough example
+  Scenario: OCP-15600 service-catalog walkthrough example
     Given I have a project
     When I run the :get admin command with:
       | resource | clusterservicebroker |
@@ -97,7 +97,7 @@ Feature: Service-catalog related scenarios
   @admin
   @destructive
   @inactive
-  Scenario: Create/get/update/delete for ClusterServiceBroker resource
+  Scenario: OCP-15604 Create/get/update/delete for ClusterServiceBroker resource
     Given I have a project
     When I run the :get admin command with:
       | resource | clusterservicebroker |
@@ -176,7 +176,7 @@ Feature: Service-catalog related scenarios
   @admin
   @destructive
   @inactive
-  Scenario: Create/get/update/delete for ServiceInstance resource
+  Scenario: OCP-15603 Create/get/update/delete for ServiceInstance resource
     Given I have a project
     When I run the :get admin command with:
       | resource | clusterservicebroker |
@@ -237,7 +237,7 @@ Feature: Service-catalog related scenarios
   @admin
   @destructive
   @inactive
-  Scenario: Create/get/update/delete for ServiceBinding resource
+  Scenario: OCP-15605 Create/get/update/delete for ServiceBinding resource
     Given I have a project
     When I run the :get admin command with:
       | resource | clusterservicebroker |
@@ -313,7 +313,7 @@ Feature: Service-catalog related scenarios
   @admin
   @destructive
   @inactive
-  Scenario: Create/get/update/delete for Clusterserviceclass/Clusterserviceplan resource
+  Scenario: OCP-15602 Create/get/update/delete for Clusterserviceclass/Clusterserviceplan resource
     Given I have a project
     When I run the :get admin command with:
       | resource | clusterservicebroker |

--- a/features/test/admin.feature
+++ b/features/test/admin.feature
@@ -1,4 +1,5 @@
 Feature: Testing Admin Scenarios
+
   @admin
   Scenario: simple create project admin scenario
     When I run the :oadm_new_project admin command with:

--- a/features/test/apiserver.feature
+++ b/features/test/apiserver.feature
@@ -1,4 +1,5 @@
 Feature: API server Test features
+
   # @author kewang@redhat.com
   @admin
   @destructive

--- a/features/test/build.feature
+++ b/features/test/build.feature
@@ -1,4 +1,5 @@
 Feature: build test related
+
   Scenario: Print build logs when buid failed
     Given I have a project
     When I create a new application with:

--- a/features/test/clean_up.feature
+++ b/features/test/clean_up.feature
@@ -1,4 +1,5 @@
 Feature: some clean up steps testing
+
   Scenario: define clean-up in different ways
     Given I register clean-up steps:
       |I log the message> Message 1  |

--- a/features/test/cli.feature
+++ b/features/test/cli.feature
@@ -1,4 +1,5 @@
 Feature: Testing CLI Scenarios
+
   Scenario: simple create project
     When I run the :new_project client command with:
       | project_name | demo |

--- a/features/test/collections.feature
+++ b/features/test/collections.feature
@@ -1,4 +1,5 @@
 Feature: some collection operations verification
+
   Scenario: substructs
     Given the expression should be true> cb.h1 = {metadata:{labels:{labelname: nil}}}
     And   the expression should be true> cb.h2 = {metadata:{labels:nil}}

--- a/features/test/containers.feature
+++ b/features/test/containers.feature
@@ -1,4 +1,5 @@
 Feature: test container related support
+
   @admin
   @destructive
   Scenario: test methods for getting containers spec

--- a/features/test/creds.feature
+++ b/features/test/creds.feature
@@ -1,4 +1,5 @@
 Feature: creds related steps testing
+
   @admin
   Scenario: test getting cloudcredentials from cluster
     Given I switch to cluster admin pseudo user

--- a/features/test/daemonset.feature
+++ b/features/test/daemonset.feature
@@ -1,4 +1,5 @@
 Feature: test daemonset methods
+
   @admin
   Scenario: Test daemonset support in the framework
     Given I have a project

--- a/features/test/endpoint.feature
+++ b/features/test/endpoint.feature
@@ -1,4 +1,5 @@
 Feature: test endpoint methods
+
   @admin
   Scenario: Test endpoint support in the framework
     Given I switch to cluster admin pseudo user

--- a/features/test/file.feature
+++ b/features/test/file.feature
@@ -1,4 +1,5 @@
 Feature: test files related steps
+
   Scenario: test directory creation
     Given I create the "tc512258" directory
     And I pry

--- a/features/test/git.feature
+++ b/features/test/git.feature
@@ -1,4 +1,5 @@
 Feature: test git steps
+
   Scenario: git test
     And I git clone the repo "https://github.com/openshift/ruby-hello-world"
     And I git clone the repo "https://github.com/openshift/ruby-hello-world" to "dummy"

--- a/features/test/kata.feature
+++ b/features/test/kata.feature
@@ -1,4 +1,5 @@
 Feature: example kata container scenarios
+
   Scenario: test get channel
     Given I extract the channel information from subscription and save it to the :channel clipboard
 

--- a/features/test/logging_metrics.feature
+++ b/features/test/logging_metrics.feature
@@ -1,4 +1,5 @@
 Feature: test logging and metrics related steps
+
   @admin
   @destructive
   Scenario: remove OLM installed logging and its related resources

--- a/features/test/meta.feature
+++ b/features/test/meta.feature
@@ -1,4 +1,5 @@
 Feature: some meta step tests
+
   Scenario: Loop over the clipboard
     Given expression should be true> cb.testvars = [1,2,3,4]
     When I repeat the following steps for each :testvar in cb.testvars:

--- a/features/test/metering.feature
+++ b/features/test/metering.feature
@@ -1,4 +1,5 @@
 Feature: test metering related steps
+
   @admin
   @destructive
   Scenario: test metering install

--- a/features/test/node.feature
+++ b/features/test/node.feature
@@ -1,4 +1,5 @@
 Feature: test nodes relates steps
+
   @admin
   @destructive
   Scenario: nodes test

--- a/features/test/node_config.feature
+++ b/features/test/node_config.feature
@@ -1,4 +1,5 @@
 Feature: test node config related steps
+
   Background:
     Given I select a random node's host
     And the value with path " " in node config is stored into the :original_cfg clipboard

--- a/features/test/oauth.feature
+++ b/features/test/oauth.feature
@@ -1,4 +1,5 @@
 Feature: oauth related
+
   @admin
   Scenario: test oauth supports
     Given I switch to cluster admin pseudo user

--- a/features/test/obsolete_update_from_api_object.feature
+++ b/features/test/obsolete_update_from_api_object.feature
@@ -1,4 +1,5 @@
 Feature: test refactor of update_from_api_object to use raw_resource
+
   Scenario: test image_stream_tag
     Given I have a project
     And I run the :tag client command with:

--- a/features/test/operators.feature
+++ b/features/test/operators.feature
@@ -1,4 +1,5 @@
 Feature: operators related
+
   @admin
   Scenario: test logging support apis
     Given I switch to cluster admin pseudo user

--- a/features/test/output.feature
+++ b/features/test/output.feature
@@ -1,4 +1,5 @@
 Feature: Output inspections
+
   Scenario: the output by order should contain/match
     When I log the messages:
       | string 1 |

--- a/features/test/parse_ini.feature
+++ b/features/test/parse_ini.feature
@@ -1,4 +1,5 @@
 Feature: test ini files
+
   @admin
   Scenario: parse ini formated file
     Given I obtain test data file "logging_metrics/default_inventory_prometheus"

--- a/features/test/pod.feature
+++ b/features/test/pod.feature
@@ -1,4 +1,5 @@
 Feature: pod testing scenarios
+
   Scenario: Show pod info when pod not ready to easier debug
     Given I have a project
     When I run the :new_app client command with:

--- a/features/test/policy.feature
+++ b/features/test/policy.feature
@@ -1,4 +1,5 @@
 Feature: Add admin user to current project
+
   Scenario: Add admin user to current project
     When I create a new project
     Then the step should succeed

--- a/features/test/pvc.feature
+++ b/features/test/pvc.feature
@@ -1,4 +1,5 @@
 Feature: pvc testing scenarios
+
   Scenario: fetch pvc detail when got wrong status
     Given I have a project
     Given I obtain test data file "storage/nfs/auto/pvc-template.json"

--- a/features/test/rc.feature
+++ b/features/test/rc.feature
@@ -1,4 +1,5 @@
 Feature: rc related test
+
   Scenario: test new rc ready method
     Given I have a project
     Given I store all replicationcontrollers in the project to the clipboard

--- a/features/test/rest.feature
+++ b/features/test/rest.feature
@@ -1,4 +1,5 @@
 Feature: Testing REST Scenarios
+
   Scenario: simple rest scenario
     When I perform the :create_project_request rest request with:
       | project name | demo |

--- a/features/test/storage_class.feature
+++ b/features/test/storage_class.feature
@@ -1,4 +1,5 @@
 Feature: StorageClass testing scenarios
+
   @admin
   Scenario: admin creates a StorageClass
     Given I have a project

--- a/features/test/transformations.feature
+++ b/features/test/transformations.feature
@@ -1,4 +1,5 @@
 Feature: test some transformations
+
   Scenario: Some Transformations
     Given I log the message> some <%= "message" %> with double <%= "expand" %>
     Then the output should contain:

--- a/features/test/version_compare.feature
+++ b/features/test/version_compare.feature
@@ -1,4 +1,5 @@
 Feature: test version compare
+
   Scenario: test version compare
     Given the master version >= "4.1"
     Given the master version >= "3.11"


### PR DESCRIPTION
Just found that I forgot to add ID to scenario names for verification-tests, no wonder why I see several failure tests in Prow CI does not contain ID in the name.


The PR is ready for review.

/hold
so that the PR merge at a proper time (maybe this Friday, which is Day of Learning) to minimize the impact to the team.