### PR TITLE
[WIP] Hypershift OVN hacks

### DIFF
--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -38,7 +38,7 @@ Feature: OVN related networking scenarios
     Given I use the "<%= cb.ovn_nb_leader_node %>" node
     And I run commands on the host:
       | pkill -f OVN_Northbound |
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
     # Making sure the pod entries are synced again when NB db is re-created
     Given I store the ovnkube-master "north" leader pod in the clipboard
@@ -97,7 +97,8 @@ Feature: OVN related networking scenarios
     # A minimum wait for 30 seconds is tested to reflect CNO deployment to be effective which will then re-spawn ovn pods
     Given 30 seconds have passed
     # This used to be 60 seconds but around the time of 4.6 60 seconds is no longer sufficient
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    # 240 on hypershift
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
     # Checking whether Kube API data is synced on OVN NB db which in this case is a test-pod created in earlier steps
     Given I store the ovnkube-master "north" leader pod in the clipboard
@@ -162,7 +163,7 @@ Feature: OVN related networking scenarios
     # A recommended wait for 30 seconds is tested to reflect CNO deployment to be in effect which will then re-spawn ovn pods
     Given 30 seconds have passed
     # This used to be 60 seconds but around the time of 4.6 60 seconds is no longer sufficient
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
     Given I store the ovnkube-master "north" leader pod in the clipboard
     # too much output, if we don't filter server-side this always fails
@@ -256,7 +257,7 @@ Feature: OVN related networking scenarios
     When I store the ovnkube-master "south" leader pod in the :new_south_leader clipboard
     Then the step should succeed
     And the expression should be true> cb.south_leader.name != cb.new_south_leader.name
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
     Given I ensure "hello-pod" pod is deleted from the "<%= cb.usr_project%>" project
     """
@@ -298,7 +299,7 @@ Feature: OVN related networking scenarios
     When I store the ovnkube-master "south" leader pod in the :new_south_leader clipboard
     Then the step should succeed
     And the expression should be true> cb.south_leader.name != cb.new_south_leader.name
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
 
     # Check pod works
@@ -356,7 +357,7 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     And the expression should be true> cb.south_leader.name != cb.new_south_leader.name
     # one instance took 55 seconds for the first pod and then timed out, so wait a while
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
     Given I use the "<%= cb.iperf_project %>" project
     When the pod named "iperf-client" status becomes :succeeded within 120 seconds
@@ -403,7 +404,7 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     And the expression should be true> cb.north_leader.name != cb.new_north_leader.name
     """
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
 
 
@@ -430,7 +431,7 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     And the expression should be true> cb.south_leader.name != cb.new_south_leader.name
     """
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
 
     When I store the ovnkube-master "north" leader pod in the clipboard
@@ -444,7 +445,7 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     And the expression should be true> cb.north_leader.name != cb.new_north_leader.name
     """
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
 
     @heterogeneous @arm64 @amd64
@@ -513,7 +514,7 @@ Feature: OVN related networking scenarios
     When I store the ovnkube-master "south" leader pod in the :after_isolated_south_leader clipboard using node "<%= cb.nodes[0].name %>"
     Then the step should succeed
     """
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
 
 
@@ -542,7 +543,7 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     And the expression should be true> cb.north_leader.name != cb.new_north_leader.name
     """
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 240 seconds with labels:
       | app=ovnkube-master |
 
 

--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -38,7 +38,8 @@ Feature: OVN related networking scenarios
     Given I use the "<%= cb.ovn_nb_leader_node %>" node
     And I run commands on the host:
       | pkill -f OVN_Northbound |
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
     # Making sure the pod entries are synced again when NB db is re-created
     Given I store the ovnkube-master "north" leader pod in the clipboard
     # too much output, if we don't filter server-side this always fails
@@ -78,7 +79,7 @@ Feature: OVN related networking scenarios
       | replicas | 0                          |
       | n        | openshift-network-operator |
     Then the step should succeed
-    And admin ensures "ovnkube-master" sts is deleted from the "<%= env.ovn_namespace %>" project
+    And admin ensures "ovnkube-master" statefulsets is deleted from the "<%= env.ovn_namespace %>" project
     And admin executes existing pods die with labels:
       | app=ovnkube-master |
     Given I have a project
@@ -96,7 +97,8 @@ Feature: OVN related networking scenarios
     # A minimum wait for 30 seconds is tested to reflect CNO deployment to be effective which will then re-spawn ovn pods
     Given 30 seconds have passed
     # This used to be 60 seconds but around the time of 4.6 60 seconds is no longer sufficient
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
     # Checking whether Kube API data is synced on OVN NB db which in this case is a test-pod created in earlier steps
     Given I store the ovnkube-master "north" leader pod in the clipboard
     # too much output, if we don't filter server-side this always fails
