### PR TITLE
Fix serviceaccount 'RuntimeError: no api accessors for user'

### DIFF
--- a/features/step_definitions/user.rb
+++ b/features/step_definitions/user.rb
@@ -24,6 +24,13 @@ end
 
 Given /^I find a bearer token of the(?: (.+?))? service account$/ do |acc|
   service_account(acc).load_bearer_tokens(user: user)
+  if service_account(acc).cached_tokens == []
+    # Starting with kube 1.24, i.e. OCP 4.11, serviceaccount's YAML does not have an automatically-generated secret-based token
+    # So we explicitly create token here
+    @result = user.cli_exec(:create_token, [[:serviceaccount, acc]])
+    raise "Could not create token for the serviceaccount #{acc}" unless @result[:success]
+    service_account(acc).add_str_token(@result[:response], protect: true)
+  end
 end
 
 Given /^the(?: ([a-z]+))? user has all owned resources cleaned$/ do |who|


### PR DESCRIPTION
Many cases failed at below steps:
```
    Given I find a bearer token of the system:serviceaccount:<%= cb.project1 %>:default service account
    Given I switch to the system:serviceaccount:<%= cb.project1 %>:default service account
    Given I use the "<%= cb.project2 %>" project
    #<RuntimeError: no api accessors for user default>
    lib/api_accessor_owner.rb:23:in `api_accessor'
```
OCP-10642 [failure link](https://url.corp.redhat.com/dc85832)
OCP-11135 [failure link](https://url.corp.redhat.com/fefdebd)

Reason: in kube 1.24, serviceaccount's YAML does not have a secret-based token any more. We need explicitly create a token when using the serviceaccount.
Pass log: https://url.corp.redhat.com/5ae0e98
@redHatGong @y4sht help review, thx, cc @liangxia
