### PR TITLE
Fix 35341

### DIFF
--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -571,8 +571,8 @@ Feature: Egress-ingress related networking scenarios
       | f | egressnetworkpolicy_1001.yaml |
       | n | <%= project.name %>           |
     Then the step should fail
-    And the output should contain:
-      | spec.egress in body should have at most 1000 items |
+    And the output should match:
+      | spec.egress.*have at most 1000 items |
 
   # @author huirwang@redhat.com
   # @case_id OCP-37491


### PR DESCRIPTION
The case failed as the error output changed, updated it matching the latest info as well.

Test log:
Matching the new output:  https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4477/console
Matching the old output:  https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4480/console

@zhaozhanqi  Could you take a look? Thanks!