@@ -145,7 +147,7 @@ Feature: OVN related networking scenarios
       | replicas | 0                          |
       | n        | openshift-network-operator |
     Then the step should succeed
-    And admin ensures "ovnkube-master" sts is deleted from the "<%= env.ovn_namespace %>" project
+    And admin ensures "ovnkube-master" statefulsets is deleted from the "<%= env.ovn_namespace %>" project
     And admin executes existing pods die with labels:
       | app=ovnkube-master |
     And I ensure "hello-pod" pod is deleted from the "<%= cb.hello_pod_project %>" project
@@ -160,7 +162,8 @@ Feature: OVN related networking scenarios
     # A recommended wait for 30 seconds is tested to reflect CNO deployment to be in effect which will then re-spawn ovn pods
     Given 30 seconds have passed
     # This used to be 60 seconds but around the time of 4.6 60 seconds is no longer sufficient
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
     Given I store the ovnkube-master "north" leader pod in the clipboard
     # too much output, if we don't filter server-side this always fails
     # making sure here that hello-pod absense is properly synced
@@ -253,7 +256,8 @@ Feature: OVN related networking scenarios
     When I store the ovnkube-master "south" leader pod in the :new_south_leader clipboard
     Then the step should succeed
     And the expression should be true> cb.south_leader.name != cb.new_south_leader.name
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
     Given I ensure "hello-pod" pod is deleted from the "<%= cb.usr_project%>" project
     """
 
@@ -294,7 +298,8 @@ Feature: OVN related networking scenarios
     When I store the ovnkube-master "south" leader pod in the :new_south_leader clipboard
     Then the step should succeed
     And the expression should be true> cb.south_leader.name != cb.new_south_leader.name
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
 
     # Check pod works
     Given I use the "<%= cb.usr_project%>" project
@@ -351,7 +356,8 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     And the expression should be true> cb.south_leader.name != cb.new_south_leader.name
     # one instance took 55 seconds for the first pod and then timed out, so wait a while
-    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
     Given I use the "<%= cb.iperf_project %>" project
     When the pod named "iperf-client" status becomes :succeeded within 120 seconds
     And I run the :logs client command with:
@@ -397,7 +403,8 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     And the expression should be true> cb.north_leader.name != cb.new_north_leader.name
     """
-    And admin waits for all pods in the project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
 
 
   # @author rbrattai@redhat.com
@@ -423,7 +430,8 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     And the expression should be true> cb.south_leader.name != cb.new_south_leader.name
     """
-    And admin waits for all pods in the project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
 
     When I store the ovnkube-master "north" leader pod in the clipboard
     Then the step should succeed
@@ -436,7 +444,8 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     And the expression should be true> cb.north_leader.name != cb.new_north_leader.name
     """
-    And admin waits for all pods in the project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
 
     @heterogeneous @arm64 @amd64
     Examples:
@@ -504,7 +513,8 @@ Feature: OVN related networking scenarios
     When I store the ovnkube-master "south" leader pod in the :after_isolated_south_leader clipboard using node "<%= cb.nodes[0].name %>"
     Then the step should succeed
     """
-    And admin waits for all pods in the project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
 
 
   # @author rbrattai@redhat.com
@@ -532,7 +542,8 @@ Feature: OVN related networking scenarios
     Then the step should succeed
     And the expression should be true> cb.north_leader.name != cb.new_north_leader.name
     """
-    And admin waits for all pods in the project to become ready up to 120 seconds
+    And admin waits for all pods in the "<%= env.ovn_namespace %>" project to become ready up to 120 seconds with labels:
+      | app=ovnkube-master |
 
 
   # @author rbrattai@redhat.com

--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -475,7 +475,9 @@ Feature: OVN related networking scenarios
     # ipv6 uses ip6tables binary
     Given evaluation of `(cb.south_leader.ip.include? ":") ? "ip6tables" : "iptables"` is stored in the :iptables_command clipboard
 
-    Given I store the masters in the clipboard excluding "<%= cb.south_leader.node_name %>"
+    # hypershift ovnkube-masters are on the workers,
+    # TODO: find all the ovnkube-master nodes
+    Given I store the nodes in the clipboard excluding "<%= cb.south_leader.node_name %>"
     And I use the "<%= cb.nodes[0].name %>" node
     # make sure to unblock after the test
     And I register clean-up steps:

