### PR TITLE
Fix OCPQE-9578

### DIFF
--- a/features/step_definitions/scc.rb
+++ b/features/step_definitions/scc.rb
@@ -36,12 +36,15 @@ Given /^scc policy #{QUOTED} is restored after scenario$/ do |policy|
   else
     raise "could not get scc: #{policy}"
   end
-
+  orig_policy = @result[:parsed]
+  orig_policy['metadata'].delete('resourceVersion')
+  orig_policy['metadata'].delete('uid')
+  orig_policy = orig_policy.to_json
   _admin = admin
   teardown_add {
-    step %Q/admin ensures "#{policy}" scc is deleted/
+    # `oc create -f` has race condition with the cluster's automatic recreation. so use `oc replace -f` here
     @result = _admin.cli_exec(
-      :create,
+      :replace,
       f: "-",
       _stdin: orig_policy
     )

--- a/features/step_definitions/scc.rb
+++ b/features/step_definitions/scc.rb
@@ -42,7 +42,6 @@ Given /^scc policy #{QUOTED} is restored after scenario$/ do |policy|
   orig_policy = orig_policy.to_json
   _admin = admin
   teardown_add {
-    # `oc create -f` has race condition with the cluster's automatic recreation. so use `oc replace -f` here
     @result = _admin.cli_exec(
       :replace,
       f: "-",


### PR DESCRIPTION
Fix issue in [OCPQE-9578](https://issues.redhat.com/browse/OCPQE-9578)
Error description
1. When restoring SCC restricted-v2 in 4.11, need to delete uid & resourceVersion
2. `oc create -f` has race condition with the cluster's automatic recreation. so using `oc replace -f`

Local cucumber test log pastebin in 4.11: 1056926
Local cucumber test log pastebin in 4.10: 1056939

self review is done, please help CR, thanks a lot. 
@xingxingxia @y4sht 