### PR TITLE
Fix OCP-11249 case issue in OCPQE-10596

### DIFF
--- a/features/cli/serviceaccount.feature
+++ b/features/cli/serviceaccount.feature
@@ -82,7 +82,8 @@ Feature: ServiceAccount and Policy Managerment
 
   # @author wjiang@redhat.com
   # @case_id OCP-11249
-  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  # There is no oc create token command below version 4.11, this case is not critical feature, so need to remove versions below 4.11
+  @4.11
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @upgrade-sanity
@@ -92,24 +93,19 @@ Feature: ServiceAccount and Policy Managerment
   @heterogeneous @arm64 @amd64
   Scenario: OCP-11249 User can get the serviceaccount token via client
     Given I have a project
-    When I run the :serviceaccounts_get_token client command with:
-      |serviceaccount_name| default|
+    When I run the :create_token client command with:
+      | serviceaccount | default |
     Then the step should succeed
-    And the output should match "eyJhbGciOiJSUzI1NiIsI.*\.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOi"
-    When I run the :serviceaccounts_get_token client command with:
-      |serviceaccount_name|builder|
+    When I run the :create_token client command with:
+      | serviceaccount | builder |
     Then the step should succeed
-    And the output should match "eyJhbGciOiJSUzI1NiIsI.*\.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOi"
-    When I run the :serviceaccounts_get_token client command with:
-      |serviceaccount_name| deployer|
+    When I run the :create_token client command with:
+      | serviceaccount | deployer |
     Then the step should succeed
-    And the output should match "eyJhbGciOiJSUzI1NiIsI.*\.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOi"
     Given an 8 characters random string of type :dns is stored into the :serviceaccount_name clipboard
     When I run the :create_serviceaccount client command with:
-      |serviceaccount_name|<%= cb.serviceaccount_name %>|
+      | serviceaccount_name | <%= cb.serviceaccount_name %> |
     Then the step should succeed
-    When I run the :serviceaccounts_get_token client command with:
-      |serviceaccount_name|<%= cb.serviceaccount_name %>|
+    When I run the :create_token client command with:
+      | serviceaccount | <%= cb.serviceaccount_name %> |
     Then the step should succeed
-    And the output should match "eyJhbGciOiJSUzI1NiIsI.*\.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOi"
-


### PR DESCRIPTION
Fix description:
**Using `oc create token` to replace `oc serviceaccount get token` in 4.11**
[PolarShift Log](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2022/06/04/04%3A28%3A16/User_can_get_the_serviceaccount_token_via_client?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20220610%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20220610T100455Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=eaecb98f4c6aaec31a773e10deced509f0b566fdf2940b7fc9ee28e1f8bf8faf)
[OCPQE-10596](https://issues.redhat.com/browse/OCPQE-10596)
Runner Test: /job/ocp-common/job/Runner/467285/console
Passed Log: 
**06-13 18:11:24.667  1 scenario (1 passed)
06-13 18:11:24.667  12 steps (12 passed)
06-13 18:11:24.667  0m23.472s**
Self review is done, please help CR, thanks a lot. @xingxingxia @y4sht 