--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -223,7 +223,7 @@ Feature: OVN related networking scenarios
     And evaluation of `@result[:response].match(/\h+:\h+:\h+:\h+:\h+:\h+/)[0]` is stored in the :hello_pod_mac clipboard
 
     Given I store the ovnkube-master "north" leader pod in the clipboard
-    And admin executes on the pod:
+    And admin executes on the pod "northd" container:
       | bash | -c | ovn-nbctl list logical_switch_port \| grep "hello-pod" -C 10 |
     Then the step should succeed
     # Make sure addresses don't say dynamic but display ip and mac assigned to the hello-pod and dynamic_addresses field should be empty

--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -67,17 +67,17 @@ Feature: OVN related networking scenarios
     """
     And I run the :scale admin command with:
       | resource | deployment                 |
-      | name     | network-operator           |
+      | name     | cluster-network-operator           |
       | replicas | 1                          |
-      | n        | openshift-network-operator |
+      | n        | <%= env.cno_namespace %> |
     Then the step should succeed
     """
     # Now scale down CNO pod to 0
     And I run the :scale admin command with:
       | resource | deployment                 |
-      | name     | network-operator           |
+      | name     | cluster-network-operator           |
       | replicas | 0                          |
-      | n        | openshift-network-operator |
+      | n        | <%= env.cno_namespace %> |
     Then the step should succeed
     And admin ensures "ovnkube-master" statefulsets is deleted from the "<%= env.ovn_namespace %>" project
     And admin executes existing pods die with labels:
@@ -90,9 +90,9 @@ Feature: OVN related networking scenarios
     # Now scale up CNO pod to 1 and check whether hello-pod is synced to NB db
     Given I run the :scale admin command with:
       | resource | deployment                 |
-      | name     | network-operator           |
+      | name     | cluster-network-operator           |
       | replicas | 1                          |
-      | n        | openshift-network-operator |
+      | n        | <%= env.cno_namespace %> |
     Then the step should succeed
     # A minimum wait for 30 seconds is tested to reflect CNO deployment to be effective which will then re-spawn ovn pods
     Given 30 seconds have passed
@@ -137,16 +137,16 @@ Feature: OVN related networking scenarios
     """
     And I run the :scale admin command with:
       | resource | deployment                 |
-      | name     | network-operator           |
+      | name     | cluster-network-operator           |
       | replicas | 1                          |
-      | n        | openshift-network-operator |
+      | n        | <%= env.cno_namespace %> |
     Then the step should succeed
     """
     And I run the :scale admin command with:
       | resource | deployment                 |
-      | name     | network-operator           |
+      | name     | cluster-network-operator           |
       | replicas | 0                          |
-      | n        | openshift-network-operator |
+      | n        | <%= env.cno_namespace %> |
     Then the step should succeed
     And admin ensures "ovnkube-master" statefulsets is deleted from the "<%= env.ovn_namespace %>" project
     And admin executes existing pods die with labels:
@@ -154,11 +154,10 @@ Feature: OVN related networking scenarios
     And I ensure "hello-pod" pod is deleted from the "<%= cb.hello_pod_project %>" project
     # Now scale up CNO pod to 1 and check whether hello-pod status is synced to NB db means it should not present in the DB
     Given I run the :scale admin command with:
-      | namespace | openshift-network-operator |
       | resource  | deployment                 |
-      | name      | network-operator           |
+      | name      | cluster-network-operator           |
       | replicas  | 1                          |
-      | n         | openshift-network-operator |
+      | n         | <%= env.cno_amespace %> |
     Then the step should succeed
     # A recommended wait for 30 seconds is tested to reflect CNO deployment to be in effect which will then re-spawn ovn pods
     Given 30 seconds have passed

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1100,7 +1100,7 @@ Given /^I store the ovnkube-master#{OPT_QUOTED} leader pod in the#{OPT_SYM} clip
   leader_node = splits.captures[1]
   leader_pod = BushSlicer::Pod.get_labeled("app=ovnkube-master", project: project("openshift-ovn-kubernetes", switch: false),
                                            user: admin, quiet: true) { |pod, hash|
-    pod.node_name == leader_node || pod.ip == leader_node
+    pod.node_name == leader_node || pod.ip == leader_node || leader_node.split('.', 2).first == pod.name
   }.first
   # update the cache so we can execute on the pod without specify the name
   cache_resources leader_pod

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1100,7 +1100,7 @@ Given /^I store the ovnkube-master#{OPT_QUOTED} leader pod in the#{OPT_SYM} clip
   leader_node = splits.captures[1]
   leader_pod = BushSlicer::Pod.get_labeled("app=ovnkube-master", project: project("openshift-ovn-kubernetes", switch: false),
                                            user: admin, quiet: true) { |pod, hash|
-    pod.node_name == leader_node || pod.ip == leader_node || leader_node.split('.', 2).first == pod.name
+    pod.node_name(user: admin) == leader_node || pod.ip(user: admin) == leader_node || leader_node.split('.', 2).first == pod.name
   }.first
   # update the cache so we can execute on the pod without specify the name
   cache_resources leader_pod

