### PR TITLE
ignore known issues

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -1318,10 +1318,15 @@ Given /^I (check|record) all pods logs in the#{OPT_QUOTED} project(?: in last (\
     error_logs = []
     logs.split("\n").each do | log |
       if !(exceptions.nil?)
+        ignore = false
         exceptions.each do | exception |
           if log.include? exception
-            next
+            ignore = true
+            break
           end
+        end
+        if ignore
+          next
         end
       else
         errors.each do | error_string |

--- a/features/test/logging_metrics.feature
+++ b/features/test/logging_metrics.feature
@@ -24,3 +24,5 @@ Feature: test logging and metrics related steps
   @admin
   Scenario: check node capacity for logging
     Given I check if the remaining_resources in woker nodes meet the requirements for logging stack
+    #Given I check all pods logs in the "openshift-operators-redhat" project in last 300 seconds
+    And I check all pods logs in the "openshift-logging" project in last 300 seconds


### PR DESCRIPTION
1. Ignore known issues when checking logging pods' logs. 
2. Print all the the error logs when there has error in the logs.

Log: https://url.corp.redhat.com/f88fd24