### PR TITLE
Fix OCP-34095

### DIFF
--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -341,5 +341,5 @@ Feature: MachineHealthCheck Test Scenarios
     When I run oc create over "mhc_validations.yaml" replacing paths:
       | ["spec"]["unhealthyConditions"][0]["timeout"] | #{cb.timeout} |
     Then the output should match:
-      | timeout: Invalid value: ".*": spec.unhealthyConditions.timeout |
+      | timeout: Invalid value: ".*": spec.unhealthyConditions.*.timeout |
     """


### PR DESCRIPTION
Now failed with error `#<RuntimeError: pattern not found: (?-mix:timeout: Invalid value: ".*": spec.unhealthyConditions.timeout)>` @jhou1 @miyadav @huali9 PTAL

Test result: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/471272/console