--- a/features/step_definitions/node.rb
+++ b/features/step_definitions/node.rb
@@ -99,7 +99,7 @@ Given /^I run( background)? commands on the host:$/ do |bg, table|
   ensure_admin_tagged
 
   raise "You must set a host prior to running this step" unless host
-  @result = host.exec(*table.raw.flatten, background: !!bg)
+  @result = host.exec_admin(*table.raw.flatten, background: !!bg)
 end
 
 Given /^I run commands on the host after scenario:$/ do |table|

--- a/features/step_definitions/resources.rb
+++ b/features/step_definitions/resources.rb
@@ -86,7 +86,8 @@ Given /^(I|admin) checks? that there are no (\w+)(?: in the#{OPT_QUOTED} project
   end
 end
 
-Given /^(I|admin) waits? for all (\w+) in the#{OPT_QUOTED} project to become ready(?: up to (\d+) seconds)?$/ do |by, type, project_name, timeout|
+Given /^(I|admin) waits? for all (\w+) in the#{OPT_QUOTED} project to become ready(?: up to (\d+) seconds)? with labels:$/ do |by, type, project_name, timeout, table|
+  labels = table.raw.flatten
   timeout = timeout ? Integer(timeout) : 180
   _user = by == "admin" ? admin : user
   clazz = resource_class(type)
@@ -95,7 +96,7 @@ Given /^(I|admin) waits? for all (\w+) in the#{OPT_QUOTED} project to become rea
     raise "#{clazz} is not a ProjectResource"
   end
 
-  list = clazz.list(user: _user, project: project(project_name))
+  list = clazz.get_labeled(*labels, user: _user, project: project(project_name))
   cache_resources *list
   logger.info("#{clazz::RESOURCE}: #{list.map(&:name)}")
 

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -150,6 +150,10 @@ module BushSlicer
       opts[:ovn_namespace] || "openshift-ovn-kubernetes"
     end
 
+    def cno_namespace
+      opts[:ovn_namespace] || "openshift-network-operator"
+    end
+
     def api_proto
       opts[:api_proto] || "https"
     end

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -146,6 +146,10 @@ module BushSlicer
       Rest::RequestExecutor
     end
 
+    def ovn_namespace
+      opts[:ovn_namespace] || "openshift-ovn-kubernetes"
+    end
+
     def api_proto
       opts[:api_proto] || "https"
     end

--- a/lib/login.rb
+++ b/lib/login.rb
@@ -15,7 +15,7 @@ module BushSlicer
       # should check if console route accessible when reporting "Error getting bearer token"
       # if console_url is accessible then it is likely Auth issue
       # if console_url is inaccessible then likely network related issue including ingress, snd or platform flake
-      console_url = env.api_endpoint_url.delete_suffix(':6443').gsub(/api/, 'console-openshift-console.apps')
+      console_url = env.web_console_url
       opts = {:url => console_url, :method => "GET" }
       opts[:proxy] = env.client_proxy if env.client_proxy
       debug_res = Http.request(**opts)


### PR DESCRIPTION


Also requires new ENV vars

```
# mgmt API URL `oc whoami --show-server`
OPENSHIFT_ENV_OCP4_ADMIN_API_ENDPOINT_URL=https://api.example.com:6443
OPENSHIFT_ENV_OCP4_ADMIN_CREDS_SPEC=file:///110471/artifact/workdir/install-dir/auth/kubeconfig
# hosted cluster API  `oc whoami --show-server`
OPENSHIFT_ENV_OCP4_HOSTS=ac384e934bbe24569a3717cf44b3cbad-f5e63a73d6dc9b5e.elb.example.com:lb
OPENSHIFT_ENV_OCP4_OVN_NAMESPACE=clusters-hypershift-ci-15114
OPENSHIFT_ENV_OCP4_SPEC=file:///110471/artifact/workdir/install-dir/hypershift_15114/hypershift-ci-15114.kubeconfig
# hosted console `oc whoami --show-console`
OPENSHIFT_ENV_OCP4_WEB_CONSOLE_URL=https://console-openshift-console.apps.hypershift-ci-15114.example.com
```