### PR TITLE
Resolve OCPQE-10621

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1014,7 +1014,7 @@ Given /^the Internal IP(v6)? of node "([^"]*)" is stored in the#{OPT_SYM} clipbo
     @result = host.exec_admin("ip -6 -brief addr show #{def_inf}")
     cb[cb_ipaddr]=@result[:response].match(/([a-f0-9:]+:+)+[a-f0-9]+/)[0]
   else
-    cb[cb_ipaddr]=inf_address[:response]
+    cb[cb_ipaddr]=inf_address[:response].split(" ").first
   end
   logger.info "The Internal IP of node is stored in the #{cb_ipaddr} clipboard."
 end


### PR DESCRIPTION
Resolve [OCPQE-10621](https://issues.redhat.com//browse/OCPQE-10621)
The case failing in dual-stack cluster because getting the InternalIP would return both IPs in dual-stack cluster.  Fix it by using the first one.
```
[04:28:35] INFO> Shell Commands: oc get node/master-00.newugd-14211.qe.devcluster.openshift.com --output=jsonpath\=\{.status.addresses\[\?\(@.type\=\=\"InternalIP\"\)\].address\} --kubeconfig=/home/jenkins/ws/workspace/ocp-upgrade/upgrade-producer/workdir/ocp4_admin.kubeconfig
06-07 12:28:36.265        147.28.154.109 2604:1380:4642:7e00::f5 
```

Dual-stack test log:
https://privatebin.corp.redhat.com/?dd304cd2159d593a#DfmyZzjdn2Di3MaXM8ESQD1csjVtcdERe6vr62neTHwT
IPv4 Common cluster test log:
https://privatebin.corp.redhat.com/?f1b85d1f8360d1cb#6qGH3fp1apQBmQGR6hJY1xyhZcE4jANhamMM6n6XEw9m

/cc @openshift/team-sdn-qe 