### PR TITLE
fix OCP-29741

### DIFF
--- a/features/upgrade/api_auth/upgrade.feature
+++ b/features/upgrade/api_auth/upgrade.feature
@@ -236,14 +236,6 @@ Feature: apiserver and auth related upgrade check
   Scenario: Check the default SCCs should not be stomped by CVO
     Given the "kube-apiserver" operator version matches the current cluster version
     And the "openshift-apiserver" operator version matches the current cluster version
-    Given the expression should be true> cluster_operator('kube-apiserver').condition(type: 'Progressing')['status'] == "False"
-    And the expression should be true> cluster_operator('kube-apiserver').condition(type: 'Available')['status'] == "True"
-    And the expression should be true> cluster_operator('kube-apiserver').condition(type: 'Degraded')['status'] == "False"
-    And the expression should be true> cluster_operator('kube-apiserver').condition(type: 'Upgradeable')['status'] == "True"
-    Given the expression should be true> cluster_operator('openshift-apiserver').condition(type: 'Progressing')['status'] == "False"
-    And the expression should be true> cluster_operator('openshift-apiserver').condition(type: 'Available')['status'] == "True"
-    And the expression should be true> cluster_operator('openshift-apiserver').condition(type: 'Degraded')['status'] == "False"
-    And the expression should be true> cluster_operator('openshift-apiserver').condition(type: 'Upgradeable')['status'] == "True"
     When I run the :get admin command with:
       | resource      | scc               |
       | resource_name | anyuid            |


### PR DESCRIPTION
Failure: `  features/upgrade/api_auth/upgrade.feature:239:in `the expression should be true> cluster_operator('kube-apiserver').condition(type: 'Progressing')['status'] == "False"' `

Failure Reason: **irrelevant lines for case**

Fix: remove unneeded lines