### PR TITLE
[ONEOCPDEPL-70] Introducing OSP launcher methods for getting OSP network capacity

### DIFF
--- a/lib/launchers/openstack.rb
+++ b/lib/launchers/openstack.rb
@@ -991,6 +991,43 @@ module BushSlicer
       return res[:parsed]["ports"]
     end
 
+    # return free network IP pool free capacity in OpenStack by network ID
+    # @param id [String] the ID of examined network in OpenStack
+    # @return free network IP capacity as reported by OpenStack
+    def get_network_free_capacity_by_id(id)
+      raise "Network ID is nil!" if id.nil?
+      id.strip!
+      raise "Network ID is empty!" unless id.length > 0
+      res = self.rest_run(self.os_network_url + "/v2.0/network-ip-availabilities/#{id}", "GET", {}, self.os_token)
+      raise res[:response] unless res[:success]
+      begin
+        network = res[:parsed]['network_ip_availability']
+        return network['total_ips'].to_i - network['used_ips'].to_i 
+      rescue => e
+        raise "Issue occurred during getting network free capacity: #{e}"
+      end
+    end
+
+    # return free network IP pool free capacity in OpenStack by network name
+    # @param name [String] the name of examined network in OpenStack
+    # @return free network IP capacity as reported by OpenStack
+    def get_network_free_capacity_by_name(name)
+      raise "Network name is nil!" if name.nil?
+      name.strip!
+      raise "Network name is empty!" unless name.length > 0
+      get_opts = {}
+      get_opts["network_name"] = name
+      res = self.rest_run(self.os_network_url + "/v2.0/network-ip-availabilities", "GET", get_opts, self.os_token)
+      raise res[:response] unless res[:success]
+      raise "Network name '#{name}' not found!" if res[:parsed]['network_ip_availabilities'].empty?
+      begin
+        network = res[:parsed]['network_ip_availabilities'][0]
+        return network['total_ips'].to_i - network['used_ips'].to_i
+      rescue => e
+        raise "Issue occurred during getting network free capacity: #{e}"
+      end
+    end
+
     # @param service_name [String] the service name of this openstack instance
     #   to lookup in configuration
     def default_opts(service_name)


### PR DESCRIPTION
- added get_network_free_capacity_by_name(osp_network_name)
- added get_network_free_capacity_by_id(osp_network_id)