### PR TITLE
Add ID to scenario name

### DIFF
--- a/features/admin/master_config.feature
+++ b/features/admin/master_config.feature
@@ -4,7 +4,7 @@ Feature: test master config related steps
   # @case_id OCP-10619
   @admin
   @destructive
-  Scenario: defaultNodeSelector options on master will make pod landing on nodes with label "infra=false"
+  Scenario: OCP-10619 defaultNodeSelector options on master will make pod landing on nodes with label "infra=false"
     Given master config is merged with the following hash:
     """
     projectConfig:
@@ -51,7 +51,7 @@ Feature: test master config related steps
   # @case_id OCP-13557
   @admin
   @destructive
-  Scenario: NodeController will sets NodeTaints when node become notReady/unreachable
+  Scenario: OCP-13557 NodeController will sets NodeTaints when node become notReady/unreachable
     Given environment has at least 2 schedulable nodes
     Given master config is merged with the following hash:
     """

--- a/features/admin/pod.feature
+++ b/features/admin/pod.feature
@@ -2,7 +2,7 @@ Feature: pod related features
 
   # @author xiuli@redhat.com
   # @case_id OCP-15808
-  Scenario: Endpoints should update in time and no delay
+  Scenario: OCP-15808 Endpoints should update in time and no delay
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/networking/list_for_pods.json |
@@ -14,7 +14,7 @@ Feature: pod related features
   # @author pruan@redhat.com
   # @case_id OCP-12432
   @admin
-  Scenario: Expose shared memory of the pod--Clustered
+  Scenario: OCP-12432 Expose shared memory of the pod--Clustered
     Given I have a project
     When I run the :new_app client command with:
       | app_repo | openshift/deployment-example |
@@ -55,7 +55,7 @@ Feature: pod related features
   # @case_id OCP-10598
   @admin
   @destructive
-  Scenario: Existing pods will not be affected when node is unschedulable
+  Scenario: OCP-10598 Existing pods will not be affected when node is unschedulable
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift/origin/master/examples/hello-openshift/hello-pod.json |
@@ -90,7 +90,7 @@ Feature: pod related features
   # @case_id OCP-10345
   @admin
   @destructive
-  Scenario: pod node label selector must be consistent with its project node label selector
+  Scenario: OCP-10345 pod node label selector must be consistent with its project node label selector
     Given I have a project
     Given a 5 characters random string of type :dns is stored into the :proj_name clipboard
     When I run the :oadm_new_project admin command with:
@@ -108,7 +108,7 @@ Feature: pod related features
   # @case_id OCP-11116
   @admin
   @destructive
-  Scenario: New pods creation will be disabled on unschedulable nodes
+  Scenario: OCP-11116 New pods creation will be disabled on unschedulable nodes
     Given I have a project
     Given I store the schedulable nodes in the :nodes clipboard
     Given I register clean-up steps:
@@ -142,7 +142,7 @@ Feature: pod related features
   # @case_id OCP-11466
   @admin
   @destructive
-  Scenario: Recovering an unschedulable node
+  Scenario: OCP-11466 Recovering an unschedulable node
     Given I have a project
     Given I run the :patch admin command with:
       | resource | namespace |
@@ -175,7 +175,7 @@ Feature: pod related features
   # @author chezhang@redhat.com
   # @case_id OCP-11752
   @admin
-  Scenario: Pod will not be copied to nodes which does not match it's node selector
+  Scenario: OCP-11752 Pod will not be copied to nodes which does not match it's node selector
     Given I have a project
     Given I run the :patch admin command with:
       | resource | namespace |
@@ -205,7 +205,7 @@ Feature: pod related features
   # @case_id OCP-11925
   @admin
   @destructive
-  Scenario: Pods will still be created by DaemonSet when nodes are SchedulingDisabled
+  Scenario: OCP-11925 Pods will still be created by DaemonSet when nodes are SchedulingDisabled
     Given I have a project
     Given I store the schedulable nodes in the :nodes clipboard
     Given I register clean-up steps:
@@ -239,7 +239,7 @@ Feature: pod related features
   # @author chezhang@redhat.com
   # @case_id OCP-12047
   @admin
-  Scenario: When node labels change, DaemonSet will add pods to newly matching nodes and delete pods from not-matching nodes
+  Scenario: OCP-12047 When node labels change, DaemonSet will add pods to newly matching nodes and delete pods from not-matching nodes
     Given I have a project
     Given I run the :patch admin command with:
       | resource | namespace |
@@ -291,7 +291,7 @@ Feature: pod related features
   # @case_id OCP-12338
   @admin
   @destructive
-  Scenario: Secret is valid after node reboot
+  Scenario: OCP-12338 Secret is valid after node reboot
     Given I have a project
     Given I run the :patch admin command with:
       | resource | namespace |
@@ -363,7 +363,7 @@ Feature: pod related features
   # @case_id OCP-11595
   @admin
   @destructive
-  Scenario: Should show image digests in node status
+  Scenario: OCP-11595 Should show image digests in node status
     Given I store the schedulable nodes in the :nodes clipboard
     Given I use the "<%= cb.nodes[0].name %>" node
     Given I run commands on the host:
@@ -403,7 +403,7 @@ Feature: pod related features
   # @author chezhang@redhat.com
   # @case_id OCP-13374
   @admin
-  Scenario: Pod and container level selinuxoptions should both work
+  Scenario: OCP-13374 Pod and container level selinuxoptions should both work
     Given I have a project
     Given SCC "privileged" is added to the "default" user
     When I run the :create client command with:

--- a/features/admin/project.feature
+++ b/features/admin/project.feature
@@ -3,7 +3,7 @@ Feature: project permissions
   # @author pruan@redhat.com
   # @case_id OCP-11717
   @admin
-  Scenario: Pod creation should fail when pod's node selector conflicts with project node selector
+  Scenario: OCP-11717 Pod creation should fail when pod's node selector conflicts with project node selector
     Given a 5 characters random string of type :dns is stored into the :proj_name clipboard
     When I run the :oadm_new_project admin command with:
       | project_name  | <%= cb.proj_name %> |
@@ -20,7 +20,7 @@ Feature: project permissions
   # @author yinzhou@redhat.com
   # @case_id OCP-10736
   @admin
-  Scenario: The job and HPA should be deleted when project has been deleted
+  Scenario: OCP-10736 The job and HPA should be deleted when project has been deleted
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/hpa/hpa.yaml |

--- a/features/admin/quota.feature
+++ b/features/admin/quota.feature
@@ -36,7 +36,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-12292
   @admin
-  Scenario: The quota usage should NOT be incremented if Requests and Limits aren't specified
+  Scenario: OCP-12292 The quota usage should NOT be incremented if Requests and Limits aren't specified
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/myquota.yaml |
@@ -65,7 +65,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-12256
   @admin
-  Scenario: The quota usage should NOT be incremented if Requests > Limits
+  Scenario: OCP-12256 The quota usage should NOT be incremented if Requests > Limits
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/myquota.yaml |
@@ -98,7 +98,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-12206
   @admin
-  Scenario: The quota usage should NOT be incremented if Requests = Limits but exceeding hard quota
+  Scenario: OCP-12206 The quota usage should NOT be incremented if Requests = Limits but exceeding hard quota
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/myquota.yaml |
@@ -127,7 +127,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11566
   @admin
-  Scenario: The quota status is calculated ASAP when editing its quota spec
+  Scenario: OCP-11566 The quota status is calculated ASAP when editing its quota spec
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/myquota.yaml |
@@ -182,7 +182,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-10801
   @admin
-  Scenario: Check BestEffort scope of resourcequota
+  Scenario: OCP-10801 Check BestEffort scope of resourcequota
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/quota-besteffort.yaml |
@@ -232,7 +232,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11251
   @admin
-  Scenario: Check NotBestEffort scope of resourcequota
+  Scenario: OCP-11251 Check NotBestEffort scope of resourcequota
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/quota-notbesteffort.yaml |
@@ -302,7 +302,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11568
   @admin
-  Scenario: Check NotTerminating scope of resourcequota
+  Scenario: OCP-11568 Check NotTerminating scope of resourcequota
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/quota-notterminating.yaml |
@@ -373,7 +373,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11780
   @admin
-  Scenario: Check Terminating scope of resourcequota
+  Scenario: OCP-11780 Check Terminating scope of resourcequota
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/quota-terminating.yaml |
@@ -453,7 +453,7 @@ Feature: Quota related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-10706
   @admin
-  Scenario: Could create quota if existing resources exceed to the hard quota but prevent to create further resources
+  Scenario: OCP-10706 Could create quota if existing resources exceed to the hard quota but prevent to create further resources
     Given I have a project
     When I run the :new_app admin command with:
       | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/quota_template.yaml |
@@ -521,7 +521,7 @@ Feature: Quota related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-11779
   @admin
-  Scenario: The usage for cpu/mem/pod counts are fixed up ASAP if delete a pod
+  Scenario: OCP-11779 The usage for cpu/mem/pod counts are fixed up ASAP if delete a pod
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/myquota.yaml |
@@ -575,7 +575,7 @@ Feature: Quota related scenarios
   # @case_id OCP-10033
   # @bug_id 1333122
   @admin
-  Scenario: Quota events for compute resource failures shouldn't be redundant
+  Scenario: OCP-10033 Quota events for compute resource failures shouldn't be redundant
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/templates/tc528448/quota.yaml |
@@ -599,7 +599,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11247
   @admin
-  Scenario: The current quota usage is calculated ASAP when adding a quota
+  Scenario: OCP-11247 The current quota usage is calculated ASAP when adding a quota
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/myquota.yaml |
@@ -643,7 +643,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11927
   @admin
-  Scenario: The quota usage should be incremented if Requests = Limits and in the range of hard quota but exceed the real node available resources
+  Scenario: OCP-11927 The quota usage should be incremented if Requests = Limits and in the range of hard quota but exceed the real node available resources
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/myquota.yaml |
@@ -681,7 +681,7 @@ Feature: Quota related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-10945
   @admin
-  Scenario: The quota usage should be released when pod completed
+  Scenario: OCP-10945 The quota usage should be released when pod completed
     Given I have a project
     When I run the :create_quota admin command with:
       | name | myquota                    |
@@ -717,7 +717,7 @@ Feature: Quota related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-11983
   @admin
-  Scenario: Quota with BestEffort and NotBestEffort scope
+  Scenario: OCP-11983 Quota with BestEffort and NotBestEffort scope
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | quota-besteffort     |
@@ -766,7 +766,7 @@ Feature: Quota related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-12086
   @admin
-  Scenario: Quota with Terminating and NotTerminating scope
+  Scenario: OCP-12086 Quota with Terminating and NotTerminating scope
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | quota-terminating |
@@ -821,7 +821,7 @@ Feature: Quota related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-11348
   @admin
-  Scenario: Quota combined scopes
+  Scenario: OCP-11348 Quota combined scopes
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | quota-notbesteffortandnotterminating |
@@ -910,7 +910,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11636
   @admin
-  Scenario: Quota scope conflict BestEffort and NotBestEffort
+  Scenario: OCP-11636 Quota scope conflict BestEffort and NotBestEffort
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | quota-besteffortnot      |
@@ -923,7 +923,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11827
   @admin
-  Scenario: Quota scope conflict Terminating and NotTerminating
+  Scenario: OCP-11827 Quota scope conflict Terminating and NotTerminating
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | quota-terminatingnot       |
@@ -936,7 +936,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11000
   @admin
-  Scenario: Negative test for requests.storage of quota
+  Scenario: OCP-11000 Negative test for requests.storage of quota
     Given I have a project
     When I run the :create_quota admin command with:
       | name   | my-quota             |
@@ -980,7 +980,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-10283
   @admin
-  Scenario: Annotation selector supports special characters
+  Scenario: OCP-10283 Annotation selector supports special characters
     Given I have a project
     Given admin ensures "crq-<%= project.name %>" cluster_resource_quota is deleted after scenario
     When I run the :create_clusterresourcequota admin command with:
@@ -1008,7 +1008,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11660
   @admin
-  Scenario: Quota requests.storage with PVC existing
+  Scenario: OCP-11660 Quota requests.storage with PVC existing
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rox.json |
@@ -1056,7 +1056,7 @@ Feature: Quota related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11389
   @admin
-  Scenario: Prevent creating further PVC if existing PVC exceeds the quota of requests.storage
+  Scenario: OCP-11389 Prevent creating further PVC if existing PVC exceeds the quota of requests.storage
     Given I have a project
     # Only quota requests.storage < 5Gi
     When I run the :create_quota admin command with:
@@ -1109,7 +1109,7 @@ Feature: Quota related scenarios
   # @case_id OCP-12820
   @admin
   @destructive
-  Scenario: Precious resources should be denied in the absence of a covering quota if they are configured on the master
+  Scenario: OCP-12820 Precious resources should be denied in the absence of a covering quota if they are configured on the master
     # Modify master-config to set default resource limits
     Given master config is merged with the following hash:
     """

--- a/features/admin/scc.feature
+++ b/features/admin/scc.feature
@@ -3,7 +3,7 @@ Feature: SCC policy related scenarios
   # @author pruan@redhat.com
   # @case_id OCP-11762
   @admin
-  Scenario: deployment hook volume inheritance with hostPath volume
+  Scenario: OCP-11762 deployment hook volume inheritance with hostPath volume
     Given I have a project
     # Create hostdir pod again with new SCC
     When I run the :create admin command with:
@@ -28,7 +28,7 @@ Feature: SCC policy related scenarios
   # @author yinzhou@redhat.com
   # @case_id OCP-11775
   @admin
-  Scenario: Create or update scc with illegal capability name should fail with prompt message
+  Scenario: OCP-11775 Create or update scc with illegal capability name should fail with prompt message
     Given I have a project
     Given admin ensures "scc-cap" scc is deleted after scenario
     Given I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/authorization/scc/scc_capabilities.yaml"

--- a/features/admin/scheduler.feature
+++ b/features/admin/scheduler.feature
@@ -2,7 +2,7 @@ Feature: Scheduler related scenarios
 
   # @author wmeng@redhat.com
   # @case_id OCP-14582
-  Scenario: When no scheduler name is supplied, the pod is automatically scheduled using the default-scheduler
+  Scenario: OCP-14582 When no scheduler name is supplied, the pod is automatically scheduled using the default-scheduler
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/scheduler/multiple-schedulers/pod-no-scheduler.yaml |

--- a/features/build/buildconfig.feature
+++ b/features/build/buildconfig.feature
@@ -2,7 +2,7 @@ Feature: buildconfig.feature
 
   # @author wzheng@redhat.com
   # @case_id OCP-12121
-  Scenario: Start build from buildConfig/build
+  Scenario: OCP-12121 Start build from buildConfig/build
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/ruby:2.2 |
@@ -23,7 +23,7 @@ Feature: buildconfig.feature
 
   # @author haowang@redhat.com
   # @case_id OCP-10667
-  Scenario: Rebuild image when the underlying image changed for Docker build
+  Scenario: OCP-10667 Rebuild image when the underlying image changed for Docker build
     Given I have a project
     When I run the :new_build client command with:
       | app_repo | openshift/ruby-22-centos7~https://github.com/openshift/ruby-hello-world.git |
@@ -39,7 +39,7 @@ Feature: buildconfig.feature
 
   # @author dyan@redhat.com
   # @case_id OCP-12020
-  Scenario: Trigger chain builds from a image update
+  Scenario: OCP-12020 Trigger chain builds from a image update
     Given I have a project
     When I run the :new_build client command with:
       | app_repo | openshift/ruby-22-centos7~https://github.com/openshift/ruby-hello-world.git |
@@ -82,7 +82,7 @@ Feature: buildconfig.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-12057
-  Scenario: Using secret to pull a docker image which be used as source input
+  Scenario: OCP-12057 Using secret to pull a docker image which be used as source input
     Given I have a project
     When I run the :new_secret client command with:
      | secret_name     | pull                                                                 |

--- a/features/build/buildlogic.feature
+++ b/features/build/buildlogic.feature
@@ -2,7 +2,7 @@ Feature: buildlogic.feature
 
   # @author haowang@redhat.com
   # @case_id OCP-11545
-  Scenario: Build with specified Dockerfile via new-build -D
+  Scenario: OCP-11545 Build with specified Dockerfile via new-build -D
     Given I have a project
     When I run the :new_build client command with:
       | D    | FROM centos:7\nRUN echo "hello" |
@@ -14,7 +14,7 @@ Feature: buildlogic.feature
 
   # @author xiazhao@redhat.com
   # @case_id OCP-11170
-  Scenario: Result image will be tried to push after multi-build
+  Scenario: OCP-11170 Result image will be tried to push after multi-build
     Given I have a project
     When I run the :new_app client command with:
       | file |  https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image/language-image-templates/php-55-rhel7-stibuild.json |
@@ -38,7 +38,7 @@ Feature: buildlogic.feature
 
   # @author gpei@redhat.com
   # @case_id OCP-11767
-  Scenario: Create build without output
+  Scenario: OCP-11767 Create build without output
     Given I have a project
     When I run the :new_build client command with:
       | app_repo  | centos/ruby-23-centos7~https://github.com/openshift/ruby-hello-world.git |
@@ -50,7 +50,7 @@ Feature: buildlogic.feature
 
   # @author yantan@redhat.com
   # @case_id OCP-10799
-  Scenario: Create new build config use dockerfile with source repo
+  Scenario: OCP-10799 Create new build config use dockerfile with source repo
     Given I have a project
     When I run the :new_build client command with:
       | app_repo | https://github.com/openshift/ruby-hello-world   |
@@ -69,7 +69,7 @@ Feature: buildlogic.feature
 
   # @author haowang@redhat.com
   # @case_id OCP-11740
-  Scenario: Prevent STI builder images from running as root - using onbuild image
+  Scenario: OCP-11740 Prevent STI builder images from running as root - using onbuild image
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/tc499516/test-buildconfig-onbuild-user0.json |
@@ -114,7 +114,7 @@ Feature: buildlogic.feature
 
   # @author yantan@redhat.com
   # @case_id OCP-10745
-  Scenario: Build with specified Dockerfile to image with same image name via new-build
+  Scenario: OCP-10745 Build with specified Dockerfile to image with same image name via new-build
     Given I have a project
     When I run the :new_build client command with:
       | D | FROM centos:7\nRUN yum install -y httpd |
@@ -148,7 +148,7 @@ Feature: buildlogic.feature
 
   # @author haowang@redhat.com
   # @case_id OCP-11720
-  Scenario: Build from private git repo with/without ssh key
+  Scenario: OCP-11720 Build from private git repo with/without ssh key
     Given I have a project
     And I have an ssh-git service in the project
     And the "secret" file is created with the following lines:
@@ -190,7 +190,7 @@ Feature: buildlogic.feature
 
   # @author yantan@redhat.com
   # @case_id OCP-11896
-  Scenario: Create new-app from private git repo with ssh key
+  Scenario: OCP-11896 Create new-app from private git repo with ssh key
     Given I have a project
     When I run the :new_app client command with:
       | image_stream   | openshift/perl:5.20       |
@@ -223,7 +223,7 @@ Feature: buildlogic.feature
 
   # @author dyan@redhat.com
   # @case_id OCP-13683
-  Scenario: Check s2i build substatus and times
+  Scenario: OCP-13683 Check s2i build substatus and times
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/tc470422/application-template-stibuild.json|
@@ -243,7 +243,7 @@ Feature: buildlogic.feature
 
   # @author dyan@redhat.com
   # @case_id OCP-13684
-  Scenario: Check docker build substatus and times
+  Scenario: OCP-13684 Check docker build substatus and times
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/application-template-dockerbuild.json |
@@ -262,7 +262,7 @@ Feature: buildlogic.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-13914
-  Scenario: Prune old builds automaticly
+  Scenario: OCP-13914 Prune old builds automaticly
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | ruby                                          |

--- a/features/build/custombuild.feature
+++ b/features/build/custombuild.feature
@@ -3,7 +3,7 @@ Feature: custombuild.feature
   # @author wzheng@redhat.com
   # @case_id OCP-11443
   @admin
-  Scenario: Build with custom image - origin-custom-docker-builder
+  Scenario: OCP-11443 Build with custom image - origin-custom-docker-builder
     Given cluster role "system:build-strategy-custom" is added to the "first" user
     Then the step should succeed
     Given I have a project

--- a/features/build/dockerbuild.feature
+++ b/features/build/dockerbuild.feature
@@ -2,7 +2,7 @@ Feature: dockerbuild.feature
 
   # @author wzheng@redhat.com
   # @case_id OCP-11078
-  Scenario: Docker build with blank source repo
+  Scenario: OCP-11078 Docker build with blank source repo
     Given I have a project
     When I run the :process client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/ruby22rhel7-template-docker-blankrepo.json |
@@ -16,7 +16,7 @@ Feature: dockerbuild.feature
   # @author wzheng@redhat.com
   # @case_id OCP-12115
   @smoke
-  Scenario: Docker build with both SourceURI and context dir
+  Scenario: OCP-12115 Docker build with both SourceURI and context dir
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/ruby20rhel7-context-docker.json |
@@ -66,7 +66,7 @@ Feature: dockerbuild.feature
 
   # @author wewang@redhat.com
   # @case_id OCP-9869
-  Scenario: Setting the nocache option in docker build strategy
+  Scenario: OCP-9869 Setting the nocache option in docker build strategy
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/ruby22rhel7-template-docker.json |
@@ -109,7 +109,7 @@ Feature: dockerbuild.feature
 
   # @author dyan@redhat.com
   # @case_id OCP-13083
-  Scenario: Docker build using Dockerfile with 'FROM scratch'
+  Scenario: OCP-13083 Docker build using Dockerfile with 'FROM scratch'
     Given I have a project
     When I run the :new_build client command with:
       | D  | FROM scratch\nENV NUM 1 |
@@ -126,7 +126,7 @@ Feature: dockerbuild.feature
 
   # @author wzheng@redhat.com
   # @case_id OCP-12762
-  Scenario: Docker build with invalid context dir
+  Scenario: OCP-12762 Docker build with invalid context dir
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/ruby20rhel7-invalidcontext-docker.json |
@@ -142,7 +142,7 @@ Feature: dockerbuild.feature
 
   # @author dyan@redhat.com
   # @case_id OCP-12855
-  Scenario: Add ARGs in docker build
+  Scenario: OCP-12855 Add ARGs in docker build
     Given I have a project
     When I run the :new_build client command with:
       | code      | https://github.com/openshift/ruby-hello-world |
@@ -181,7 +181,7 @@ Feature: dockerbuild.feature
 
   # @author wewang@redhat.com
   # @case_id OCP-15461
-  Scenario: Allow nocache to be specified on docker build request
+  Scenario: OCP-15461 Allow nocache to be specified on docker build request
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/application-template-dockerbuild.json |
@@ -214,7 +214,7 @@ Feature: dockerbuild.feature
 
   # @author wewang@redhat.com
   # @case_id OCP-15462
-  Scenario: Override nocache setting using --no-cache flag when docker build request
+  Scenario: OCP-15462 Override nocache setting using --no-cache flag when docker build request
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/application-template-dockerbuild.json |
@@ -243,7 +243,7 @@ Feature: dockerbuild.feature
 
   # @author wzheng@redhat.com
   # @case_id OCP-18501
-  Scenario: Support additional EXPOSE values in new-app
+  Scenario: OCP-18501 Support additional EXPOSE values in new-app
     Given I have a project
     When I run the :new_app client command with:
       | code | https://github.com/openshift-qe/oc_newapp_expose |

--- a/features/build/env.feature
+++ b/features/build/env.feature
@@ -2,7 +2,7 @@ Feature: env.feature
 
   # @author shiywang@redhat.com
   # @case_id OCP-11543
-  Scenario: Can set env vars on buildconfig with new-app --env and --env-file
+  Scenario: OCP-11543 Can set env vars on buildconfig with new-app --env and --env-file
     Given I have a project
     When I run the :new_app client command with:
       | app_repo | ruby:2.2~https://github.com/openshift/ruby-hello-world |

--- a/features/build/genericbuild.feature
+++ b/features/build/genericbuild.feature
@@ -2,7 +2,7 @@ Feature: genericbuild.feature
 
   # @author wewang@redhat.com
   # @case_id OCP-14373
-  Scenario: Support valueFrom with filedRef syntax for pod field
+  Scenario: OCP-14373 Support valueFrom with filedRef syntax for pod field
     Given I have a project
     Given I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/tc14373/test-valuefrom.json"
     And I run the :create client command with:
@@ -24,7 +24,7 @@ Feature: genericbuild.feature
 
   # @author wewang@redhat.com
   # @case_id OCP-14381
-  Scenario: Support valueFrom with configMapKeyRef syntax for pod field
+  Scenario: OCP-14381 Support valueFrom with configMapKeyRef syntax for pod field
     Given I have a project
     When I run the :create_configmap client command with:
       | name         | special-config     |
@@ -61,7 +61,7 @@ Feature: genericbuild.feature
   # @case_id OCP-10965
   @admin
   @destructive
-  Scenario: Configure the noproxy BuildDefaults when build
+  Scenario: OCP-10965 Configure the noproxy BuildDefaults when build
     Given I have a project
     Given master config is merged with the following hash:
     """

--- a/features/build/stibuild.feature
+++ b/features/build/stibuild.feature
@@ -2,7 +2,7 @@ Feature: stibuild.feature
 
   # @author haowang@redhat.com
   # @case_id OCP-11099
-  Scenario: STI build with invalid context dir
+  Scenario: OCP-11099 STI build with invalid context dir
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image/language-image-templates/python-27-rhel7-errordir-stibuild.json |

--- a/features/cli/allinone-volume.feature
+++ b/features/cli/allinone-volume.feature
@@ -2,7 +2,7 @@ Feature: All in one volume
 
   # @author chezhang@redhat.com
   # @case_id OCP-11683
-  Scenario: Project secrets, configmap and downward API into the same volume with normal keys and path
+  Scenario: OCP-11683 Project secrets, configmap and downward API into the same volume with normal keys and path
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/allinone-volume/configmap.yaml |

--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -2,7 +2,7 @@ Feature: build 'apps' with CLI
 
   # @author cryan@redhat.com
   # @case_id OCP-11132
-  Scenario: Create a build config based on the provided image and source code
+  Scenario: OCP-11132 Create a build config based on the provided image and source code
     Given I have a project
     When I run the :new_build client command with:
       | code         | https://github.com/openshift/ruby-hello-world |
@@ -68,7 +68,7 @@ Feature: build 'apps' with CLI
 
   # @author xiuwang@redhat.com
   # @case_id OCP-11133
-  Scenario: Create a build config based on the source code in the current git repository
+  Scenario: OCP-11133 Create a build config based on the source code in the current git repository
     Given I have a project
     And I git clone the repo "https://github.com/openshift/ruby-hello-world.git"
     When I run the :new_build client command with:
@@ -129,7 +129,7 @@ Feature: build 'apps' with CLI
 
   # @author xiuwang@redhat.com
   # @case_id OCP-11139
-  Scenario: Create applications only with multiple db images
+  Scenario: OCP-11139 Create applications only with multiple db images
     Given I create a new project
     When I run the :new_app client command with:
       | image_stream      | openshift/mongodb:2.6                               |
@@ -181,7 +181,7 @@ Feature: build 'apps' with CLI
 
   # @author cryan@redhat.com
   # @case_id OCP-11227
-  Scenario: Add multiple source inputs
+  Scenario: OCP-11227 Add multiple source inputs
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/templates/tc517667/ruby22rhel7-template-sti.json |
@@ -204,7 +204,7 @@ Feature: build 'apps' with CLI
       | xiuwangs2i-2 |
 
   # @case_id OCP-10771
-  Scenario: Add a image with multiple paths as source input
+  Scenario: OCP-10771 Add a image with multiple paths as source input
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/templates/tc517666/ruby22rhel7-template-sti.json |
@@ -220,7 +220,7 @@ Feature: build 'apps' with CLI
 
   # @author cryan@redhat.com
   # @case_id OCP-11943
-  Scenario: Using a docker image as source input using new-build cmd
+  Scenario: OCP-11943 Using a docker image as source input using new-build cmd
     Given I have a project
     When I run the :tag client command with:
       | source | openshift/python:latest |
@@ -281,7 +281,7 @@ Feature: build 'apps' with CLI
 
   # @author cryan@redhat.com
   # @case_id OCP-11776
-  Scenario: Cannot create secret from local file and with same name via oc new-build
+  Scenario: OCP-11776 Cannot create secret from local file and with same name via oc new-build
     Given I have a project
     #Reusing similar secrets to TC #519256
     When I run the :create client command with:
@@ -307,7 +307,7 @@ Feature: build 'apps' with CLI
 
   # @author xiuwang@redhat.com
   # @case_id OCP-11552
-  Scenario: Using a docker image as source input for docker build
+  Scenario: OCP-11552 Using a docker image as source input for docker build
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/templates/tc517668/ruby22rhel7-template-docker.json |
@@ -358,7 +358,7 @@ Feature: build 'apps' with CLI
 
   # @author cryan@redhat.com
   # @case_id OCP-11582
-  Scenario: Change runpolicy to SerialLatestOnly build
+  Scenario: OCP-11582 Change runpolicy to SerialLatestOnly build
     Given I have a project
     And I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/ruby22rhel7-template-sti.json"
     And I replace lines in "ruby22rhel7-template-sti.json":
@@ -635,7 +635,7 @@ Feature: build 'apps' with CLI
 
   # @author pruan@redhat.com
   # @case_id OCP-10944
-  Scenario: Simple error message return when no value followed with oc build-logs
+  Scenario: OCP-10944 Simple error message return when no value followed with oc build-logs
     Given I have a project
     When I run the :build_logs client command with:
       | build_name | |
@@ -660,7 +660,7 @@ Feature: build 'apps' with CLI
 
   # @author cryan@redhat.com
   # @case_id OCP-11023
-  Scenario: Handle build naming collisions
+  Scenario: OCP-11023 Handle build naming collisions
     Given I have a project
     When I run the :new_build client command with:
       | app_repo     | https://github.com/openshift/ruby-hello-world.git |
@@ -682,7 +682,7 @@ Feature: build 'apps' with CLI
 
   # @author xiuwang@redhat.com
   # @case_id OCP-10942
-  Scenario: Build env vars are set correctly for Extended build
+  Scenario: OCP-10942 Build env vars are set correctly for Extended build
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/test-for-s2i-extendbuild/master/extended-bc-scripts-in-repo.json |
@@ -705,7 +705,7 @@ Feature: build 'apps' with CLI
 
   # @author wzheng@redhat.com
   # @case_id OCP-17523
-  Scenario: io.openshift.build.commit.ref displays correctly in build reference on imagestreamtag if building from git branch reference
+  Scenario: OCP-17523 io.openshift.build.commit.ref displays correctly in build reference on imagestreamtag if building from git branch reference
     Given I have a project
     When I run the :new_app client command with:
       | app_repo | https://github.com/openshift/ruby-hello-world#beta4 |
@@ -720,7 +720,7 @@ Feature: build 'apps' with CLI
 
   # @author xiuwang@redhat.com
   # @case_id OCP-19631
-  Scenario: Insert configmap when create a buildconfig
+  Scenario: OCP-19631 Insert configmap when create a buildconfig
     Given I have a project
     Given a "configmap.test" file is created with the following lines:
     """
@@ -856,7 +856,7 @@ Feature: build 'apps' with CLI
 
   # @author xiuwang@redhat.com
   # @case_id OCP-18962
-  Scenario: Allow using a configmap as an input to a docker build
+  Scenario: OCP-18962 Allow using a configmap as an input to a docker build
     Given I have a project
     Given a "configmap1.test" file is created with the following lines:
     """

--- a/features/cli/configmap.feature
+++ b/features/cli/configmap.feature
@@ -3,7 +3,7 @@ Feature: configMap
   # @author chezhang@redhat.com
   # @case_id OCP-10805
   @smoke
-  Scenario: Consume ConfigMap in environment variables
+  Scenario: OCP-10805 Consume ConfigMap in environment variables
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/configmap/configmap.yaml |
@@ -34,7 +34,7 @@ Feature: configMap
   # @author chezhang@redhat.com
   # @case_id OCP-11255
   @smoke
-  Scenario: Consume ConfigMap via volume plugin
+  Scenario: OCP-11255 Consume ConfigMap via volume plugin
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/configmap/configmap.yaml |
@@ -72,7 +72,7 @@ Feature: configMap
 
   # @author chezhang@redhat.com
   # @case_id OCP-11572
-  Scenario: Perform CRUD operations against a ConfigMap resource
+  Scenario: OCP-11572 Perform CRUD operations against a ConfigMap resource
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/configmap/configmap-example.yaml |
@@ -112,7 +112,7 @@ Feature: configMap
   # @author chezhang@redhat.com
   # @case_id OCP-9882
   @smoke
-  Scenario: Set command-line arguments with ConfigMap
+  Scenario: OCP-9882 Set command-line arguments with ConfigMap
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/configmap/configmap.yaml |
@@ -141,7 +141,7 @@ Feature: configMap
 
   # @author chezhang@redhat.com
   # @case_id OCP-9884
-  Scenario: Configuring redis using ConfigMap
+  Scenario: OCP-9884 Configuring redis using ConfigMap
     Given I have a project
     Given a "redis-config" file is created with the following lines:
     """
@@ -176,7 +176,7 @@ Feature: configMap
   # @author chezhang@redhat.com
   # @case_id OCP-9880
   @smoke
-  Scenario: Create ConfigMap from file
+  Scenario: OCP-9880 Create ConfigMap from file
     Given I have a project
     Given I create the "configmap-test" directory
     Given a "configmap-test/game.properties" file is created with the following lines:
@@ -269,7 +269,7 @@ Feature: configMap
 
   # @author chezhang@redhat.com
   # @case_id OCP-9881
-  Scenario: Create ConfigMap from literal values
+  Scenario: OCP-9881 Create ConfigMap from literal values
     Given I have a project
     When I run the :create_configmap client command with:
       | name         | special-config     |
@@ -292,7 +292,7 @@ Feature: configMap
 
   # @author chezhang@redhat.com
   # @case_id OCP-9879
-  Scenario: Create ConfigMap from directories
+  Scenario: OCP-9879 Create ConfigMap from directories
     Given I have a project
     Given I create the "configmap-test" directory
     Given a "configmap-test/game.properties" file is created with the following lines:
@@ -342,7 +342,7 @@ Feature: configMap
 
  # @author xiuli@redhat.com
  # @case_id OCP-16721
-  Scenario: Changes to ConfigMap should be auto-updated into container	
+  Scenario: OCP-16721 Changes to ConfigMap should be auto-updated into container	
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/configmap/configmap.json |

--- a/features/cli/create.feature
+++ b/features/cli/create.feature
@@ -2,7 +2,7 @@ Feature: creating 'apps' with CLI
 
   # @author wsun@redhat.com
   # @case_id OCP-10593
-  Scenario: Could not create any context in non-existent project
+  Scenario: OCP-10593 Could not create any context in non-existent project
     Given I create a new application with:
       | docker image | openshift/ruby-20-centos7~https://github.com/openshift/ruby-hello-world |
       | name         | myapp          |
@@ -33,7 +33,7 @@ Feature: creating 'apps' with CLI
   # @author yinzhou@redhat.com
   # @case_id OCP-11761
   @admin
-  Scenario: Process with special FSGroup id can be ran when using RunAsAny as the RunAsGroupStrategy
+  Scenario: OCP-11761 Process with special FSGroup id can be ran when using RunAsAny as the RunAsGroupStrategy
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/pod_with_special_fsGroup.json |
@@ -52,7 +52,7 @@ Feature: creating 'apps' with CLI
 
   # @author cryan@redhat.com
   # @case_id OCP-12399
-  Scenario: Create an application from source code
+  Scenario: OCP-12399 Create an application from source code
     Given I have a project
     When I git clone the repo "https://github.com/openshift/ruby-hello-world"
     Then the step should succeed

--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -2,7 +2,7 @@ Feature: deployment related features
 
   # @author xxing@redhat.com
   # @case_id OCP-12543
-  Scenario: Restart a failed deployment by oc deploy
+  Scenario: OCP-12543 Restart a failed deployment by oc deploy
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/dc-with-pre-mid-post.yaml |
@@ -31,7 +31,7 @@ Feature: deployment related features
   # @author xxing@redhat.com
   # @case_id OCP-10643
   @smoke
-  Scenario: Manually make deployment
+  Scenario: OCP-10643 Manually make deployment
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/manual.json |
@@ -68,7 +68,7 @@ Feature: deployment related features
 
   # @author xxing@redhat.com
   # @case_id OCP-11695
-  Scenario: CLI rollback output to file
+  Scenario: OCP-11695 CLI rollback output to file
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment1.json |
@@ -147,7 +147,7 @@ Feature: deployment related features
 
   # @author xxing@redhat.com
   # @case_id OCP-11877
-  Scenario: CLI rollback with one component
+  Scenario: OCP-11877 CLI rollback with one component
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment1.json |
@@ -185,7 +185,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-12133
-  Scenario: Can't stop a deployment in Failed status
+  Scenario: OCP-12133 Can't stop a deployment in Failed status
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/test-stop-failed-deployment.json |
@@ -218,7 +218,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-12246
-  Scenario: Stop a "Running" deployment
+  Scenario: OCP-12246 Stop a "Running" deployment
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/dc-with-pre-mid-post.yaml |
@@ -240,7 +240,7 @@ Feature: deployment related features
 
   # @author cryan@redhat.com
   # @case_id OCP-10648
-  Scenario: Rollback via CLI when previous version failed
+  Scenario: OCP-10648 Rollback via CLI when previous version failed
     Given I have a project
     When I run the :new_app client command with:
       | app_repo | aosqe/hello-openshift |
@@ -269,7 +269,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-12528
-  Scenario: Make multiple deployment by oc deploy
+  Scenario: OCP-12528 Make multiple deployment by oc deploy
     Given I have a project
     And I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment1.json |
@@ -290,7 +290,7 @@ Feature: deployment related features
 
   # @author xiaocwan@redhat.com
   # @case_id OCP-10717
-  Scenario: View the logs of the latest deployment
+  Scenario: OCP-10717 View the logs of the latest deployment
     # check deploy log when deploying
     Given I have a project
     When I run the :run client command with:
@@ -318,7 +318,7 @@ Feature: deployment related features
 
   # @author yinzhou@redhat.com
   # @case_id OCP-9563
-  Scenario: A/B Deployment
+  Scenario: OCP-9563 A/B Deployment
     Given I have a project
     When I run the :new_app client command with:
       | docker_image | <%= project_docker_repo %>openshift/deployment-example |
@@ -367,7 +367,7 @@ Feature: deployment related features
 
   # @author yinzhou@redhat.com
   # @case_id OCP-9566
-  Scenario: Blue-Green Deployment
+  Scenario: OCP-9566 Blue-Green Deployment
     Given I have a project
     When I run the :new_app client command with:
       | docker_image | <%= project_docker_repo %>openshift/deployment-example:v1 |
@@ -399,7 +399,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-12532
-  Scenario: Manually start deployment by oc deploy
+  Scenario: OCP-12532 Manually start deployment by oc deploy
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment1.json |
@@ -412,7 +412,7 @@ Feature: deployment related features
 
   # @author yinzhou@redhat.com
   # @case_id OCP-12468
-  Scenario: Pre and post deployment hooks
+  Scenario: OCP-12468 Pre and post deployment hooks
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/testhook.json |
@@ -432,7 +432,7 @@ Feature: deployment related features
 
   # @author yinzhou@redhat.com
   # @case_id OCP-10724
-  Scenario: deployment hook volume inheritance that volume name was null
+  Scenario: OCP-10724 deployment hook volume inheritance that volume name was null
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/tc510606/hooks-null-volume.json |
@@ -442,7 +442,7 @@ Feature: deployment related features
   # @author yadu@redhat.com
   # @case_id OCP-9567
   @smoke
-  Scenario: Recreate deployment strategy
+  Scenario: OCP-9567 Recreate deployment strategy
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift/origin/master/examples/deployment/recreate-example.yaml |
@@ -464,7 +464,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-11939
-  Scenario: start deployment when the latest deployment is completed
+  Scenario: OCP-11939 start deployment when the latest deployment is completed
     Given I have a project
     And I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment1.json |
@@ -479,7 +479,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-12056
-  Scenario: Manual scale dc will update the deploymentconfig's replicas
+  Scenario: OCP-12056 Manual scale dc will update the deploymentconfig's replicas
     Given I have a project
     And I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment1.json |
@@ -503,7 +503,7 @@ Feature: deployment related features
 
   # @author pruan@redhat.com
   # @case_id OCP-10728
-  Scenario: Inline deployer hook logs
+  Scenario: OCP-10728 Inline deployer hook logs
     Given I have a project
     And I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/Inline-logs.json |
@@ -520,7 +520,7 @@ Feature: deployment related features
 
   # @author yinzhou@redhat.com
   # @case_id OCP-11070
-  Scenario: Trigger info is retained for deployment caused by image changes
+  Scenario: OCP-11070 Trigger info is retained for deployment caused by image changes
     Given I have a project
     When I process and create "https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/application-template-stibuild.json"
     Then the step should succeed
@@ -536,7 +536,7 @@ Feature: deployment related features
 
   # @author yinzhou@redhat.com
   # @case_id OCP-11769
-  Scenario: Start new deployment when deployment running
+  Scenario: OCP-11769 Start new deployment when deployment running
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/testhook.json |
@@ -555,7 +555,7 @@ Feature: deployment related features
 
   # @author cryan@redhat.com
   # @case_id OCP-12151
-  Scenario: When the latest deployment failed auto rollback to the active deployment
+  Scenario: OCP-12151 When the latest deployment failed auto rollback to the active deployment
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment1.json |
@@ -607,7 +607,7 @@ Feature: deployment related features
   # @author yinzhou@redhat.com
   # @case_id OCP-10617
   @admin
-  Scenario: DeploymentConfig should allow valid value of resource requirements
+  Scenario: OCP-10617 DeploymentConfig should allow valid value of resource requirements
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/limits.yaml |
@@ -639,7 +639,7 @@ Feature: deployment related features
 
   # @author yinzhou@redhat.com
   # @case_id OCP-11221
-  Scenario: Scale up when deployment running
+  Scenario: OCP-11221 Scale up when deployment running
     Given I have a project
     When I run the :new_app client command with:
       | docker_image   | <%= project_docker_repo %>openshift/deployment-example |
@@ -659,7 +659,7 @@ Feature: deployment related features
 
   # @author qwang@redhat.com
   # @case_id OCP-12356
-  Scenario: configchange triggers deploy automatically
+  Scenario: OCP-12356 configchange triggers deploy automatically
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment1.json |
@@ -683,7 +683,7 @@ Feature: deployment related features
   # @author yinzhou@redhat.com
   # @case_id OCP-11326
   @smoke
-  Scenario: Support verbs of Deployment in OpenShift
+  Scenario: OCP-11326 Support verbs of Deployment in OpenShift
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/extensions/deployment.yaml |
@@ -760,7 +760,7 @@ Feature: deployment related features
   # @author mcurlej@redhat.com
   # @case_id OCP-10902
   @smoke
-  Scenario: Auto cleanup old RCs
+  Scenario: OCP-10902 Auto cleanup old RCs
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/tc532411/history-limit-dc.yaml |
@@ -792,7 +792,7 @@ Feature: deployment related features
 
   # @author haowang@redhat.com
   # @case_id OCP-16443
-  Scenario: Trigger info is retained for deployment caused by image changes 37 new feature
+  Scenario: OCP-16443 Trigger info is retained for deployment caused by image changes 37 new feature
     Given the master version >= "3.7"
     Given I have a project
     And I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/OCP-11384/application-template-stibuild.json"

--- a/features/cli/deployment.feature
+++ b/features/cli/deployment.feature
@@ -2,7 +2,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11421
-  Scenario: Add perma-failed - Deplyment succeed after change pod template by edit deployment
+  Scenario: OCP-11421 Add perma-failed - Deplyment succeed after change pod template by edit deployment
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment-perme-failed-1.yaml |
@@ -75,7 +75,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11046
-  Scenario: Add perma-failed - Deployment failed after pausing and resuming
+  Scenario: OCP-11046 Add perma-failed - Deployment failed after pausing and resuming
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment-perme-failed-1.yaml |
@@ -167,7 +167,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11681
-  Scenario: Add perma-failed - Failing deployment can be rolled back successful
+  Scenario: OCP-11681 Add perma-failed - Failing deployment can be rolled back successful
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment-perme-failed-3.yaml |
@@ -265,7 +265,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-12110
-  Scenario: Add perma-failed - Rolling back to a failing deployment revision
+  Scenario: OCP-12110 Add perma-failed - Rolling back to a failing deployment revision
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment-perme-failed-3.yaml |
@@ -371,7 +371,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11865
-  Scenario: Add perma-failed - Make a change outside pod template for failing deployment
+  Scenario: OCP-11865 Add perma-failed - Make a change outside pod template for failing deployment
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment-perme-failed-1.yaml |
@@ -462,7 +462,7 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-12009
-  Scenario: Add perma-failed - Negative value test of progressDeadlineSeconds in failing deployment
+  Scenario: OCP-12009 Add perma-failed - Negative value test of progressDeadlineSeconds in failing deployment
     Given I have a project
     Given I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment-perme-failed-2.yaml"
     When I run the :create client command with:

--- a/features/cli/downwardapi.feature
+++ b/features/cli/downwardapi.feature
@@ -2,7 +2,7 @@ Feature: Downward API
 
   # @author qwang@redhat.com
   # @case_id OCP-10707
-  Scenario: Pods can get IPs via downward API under race condition
+  Scenario: OCP-10707 Pods can get IPs via downward API under race condition
     Given I have a project
     When I run the :create client command with:
       | filename  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/downwardapi/tc509097/pod-downwardapi-env.yaml |
@@ -15,7 +15,7 @@ Feature: Downward API
   # @author cryan@redhat.com
   # @case_id OCP-10628
   @smoke
-  Scenario: downward api pod name and pod namespace as env variables
+  Scenario: OCP-10628 downward api pod name and pod namespace as env variables
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/downwardapi/tc483203/downward-example.yaml |
@@ -31,7 +31,7 @@ Feature: Downward API
   # @author qwang@redhat.com
   # @case_id OCP-10708
   @smoke
-  Scenario: Container consume infomation from the downward API using a volume plugin
+  Scenario: OCP-10708 Container consume infomation from the downward API using a volume plugin
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/downwardapi/pod-dapi-volume.yaml |
@@ -96,7 +96,7 @@ Feature: Downward API
   # @author qwang@redhat.com
   # @case_id OCP-11977
   @admin
-  Scenario: Using resources downward API via volume plugin should be compatible with metadata downward API
+  Scenario: OCP-11977 Using resources downward API via volume plugin should be compatible with metadata downward API
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/downwardapi/dapi-resources-metadata-volume-pod.yaml |
@@ -178,7 +178,7 @@ Feature: Downward API
   # @author qwang@redhat.com
   # @case_id OCP-11618
   @admin
-  Scenario: Could expose resouces limits and requests via volume plugin from Downward APIs with magics keys
+  Scenario: OCP-11618 Could expose resouces limits and requests via volume plugin from Downward APIs with magics keys
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/downwardapi/dapi-resources-volume-magic-keys-pod.yaml |
@@ -228,7 +228,7 @@ Feature: Downward API
   # @author qwang@redhat.com
   # @case_id OCP-11816
   @admin
-  Scenario: Using resources downward API via ENV should be compatible with metadata downward API
+  Scenario: OCP-11816 Using resources downward API via ENV should be compatible with metadata downward API
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/downwardapi/dapi-resources-metadata-env-pod.yaml |

--- a/features/cli/event.feature
+++ b/features/cli/event.feature
@@ -3,7 +3,7 @@ Feature: Event related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-10751
   @admin
-  Scenario: check event compressed in kube
+  Scenario: OCP-10751 check event compressed in kube
     Given I have a project
     When I run the :new_app admin command with:
       | file  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/quota_template.yaml |
@@ -48,7 +48,7 @@ Feature: Event related scenarios
 
   # @author chezhang@redhat.com
   # @case_id OCP-10750
-  Scenario: Check normal and warning information for kubernetes events
+  Scenario: OCP-10750 Check normal and warning information for kubernetes events
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/hello-pod.json |
@@ -89,7 +89,7 @@ Feature: Event related scenarios
 
   # @author dma@redhat.com
   # @case_id OCP-10208
-  Scenario: Event should show full failed reason when readiness probe failed
+  Scenario: OCP-10208 Event should show full failed reason when readiness probe failed
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/tc533910/readiness-probe-exec.yaml |

--- a/features/cli/hpa.feature
+++ b/features/cli/hpa.feature
@@ -2,7 +2,7 @@ Feature: hpa scale
 
   # @author chezhang@redhat.com
   # @case_id OCP-10931
-  Scenario: HPA shouldn't scale up target if the replicas of dc is 0
+  Scenario: OCP-10931 HPA shouldn't scale up target if the replicas of dc is 0
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/hpa/dc-hello-openshift.yaml |
@@ -36,7 +36,7 @@ Feature: hpa scale
 
   # @author chezhang@redhat.com
   # @case_id OCP-11338
-  Scenario: HPA shouldn't scale up target if the replicas of rc is 0
+  Scenario: OCP-11338 HPA shouldn't scale up target if the replicas of rc is 0
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/hpa/rc-hello-openshift.yaml |
@@ -70,7 +70,7 @@ Feature: hpa scale
   # @author chezhang@redhat.com
   # @case_id OCP-11259
   @smoke
-  Scenario: Creates autoscaler for replication controller by oc autoscale
+  Scenario: OCP-11259 Creates autoscaler for replication controller by oc autoscale
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/hpa/rc-hello-openshift.yaml |
@@ -117,7 +117,7 @@ Feature: hpa scale
 
   # @author chezhang@redhat.com
   # @case_id OCP-11576
-  Scenario: Creates autoscaler for replication controller with invalid value
+  Scenario: OCP-11576 Creates autoscaler for replication controller with invalid value
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/hpa/rc-hello-openshift.yaml |

--- a/features/cli/initcontainers.feature
+++ b/features/cli/initcontainers.feature
@@ -2,7 +2,7 @@ Feature: InitContainers
 
   # @author dma@redhat.com
   # @case_id OCP-11318
-  Scenario: App container run depends on initContainer results in pod
+  Scenario: OCP-11318 App container run depends on initContainer results in pod
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/initContainers/init-containers-success.yaml |
@@ -30,7 +30,7 @@ Feature: InitContainers
 
   # @author dma@redhat.com
   # @case_id OCP-11814
-  Scenario: Check volume and readiness probe field in initContainer
+  Scenario: OCP-11814 Check volume and readiness probe field in initContainer
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/initContainers/volume-init-containers.yaml |
@@ -51,7 +51,7 @@ Feature: InitContainers
 
   # @author dma@redhat.com
   # @case_id OCP-12166
-  Scenario: InitContainer should failed after exceed activeDeadlineSeconds
+  Scenario: OCP-12166 InitContainer should failed after exceed activeDeadlineSeconds
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/initContainers/init-containers-deadline.yaml |
@@ -67,7 +67,7 @@ Feature: InitContainers
 
   # @author chezhang@redhat.com
   # @case_id OCP-10908
-  Scenario: Access init container by oc command
+  Scenario: OCP-10908 Access init container by oc command
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/initContainers/init-containers-sleep.yaml |
@@ -120,7 +120,7 @@ Feature: InitContainers
   # @author chezhang@redhat.com
   # @case_id OCP-11975
   @admin
-  Scenario: Init containers properly apply to quota and limits
+  Scenario: OCP-11975 Init containers properly apply to quota and limits
     Given I have a project
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/initContainers/quota.yaml |
@@ -169,7 +169,7 @@ Feature: InitContainers
   # @author chezhang@redhat.com
   # @case_id OCP-12222
   @admin
-  Scenario: SCC rules should apply to init containers
+  Scenario: OCP-12222 SCC rules should apply to init containers
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/initContainers/init-containers-privilege.yaml |

--- a/features/cli/job.feature
+++ b/features/cli/job.feature
@@ -2,7 +2,7 @@ Feature: job.feature
 
   # @author cryan@redhat.com
   # @case_id OCP-11206
-  Scenario: Create job with multiple completions
+  Scenario: OCP-11206 Create job with multiple completions
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/templates/tc511597/job.yaml |
@@ -42,7 +42,7 @@ Feature: job.feature
 
   # @author chezhang@redhat.com
   # @case_id OCP-11935
-  Scenario: Go through the job example
+  Scenario: OCP-11935 Go through the job example
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/job/job.yaml |
@@ -81,7 +81,7 @@ Feature: job.feature
 
   # @author qwang@redhat.com
   # @case_id OCP-11539
-  Scenario: Create job with pod parallelism
+  Scenario: OCP-11539 Create job with pod parallelism
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/job/job_with_0_activeDeadlineSeconds.yaml" replacing paths:
       | ["spec"]["parallelism"]           | 1    |
@@ -169,7 +169,7 @@ Feature: job.feature
 
   # @author qwang@redhat.com
   # @case_id OCP-9948
-  Scenario: Create job with activeDeadlineSeconds
+  Scenario: OCP-9948 Create job with activeDeadlineSeconds
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/job/job_with_lessthan_runtime_activeDeadlineSeconds.yaml |
@@ -189,7 +189,7 @@ Feature: job.feature
 
   # @author qwang@redhat.com
   # @case_id OCP-9952
-  Scenario: Specifying your own pod selector for job
+  Scenario: OCP-9952 Specifying your own pod selector for job
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/job/job-manualselector.yaml |
@@ -206,7 +206,7 @@ Feature: job.feature
 
   # @author qwang@redhat.com
   # @case_id OCP-10734
-  Scenario: Create job with different pod restartPolicy
+  Scenario: OCP-10734 Create job with different pod restartPolicy
     Given I have a project
     Given I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/job/job-restartpolicy.yaml"
     # Create job without restartPolicy
@@ -313,7 +313,7 @@ Feature: job.feature
 
   # @author yinzhou@redhat.com
   # @case_id OCP-10781
-  Scenario: Create job with specific deadline
+  Scenario: OCP-10781 Create job with specific deadline
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/job/job_with_0_activeDeadlineSeconds.yaml |
@@ -360,7 +360,7 @@ Feature: job.feature
 
   # @author chuyu@redhat.com
   # @case_id OCP-11644
-  Scenario: User can schedule a job execution with cron format time
+  Scenario: OCP-11644 User can schedule a job execution with cron format time
     Given I have a project
     When I run the :run client command with:
        | name    | sj3          	|
@@ -540,7 +540,7 @@ Feature: job.feature
 
   # @author geliu@redhat.com
   # @case_id OCP-17515
-  Scenario: User can schedule a Cronjob execution with cron format time
+  Scenario: OCP-17515 User can schedule a Cronjob execution with cron format time
     Given I have a project
     When I run the :run client command with:
        | name     | sj3       |

--- a/features/cli/limits.feature
+++ b/features/cli/limits.feature
@@ -62,7 +62,7 @@ Feature: limit range related scenarios:
   # @author pruan@redhat.com, dma@redhat.com, azagayno@redhat.com
   # @case_id OCP-12250
   @admin
-  Scenario: Limit range does not allow min > defaultRequest
+  Scenario: OCP-12250 Limit range does not allow min > defaultRequest
     Given I have a project
     Given admin uses the "<%= project.name %>" project
     When I run oc create as admin over ERB URL: https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/limits/tc508046/limit.yaml
@@ -74,7 +74,7 @@ Feature: limit range related scenarios:
   # @author gpei@redhat.com, dma@redhat.com, azagayno@redhat.com
   # @case_id OCP-11918
   @admin
-  Scenario: Limit range does not allow defaultRequest > default
+  Scenario: OCP-11918 Limit range does not allow defaultRequest > default
     Given I have a project
     Given admin uses the "<%= project.name %>" project
     When I run oc create as admin over ERB URL: https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/limits/tc508042/limit.yaml
@@ -86,7 +86,7 @@ Feature: limit range related scenarios:
   # @author gpei@redhat.com, dma@redhat.com, azagayno@redhat.com
   # @case_id OCP-12043
   @admin
-  Scenario: Limit range does not allow defaultRequest > max
+  Scenario: OCP-12043 Limit range does not allow defaultRequest > max
     Given I have a project
     Given admin uses the "<%= project.name %>" project
     When I run oc create as admin over ERB URL: https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/limits/tc508043/limit.yaml
@@ -98,7 +98,7 @@ Feature: limit range related scenarios:
   # @author gpei@redhat.com, dma@redhat.com, azagayno@redhat.com
   # @case_id OCP-12139
   @admin
-  Scenario: Limit range does not allow maxLimitRequestRatio > Limit/Request
+  Scenario: OCP-12139 Limit range does not allow maxLimitRequestRatio > Limit/Request
     Given I have a project
     Given admin uses the "<%= project.name %>" project
     When I run oc create as admin over ERB URL: https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/limits/tc508044/limit.yaml
@@ -118,7 +118,7 @@ Feature: limit range related scenarios:
   # @author gpei@redhat.com, azagayno@redhat.com
   # @case_id OCP-12315
   @admin
-  Scenario: Limit range with all values set with proper values
+  Scenario: OCP-12315 Limit range with all values set with proper values
     Given I have a project
     Given admin uses the "<%= project.name %>" project
     When I run oc create as admin over ERB URL: https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/limits/tc508048/limit.yaml

--- a/features/cli/oc_attach.feature
+++ b/features/cli/oc_attach.feature
@@ -2,7 +2,7 @@ Feature: oc attach related scenarios
 
   # @author yapei@redhat.com
   # @case_id OCP-11162
-  Scenario: check oc attach functionality
+  Scenario: OCP-11162 check oc attach functionality
     Given I have a project
     And evaluation of `"doublecontainers"` is stored in the :pod_name clipboard
     When I run the :create client command with:

--- a/features/cli/oc_delete.feature
+++ b/features/cli/oc_delete.feature
@@ -2,7 +2,7 @@ Feature: oc_delete.feature
 
   # @author cryan@redhat.com
   # @case_id OCP-11184
-  Scenario: Gracefully delete a pod with '--grace-period' option
+  Scenario: OCP-11184 Gracefully delete a pod with '--grace-period' option
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/graceful-delete/10.json |
@@ -49,7 +49,7 @@ Feature: oc_delete.feature
   # @case_id OCP-12048
   # @bug_id 1277101
   @admin
-  Scenario: The namespace will not be deleted until all pods gracefully terminate
+  Scenario: OCP-12048 The namespace will not be deleted until all pods gracefully terminate
     Given I have a project
     And evaluation of `project.name` is stored in the :prj1 clipboard
     When I run the :create client command with:
@@ -81,7 +81,7 @@ Feature: oc_delete.feature
 
   # @author cryan@redhat.com
   # @case_id OCP-10705
-  Scenario: Default termination grace period is 30s if it's not set
+  Scenario: OCP-10705 Default termination grace period is 30s if it's not set
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/graceful-delete/default.json |
@@ -107,7 +107,7 @@ Feature: oc_delete.feature
 
   # @author cryan@redhat.com
   # @case_id OCP-12144
-  Scenario: Verify pod is gracefully deleted when DeletionGracePeriodSeconds is specified.
+  Scenario: OCP-12144 Verify pod is gracefully deleted when DeletionGracePeriodSeconds is specified.
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/graceful-delete/10.json |
@@ -132,7 +132,7 @@ Feature: oc_delete.feature
 
   # @author cryan@redhat.com
   # @case_id OCP-11526
-  Scenario: Pod should be immediately deleted if TerminationGracePeriodSeconds is 0
+  Scenario: OCP-11526 Pod should be immediately deleted if TerminationGracePeriodSeconds is 0
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/graceful-delete/0.json |

--- a/features/cli/oc_env.feature
+++ b/features/cli/oc_env.feature
@@ -2,7 +2,7 @@ Feature: oc_env.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-11032
-  Scenario: Set environment variables when creating application using non-DeploymentConfig template
+  Scenario: OCP-11032 Set environment variables when creating application using non-DeploymentConfig template
     Given I have a project
     When I run the :new_app client command with:
       | template | cakephp-mysql-example |

--- a/features/cli/oc_expose.feature
+++ b/features/cli/oc_expose.feature
@@ -2,7 +2,7 @@ Feature: oc_expose.feature
 
   # @author pruan@redhat.com
   # @case_id OCP-10873
-  Scenario: Access app througth secure service and regenerate service serving certs if it about to expire
+  Scenario: OCP-10873 Access app througth secure service and regenerate service serving certs if it about to expire
     Given the master version >= "3.3"
     Given I have a project
     Given a "caddyfile.conf" file is created with the following lines:

--- a/features/cli/oc_help.feature
+++ b/features/cli/oc_help.feature
@@ -2,7 +2,7 @@ Feature: oc related features
 
   # @author chezhang@redhat.com
   # @case_id OCP-11565
-  Scenario: kubectl secret subcommand - help
+  Scenario: OCP-11565 kubectl secret subcommand - help
     Given I have a project
     When I run the :create_secret client command with:
       | secret_type | |
@@ -85,7 +85,7 @@ Feature: oc related features
 
   # @author chezhang@redhat.com
   # @case_id OCP-10812
-  Scenario: Check `oc autoscale` help info
+  Scenario: OCP-10812 Check `oc autoscale` help info
     Given I have a project
     When I run the :autoscale client command with:
       | name  | :false |

--- a/features/cli/oc_idle.feature
+++ b/features/cli/oc_idle.feature
@@ -2,7 +2,7 @@ Feature: oc idle
 
   # @author chezhang@redhat.com
   # @case_id OCP-11633
-  Scenario: CLI - Idle all the service in the same project
+  Scenario: OCP-11633 CLI - Idle all the service in the same project
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/rc/idle-rc-1.yaml |
@@ -43,7 +43,7 @@ Feature: oc idle
 
   # @author chezhang@redhat.com
   # @case_id OCP-11980
-  Scenario: CLI - Idle service by label
+  Scenario: OCP-11980 CLI - Idle service by label
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/rc/idle-rc-2.yaml |
@@ -78,7 +78,7 @@ Feature: oc idle
 
   # @author chezhang@redhat.com
   # @case_id OCP-12085
-  Scenario: CLI - Idle service from file
+  Scenario: OCP-12085 CLI - Idle service from file
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/rc/idle-rc-2.yaml |
@@ -118,7 +118,7 @@ Feature: oc idle
 
   # @author chezhang@redhat.com
   # @case_id OCP-12169
-  Scenario: CLI - Idle service with dry-run
+  Scenario: OCP-12169 CLI - Idle service with dry-run
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/rc/idle-rc-2.yaml |
@@ -148,7 +148,7 @@ Feature: oc idle
 
   # @author chezhang@redhat.com
   # @case_id OCP-10941
-  Scenario: Idling service with dc
+  Scenario: OCP-10941 Idling service with dc
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift/origin/master/test/extended/testdata/idling-echo-server.yaml |
@@ -212,7 +212,7 @@ Feature: oc idle
 
   # @author chezhang@redhat.com
   # @case_id OCP-11345
-  Scenario: Idling service with rc
+  Scenario: OCP-11345 Idling service with rc
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/rc/idle-rc-2.yaml |

--- a/features/cli/oc_import_image.feature
+++ b/features/cli/oc_import_image.feature
@@ -36,7 +36,7 @@ Feature: oc import-image related feature
 
   # @author chaoyang@redhat.com
   # @case_id OCP-10585
-  Scenario: Do not create tags for ImageStream if image repository does not have tags
+  Scenario: OCP-10585 Do not create tags for ImageStream if image repository does not have tags
     When I have a project
     And I run the :create client command with:
       | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image-streams/is_without_tags.json |
@@ -52,7 +52,7 @@ Feature: oc import-image related feature
 
   # @author wjiang@redhat.com
   # @case_id OCP-10721
-  Scenario: Could not import the tag when reference is true
+  Scenario: OCP-10721 Could not import the tag when reference is true
     Given I have a project
     When I run the :create client command with:
       | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image-streams/tc510523.json |
@@ -68,7 +68,7 @@ Feature: oc import-image related feature
 
   # @author wsun@redhat.com
   # @case_id OCP-11200
-  Scenario: Import image when pointing to non-existing docker image
+  Scenario: OCP-11200 Import image when pointing to non-existing docker image
     Given I have a project
     When I run the :create client command with:
       | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image-streams/tc510524.json |
@@ -83,7 +83,7 @@ Feature: oc import-image related feature
 
   # @author wjiang@redhat.com
   # @case_id OCP-11536
-  Scenario: Import image when spec.DockerImageRepository defined without any tags
+  Scenario: OCP-11536 Import image when spec.DockerImageRepository defined without any tags
     Given I have a project
     When I run the :create client command with:
       | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image-streams/tc510525.json |
@@ -99,7 +99,7 @@ Feature: oc import-image related feature
 
   # @author wjiang@redhat.com
   # @case_id OCP-11760
-  Scenario: Import Image when spec.DockerImageRepository not defined
+  Scenario: OCP-11760 Import Image when spec.DockerImageRepository not defined
     Given I have a project
     When I run the :create client command with:
       | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image-streams/tc510526.json |
@@ -117,7 +117,7 @@ Feature: oc import-image related feature
 
   # @author wjiang@redhat.com
   # @case_id OCP-11931
-  Scenario: Import image when spec.DockerImageRepository with some tags defined when Kind!=DockerImage
+  Scenario: OCP-11931 Import image when spec.DockerImageRepository with some tags defined when Kind!=DockerImage
     Given I have a project
     When I run the :create client command with:
       | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image-streams/tc510525.json |
@@ -147,7 +147,7 @@ Feature: oc import-image related feature
   # @author wjiang@redhat.com
   # @case_id OCP-12052
   @smoke
-  Scenario: Import image when spec.DockerImageRepository with some tags defined when Kind==DockerImage
+  Scenario: OCP-12052 Import image when spec.DockerImageRepository with some tags defined when Kind==DockerImage
     Given I have a project
     When I run the :create client command with:
       | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image-streams/tc510528.json |
@@ -163,7 +163,7 @@ Feature: oc import-image related feature
 
   # @author wsun@redhat.com
   # @case_id OCP-12147
-  Scenario: Import Image without tags and spec.DockerImageRepository set
+  Scenario: OCP-12147 Import Image without tags and spec.DockerImageRepository set
     Given I have a project
     When I run the :create client command with:
       | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image-streams/tc510529.json |
@@ -176,7 +176,7 @@ Feature: oc import-image related feature
 
   # @author xiaocwan@redhat.com
   # @case_id OCP-11089
-  Scenario: Tags should be added to ImageStream if image repository is from an external docker registry
+  Scenario: OCP-11089 Tags should be added to ImageStream if image repository is from an external docker registry
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image-streams/external.json |
@@ -196,7 +196,7 @@ Feature: oc import-image related feature
 
   # @author geliu@redhat.com
   # @case_id OCP-12765
-  Scenario: Allow imagestream request deployment config triggers by different mode('TagreferencePolicy':source/local)
+  Scenario: OCP-12765 Allow imagestream request deployment config triggers by different mode('TagreferencePolicy':source/local)
     Given I have a project
     When I run the :tag client command with:
       | source_type | docker                                          |
@@ -254,7 +254,7 @@ Feature: oc import-image related feature
 
   # @author geliu@redhat.com
   # @case_id OCP-12766
-  Scenario: Allow imagestream request build config triggers by different mode('TagreferencePolicy':source/local)
+  Scenario: OCP-12766 Allow imagestream request build config triggers by different mode('TagreferencePolicy':source/local)
     Given I have a project
     When I run the :import_image client command with:
       | from       | quay.io/openshifttest/ruby-25-centos7 |

--- a/features/cli/oc_login.feature
+++ b/features/cli/oc_login.feature
@@ -3,7 +3,7 @@ Feature: oc_login.feature
   # @author xiaocwan@redhat.com
   # @case_id OCP-11888
   @smoke
-  Scenario: User can login with the new generated token via web page for oc
+  Scenario: OCP-11888 User can login with the new generated token via web page for oc
     Given I log the message> this scenario can pass only when user accounts have a known password
     When I perform the :request_token_with_password web console action with:
       | url    | <%= env.api_endpoint_url %>/oauth/token/request |

--- a/features/cli/oc_patch_apply.feature
+++ b/features/cli/oc_patch_apply.feature
@@ -3,7 +3,7 @@ Feature: oc patch/apply related scenarios
   # @author xxia@redhat.com
   # @case_id OCP-10696
   @smoke
-  Scenario: oc patch can update one or more fields of rescource
+  Scenario: OCP-10696 oc patch can update one or more fields of rescource
     Given I have a project
     And I run the :run client command with:
       | name      | hello             |

--- a/features/cli/oc_portforward.feature
+++ b/features/cli/oc_portforward.feature
@@ -2,7 +2,7 @@ Feature: oc_portforward.feature
 
   # @author pruan@redhat.com
   # @case_id OCP-11195
-  Scenario: Forward multi local ports to a pod
+  Scenario: OCP-11195 Forward multi local ports to a pod
     Given I have a project
     And evaluation of `rand(5000..7999)` is stored in the :porta clipboard
     And evaluation of `rand(5000..7999)` is stored in the :portb clipboard

--- a/features/cli/oc_process.feature
+++ b/features/cli/oc_process.feature
@@ -2,7 +2,7 @@ Feature: oc_process.feature
 
   # @author shiywang@redhat.com
   # @case_id OCP-11044
-  Scenario: Supply oc new-app parameter list+env vars via a file
+  Scenario: OCP-11044 Supply oc new-app parameter list+env vars via a file
     Given I have a project
     Given a "test1.env" file is created with the following lines:
     """

--- a/features/cli/oc_secrets.feature
+++ b/features/cli/oc_secrets.feature
@@ -2,7 +2,7 @@ Feature: oc_secrets.feature
 
   # @author cryan@redhat.com
   # @case_id OCP-12600
-  Scenario: Add secrets to serviceaccount via oc secrets add
+  Scenario: OCP-12600 Add secrets to serviceaccount via oc secrets add
     Given I have a project
     When I run the :secrets client command with:
       | action | new        |
@@ -54,7 +54,7 @@ Feature: oc_secrets.feature
   # @author qwang@redhat.com
   # @case_id OCP-12244
   @smoke
-  Scenario: CRUD operations on secrets
+  Scenario: OCP-12244 CRUD operations on secrets
     Given I have a project
     # 1.1 Create a secret with a non-existing namespace
     When I run the :create client command with:
@@ -165,7 +165,7 @@ Feature: oc_secrets.feature
 
   # @author xxia@redhat.com
   # @case_id OCP-11900
-  Scenario: Check name requirements for oc secret
+  Scenario: OCP-11900 Check name requirements for oc secret
     Given I have a project
     And I run the :get client command with:
       | resource      | project |
@@ -218,7 +218,7 @@ Feature: oc_secrets.feature
 
   # @author wjiang@redhat.com
   # @case_id OCP-11482
-  Scenario: Bundle secret will not load subdir and warning message will be displayed when -q is not present
+  Scenario: OCP-11482 Bundle secret will not load subdir and warning message will be displayed when -q is not present
     Given I have a project
     Given a "first/second/test" file is created with the following lines:
       |second test|

--- a/features/cli/oc_set_build_hook.feature
+++ b/features/cli/oc_set_build_hook.feature
@@ -3,7 +3,7 @@ Feature: oc_set_build_hook
   # @author cryan@redhat.com
   # @case_id OCP-11602
   # @bug_id 1351797
-  Scenario: Set post-build-commit on buildconfig via oc set build-hook
+  Scenario: OCP-11602 Set post-build-commit on buildconfig via oc set build-hook
     Given I have a project
     When I run the :new_app client command with:
       | template | rails-postgresql-example |

--- a/features/cli/oc_set_deployment_hook.feature
+++ b/features/cli/oc_set_deployment_hook.feature
@@ -2,7 +2,7 @@ Feature: set deployment-hook/build-hook with CLI
 
   # @author dyan@redhat.com
   # @case_id OCP-11805
-  Scenario: Set pre/mid/post deployment hooks on deployment config via oc set deployment-hook
+  Scenario: OCP-11805 Set pre/mid/post deployment hooks on deployment config via oc set deployment-hook
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json |
@@ -85,7 +85,7 @@ Feature: set deployment-hook/build-hook with CLI
 
   # @author dyan@redhat.com
   # @case_id OCP-11298
-  Scenario: Set invalid pre/mid/post deployment hooks on deployment config via oc set deployment-hook
+  Scenario: OCP-11298 Set invalid pre/mid/post deployment hooks on deployment config via oc set deployment-hook
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json |

--- a/features/cli/oc_set_env.feature
+++ b/features/cli/oc_set_env.feature
@@ -2,7 +2,7 @@ Feature: oc_set_env.feature
 
   # @author wewang@redhat.com
   # @case_id OCP-11248
-  Scenario: Set environment variables for resources using oc set env
+  Scenario: OCP-11248 Set environment variables for resources using oc set env
     Given I have a project
     When I run the :new_app client command with:
       | app_repo | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/tc470422/application-template-stibuild.json |
@@ -55,7 +55,7 @@ Feature: oc_set_env.feature
 
   # @author wewang@redhat.com
   # @case_id OCP-10798
-  Scenario: Remove environment variables for resources using oc set env
+  Scenario: OCP-10798 Remove environment variables for resources using oc set env
     Given I have a project
     When I run the :new_app client command with:
       | app_repo | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/tc470422/application-template-stibuild.json |

--- a/features/cli/oc_set_probe.feature
+++ b/features/cli/oc_set_probe.feature
@@ -2,7 +2,7 @@ Feature: oc_set_probe.feature
 
   # @author dyan@redhat.com
   # @case_id OCP-9870
-  Scenario: Set a probe to open a TCP socket
+  Scenario: OCP-9870 Set a probe to open a TCP socket
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mysql:5.6 |
@@ -59,7 +59,7 @@ Feature: oc_set_probe.feature
 
   # @author dyan@redhat.com
   # @case_id OCP-9871
-  Scenario: Set a probe over HTTPS/HTTP
+  Scenario: OCP-9871 Set a probe over HTTPS/HTTP
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mysql:5.6 |
@@ -104,7 +104,7 @@ Feature: oc_set_probe.feature
 
   # @author dyan@redhat.com
   # @case_id OCP-9872
-  Scenario: Set an exec action probe
+  Scenario: OCP-9872 Set an exec action probe
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mysql:5.6 |

--- a/features/cli/oc_tag.feature
+++ b/features/cli/oc_tag.feature
@@ -2,7 +2,7 @@ Feature: oc tag related scenarios
 
   # @author xxia@redhat.com
   # @case_id OCP-11496
-  Scenario: Tag an image into mutliple image streams
+  Scenario: OCP-11496 Tag an image into mutliple image streams
     Given I have a project
     When I run the :tag client command with:
       | source_type  | docker                     |
@@ -57,7 +57,7 @@ Feature: oc tag related scenarios
 
   # @author mcurlej@redhat.com
   # @case_id OCP-12154
-  Scenario: Tag should correctly add muptiple imagestreamtags to one imagestream
+  Scenario: OCP-12154 Tag should correctly add muptiple imagestreamtags to one imagestream
     Given I have a project
     When I run the :tag client command with:
       | source_type  | docker                  |

--- a/features/cli/oc_volume.feature
+++ b/features/cli/oc_volume.feature
@@ -3,7 +3,7 @@ Feature: oc_volume.feature
   # @author xxia@redhat.com
   # @case_id OCP-12194
   @smoke
-  Scenario: Create a pod that consumes the secret in a volume
+  Scenario: OCP-12194 Create a pod that consumes the secret in a volume
     Given I have a project
     When I run the :secrets client command with:
       | action         | new-basicauth     |
@@ -48,7 +48,7 @@ Feature: oc_volume.feature
   # @author xxia@redhat.com
   # @case_id OCP-11906
   @smoke
-  Scenario: Add secret volume to dc and rc
+  Scenario: OCP-11906 Add secret volume to dc and rc
     Given I have a project
     When I run the :run client command with:
       | name   | mydc                 |
@@ -101,7 +101,7 @@ Feature: oc_volume.feature
   # @author xxia@redhat.com
   # @case_id OCP-11141
   @smoke
-  Scenario: Add gitRepo volume to pod, dc and rc
+  Scenario: OCP-11141 Add gitRepo volume to pod, dc and rc
     Given I have a project
     And I run the :run client command with:
       | name      | mydc              |

--- a/features/cli/pod.feature
+++ b/features/cli/pod.feature
@@ -2,7 +2,7 @@ Feature: pods related scenarios
 
   # @author chezhang@redhat.com
   # @case_id OCP-11218
-  Scenario: kubectl describe pod should show qos tier info when pod without limits and request info
+  Scenario: OCP-11218 kubectl describe pod should show qos tier info when pod without limits and request info
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/hello-pod.json |
@@ -18,7 +18,7 @@ Feature: pods related scenarios
 
   # @author chezhang@redhat.com
   # @case_id OCP-11527
-  Scenario: kubectl describe pod should show qos tier info
+  Scenario: OCP-11527 kubectl describe pod should show qos tier info
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/quota/pod-notbesteffort.yaml |
@@ -50,7 +50,7 @@ Feature: pods related scenarios
 
   # @author chezhang@redhat.com
   # @case_id OCP-10729
-  Scenario: Implement supplemental groups for pod
+  Scenario: OCP-10729 Implement supplemental groups for pod
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/tc510724/pod-supplementalGroups.yaml |
@@ -92,7 +92,7 @@ Feature: pods related scenarios
 
   # @author chezhang@redhat.com
   # @case_id OCP-11753
-  Scenario: Pod should be immediately deleted if it's not scheduled even if graceful termination period is set
+  Scenario: OCP-11753 Pod should be immediately deleted if it's not scheduled even if graceful termination period is set
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/graceful-delete/10.json |
@@ -108,7 +108,7 @@ Feature: pods related scenarios
   # @author cryan@redhat.com
   # @case_id OCP-10813
   # @bug_id 1324396
-  Scenario: Update ActiveDeadlineSeconds for pod
+  Scenario: OCP-10813 Update ActiveDeadlineSeconds for pod
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/tc521546/hello-pod.json |
@@ -140,7 +140,7 @@ Feature: pods related scenarios
 
   # @author chuyu@redhat.com
   # @case_id OCP-10986
-  Scenario: Oauth provider info should be consumed in a pod
+  Scenario: OCP-10986 Oauth provider info should be consumed in a pod
     Given the master version >= "3.4"
     Given I have a project
     When I run the :new_app client command with:
@@ -158,7 +158,7 @@ Feature: pods related scenarios
 
   # @author qwang@redhat.com
   # @case_id OCP-11055
-  Scenario: /dev/shm can be automatically shared among all of a pod's containers
+  Scenario: OCP-11055 /dev/shm can be automatically shared among all of a pod's containers
     Given I have a project
     When I run oc create over ERB URL: https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/pod_with_two_containers.json
     Then the step should succeed
@@ -206,7 +206,7 @@ Feature: pods related scenarios
 
   # @author chuyu@redhat.com
   # @case_id OCP-22283
-  Scenario: 4.0 Oauth provider info should be consumed in a pod
+  Scenario: OCP-22283 4.0 Oauth provider info should be consumed in a pod
     Given I have a project
     When I run the :new_app client command with:
       | docker_image     | aosqe/ruby-ex        |

--- a/features/cli/policy.feature
+++ b/features/cli/policy.feature
@@ -2,7 +2,7 @@ Feature: change the policy of user/service account
 
   # @author xxing@redhat.com
   # @case_id OCP-11074
-  Scenario: User can view ,add, remove and modify roleBinding via admin role user
+  Scenario: OCP-11074 User can view ,add, remove and modify roleBinding via admin role user
     Given I have a project
     When I run the :get client command with:
       | resource      | rolebinding |
@@ -50,7 +50,7 @@ Feature: change the policy of user/service account
   # @author xxing@redhat.com
   # @case_id OCP-12430
   @admin
-  Scenario: Could get projects for new role which has permission to get projects
+  Scenario: OCP-12430 Could get projects for new role which has permission to get projects
     When I run the :create admin command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/authorization/policy/clustergetproject.json |
     Then the step should succeed
@@ -125,7 +125,7 @@ Feature: change the policy of user/service account
   # @author wsun@redhat.com
   # @case_id OCP-11273
   @admin
-  Scenario: UserA could impersonate UserB
+  Scenario: OCP-11273 UserA could impersonate UserB
     Given I have a project
     Given cluster role "sudoer" is added to the "first" user
     When I run the :create client command with:
@@ -143,7 +143,7 @@ Feature: change the policy of user/service account
   # @author chezhang@redhat.com
   # @case_id OCP-10211
   @admin
-  Scenario: DaemonSet only support Always restartPolicy
+  Scenario: OCP-10211 DaemonSet only support Always restartPolicy
     Given I have a project
     Given cluster role "sudoer" is added to the "first" user
     When I run the :create client command with:
@@ -165,7 +165,7 @@ Feature: change the policy of user/service account
 
   # @author chaoyang@redhat.com
   # @case_id OCP-10447
-  Scenario: Basic user could not get deeper storageclass object info
+  Scenario: OCP-10447 Basic user could not get deeper storageclass object info
     Given I have a project
     When I run the :get client command with:
       | resource | storageclass |
@@ -208,7 +208,7 @@ Feature: change the policy of user/service account
   # @author chaoyang@redhat.com
   # @case_id OCP-10448
   @admin
-  Scenario: User with role storage-admin can check deeper storageclass object info
+  Scenario: OCP-10448 User with role storage-admin can check deeper storageclass object info
     Given I have a project
     And admin ensures "sc-<%= project.name %>" storageclasses is deleted after scenario
     Given cluster role "storage-admin" is added to the "first" user
@@ -263,7 +263,7 @@ Feature: change the policy of user/service account
   # @author chaoyang@redhat.com
   # @case_id OCP-10466
   @admin
-  Scenario: User with role storage-admin can check deeper pv object info
+  Scenario: OCP-10466 User with role storage-admin can check deeper pv object info
     Given I have a project
     And admin ensures "pv-<%= project.name %>" pv is deleted after scenario
     Given cluster role "storage-admin" is added to the "first" user
@@ -321,7 +321,7 @@ Feature: change the policy of user/service account
   # @author chaoyang@redhat.com
   # @case_id OCP-10467
   @admin
-  Scenario: User with role storage-admin can get pvc object info
+  Scenario: OCP-10467 User with role storage-admin can get pvc object info
     Given I have a project
     And evaluation of `project.name` is stored in the :project clipboard
 
@@ -370,7 +370,7 @@ Feature: change the policy of user/service account
 
   # @author chaoyang@redhat.com
   # @case_id OCP-10465
-  Scenario: Basic user could not get pv object info
+  Scenario: OCP-10465 Basic user could not get pv object info
     Given I have a project
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
       | ["metadata"]["name"] | pvc-<%= project.name %> |
@@ -399,7 +399,7 @@ Feature: change the policy of user/service account
 
   # @author chuyu@redhat.com
   # @case_id OCP-9551
-  Scenario: User can know if he can create podspec against the current scc rules via CLI
+  Scenario: OCP-9551 User can know if he can create podspec against the current scc rules via CLI
     Given I have a project
     When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/authorization/scc/tc538262/PodSecurityPolicySubjectReview_privileged_false.json"
     Then the step should succeed
@@ -431,7 +431,7 @@ Feature: change the policy of user/service account
   # @author chuyu@redhat.com
   # @case_id OCP-9552
   @admin
-  Scenario: User can know which serviceaccount and SA groups can create the podspec against the current sccs by CLI
+  Scenario: OCP-9552 User can know which serviceaccount and SA groups can create the podspec against the current sccs by CLI
     Given I have a project
     When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/authorization/scc/tc538264/PodSecurityPolicyReview.json"
     Then the step should succeed
@@ -487,7 +487,7 @@ Feature: change the policy of user/service account
 
   # @author chuyu@redhat.com
   # @case_id OCP-9553
-  Scenario: User can know whether the PodSpec he's describing will actually be allowed by the current SCC rules via CLI
+  Scenario: OCP-9553 User can know whether the PodSpec he's describing will actually be allowed by the current SCC rules via CLI
     Given I have a project
     When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/authorization/scc/tc538263/PodSecurityPolicySubjectReview.json"
     Then the step should succeed

--- a/features/cli/projects.feature
+++ b/features/cli/projects.feature
@@ -2,7 +2,7 @@ Feature: projects related features via cli
 
   # @author yapei@redhat.com
   # @case_id OCP-11887
-  Scenario: Could delete all resources when delete the project
+  Scenario: OCP-11887 Could delete all resources when delete the project
     Given a 5 characters random string of type :dns is stored into the :prj_name clipboard
     When I run the :new_project client command with:
       | project_name | <%= cb.prj_name %> |
@@ -75,7 +75,7 @@ Feature: projects related features via cli
   # @author cryan@redhat.com
   # @case_id OCP-12193
   @admin
-  Scenario: User can get node selector from a project
+  Scenario: OCP-12193 User can get node selector from a project
     Given  an 8 character random string of type :dns is stored into the :oadmproj1 clipboard
     Given  an 8 character random string of type :dns is stored into the :oadmproj2 clipboard
     When admin creates a project with:
@@ -101,7 +101,7 @@ Feature: projects related features via cli
 
   # @author cryan@redhat.com
   # @case_id OCP-12561
-  Scenario: Could remove user and group from the current project
+  Scenario: OCP-12561 Could remove user and group from the current project
     Given I have a project
     When I run the :oadm_add_role_to_user client command with:
       | role_name        | admin                              |
@@ -135,7 +135,7 @@ Feature: projects related features via cli
 
   # @author yinzhou@redhat.com
   # @case_id OCP-11201
-  Scenario: Process with default FSGroup id can be ran when using the default MustRunAs as the RunAsGroupStrategy
+  Scenario: OCP-11201 Process with default FSGroup id can be ran when using the default MustRunAs as the RunAsGroupStrategy
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/hello-pod.json |

--- a/features/cli/replica_set.feature
+++ b/features/cli/replica_set.feature
@@ -3,7 +3,7 @@ Feature: replicaSet related tests
   # @author pruan@redhat.com
   # @case_id OCP-10917
   @smoke
-  Scenario: Support endpoints of RS in OpenShift
+  Scenario: OCP-10917 Support endpoints of RS in OpenShift
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/replicaSet/tc533162/rs_endpoints.yaml |

--- a/features/cli/resources.feature
+++ b/features/cli/resources.feature
@@ -2,7 +2,7 @@ Feature: resouces related scenarios
 
   # @author xxia@redhat.com
   # @case_id OCP-11882
-  Scenario: Return description of resources with cli describe
+  Scenario: OCP-11882 Return description of resources with cli describe
     Given I have a project
     And I create a new application with:
       | file     | https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/application-template-stibuild.json |

--- a/features/cli/rolling_deploy.feature
+++ b/features/cli/rolling_deploy.feature
@@ -2,7 +2,7 @@ Feature: rolling deployment related scenarios
 
   # @author pruan@redhat.com
   # @case_id OCP-12359
-  Scenario: Rolling-update pods with default value for maxSurge/maxUnavailable
+  Scenario: OCP-12359 Rolling-update pods with default value for maxSurge/maxUnavailable
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/rolling.json |

--- a/features/cli/route.feature
+++ b/features/cli/route.feature
@@ -2,7 +2,7 @@ Feature: route related features via cli
 
   # @author cryan@redhat.com
   # @case_id OCP-10629
-  Scenario: Expose routes from services
+  Scenario: OCP-10629 Expose routes from services
     Given I have a project
     When I run the :new_app client command with:
       | code | https://github.com/sclorg/s2i-perl-container |
@@ -27,7 +27,7 @@ Feature: route related features via cli
 
   # @author cryan@redhat.com
   # @case_id OCP-12022
-  Scenario: Be unable to add an existed alias name for service
+  Scenario: OCP-12022 Be unable to add an existed alias name for service
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/unsecure/route_unsecure.json |

--- a/features/cli/rsh.feature
+++ b/features/cli/rsh.feature
@@ -2,7 +2,7 @@ Feature: rsh.feature
 
   # @author cryan@redhat.com
   # @case_id OCP-10658
-  Scenario: Check oc rsh for simpler access to a remote shell
+  Scenario: OCP-10658 Check oc rsh for simpler access to a remote shell
     Given I have a project
     Then evaluation of `project.name` is stored in the :proj_name clipboard
     When I run the :create client command with:

--- a/features/cli/scale.feature
+++ b/features/cli/scale.feature
@@ -2,7 +2,7 @@ Feature: scaling related scenarios
 
   # @author pruan@redhat.com
   # @case_id OCP-10626
-  Scenario: Scale replicas via replicationcontrollers and deploymentconfig
+  Scenario: OCP-10626 Scale replicas via replicationcontrollers and deploymentconfig
     Given I have a project
     And I create a new application with:
       | image_stream | openshift/perl:5.20                   |
@@ -49,7 +49,7 @@ Feature: scaling related scenarios
 
   # @author pruan@redhat.com
   # @case_id OCP-11764
-  Scenario: Scale up/down jobs
+  Scenario: OCP-11764 Scale up/down jobs
     Given I have a project
     And I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/templates/tc511599/job.yaml |

--- a/features/cli/secrets.feature
+++ b/features/cli/secrets.feature
@@ -2,7 +2,7 @@ Feature: secrets related scenarios
 
   # @author yinzhou@redhat.com
   # @case_id OCP-10725
-  Scenario: deployment hook volume inheritance --with secret volume
+  Scenario: OCP-10725 deployment hook volume inheritance --with secret volume
     Given I have a project
     When I run the :secrets client command with:
       | action | new        |
@@ -27,7 +27,7 @@ Feature: secrets related scenarios
 
   # @author xiuwang@redhat.com
   # @case_id OCP-12290
-  Scenario: Create new secrets for ssh authentication
+  Scenario: OCP-12290 Create new secrets for ssh authentication
     Given I have a project
     When I download a file from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/cases/508971/id_rsa"
     When I run the :oc_secrets_new_sshauth client command with:
@@ -59,7 +59,7 @@ Feature: secrets related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-12281
   @smoke
-  Scenario: Pods do not have access to each other's secrets in the same namespace
+  Scenario: OCP-12281 Pods do not have access to each other's secrets in the same namespace
     Given I have a project
     When I run the :create client command with:
       | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/secrets/tc483168/first-secret.json |
@@ -100,7 +100,7 @@ Feature: secrets related scenarios
 
   # @author qwang@redhat.com
   # @case_id OCP-12310
-  Scenario: Pods do not have access to each other's secrets with the same secret name in different namespaces
+  Scenario: OCP-12310 Pods do not have access to each other's secrets with the same secret name in different namespaces
     Given I have a project
     Given evaluation of `project.name` is stored in the :project0 clipboard
     When I run the :create client command with:
@@ -135,7 +135,7 @@ Feature: secrets related scenarios
 
   # @author cryan@redhat.com
   # @case_id OCP-10690
-  Scenario: Add an arbitrary list of secrets to custom builds
+  Scenario: OCP-10690 Add an arbitrary list of secrets to custom builds
     Given I have a project
     Given an 8 characters random string of type :dns is stored into the :pass1 clipboard
     Given an 8 characters random string of type :dns is stored into the :pass2 clipboard
@@ -240,7 +240,7 @@ Feature: secrets related scenarios
 
   # @author xiuwang@redhat.com
   # @case_id OCP-10851
-  Scenario: Build from private repo with/without secret of token --persistent gitserver
+  Scenario: OCP-10851 Build from private repo with/without secret of token --persistent gitserver
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image/gitserver/gitserver-persistent.yaml |
@@ -362,7 +362,7 @@ Feature: secrets related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-10814
   @smoke
-  Scenario: Consume the same Secrets as environment variables in multiple pods
+  Scenario: OCP-10814 Consume the same Secrets as environment variables in multiple pods
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/secrets/secret.yaml |
@@ -410,7 +410,7 @@ Feature: secrets related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-11260
   @smoke
-  Scenario: Using Secrets as Environment Variables
+  Scenario: OCP-11260 Using Secrets as Environment Variables
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/secrets/secret.yaml |
@@ -433,7 +433,7 @@ Feature: secrets related scenarios
 
   # @author xiuwang@redhat.com
   # @case_id OCP-12204
-  Scenario: Build from private repos with secret of multiple auth methods
+  Scenario: OCP-12204 Build from private repos with secret of multiple auth methods
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/image/gitserver/gitserver-persistent.yaml |
@@ -588,7 +588,7 @@ Feature: secrets related scenarios
   # @author qwang@redhat.com
   # @case_id OCP-11311
   @smoke
-  Scenario: Secret volume should update when secret is updated
+  Scenario: OCP-11311 Secret volume should update when secret is updated
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/secrets/tc483169/secret1.json |
@@ -621,7 +621,7 @@ Feature: secrets related scenarios
 
   # @author qwang@redhat.com
   # @case_id OCP-10899
-  Scenario: Mapping specified secret volume should update when secret is updated
+  Scenario: OCP-10899 Mapping specified secret volume should update when secret is updated
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/secrets/tc483169/secret1.json |
@@ -651,7 +651,7 @@ Feature: secrets related scenarios
 
   # @author qwang@redhat.com
   # @case_id OCP-10569
-  Scenario: Allow specifying secret data using strings and images
+  Scenario: OCP-10569 Allow specifying secret data using strings and images
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/secrets/secret-datastring-image.json |
@@ -695,7 +695,7 @@ Feature: secrets related scenarios
 
   # @author xiuwang@redhat.com
   # @case_id OCP-10982
-  Scenario: oc new-app to gather git creds
+  Scenario: OCP-10982 oc new-app to gather git creds
     Given I have a project
     When I have an http-git service in the project
     And I run the :set_env client command with:
@@ -772,7 +772,7 @@ Feature: secrets related scenarios
 
   # @author shiywang@redhat.com xiuwang@redhat.com
   # @case_id OCP-12838
-  Scenario: Use build source secret based on annotation on Secret --http
+  Scenario: OCP-12838 Use build source secret based on annotation on Secret --http
     Given I have a project
     When I have an http-git service in the project
     And I run the :set_env client command with:

--- a/features/cli/serviceaccount.feature
+++ b/features/cli/serviceaccount.feature
@@ -2,7 +2,7 @@ Feature: ServiceAccount and Policy Managerment
 
   # @author anli@redhat.com
   # @case_id OCP-10642
-  Scenario: Could grant admin permission for the service account username to access to its own project
+  Scenario: OCP-10642 Could grant admin permission for the service account username to access to its own project
     Given I have a project
     When I create a new application with:
       | image_stream | ruby         |
@@ -27,7 +27,7 @@ Feature: ServiceAccount and Policy Managerment
 
   # @author xiaocwan@redhat.com
   # @case_id OCP-11494
-  Scenario: Could grant admin permission for the service account group to access to its own project
+  Scenario: OCP-11494 Could grant admin permission for the service account group to access to its own project
     Given I have a project
     When I run the :new_app client command with:
       | docker_image | openshift/hello-openshift |
@@ -60,7 +60,7 @@ Feature: ServiceAccount and Policy Managerment
 
   # @author wjiang@redhat.com
   # @case_id OCP-11249
-  Scenario: User can get the serviceaccount token via client
+  Scenario: OCP-11249 User can get the serviceaccount token via client
     Given I have a project
     When I run the :serviceaccounts_get_token client command with:
       |serviceaccount_name| default|

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -2,7 +2,7 @@ Feature: Check status via oc status, wait etc
 
   # @author yapei@redhat.com
   # @case_id OCP-11147
-  Scenario: Show RC info and indicate bad secrets reference in 'oc status'
+  Scenario: OCP-11147 Show RC info and indicate bad secrets reference in 'oc status'
     Given I have a project
 
     # Check standalone RC info is dispalyed in oc status output

--- a/features/cli/taint-toleration.feature
+++ b/features/cli/taint-toleration.feature
@@ -4,7 +4,7 @@ Feature: taint toleration related scenarios
   # @case_id OCP-13542
   @admin
   @destructive
-  Scenario: Add default tolerations to pod when enable DefaultTolerationSecond
+  Scenario: OCP-13542 Add default tolerations to pod when enable DefaultTolerationSecond
     Given master config is merged with the following hash:
     """
     admissionConfig:

--- a/features/cluster_configuration/csi.feature
+++ b/features/cluster_configuration/csi.feature
@@ -1,4 +1,5 @@
 Feature: Enable CSI in OCP cluster
+
   # @author piqin@redhat.com
   @admin
   @destructive

--- a/features/cluster_configuration/localstorage.feature
+++ b/features/cluster_configuration/localstorage.feature
@@ -1,4 +1,5 @@
 Feature: Deploy LocalVolume provisoner in OCP cluster
+
   # @author piqin@redhat.com
   @admin
   @destructive

--- a/features/cluster_configuration/snapshot.feature
+++ b/features/cluster_configuration/snapshot.feature
@@ -1,4 +1,5 @@
 Feature: Enable volume snapshot on the cluster
+
   # @author lxia@redhat.com
   @admin
   @destructive

--- a/features/containers/containers.feature
+++ b/features/containers/containers.feature
@@ -4,7 +4,7 @@ Feature: Container test feature
   # @case_id OCP-9863
   # @bug_id 1292666
   @smoke
-  Scenario: Setuid binaries shouldn't work inside of a running container
+  Scenario: OCP-9863 Setuid binaries shouldn't work inside of a running container
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/pod-setuid.yaml |

--- a/features/images/jenkins.feature
+++ b/features/images/jenkins.feature
@@ -258,7 +258,7 @@ Feature: jenkins.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-12773
-  Scenario: new-app/new-build support for pipeline buildconfigs
+  Scenario: OCP-12773 new-app/new-build support for pipeline buildconfigs
     Given I have a project
     When I run the :new_app client command with:
       | app_repo    | https://github.com/sclorg/nodejs-ex |
@@ -448,7 +448,7 @@ Feature: jenkins.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-15384
-  Scenario: Jenkins pipeline build with OpenShift Client Plugin Example
+  Scenario: OCP-15384 Jenkins pipeline build with OpenShift Client Plugin Example
     And I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift/origin/master/examples/jenkins/pipeline/openshift-client-plugin-pipeline.yaml |
@@ -474,7 +474,7 @@ Feature: jenkins.feature
 
   # @author xiuwang@redhat.com
   # @case_id OCP-17357
-  Scenario: Explicitly set jdk version via env var in jenkins-2-rhel7
+  Scenario: OCP-17357 Explicitly set jdk version via env var in jenkins-2-rhel7
     Given I have a project
     When I run the :new_app client command with:
       | template | jenkins-ephemeral |

--- a/features/infrastructure/cluster-capacity.feature
+++ b/features/infrastructure/cluster-capacity.feature
@@ -3,7 +3,7 @@ Feature: cluster-capacity related features
   # @author wjiang@redhat.com
   # @case_id OCP-14799
   @admin
-  Scenario: Cluster capacity image support: Cluster capacity can work well with a simple pod
+  Scenario: OCP-14799 Cluster capacity image support: Cluster capacity can work well with a simple pod
     Given environment has at least 2 schedulable nodes
     Given I have a project
     Given I have a cluster-capacity pod in my project

--- a/features/logging/elasticsearch.feature
+++ b/features/logging/elasticsearch.feature
@@ -4,7 +4,7 @@ Feature: elasticsearch related tests
   # @case_id OCP-16688
   @admin
   @destructive
-  Scenario: The journald log can be retrived from elasticsearch
+  Scenario: OCP-16688 The journald log can be retrived from elasticsearch
     Given I create a project with non-leading digit name
     And logging service is installed in the system
     And I run commands on the host:
@@ -35,7 +35,7 @@ Feature: elasticsearch related tests
   # @case_id OCP-11266
   @admin
   @destructive
-  Scenario: Use index names of project_name.project_uuid.xxx in Elasticsearch
+  Scenario: OCP-11266 Use index names of project_name.project_uuid.xxx in Elasticsearch
     Given the master version < "3.4"
     Given I create a project with non-leading digit name
     And logging service is installed in the system

--- a/features/logging/fluentd.feature
+++ b/features/logging/fluentd.feature
@@ -4,7 +4,7 @@ Feature: fluentd related tests
   # @case_id OCP-10995
   @admin
   @destructive
-  Scenario: Check fluentd changes for common data model and index naming
+  Scenario: OCP-10995 Check fluentd changes for common data model and index naming
     Given I create a project with non-leading digit name
     And evaluation of `project` is stored in the :org_project clipboard
     When I run the :new_app client command with:

--- a/features/logging/install_uninstall.feature
+++ b/features/logging/install_uninstall.feature
@@ -4,7 +4,7 @@ Feature: install and uninstall related scenarios
   # @case_id OCP-11061
   @admin
   @destructive
-  Scenario: Deploy logging via Ansible: clean install when OPS cluster is enabled
+  Scenario: OCP-11061 Deploy logging via Ansible: clean install when OPS cluster is enabled
     Given I create a project with non-leading digit name
     Given the master version >= "3.5"
     And logging service is installed with ansible using:
@@ -18,7 +18,7 @@ Feature: install and uninstall related scenarios
   # @case_id OCP-12377
   @admin
   @destructive
-  Scenario: Uninstall logging via Ansible
+  Scenario: OCP-12377 Uninstall logging via Ansible
     Given the master version >= "3.5"
     Given I create a project with non-leading digit name
     # the clean up steps registered with the install step will be using uninstall
@@ -29,7 +29,7 @@ Feature: install and uninstall related scenarios
   # @case_id OCP-11431
   @admin
   @destructive
-  Scenario: Deploy logging via Ansible - clean install when OPS cluster is not enabled
+  Scenario: OCP-11431 Deploy logging via Ansible - clean install when OPS cluster is not enabled
     Given the master version >= "3.5"
     Given I create a project with non-leading digit name
     Given logging service is installed with ansible using:

--- a/features/metrics/install_uninstall.feature
+++ b/features/metrics/install_uninstall.feature
@@ -4,7 +4,7 @@ Feature: metrics logging and uninstall tests
   # @case_id OCP-12234
   @admin
   @destructive
-  Scenario: Metrics Admin Command - fresh deploy with default values
+  Scenario: OCP-12234 Metrics Admin Command - fresh deploy with default values
     Given I create a project with non-leading digit name
     Given the master version >= "3.5"
     And metrics service is installed with ansible using:
@@ -14,7 +14,7 @@ Feature: metrics logging and uninstall tests
   # @case_id OCP-12305
   @admin
   @destructive
-  Scenario: Metrics Admin Command - clean and install
+  Scenario: OCP-12305 Metrics Admin Command - clean and install
     Given the master version >= "3.5"
     Given I create a project with non-leading digit name
     And metrics service is installed with ansible using:
@@ -30,7 +30,7 @@ Feature: metrics logging and uninstall tests
   # @case_id OCP-10214
   @admin
   @destructive
-  Scenario: deploy metrics with dynamic volume
+  Scenario: OCP-10214 deploy metrics with dynamic volume
     Given the master version >= "3.5"
     Given I create a project with non-leading digit name
     And metrics service is installed with ansible using:
@@ -44,7 +44,7 @@ Feature: metrics logging and uninstall tests
   # @case_id OCP-17163
   @admin
   @destructive
-  Scenario: deploy metrics with dynamic volume along with OCP
+  Scenario: OCP-17163 deploy metrics with dynamic volume along with OCP
     Given the master version >= "3.7"
     Given I create a project with non-leading digit name
     And metrics service is installed in the system using:

--- a/features/metrics/system_metric.feature
+++ b/features/metrics/system_metric.feature
@@ -4,7 +4,7 @@ Feature: system metric related tests
   # @case_id OCP-15527
   @admin
   @destructive
-  Scenario: Deploy Prometheus via ansible with default values
+  Scenario: OCP-15527 Deploy Prometheus via ansible with default values
     Given the master version >= "3.7"
     Given I create a project with non-leading digit name
     And metrics service is installed with ansible using:
@@ -14,7 +14,7 @@ Feature: system metric related tests
   # @case_id OCP-10927
   @admin
   @destructive
-  Scenario: Access the external Hawkular Metrics API interface as cluster-admin
+  Scenario: OCP-10927 Access the external Hawkular Metrics API interface as cluster-admin
     Given I have a project
     Given metrics service is installed in the system using:
       | inventory       | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/logging_metrics/OCP-11821/inventory              |
@@ -51,7 +51,7 @@ Feature: system metric related tests
   @admin
   @destructive
   @smoke
-  Scenario: Access heapster interface,Check jboss wildfly version from hawkular-metrics pod logs
+  Scenario: OCP-14162 Access heapster interface,Check jboss wildfly version from hawkular-metrics pod logs
     Given I create a project with non-leading digit name
     Given metrics service is installed in the system using:
       | inventory       | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/logging_metrics/OCP-11821/inventory              |
@@ -87,7 +87,7 @@ Feature: system metric related tests
   # @case_id OCP-14519
   @admin
   @destructive
-  Scenario: Show CPU,memory, network metrics statistics on pod page of openshift web console
+  Scenario: OCP-14519 Show CPU,memory, network metrics statistics on pod page of openshift web console
     Given I create a project with non-leading digit name
     And metrics service is installed in the system
     And I switch to the first user

--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -4,7 +4,7 @@ Feature: Egress-ingress related networking scenarios
   # @case_id OCP-11639
   @admin
   @destructive
-  Scenario: EgressNetworkPolicy will not take effect after delete it
+  Scenario: OCP-11639 EgressNetworkPolicy will not take effect after delete it
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -40,7 +40,7 @@ Feature: Egress-ingress related networking scenarios
   # @author weliang@redhat.com
   # @case_id OCP-13502
   @admin
-  Scenario: Apply different egress network policy in different projects
+  Scenario: OCP-13502 Apply different egress network policy in different projects
     Given the env is using multitenant or networkpolicy network
     Given I have a project 
     Given I have a pod-for-ping in the project
@@ -103,7 +103,7 @@ Feature: Egress-ingress related networking scenarios
   # @author weliang@redhat.com
   # @case_id OCP-13507
   @admin
-  Scenario: The rules of egress network policy are added in openflow
+  Scenario: OCP-13507 The rules of egress network policy are added in openflow
     Given the env is using multitenant or networkpolicy network
     Given I have a project 
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -142,7 +142,7 @@ Feature: Egress-ingress related networking scenarios
   # @author weliang@redhat.com
   # @case_id OCP-13509
   @admin
-  Scenario: Egress network policy use dnsname with multiple ipv4 addresses
+  Scenario: OCP-13509 Egress network policy use dnsname with multiple ipv4 addresses
     Given the env is using multitenant or networkpolicy network
     Given I have a project  
     Given I have a pod-for-ping in the project
@@ -173,7 +173,7 @@ Feature: Egress-ingress related networking scenarios
   # @author weliang@redhat.com
   # @case_id OCP-15005
   @admin
-  Scenario: Service with a DNS name can not by pass Egressnetworkpolicy with that DNS name	
+  Scenario: OCP-15005 Service with a DNS name can not by pass Egressnetworkpolicy with that DNS name	
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -227,7 +227,7 @@ Feature: Egress-ingress related networking scenarios
   # @author weliang@redhat.com
   # @case_id OCP-15017
   @admin
-  Scenario: Add nodes local IP address to OVS rules for egressnetworkpolicy
+  Scenario: OCP-15017 Add nodes local IP address to OVS rules for egressnetworkpolicy
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project

--- a/features/networking/egress-ip.feature
+++ b/features/networking/egress-ip.feature
@@ -2,7 +2,7 @@ Feature: Egress IP related features
 
   # @author bmeng@redhat.com
   # @case_id OCP-15465
-  Scenario: Only cluster admin can add/remove egressIPs on hostsubnet
+  Scenario: OCP-15465 Only cluster admin can add/remove egressIPs on hostsubnet
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
 
@@ -16,7 +16,7 @@ Feature: Egress IP related features
 
   # @author bmeng@redhat.com
   # @case_id OCP-15466
-  Scenario: Only cluster admin can add/remove egressIPs on netnamespaces
+  Scenario: OCP-15466 Only cluster admin can add/remove egressIPs on netnamespaces
     # Try to add the egress ip to the netnamespace with normal user
     Given I have a project
     And evaluation of `project.name` is stored in the :project clipboard
@@ -30,7 +30,7 @@ Feature: Egress IP related features
   # @author bmeng@redhat.com
   # @case_id OCP-15471
   @admin
-  Scenario: All the pods egress connection will get out through the egress IP if the egress IP is set to netns and egress node can host the IP
+  Scenario: OCP-15471 All the pods egress connection will get out through the egress IP if the egress IP is set to netns and egress node can host the IP
     Given the cluster is running on OpenStack
     And the env is using multitenant or networkpolicy network
     Given I select a random node's host

--- a/features/networking/egress-router.feature
+++ b/features/networking/egress-router.feature
@@ -3,7 +3,7 @@ Feature: Egress router related features
   # @author bmeng@redhat.com
   # @case_id OCP-14106
   @admin
-  Scenario: User can use egress router as both initContainer mode and legacy mode
+  Scenario: OCP-14106 User can use egress router as both initContainer mode and legacy mode
     Given the cluster is running on OpenStack
     And the node's default gateway is stored in the clipboard
     And default router image is stored into the :router_image clipboard
@@ -37,7 +37,7 @@ Feature: Egress router related features
   # @author bmeng@redhat.com
   # @case_id OCP-14686
   @admin
-  Scenario: Multiple destination values for http proxy
+  Scenario: OCP-14686 Multiple destination values for http proxy
     Given the cluster is running on OpenStack
     And the node's default gateway is stored in the clipboard
     And default router image is stored into the :router_image clipboard
@@ -79,7 +79,7 @@ Feature: Egress router related features
   # @author bmeng@redhat.com
   # @case_id OCP-15056
   @admin
-  Scenario: Egress router works with multiple DNS names destination
+  Scenario: OCP-15056 Egress router works with multiple DNS names destination
     Given the cluster is running on OpenStack
     And the node's default gateway is stored in the clipboard
     And default router image is stored into the :router_image clipboard
@@ -133,7 +133,7 @@ Feature: Egress router related features
   # @author bmeng@redhat.com
   # @case_id OCP-15057
   @admin
-  Scenario: Egress router works with DNS names destination configured in ConfigMap
+  Scenario: OCP-15057 Egress router works with DNS names destination configured in ConfigMap
     Given the cluster is running on OpenStack
     And the node's default gateway is stored in the clipboard
     And default router image is stored into the :router_image clipboard

--- a/features/networking/isolation.feature
+++ b/features/networking/isolation.feature
@@ -3,7 +3,7 @@ Feature: networking isolation related scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-9565
   @admin
-  Scenario: The pods in default namespace can communicate with all the other pods
+  Scenario: OCP-9565 The pods in default namespace can communicate with all the other pods
     Given the env is using multitenant network
     Given I have a project
     And evaluation of `project.name` is stored in the :u1p1 clipboard
@@ -85,7 +85,7 @@ Feature: networking isolation related scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-9564
   @admin
-  Scenario: Only the pods nested in a same namespace can communicate with each other
+  Scenario: OCP-9564 Only the pods nested in a same namespace can communicate with each other
     Given the env is using multitenant network
     Given I have a project
     When I run the :create client command with:
@@ -125,7 +125,7 @@ Feature: networking isolation related scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-9641
   @admin
-  Scenario: Make the network of given project be accessible to other projects
+  Scenario: OCP-9641 Make the network of given project be accessible to other projects
     # Create 3 projects and each contains 1 pod and 1 service
     Given the env is using multitenant network
     Given I have a project
@@ -275,7 +275,7 @@ Feature: networking isolation related scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-12659
   @admin
-  Scenario: Make the network of given projects be accessible globally
+  Scenario: OCP-12659 Make the network of given projects be accessible globally
     # Create 3 projects and each contains 1 pod and 1 service
     Given the env is using multitenant network
     Given I have a project
@@ -399,7 +399,7 @@ Feature: networking isolation related scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-9646
   @admin
-  Scenario: Isolate the network for the project which already make network global
+  Scenario: OCP-9646 Isolate the network for the project which already make network global
     Given the env is using multitenant network
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard

--- a/features/networking/multicast.feature
+++ b/features/networking/multicast.feature
@@ -3,7 +3,7 @@ Feature: testing multicast scenarios
   # @author hongli@redhat.com
   # @case_id OCP-12926
   @admin
-  Scenario: pods should be able to subscribe send and receive multicast traffic
+  Scenario: OCP-12926 pods should be able to subscribe send and receive multicast traffic
     Given the env is using multitenant or networkpolicy network
 
     # create some multicast testing pods
@@ -85,7 +85,7 @@ Feature: testing multicast scenarios
   # @author hongli@redhat.com
   # @case_id OCP-12977
   @admin
-  Scenario: multicast is disabled by default if not annotate the netnamespace
+  Scenario: OCP-12977 multicast is disabled by default if not annotate the netnamespace
     Given the env is using multitenant or networkpolicy network
 
     # create multicast testing pods in the project and without multicast enable

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -3,7 +3,7 @@ Feature: Pod related networking scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-9747
   @admin
-  Scenario: Pod cannot claim UDP port 4789 on the node as part of a port mapping
+  Scenario: OCP-9747 Pod cannot claim UDP port 4789 on the node as part of a port mapping
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     When I run the :create client command with:
@@ -20,7 +20,7 @@ Feature: Pod related networking scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-9802
   @admin
-  Scenario: The user created docker container in openshift cluster should have outside network access
+  Scenario: OCP-9802 The user created docker container in openshift cluster should have outside network access
     Given I select a random node's host
     And I run commands on the host:
       | docker run -td --name=test-container bmeng/hello-openshift |
@@ -39,7 +39,7 @@ Feature: Pod related networking scenarios
   # @author yadu@redhat.com
   # @case_id OCP-10031
   @smoke
-  Scenario: Container could reach the dns server
+  Scenario: OCP-10031 Container could reach the dns server
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/tc528410/tc_528410_pod.json |
@@ -55,7 +55,7 @@ Feature: Pod related networking scenarios
   # @author yadu@redhat.com
   # @case_id OCP-14986
   @admin
-  Scenario: The openflow list will be cleaned after delete the pods
+  Scenario: OCP-14986 The openflow list will be cleaned after delete the pods
     Given I have a project
     Given I have a pod-for-ping in the project
     Then I use the "<%= pod.node_name(user: user) %>" node
@@ -78,7 +78,7 @@ Feature: Pod related networking scenarios
   # @case_id OCP-16729
   @admin
   @destructive
-  Scenario: KUBE-HOSTPORTS chain rules won't be flushing when there is no pod with hostPort
+  Scenario: OCP-16729 KUBE-HOSTPORTS chain rules won't be flushing when there is no pod with hostPort
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I store the schedulable nodes in the :nodes clipboard
@@ -133,7 +133,7 @@ Feature: Pod related networking scenarios
   # @auther bmeng@redhat.com
   # @case_id OCP-10817
   @admin
-  Scenario: Check QoS after creating pod
+  Scenario: OCP-10817 Check QoS after creating pod
     Given I have a project
     # setup iperf server to receive the traffic
     When I run the :create client command with:
@@ -193,7 +193,7 @@ Feature: Pod related networking scenarios
   # @author anusaxen@redhat.com
   # @case_id OCP-19810
   @admin
-  Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted
+  Scenario: OCP-19810 Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted
     Given the master version <= "3.11"
     Given I store the schedulable nodes in the :nodes clipboard
     Given I use the "<%= cb.nodes[0].name %>" node

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -4,7 +4,7 @@ Feature: SDN related networking scenarios
   # @case_id OCP-10025
   @admin
   @destructive
-  Scenario: kubelet proxy could change to userspace mode
+  Scenario: OCP-10025 kubelet proxy could change to userspace mode
     Given the env is using one of the listed network plugins:
       | subnet      |
       | multitenant |
@@ -37,7 +37,7 @@ Feature: SDN related networking scenarios
   # @case_id OCP-11286
   @admin
   @destructive
-  Scenario: iptables rules will be repaired automatically once it gets destroyed
+  Scenario: OCP-11286 iptables rules will be repaired automatically once it gets destroyed
     Given I select a random node's host
     And the node iptables config is verified
     And the node service is restarted on the host after scenario
@@ -49,7 +49,7 @@ Feature: SDN related networking scenarios
   # @author hongli@redhat.com
   # @case_id OCP-13847
   @admin
-  Scenario: an empty OPENSHIFT-ADMIN-OUTPUT-RULES chain is created in filter table at startup
+  Scenario: OCP-13847 an empty OPENSHIFT-ADMIN-OUTPUT-RULES chain is created in filter table at startup
     Given the master version >= "3.6"
     Given I select a random node's host
     And the node service is verified
@@ -65,7 +65,7 @@ Feature: SDN related networking scenarios
   # @case_id OCP-16217
   @admin
   @destructive
-  Scenario: SDN will detect the version and plugin type mismatch in openflow and restart node automatically
+  Scenario: OCP-16217 SDN will detect the version and plugin type mismatch in openflow and restart node automatically
     Given the master version >= "3.10"
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :node_name clipboard
@@ -128,7 +128,7 @@ Feature: SDN related networking scenarios
   # @case_id OCP-15251
   @admin
   @destructive
-  Scenario: net.ipv4.ip_forward should be always enabled on node service startup
+  Scenario: OCP-15251 net.ipv4.ip_forward should be always enabled on node service startup
     Given I select a random node's host
     And the node service is verified
     And the node network is verified
@@ -161,7 +161,7 @@ Feature: SDN related networking scenarios
   # @case_id OCP-14985
   @admin
   @destructive
-  Scenario: The openflow list will be cleaned after deleted the node
+  Scenario: OCP-14985 The openflow list will be cleaned after deleted the node
     Given environment has at least 2 nodes
     And I store the nodes in the :nodes clipboard
     Given I switch to cluster admin pseudo user
@@ -207,7 +207,7 @@ Feature: SDN related networking scenarios
   # @author hongli@redhat.com
   # @case_id OCP-18535
   @admin
-  Scenario: should not show "No such device" message when run "ovs-vsctl show" command
+  Scenario: OCP-18535 should not show "No such device" message when run "ovs-vsctl show" command
     Given I have a project
     And I have a pod-for-ping in the project
     Then I use the "<%= pod.node_name(user: user) %>" node

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -3,7 +3,7 @@ Feature: Service related networking scenarios
   # @author yadu@redhat.com
   # @case_id OCP-9604
   @admin
-  Scenario: tenants can access their own services
+  Scenario: OCP-9604 tenants can access their own services
     # create pod and service in project1
     Given the env is using multitenant network
     Given I have a project
@@ -45,7 +45,7 @@ Feature: Service related networking scenarios
   # @case_id OCP-9977
   @admin
   @destructive
-  Scenario: Create service with external IP
+  Scenario: OCP-9977 Create service with external IP
     Given master config is merged with the following hash:
     """
     networkConfig:
@@ -80,7 +80,7 @@ Feature: Service related networking scenarios
   # @author yadu@redhat.com
   # @case_id OCP-15032
   @admin
-  Scenario: The openflow list will be cleaned after delete the services
+  Scenario: OCP-15032 The openflow list will be cleaned after delete the services
     Given the env is using one of the listed network plugins:
       | subnet      |
       | multitenant |

--- a/features/node/node.feature
+++ b/features/node/node.feature
@@ -3,7 +3,7 @@ Feature: Node management
   # @author chaoyang@redhat.com
   # @case_id OCP-11084
   @admin
-  Scenario: admin can get nodes
+  Scenario: OCP-11084 admin can get nodes
     Given I have a project
     When I run the :get admin command with:
       |resource|nodes|
@@ -14,7 +14,7 @@ Feature: Node management
   # @case_id OCP-15111
   @admin
   @destructive
-  Scenario: Pod will be OOMKilled when memory request is more than node allocatable
+  Scenario: OCP-15111 Pod will be OOMKilled when memory request is more than node allocatable
     Given I have a project
     # Make sure when there are multi-node, you just modify one and schedule pods here
     Given I store the schedulable nodes in the :nodes clipboard

--- a/features/node/seccomp.feature
+++ b/features/node/seccomp.feature
@@ -2,7 +2,7 @@ Feature: Seccomp
 
   # @author wmeng@redhat.com
   # @case_id OCP-10483
-  Scenario: seccomp=unconfined used by default
+  Scenario: OCP-10483 seccomp=unconfined used by default
     Given I have a project
     When I run the :create client command with:
       | filename  | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/hello-pod.json |

--- a/features/online/accountant.feature
+++ b/features/online/accountant.feature
@@ -2,7 +2,7 @@ Feature: ONLY Accountant console related feature's scripts in this file
 
   # @author xiaocwan@redhat.com
   # @case_id OCP-12754
-  Scenario: Cancel and resume service - UI
+  Scenario: OCP-12754 Cancel and resume service - UI
     Given I open accountant console in a browser
     When I run the :click_to_change_plan web action
     Then the step should succeed
@@ -23,7 +23,7 @@ Feature: ONLY Accountant console related feature's scripts in this file
   # @author yuwan@redhat.com
   # @case_id OCP-12758
   # @note this scenario requires a user who have pro cluster(1) left to resigster
-  Scenario: an existed Red Hat account's contact details can be pre-populated to accountant profile during registration
+  Scenario: OCP-12758 an existed Red Hat account's contact details can be pre-populated to accountant profile during registration
     Given I open accountant console in a browser
     When I run the :go_to_register_pro_cluster_page web action
     Then the step should succeed

--- a/features/online/build.feature
+++ b/features/online/build.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE related feature's scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-9781
-  Scenario: cli disables Docker builds and custom builds and allow only sti builds
+  Scenario: OCP-9781 cli disables Docker builds and custom builds and allow only sti builds
     Given I have a project
     When I run the :new_build client command with:
       | app_repo | centos/ruby-22-centos7~https://github.com/openshift/ruby-hello-world.git |

--- a/features/online/check_link.feature
+++ b/features/online/check_link.feature
@@ -2,7 +2,7 @@ Feature: Check links in Openshift
 
   # @author yasun@redhat.com
   # @case_id OCP-9873
-  Scenario: Check the CLI download links on web page
+  Scenario: OCP-9873 Check the CLI download links on web page
     When I run the :version client command
     Then the step should succeed
     And evaluation of `@result[:props][:openshift_server_version]` is stored in the :server_version clipboard

--- a/features/online/create.feature
+++ b/features/online/create.feature
@@ -38,7 +38,7 @@ Feature: ONLY ONLINE Create related feature's scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-10270
-  Scenario: Create Laravel application with a MySQL database using default template laravel-mysql-example
+  Scenario: OCP-10270 Create Laravel application with a MySQL database using default template laravel-mysql-example
     Given I have a project
     Then I run the :new_app client command with:
       | template | laravel-mysql-persistent |
@@ -52,7 +52,7 @@ Feature: ONLY ONLINE Create related feature's scripts in this file
 
   # @author yuwan@redhat.com
   # @case_id OCP-12687
-  Scenario: PyPi index can be used to providing dependencies for django-psql-example template	
+  Scenario: OCP-12687 PyPi index can be used to providing dependencies for django-psql-example template	
     Given I have a project
     When I run the :new_app client command with:
       | template | django-psql-persistent                                               |

--- a/features/online/deploy.feature
+++ b/features/online/deploy.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Deployment related scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-10075
-  Scenario: OSO Starter Specify resource constraints for standalone dc and rc in web console with project limits already set
+  Scenario: OCP-10075 OSO Starter Specify resource constraints for standalone dc and rc in web console with project limits already set
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/dc-with-two-containers.yaml |
@@ -148,7 +148,7 @@ Feature: ONLY ONLINE Deployment related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-14969
-  Scenario: OSO Pro Specify resource constraints for standalone dc and rc in web console with project limits already set
+  Scenario: OCP-14969 OSO Pro Specify resource constraints for standalone dc and rc in web console with project limits already set
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/dc-with-two-containers.yaml |

--- a/features/online/fuse.feature
+++ b/features/online/fuse.feature
@@ -3,7 +3,7 @@ Feature: ONLY Fuse Plan related scripts in this file
   # @author yuwan@redhat.com
   # @case_id OCP-20439
   # @note this scenario requires a user who have pro cluster(1) left to resigster
-  Scenario: an existed Red Hat account's contact details can be pre-populated to accountant profile during registration - Fuse
+  Scenario: OCP-20439 an existed Red Hat account's contact details can be pre-populated to accountant profile during registration - Fuse
     Given I open accountant console in a browser
     When I run the :go_to_register_fuse_profile_page web action
     Then the step should succeed

--- a/features/online/images.feature
+++ b/features/online/images.feature
@@ -3,7 +3,7 @@ Feature: ONLY ONLINE Images related scripts in this file
   # @author etrott@redhat.com
   # @case_id OCP-11614
   @smoke
-  Scenario: Create mongo resources with persistent template for mongodb-32-rhel7 images
+  Scenario: OCP-11614 Create mongo resources with persistent template for mongodb-32-rhel7 images
     Given I have a project
     Then I run the :new_app client command with:
       | template | mongodb-persistent           |
@@ -25,7 +25,7 @@ Feature: ONLY ONLINE Images related scripts in this file
   # @author etrott@redhat.com
   # @case_id OCP-10144
   @smoke
-  Scenario: Add env variables to postgresql-95-rhel7 image
+  Scenario: OCP-10144 Add env variables to postgresql-95-rhel7 image
     Given I have a project
     When I run the :new_app client command with:
       | name  | psql                           |
@@ -68,7 +68,7 @@ Feature: ONLY ONLINE Images related scripts in this file
   # @author etrott@redhat.com
   # @case_id OCP-10147
   @smoke
-  Scenario: Verify Mariadb can be connected after admin and user password are changed and re-deployment for persistent storage - marialdb-101-rhel7
+  Scenario: OCP-10147 Verify Mariadb can be connected after admin and user password are changed and re-deployment for persistent storage - marialdb-101-rhel7
     Given I have a project
     And I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/templates/tc532739/mariadb-persistent.json |
@@ -115,7 +115,7 @@ Feature: ONLY ONLINE Images related scripts in this file
 
     # @author etrott@redhat.com
     # @case_id OCP-12681
-    Scenario: mem based auto-tuning mariadb
+    Scenario: OCP-12681 mem based auto-tuning mariadb
       Given I have a project
       When I run the :new_app client command with:
         | name  | mariadb                  |

--- a/features/online/imagestreams.feature
+++ b/features/online/imagestreams.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Imagestreams related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-10509
-  Scenario: Check Online Pro default images
+  Scenario: OCP-10509 Check Online Pro default images
     When I run the :get client command with:
       | resource      | imagestreamtag  |
       | n             | openshift       |
@@ -81,7 +81,7 @@ Feature: ONLY ONLINE Imagestreams related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-17285
-  Scenario: Check Online Starter default images
+  Scenario: OCP-17285 Check Online Starter default images
     When I run the :get client command with:
       | resource      | imagestreamtag  |
       | n             | openshift       |

--- a/features/online/infra.feature
+++ b/features/online/infra.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Infra related scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-10142
-  Scenario: User cannot deploy a pod to an infra node
+  Scenario: OCP-10142 User cannot deploy a pod to an infra node
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/pods/tc532324/pod_nodeSelector_infra.yaml |
@@ -12,7 +12,7 @@ Feature: ONLY ONLINE Infra related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-11230
-  Scenario: Specify runtime duration of run-once pods globally in master config
+  Scenario: OCP-11230 Specify runtime duration of run-once pods globally in master config
     Given I have a project
     When I run the :run client command with:
       | name    | run-once-pod     |

--- a/features/online/logging.feature
+++ b/features/online/logging.feature
@@ -2,7 +2,7 @@ Feature: online logging tests
 
   # @author pruan@redhat.com
   # @case_id OCP-10767
-  Scenario: Logout kibana web console
+  Scenario: OCP-10767 Logout kibana web console
     Given I create a project with non-leading digit name
     Given I login to kibana logging web console
     When I perform the :logout_kibana web action with:

--- a/features/online/metrics.feature
+++ b/features/online/metrics.feature
@@ -2,7 +2,7 @@ Feature: Online metrics related tests
 
   # @author pruan@redhat.com
   # @case_id OCP-15214
-  Scenario: Ordinary user could view CPU,memory, network metrics statistics on pod page of openshift web console
+  Scenario: OCP-15214 Ordinary user could view CPU,memory, network metrics statistics on pod page of openshift web console
     Given I have a project
     Given I login via web console
     When I run the :create client command with:

--- a/features/online/notification.feature
+++ b/features/online/notification.feature
@@ -2,7 +2,7 @@ Feature: Online "Notification" related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-12870
-  Scenario: Notification UI should correctly display in web console
+  Scenario: OCP-12870 Notification UI should correctly display in web console
     Given I have a project
     When I perform the :check_notification_message web console action with:
       | project_name | <%= project.name %> |
@@ -12,7 +12,7 @@ Feature: Online "Notification" related scripts in this file
   # @author bingli@redhat.com
   # @case_id OCP-10334
   # @case_id OCP-10341
-  Scenario: Enable/Disable online notification in web console - UI
+  Scenario: OCP-10334 Enable/Disable online notification in web console - UI
     Given I have a project
     When I perform the :goto_notification_page web console action with:
       | project_name | <%= project.name %> |

--- a/features/online/projects.feature
+++ b/features/online/projects.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Projects related feature's scripts in this file
 
   # @author etrott@redhat.com
   # @case_id OCP-12547
-  Scenario: Should use and show the existing projects after the user login
+  Scenario: OCP-12547 Should use and show the existing projects after the user login
     Given I create a new project
     When I run the :login client command with:
       | server   | <%= env.api_endpoint_url %>         |
@@ -45,7 +45,7 @@ Feature: ONLY ONLINE Projects related feature's scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-14100
-  Scenario: Should use and show the existing projects after the user login - starter
+  Scenario: OCP-14100 Should use and show the existing projects after the user login - starter
     When I run the :login client command with:
       | server   | <%= env.api_endpoint_url %>         |
       | token    | <%= user.cached_tokens.first %>  |
@@ -65,7 +65,7 @@ Feature: ONLY ONLINE Projects related feature's scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-13073
-  Scenario: a new paid-user can not create muti-projects exceed the selected plan limitation
+  Scenario: OCP-13073 a new paid-user can not create muti-projects exceed the selected plan limitation
     Given I run the steps <%= user.plan.max_projects %> times:
     """
       Given I create a new project

--- a/features/online/quota.feature
+++ b/features/online/quota.feature
@@ -3,7 +3,7 @@ Feature: ONLY ONLINE Quota related scripts in this file
   # @author bingli@redhat.com
   # @case_id OCP-13171
   # @case_id OCP-12700
-  Scenario: CRUD operation to the resource quota as project owner
+  Scenario: OCP-13171 CRUD operation to the resource quota as project owner
     Given I have a project
     When I run the :describe client command with:
       | resource | rolebinding   |
@@ -72,7 +72,7 @@ Feature: ONLY ONLINE Quota related scripts in this file
 
   # @author yuwei@redhat.com
   # @case_id OCP-10291
-  Scenario: Can not create resource exceed the hard quota in appliedclusterresourcequota  
+  Scenario: OCP-10291 Can not create resource exceed the hard quota in appliedclusterresourcequota  
     Given I have a project  
     And evaluation of `BushSlicer::AppliedClusterResourceQuota.list(user: user, project: project)` is stored in the :acrq clipboard
     And evaluation of `cb.acrq.find{|o|o.name.end_with?("-compute")}` is stored in the :memory_crq clipboard

--- a/features/online/rolebindingrestriction.feature
+++ b/features/online/rolebindingrestriction.feature
@@ -71,7 +71,7 @@ Feature: rolebindingrestriction.feature
 
   # @author zhaliu@redhat.com
   # @case_id OCP-13798
-  Scenario: After the project is deleted the rolebindingrestriction will be deleted too
+  Scenario: OCP-13798 After the project is deleted the rolebindingrestriction will be deleted too
     Given I have a project
     And evaluation of `project.name` is stored in the :project_name clipboard
     When I run the :get client command with:

--- a/features/online/route.feature
+++ b/features/online/route.feature
@@ -2,7 +2,7 @@ Feature: Route test in online environments
 
   # @author zhaliu@redhat.com
   # @case_id OCP-16320
-  Scenario: Custom hostname is prohibited for passthrough terminated route
+  Scenario: OCP-16320 Custom hostname is prohibited for passthrough terminated route
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/passthrough/service_secure.json |
@@ -21,7 +21,7 @@ Feature: Route test in online environments
 
   # @author zhaliu@redhat.com
   # @case_id OCP-16318
-  Scenario: Custom hostname is prohibited for unsecure route
+  Scenario: OCP-16318 Custom hostname is prohibited for unsecure route
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/unsecure/service_unsecure.json |
@@ -42,7 +42,7 @@ Feature: Route test in online environments
 
   # @author zhaliu@redhat.com
   # @case_id OCP-16319
-  Scenario: Custom hostname and cert are prohibited for edge terminated route
+  Scenario: OCP-16319 Custom hostname and cert are prohibited for edge terminated route
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/edge/service_unsecure.json |
@@ -83,7 +83,7 @@ Feature: Route test in online environments
 
   # @author zhaliu@redhat.com
   # @case_id OCP-16321
-  Scenario: Custom hostname and cert are prohibited for reencrypt terminated route
+  Scenario: OCP-16321 Custom hostname and cert are prohibited for reencrypt terminated route
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/reencrypt/reencrypt-without-all-cert.yaml |

--- a/features/online/storage.feature
+++ b/features/online/storage.feature
@@ -2,7 +2,7 @@ Feature: ONLY ONLINE Storage related scripts in this file
 
   # @author bingli@redhat.com
   # @case_id OCP-9967
-  Scenario: Delete pod with mounting error
+  Scenario: OCP-9967 Delete pod with mounting error
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/online/tc526564/pod_volumetest.json |
@@ -35,7 +35,7 @@ Feature: ONLY ONLINE Storage related scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-9809
-  Scenario: Pod should not create directories within /var/lib/docker/volumes/ on nodes
+  Scenario: OCP-9809 Pod should not create directories within /var/lib/docker/volumes/ on nodes
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/online/tc526564/pod_volumetest.json |
@@ -57,7 +57,7 @@ Feature: ONLY ONLINE Storage related scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-13108
-  Scenario: Basic user could not get pv object info
+  Scenario: OCP-13108 Basic user could not get pv object info
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/ebs/claim.json" replacing paths:
       | ["metadata"]["name"]                           | ebsc-<%= project.name %> |
@@ -97,7 +97,7 @@ Feature: ONLY ONLINE Storage related scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-9923
-  Scenario: Claim requesting to get the maximum capacity
+  Scenario: OCP-9923 Claim requesting to get the maximum capacity
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/online/dynamic_persistent_volumes/pvc-equal.yaml |
@@ -150,7 +150,7 @@ Feature: ONLY ONLINE Storage related scripts in this file
 
   # @author yasun@redhat.com
   # @case_id OCP-9792
-  Scenario: Volume emptyDir is limited in the Pod in online openshift
+  Scenario: OCP-9792 Volume emptyDir is limited in the Pod in online openshift
     Given I have a project
     And evaluation of `project.mcs(user: user)` is stored in the :proj_selinux_options clipboard
     And evaluation of `project.supplemental_groups(user: user).begin` is stored in the :supplemental_groups clipboard

--- a/features/registry/is.feature
+++ b/features/registry/is.feature
@@ -4,7 +4,7 @@ Feature: Testing imagestream
   # @case_id OCP-13895
   @destructive
   @admin
-  Scenario: Should prune the extenal image correctly
+  Scenario: OCP-13895 Should prune the extenal image correctly
     And default docker-registry route is stored in the :registry_hostname clipboard
     Given I have a project
     And I have a skopeo pod in the project

--- a/features/registry/registry.feature
+++ b/features/registry/registry.feature
@@ -4,7 +4,7 @@ Feature: Testing registry
   # @case_id OCP-12400
   @admin
   @destructive
-  Scenario: Prune images by command oadm_prune_images
+  Scenario: OCP-12400 Prune images by command oadm_prune_images
     Given cluster role "system:image-pruner" is added to the "first" user
     And default docker-registry route is stored in the :registry_ip clipboard
     And I have a project
@@ -45,7 +45,7 @@ Feature: Testing registry
   # @author haowang@redhat.com
   # @case_id OCP-11310
   @admin
-  Scenario: Have size information for images pushed to internal registry
+  Scenario: OCP-11310 Have size information for images pushed to internal registry
     Given I have a project
     And I find a bearer token of the builder service account
     And default docker-registry route is stored in the :registry_ip clipboard

--- a/features/registry/remote.feature
+++ b/features/registry/remote.feature
@@ -3,7 +3,7 @@ Feature: remote registry related scenarios
   # @author pruan@redhat.com
   # @case_id OCP-11235
   @admin
-  Scenario: Pull image by digest value in the OpenShift registry
+  Scenario: OCP-11235 Pull image by digest value in the OpenShift registry
     Given I have a project
     And I find a bearer token of the deployer service account
     When I run the :tag client command with:
@@ -30,7 +30,7 @@ Feature: remote registry related scenarios
   # @author yinzhou@redhat.com
   # @case_id OCP-10636
   @admin
-  Scenario: User should be denied pushing when it does not have 'admin' role
+  Scenario: OCP-10636 User should be denied pushing when it does not have 'admin' role
     Given I have a project
     And default docker-registry route is stored in the :integrated_reg_ip clipboard
     And I give project view role to the second user
@@ -71,7 +71,7 @@ Feature: remote registry related scenarios
   # @author yinzhou@redhat.com
   # @case_id OCP-11113
   @admin
-  Scenario: Tracking tags with imageStream spec.tag
+  Scenario: OCP-11113 Tracking tags with imageStream spec.tag
     Given I have a project
     Given default docker-registry route is stored in the :integrated_reg_ip clipboard
     When I run the :create client command with:
@@ -103,7 +103,7 @@ Feature: remote registry related scenarios
   # @author yinzhou@redhat.com
   # @case_id OCP-10904
   @admin
-  Scenario: Support unauthenticated with registry-admin role
+  Scenario: OCP-10904 Support unauthenticated with registry-admin role
     Given I have a project
     When I run the :policy_add_role_to_user client command with:
       | role            | registry-admin   |

--- a/features/rest/webhook.feature
+++ b/features/rest/webhook.feature
@@ -49,7 +49,7 @@ Feature: Webhook REST Related Tests
 
   # @author cryan@redhat.com
   # @case_id OCP-11270
-  Scenario: New parameter can be passed via generic webhook
+  Scenario: OCP-11270 New parameter can be passed via generic webhook
     Given I have a project
     When I run the :new_app client command with:
       | file | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/ruby22rhel7-template-sti.json |

--- a/features/routing/abrouting.feature
+++ b/features/routing/abrouting.feature
@@ -2,7 +2,7 @@ Feature: Testing abrouting
 
   # @author yadu@redhat.com
   # @case_id OCP-12076
-  Scenario: Set backends weight for unsecure route
+  Scenario: OCP-12076 Set backends weight for unsecure route
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/abrouting/caddy-docker.json |
@@ -80,7 +80,7 @@ Feature: Testing abrouting
 
   # @author yadu@redhat.com
   # @case_id OCP-11970
-  Scenario: Set backends weight for reencrypt route
+  Scenario: OCP-11970 Set backends weight for reencrypt route
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -186,7 +186,7 @@ Feature: Testing abrouting
   # @author yadu@redhat.com
   # @case_id OCP-13519
   @admin
-  Scenario: The edge route with multiple service will set load balance policy to RoundRobin by default
+  Scenario: OCP-13519 The edge route with multiple service will set load balance policy to RoundRobin by default
     #Create pod/service/route
     Given I have a project
     When I run the :create client command with:
@@ -272,7 +272,7 @@ Feature: Testing abrouting
 
   # @author yadu@redhat.com
   # @case_id OCP-15910
-  Scenario: Each endpoint gets weight/numberOfEndpoints portion of the requests - unsecure route
+  Scenario: OCP-15910 Each endpoint gets weight/numberOfEndpoints portion of the requests - unsecure route
     # Create pods and services
     Given I have a project
     When I run the :create client command with:
@@ -341,7 +341,7 @@ Feature: Testing abrouting
 
   # @author yadu@redhat.com
   # @case_id OCP-15994
-  Scenario: Each endpoint gets weight/numberOfEndpoints portion of the requests - passthrough route
+  Scenario: OCP-15994 Each endpoint gets weight/numberOfEndpoints portion of the requests - passthrough route
     # Create pods and services
     Given I have a project
     When I run the :create client command with:

--- a/features/routing/config-manager.feature
+++ b/features/routing/config-manager.feature
@@ -4,7 +4,7 @@ Feature: Testing HAProxy dynamic configuration manager related scenarios
   # @case_id OCP-19863
   @admin
   @destructive
-  Scenario: unsecured route support haproxy dynamic changes
+  Scenario: OCP-19863 unsecured route support haproxy dynamic changes
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
     And I use the router project
@@ -37,7 +37,7 @@ Feature: Testing HAProxy dynamic configuration manager related scenarios
   # @case_id OCP-19864
   @admin
   @destructive
-  Scenario: edge route support haproxy dynamic changes
+  Scenario: OCP-19864 edge route support haproxy dynamic changes
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
     And I use the router project
@@ -72,7 +72,7 @@ Feature: Testing HAProxy dynamic configuration manager related scenarios
   # @case_id OCP-19865
   @admin
   @destructive
-  Scenario: passthrough route support haproxy dynamic changes
+  Scenario: OCP-19865 passthrough route support haproxy dynamic changes
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
     And I use the router project

--- a/features/routing/f5-router.feature
+++ b/features/routing/f5-router.feature
@@ -4,7 +4,7 @@ Feature: F5 router related scenarios
   # @case_id OCP-24080
   @admin
   @destructive
-  Scenario: the f5 router image should contains openssh-clients package
+  Scenario: OCP-24080 the f5 router image should contains openssh-clients package
     Given I switch to cluster admin pseudo user
     And I use the router project
     And default router image is stored into the :router_image clipboard

--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -3,7 +3,7 @@ Feature: Testing haproxy router
   # @author zzhao@redhat.com
   # @case_id OCP-9736
   @admin
-  Scenario: HTTP response header should return for default haproxy 503
+  Scenario: OCP-9736 HTTP response header should return for default haproxy 503
     Given I switch to cluster admin pseudo user
     And I use the router project
     And all default router pods become ready
@@ -14,7 +14,7 @@ Feature: Testing haproxy router
   # @author bmeng@redhat.com
   # @case_id OCP-11903
   @smoke
-  Scenario: haproxy cookies based sticky session for unsecure routes
+  Scenario: OCP-11903 haproxy cookies based sticky session for unsecure routes
     #create route and service which has two endpoints
     Given I have a project
     When I run the :create client command with:
@@ -67,7 +67,7 @@ Feature: Testing haproxy router
 
   # @author bmeng@redhat.com
   # @case_id OCP-11130
-  Scenario: haproxy cookies based sticky session for edge termination routes
+  Scenario: OCP-11130 haproxy cookies based sticky session for edge termination routes
     #create route and service which has two endpoints
     Given I have a project
     When I run the :create client command with:
@@ -127,7 +127,7 @@ Feature: Testing haproxy router
   # @case_id OCP-11583
   @admin
   @destructive
-  Scenario: Router with specific ROUTE_LABELS will only work for specific routes
+  Scenario: OCP-11583 Router with specific ROUTE_LABELS will only work for specific routes
     Given admin ensures new router pod becomes ready after following env added:
       | ROUTE_LABELS=router=router1 |
 
@@ -201,7 +201,7 @@ Feature: Testing haproxy router
   # @case_id OCP-11549
   @admin
   @destructive
-  Scenario: Haproxy router health check will use 1936 port if user disable the stats port
+  Scenario: OCP-11549 Haproxy router health check will use 1936 port if user disable the stats port
     Given I switch to cluster admin pseudo user
     And I use the router project
     And default router image is stored into the :default_router_image clipboard
@@ -230,7 +230,7 @@ Feature: Testing haproxy router
   # @case_id OCP-12651
   @admin
   @destructive
-  Scenario: The route auto generated can be accessed using the default cert
+  Scenario: OCP-12651 The route auto generated can be accessed using the default cert
     Given I switch to cluster admin pseudo user
     And I use the router project
     And default router image is stored into the :default_router_image clipboard
@@ -291,7 +291,7 @@ Feature: Testing haproxy router
   # @case_id OCP-11236
   @admin
   @destructive
-  Scenario: Set reload time for haproxy router script - Create routes
+  Scenario: OCP-11236 Set reload time for haproxy router script - Create routes
     # prepare router
     Given default router is disabled and replaced by a duplicate
     And I switch to cluster admin pseudo user
@@ -388,7 +388,7 @@ Feature: Testing haproxy router
 
   # @author bmeng@redhat.com
   # @case_id OCP-11619
-  Scenario: Limit the number of TCP connection per IP in specified time period
+  Scenario: OCP-11619 Limit the number of TCP connection per IP in specified time period
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/caddy-docker.json |
@@ -433,7 +433,7 @@ Feature: Testing haproxy router
   # @author hongli@redhat.com
   # @case_id OCP-15044
   @admin
-  Scenario: The backend health check interval of unsecure route can be set by annotation
+  Scenario: OCP-15044 The backend health check interval of unsecure route can be set by annotation
     Given I switch to cluster admin pseudo user
     And I use the router project
     Given all default router pods become ready
@@ -471,7 +471,7 @@ Feature: Testing haproxy router
   # @author hongli@redhat.com
   # @case_id OCP-15049
   @admin
-  Scenario: The backend health check interval of edge route can be set by annotation
+  Scenario: OCP-15049 The backend health check interval of edge route can be set by annotation
     Given I switch to cluster admin pseudo user
     And I use the router project
     Given all default router pods become ready
@@ -509,7 +509,7 @@ Feature: Testing haproxy router
 
   # @author bmeng@redhat.com
   # @case_id OCP-10043
-  Scenario: Set balance leastconn for passthrough routes
+  Scenario: OCP-10043 Set balance leastconn for passthrough routes
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -557,7 +557,7 @@ Feature: Testing haproxy router
 
   # @author yadu@redhat.com
   # @case_id OCP-11679
-  Scenario: Disable haproxy hash based sticky session for unsecure routes
+  Scenario: OCP-11679 Disable haproxy hash based sticky session for unsecure routes
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/caddy-docker.json |
@@ -597,7 +597,7 @@ Feature: Testing haproxy router
   # @case_id OCP-11437
   @admin
   @destructive
-  Scenario: the routes should be loaded on initial sync
+  Scenario: OCP-11437 the routes should be loaded on initial sync
     Given I have a project
     And evaluation of `project.name` is stored in the :proj_name clipboard
     When I run the :create client command with:
@@ -634,7 +634,7 @@ Feature: Testing haproxy router
   # @case_id OCP-12923
   @admin
   @destructive
-  Scenario: same host with different path can be admitted
+  Scenario: OCP-12923 same host with different path can be admitted
     Given admin ensures new router pod becomes ready after following env added:
       | ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK=true  |
 
@@ -731,7 +731,7 @@ Feature: Testing haproxy router
 
   # @author hongli@redhat.com
   # @case_id OCP-15872
-  Scenario: can set cookie name for unsecure routes by annotation
+  Scenario: OCP-15872 can set cookie name for unsecure routes by annotation
     #create route and service which has two endpoints
     Given the master version >= "3.7"
     Given I have a project
@@ -773,7 +773,7 @@ Feature: Testing haproxy router
 
   # @author hongli@redhat.com
   # @case_id OCP-15873
-  Scenario: can set cookie name for edge routes by annotation
+  Scenario: OCP-15873 can set cookie name for edge routes by annotation
     #create route and service which has two endpoints
     Given the master version >= "3.7"
     Given I have a project
@@ -820,7 +820,7 @@ Feature: Testing haproxy router
   # @case_id OCP-15457
   @admin
   @destructive
-  Scenario: The router configuration should be loaded immediately after the namespace label added
+  Scenario: OCP-15457 The router configuration should be loaded immediately after the namespace label added
     Given the master version >= "3.7"
     Given admin ensures new router pod becomes ready after following env added:
       | NAMESPACE_LABELS=team=red |

--- a/features/routing/http2.feature
+++ b/features/routing/http2.feature
@@ -4,7 +4,7 @@ Feature: Testing HTTP/2 related scenarios
   # @case_id OCP-19705
   @admin
   @destructive
-  Scenario: edge route support http2 protocol
+  Scenario: OCP-19705 edge route support http2 protocol
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
     And I use the router project
@@ -45,7 +45,7 @@ Feature: Testing HTTP/2 related scenarios
   # @case_id OCP-19706
   @admin
   @destructive
-  Scenario: reencrypt route support http2 protocol
+  Scenario: OCP-19706 reencrypt route support http2 protocol
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
     And I use the router project

--- a/features/routing/idle.feature
+++ b/features/routing/idle.feature
@@ -3,7 +3,7 @@ Feature: idle service related scenarios
   # @author hongli@redhat.com
   # @case_id OCP-10935
   @smoke
-  Scenario: Pod can be changed to un-idle when there is unsecure or edge or passthrough route coming
+  Scenario: OCP-10935 Pod can be changed to un-idle when there is unsecure or edge or passthrough route coming
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/list_for_caddy.json" replacing paths:
       | ["items"][0]["spec"]["replicas"] | 1 |
@@ -92,7 +92,7 @@ Feature: idle service related scenarios
 
   # @author hongli@redhat.com
   # @case_id OCP-13837
-  Scenario: Pod can be changed to un-idle when there is reencrypt route coming
+  Scenario: OCP-13837 Pod can be changed to un-idle when there is reencrypt route coming
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/list_for_caddy.json" replacing paths:
       | ["items"][0]["spec"]["replicas"] | 1 |

--- a/features/routing/ingress-route.feature
+++ b/features/routing/ingress-route.feature
@@ -2,7 +2,7 @@ Feature: Testing ingress to route object
 
   # @author zzhao@redhat.com
   # @case_id OCP-18789
-  Scenario: Ingress generic support 
+  Scenario: OCP-18789 Ingress generic support 
     Given the master version >= "3.10"
     Given I have a project
     And I store default router IPs in the :router_ip clipboard

--- a/features/routing/ingress.feature
+++ b/features/routing/ingress.feature
@@ -4,7 +4,7 @@ Feature: Testing ingress object
   # @case_id OCP-11069
   @admin
   @destructive
-  Scenario: haproxy support ingress object
+  Scenario: OCP-11069 haproxy support ingress object
     Given required cluster roles are added to router service account for ingress
     And admin ensures new router pod becomes ready after following env added:
       | ROUTER_ENABLE_INGRESS=true |

--- a/features/routing/ipfailover.feature
+++ b/features/routing/ipfailover.feature
@@ -4,7 +4,7 @@ Feature: Testing ipfailover scenarios
   # @case_id OCP-9767
   @admin
   @destructive
-  Scenario: Configure a highly available network service
+  Scenario: OCP-9767 Configure a highly available network service
     Given the cluster is running on OpenStack
     And I switch to cluster admin pseudo user
     And I use the "default" project

--- a/features/routing/logging.feature
+++ b/features/routing/logging.feature
@@ -4,7 +4,7 @@ Feature: Testing HAProxy router logging related scenarios
   # @case_id OCP-19830
   @admin
   @destructive
-  Scenario: deploy haproxy router with an rsyslog sidecar container
+  Scenario: OCP-19830 deploy haproxy router with an rsyslog sidecar container
     Given the master version >= "3.11"
     Given I switch to cluster admin pseudo user
     And I use the router project

--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -3,7 +3,7 @@ Feature: Testing route
   # @author zzhao@redhat.com
   # @case_id OCP-12122
   @smoke
-  Scenario: Alias will be invalid after removing it
+  Scenario: OCP-12122 Alias will be invalid after removing it
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/routing/header-test/dc.json |
@@ -27,7 +27,7 @@ Feature: Testing route
   # @author yadu@redhat.com
   # @case_id OCP-10660
   @smoke
-  Scenario: Service endpoint can be work well if the mapping pod ip is updated
+  Scenario: OCP-10660 Service endpoint can be work well if the mapping pod ip is updated
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift/verification-tests/master/testdata/networking/list_for_pods.json" replacing paths:
       | ["items"][0]["spec"]["replicas"] | 1 |
@@ -71,7 +71,7 @@ Feature: Testing route
   # @author zzhao@redhat.com
   # @case_id OCP-12652
   @smoke
-  Scenario: The later route should be HostAlreadyClaimed when there is a same host exist
+  Scenario: OCP-12652 The later route should be HostAlreadyClaimed when there is a same host exist
     Given I have a project
     When I run the :create client command with:
       | f |  https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/unsecure/route_unsecure.json  |
@@ -88,7 +88,7 @@ Feature: Testing route
   # @author bmeng@redhat.com
   # @case_id OCP-12472
   @smoke
-  Scenario: Edge terminated route with custom cert
+  Scenario: OCP-12472 Edge terminated route with custom cert
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -135,7 +135,7 @@ Feature: Testing route
 
   # @author bmeng@redhat.com
   # @case_id OCP-12477
-  Scenario: Passthrough terminated route with custom cert
+  Scenario: OCP-12477 Passthrough terminated route with custom cert
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -168,7 +168,7 @@ Feature: Testing route
 
   # @author bmeng@redhat.com
   # @case_id OCP-12481
-  Scenario: Reencrypt terminated route with custom cert
+  Scenario: OCP-12481 Reencrypt terminated route with custom cert
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -217,7 +217,7 @@ Feature: Testing route
 
   # @author zzhao@redhat.com
   # @case_id OCP-12562
-  Scenario: The path specified in route can work well for edge terminated
+  Scenario: OCP-12562 The path specified in route can work well for edge terminated
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/caddy-docker.json |
@@ -259,7 +259,7 @@ Feature: Testing route
   # @author zzhao@redhat.com
   # @case_id OCP-12564
   @smoke
-  Scenario: The path specified in route can work well for reencrypt terminated
+  Scenario: OCP-12564 The path specified in route can work well for reencrypt terminated
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -309,7 +309,7 @@ Feature: Testing route
 
   # @author yadu@redhat.com
   # @case_id OCP-9651
-  Scenario: Config insecureEdgeTerminationPolicy to Redirect for route
+  Scenario: OCP-9651 Config insecureEdgeTerminationPolicy to Redirect for route
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -352,7 +352,7 @@ Feature: Testing route
 
   # @author yadu@redhat.com
   # @case_id OCP-9650
-  Scenario: Config insecureEdgeTerminationPolicy to Allow for route
+  Scenario: OCP-9650 Config insecureEdgeTerminationPolicy to Allow for route
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -414,7 +414,7 @@ Feature: Testing route
 
   # @author yadu@redhat.com
   # @case_id OCP-12635
-  Scenario: Enabled Active/Active routers can do round-robin on multiple target IPs
+  Scenario: OCP-12635 Enabled Active/Active routers can do round-robin on multiple target IPs
     # The case need to run on multi-node env
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
@@ -452,7 +452,7 @@ Feature: Testing route
   # @author yadu@redhat.com
   # @case_id OCP-10024
   @smoke
-  Scenario: Route could NOT be updated after created
+  Scenario: OCP-10024 Route could NOT be updated after created
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/tc/tc470732/route_withouthost1.json |
@@ -466,7 +466,7 @@ Feature: Testing route
 
   # @author zzhao@redhat.com
   # @case_id OCP-11036
-  Scenario: Set insecureEdgeTerminationPolicy to Redirect for passthrough route
+  Scenario: OCP-11036 Set insecureEdgeTerminationPolicy to Redirect for passthrough route
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -513,7 +513,7 @@ Feature: Testing route
 
   # @author zzhao@redhat.com
   # @case_id OCP-11839
-  Scenario: Set insecureEdgeTerminationPolicy to Redirect and Allow for reencrypt route
+  Scenario: OCP-11839 Set insecureEdgeTerminationPolicy to Redirect and Allow for reencrypt route
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -570,7 +570,7 @@ Feature: Testing route
 
   # @author zzhao@redhat.com
   # @case_id OCP-13248
-  Scenario: The hostname should be converted to available route when met special character
+  Scenario: OCP-13248 The hostname should be converted to available route when met special character
     Given I have a project
     When I run the :create client command with:
       | f  |   https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/unsecure/service_unsecure.json |
@@ -607,7 +607,7 @@ Feature: Testing route
 
   # @author zzhao@redhat.com
   # @case_id OCP-13753
-  Scenario: Check the cookie if using secure mode when insecureEdgeTerminationPolicy to Redirect for edge/reencrypt route
+  Scenario: OCP-13753 Check the cookie if using secure mode when insecureEdgeTerminationPolicy to Redirect for edge/reencrypt route
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:
@@ -682,7 +682,7 @@ Feature: Testing route
 
   # @author zzhao@redhat.com
   # @case_id OCP-14059
-  Scenario: Use the default destination CA of router if the route does not specify one for reencrypt route
+  Scenario: OCP-14059 Use the default destination CA of router if the route does not specify one for reencrypt route
     Given I have a project
     When I run the :create client command with:
       | f |  https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/reencrypt/reencrypt-without-all-cert.yaml |
@@ -695,7 +695,7 @@ Feature: Testing route
 
   # @author yadu@redhat.com
   # @case_id OCP-14678
-  Scenario: Only the host in whitelist could access the route - unsecure route
+  Scenario: OCP-14678 Only the host in whitelist could access the route - unsecure route
     Given I have a project
     And I have a header test service in the project
     And evaluation of `"haproxy.router.openshift.io/ip_whitelist=#{cb.req_headers["x-forwarded-for"]}"` is stored in the :my_whitelist clipboard
@@ -730,7 +730,7 @@ Feature: Testing route
 
   # @author zzhao@redhat.com
   # @case_id OCP-15976
-  Scenario: The edge route should support HSTS
+  Scenario: OCP-15976 The edge route should support HSTS
     Given the master version >= "3.7"
     And I have a project
     When I run the :create client command with:
@@ -784,7 +784,7 @@ Feature: Testing route
 
   # @author zzhao@redhat.com
   # @case_id OCP-16368
-  Scenario: The reencrypt route should support HSTS
+  Scenario: OCP-16368 The reencrypt route should support HSTS
     Given the master version >= "3.7"
     And I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/reencrypt/reencrypt-without-all-cert.yaml" replacing paths:

--- a/features/routing/timeout.feature
+++ b/features/routing/timeout.feature
@@ -2,7 +2,7 @@ Feature: Testing timeout route
 
   # @author yadu@redhat.com
   # @case_id OCP-11635
-  Scenario: Set timeout server for passthough route
+  Scenario: OCP-11635 Set timeout server for passthough route
     Given I have a project
     And I store default router IPs in the :router_ip clipboard
     When I run the :create client command with:

--- a/features/routing/websocket.feature
+++ b/features/routing/websocket.feature
@@ -2,7 +2,7 @@ Feature: Testing websocket features
 
   # @author hongli@redhat.com
   # @case_id OCP-17145
-  Scenario: haproxy router support websocket via unsecure route
+  Scenario: OCP-17145 haproxy router support websocket via unsecure route
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/websocket/pod.json |

--- a/features/service_catalog_tsb/tsb.feature
+++ b/features/service_catalog_tsb/tsb.feature
@@ -15,7 +15,7 @@ Feature: Template service broker related features
   # @author zitang@redhat.com
   # @case_id OCP-14477
   @admin
-  Scenario: Provision a templateinstance 
+  Scenario: OCP-14477 Provision a templateinstance 
     Given I have a project
     # Provision jenkins instance
     When I process and create:

--- a/features/storage/add_update_delete_volume.feature
+++ b/features/storage/add_update_delete_volume.feature
@@ -3,7 +3,7 @@ Feature: Add, update remove volume to rc/dc and --overwrite option
   # @author chaoyang@redhat.com
   # @case_id OCP-10284
   @smoke
-  Scenario: Check add or remove volume from dc works fine
+  Scenario: OCP-10284 Check add or remove volume from dc works fine
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/mongodb:latest   |

--- a/features/storage/aws.feature
+++ b/features/storage/aws.feature
@@ -3,7 +3,7 @@ Feature: AWS specific scenarios
   # @author chaoyang@redhat.com
   # @case_id OCP-14335
   @admin
-  Scenario: Check two pods using one efs pv is working correctly
+  Scenario: OCP-14335 Check two pods using one efs pv is working correctly
     Given I have a project
     And I have a efs-provisioner in the project
     When admin creates a StorageClass from "https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/aws/efs/deploy/class.yaml" where:

--- a/features/storage/cinder.feature
+++ b/features/storage/cinder.feature
@@ -3,7 +3,7 @@ Feature: Cinder Persistent Volume
   # @author wehe@redhat.com
   # @case_id OCP-9643
   @admin
-  Scenario: Persistent Volume with cinder volume plugin
+  Scenario: OCP-9643 Persistent Volume with cinder volume plugin
     Given I have a project
     And I have a 1 GB volume and save volume id in the :vid clipboard
 

--- a/features/storage/dynamic_provisioning.feature
+++ b/features/storage/dynamic_provisioning.feature
@@ -59,7 +59,7 @@ Feature: Dynamic provisioning
   # @author lxia@redhat.com
   # @case_id OCP-10790
   @admin
-  Scenario: Check only one pv created for one pvc for dynamic provisioner
+  Scenario: OCP-10790 Check only one pv created for one pvc for dynamic provisioner
     Given I have a project
     And I run the steps 30 times:
     """

--- a/features/storage/glusterfs.feature
+++ b/features/storage/glusterfs.feature
@@ -4,7 +4,7 @@ Feature: Storage of GlusterFS plugin testing
   # @case_id OCP-9707
   @admin
   @destructive
-  Scenario: Glusterfs volume security testing
+  Scenario: OCP-9707 Glusterfs volume security testing
     Given I have a project
     And I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
@@ -65,7 +65,7 @@ Feature: Storage of GlusterFS plugin testing
   # @author jhou@redhat.com
   # @case_id OCP-10267
   @admin
-  Scenario: Dynamically provision a GlusterFS volume
+  Scenario: OCP-10267 Dynamically provision a GlusterFS volume
     Given I have a StorageClass named "glusterprovisioner"
     And I have a project
 
@@ -105,7 +105,7 @@ Feature: Storage of GlusterFS plugin testing
   # @author jhou@redhat.com
   # @case_id OCP-10266
   @admin
-  Scenario: Reclaim a provisioned GlusterFS volume
+  Scenario: OCP-10266 Reclaim a provisioned GlusterFS volume
     Given I have a StorageClass named "glusterprovisioner"
     And I have a project
 
@@ -127,7 +127,7 @@ Feature: Storage of GlusterFS plugin testing
   # @author jhou@redhat.com
   # @case_id OCP-10356
   @admin
-  Scenario: Dynamically provision a GlusterFS volume using heketi secret
+  Scenario: OCP-10356 Dynamically provision a GlusterFS volume using heketi secret
     # A StorageClass preconfigured on the test env
     Given I have a StorageClass named "glusterprovisioner1"
     And admin checks that the "heketi-secret" secret exists in the "default" project
@@ -151,7 +151,7 @@ Feature: Storage of GlusterFS plugin testing
   # @author jhou@redhat.com
   # @case_id OCP-10554
   @admin
-  Scenario: Pods should be assigned a valid GID using GlusterFS dynamic provisioner
+  Scenario: OCP-10554 Pods should be assigned a valid GID using GlusterFS dynamic provisioner
     Given I have a StorageClass named "glusterprovisioner"
     And I have a project
 
@@ -215,7 +215,7 @@ Feature: Storage of GlusterFS plugin testing
   # @author jhou@redhat.com
   # @case_id OCP-10354
   @admin
-  Scenario: Provisioned GlusterFS volume should be replicated with 3 replicas
+  Scenario: OCP-10354 Provisioned GlusterFS volume should be replicated with 3 replicas
     Given I have a StorageClass named "glusterprovisioner"
     And I have a project
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/gluster/dynamic-provisioning/claim.yaml" replacing paths:

--- a/features/storage/iscsi.feature
+++ b/features/storage/iscsi.feature
@@ -4,7 +4,7 @@ Feature: ISCSI volume plugin testing
   # @case_id OCP-9638
   @admin
   @destructive
-  Scenario: ISCSI volume security test
+  Scenario: OCP-9638 ISCSI volume security test
     Given I have a iSCSI setup in the environment
     And I have a project
 

--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -4,7 +4,7 @@ Feature: NFS Persistent Volume
   # @case_id OCP-9572
   @admin
   @destructive
-  Scenario: Share NFS with multiple pods with ReadWriteMany mode
+  Scenario: OCP-9572 Share NFS with multiple pods with ReadWriteMany mode
     Given I have a project
     And I have a NFS service in the project
 
@@ -101,7 +101,7 @@ Feature: NFS Persistent Volume
   # @author chaoyang@redhat.com
   # @case_id OCP-10281
   @admin
-  Scenario: Permission denied when nfs pv annotaion is not right
+  Scenario: OCP-10281 Permission denied when nfs pv annotaion is not right
     Given I have a project
     And I have a NFS service in the project
     When I execute on the pod:

--- a/features/storage/persistent_volume.feature
+++ b/features/storage/persistent_volume.feature
@@ -41,7 +41,7 @@ Feature: Persistent Volume Claim binding policies
 
   # @author yinzhou@redhat.com
   # @case_id OCP-11933
-  Scenario: deployment hook volume inheritance -- with persistentvolumeclaim Volume
+  Scenario: OCP-11933 deployment hook volume inheritance -- with persistentvolumeclaim Volume
     Given I have a project
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
       | ["metadata"]["name"] | nfsc |
@@ -67,7 +67,7 @@ Feature: Persistent Volume Claim binding policies
   # @case_id OCP-9931
   @admin
   @destructive
-  Scenario: PV can not bind PVC which request more storage and mismatched accessMode
+  Scenario: OCP-9931 PV can not bind PVC which request more storage and mismatched accessMode
     Given I have a project
     When admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/auto/pv-template.json" where:
       | ["metadata"]["name"]       | pv-<%= project.name %> |
@@ -147,7 +147,7 @@ Feature: Persistent Volume Claim binding policies
   # @case_id OCP-9937
   @admin
   @destructive
-  Scenario: PV and PVC bound and unbound many times
+  Scenario: OCP-9937 PV and PVC bound and unbound many times
     Given default storage class is deleted
     Given I have a project
     And I have a NFS service in the project

--- a/features/storage/pre-bind.feature
+++ b/features/storage/pre-bind.feature
@@ -4,7 +4,7 @@ Feature: Testing for pv and pvc pre-bind feature
   # @case_id OCP-10107
   @admin
   @destructive
-  Scenario: Prebound pv is availabe due to requested pvc status is bound
+  Scenario: OCP-10107 Prebound pv is availabe due to requested pvc status is bound
     Given I have a project
     Given admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/nfs.json" where:
       | ["metadata"]["name"]            | nfspv1-<%= project.name %> |
@@ -22,7 +22,7 @@ Feature: Testing for pv and pvc pre-bind feature
   # @author chaoyang@redhat.com
   # @case_id OCP-10109
   @admin
-  Scenario: Prebound pv is availabe due to mismatched accessmode with requested pvc
+  Scenario: OCP-10109 Prebound pv is availabe due to mismatched accessmode with requested pvc
     Given I have a project
     Given admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/preboundpv-rwo.yaml" where:
       | ["metadata"]["name"]              | nfspv-<%= project.name %> |
@@ -40,7 +40,7 @@ Feature: Testing for pv and pvc pre-bind feature
   # @case_id OCP-10111
   @admin
   @destructive
-  Scenario: Prebound pvc is pending due to requested pv status is bound
+  Scenario: OCP-10111 Prebound pvc is pending due to requested pv status is bound
     Given I have a project
     Given admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/nfs.json" where:
       | ["metadata"]["name"]            | nfspv1-<%= project.name %> |
@@ -58,7 +58,7 @@ Feature: Testing for pv and pvc pre-bind feature
   # @case_id OCP-10113
   @admin
   @destructive
-  Scenario: Prebound PVC is pending due to mismatched accessmode with requested PV
+  Scenario: OCP-10113 Prebound PVC is pending due to mismatched accessmode with requested PV
     Given I have a project
     Given admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/nfs.json" where:
       | ["metadata"]["name"]            | nfspv-<%= project.name %> |
@@ -76,7 +76,7 @@ Feature: Testing for pv and pvc pre-bind feature
   # @case_id OCP-10114
   @admin
   @destructive
-  Scenario: Prebound PVC is pending due to mismatched volume size with requested PV
+  Scenario: OCP-10114 Prebound PVC is pending due to mismatched volume size with requested PV
     Given I have a project
     Given admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/nfs.json" where:
       | ["metadata"]["name"]            | nfspv-<%= project.name %> |
@@ -94,7 +94,7 @@ Feature: Testing for pv and pvc pre-bind feature
   # @case_id OCP-9941
   @admin
   @destructive
-  Scenario: PV and PVC bound successfully when pvc created prebound to pv
+  Scenario: OCP-9941 PV and PVC bound successfully when pvc created prebound to pv
     Given I have a project
     Given admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/nfs.json" where:
       | ["metadata"]["name"]            | nfspv1-<%= project.name %> |
@@ -117,7 +117,7 @@ Feature: Testing for pv and pvc pre-bind feature
   # @case_id OCP-9940
   @admin
   @destructive
-  Scenario: PV and PVC bound successfully when pv created prebound to pvc
+  Scenario: OCP-9940 PV and PVC bound successfully when pv created prebound to pvc
     Given I have a project
     Given admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/preboundpv-rwo.yaml" where:
       | ["metadata"]["name"]              | nfspv-<%= project.name %> |
@@ -136,7 +136,7 @@ Feature: Testing for pv and pvc pre-bind feature
   # @case_id OCP-9939
   @admin
   @destructive
-  Scenario: PVC is bond to PV successfully when pvc is created first
+  Scenario: OCP-9939 PVC is bond to PV successfully when pvc is created first
     Given I have a project
     Then I create a manual pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/claim-rwo.json" replacing paths:
       | ["metadata"]["name"]                         | nfsc-<%= project.name %> |

--- a/features/storage/quota.feature
+++ b/features/storage/quota.feature
@@ -3,7 +3,7 @@ Feature: ResourceQuata for storage
   # @author jhou@redhat.com
   # @case_id OCP-14173
   @admin
-  Scenario: Requested storage can not exceed the namespace's storage quota
+  Scenario: OCP-14173 Requested storage can not exceed the namespace's storage quota
     Given I have a project
     And I switch to cluster admin pseudo user
     And I use the "<%= project.name %>" project
@@ -62,7 +62,7 @@ Feature: ResourceQuata for storage
   # @author jhou@redhat.com
   # @case_id OCP-14382
   @admin
-  Scenario: Setting quota for a StorageClass
+  Scenario: OCP-14382 Setting quota for a StorageClass
     Given I have a project
     And I have a nfs-provisioner service in the project
     And I switch to cluster admin pseudo user

--- a/features/storage/rbd.feature
+++ b/features/storage/rbd.feature
@@ -3,7 +3,7 @@ Feature: Storage of Ceph plugin testing
   # @author jhou@redhat.com
   # @case_id OCP-10485
   @admin
-  Scenario: Dynamically provision Ceph RBD volumes
+  Scenario: OCP-10485 Dynamically provision Ceph RBD volumes
     Given I have a StorageClass named "cephrbdprovisioner"
     And admin checks that the "cephrbd-secret" secret exists in the "default" project
 
@@ -51,7 +51,7 @@ Feature: Storage of Ceph plugin testing
   # @author jhou@redhat.com
   # @case_id OCP-10268
   @admin
-  Scenario: Dynamically provisioned rbd volumes should have correct capacity
+  Scenario: OCP-10268 Dynamically provisioned rbd volumes should have correct capacity
     Given I have a StorageClass named "cephrbdprovisioner"
     # CephRBD provisioner needs secret, verify secret and StorageClass both exists
     And admin checks that the "cephrbd-secret" secret exists in the "default" project

--- a/features/storage/regression.feature
+++ b/features/storage/regression.feature
@@ -3,7 +3,7 @@ Feature: Regression testing cases
   # @author jhou@redhat.com
   # @case_id OCP-16485
   @admin
-  Scenario: RWO volumes are exclusively mounted on different nodes
+  Scenario: OCP-16485 RWO volumes are exclusively mounted on different nodes
     Given I have a project
 
     Given I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:

--- a/features/storage/security.feature
+++ b/features/storage/security.feature
@@ -103,7 +103,7 @@ Feature: storage security check
   # @author chaoyang@redhat.com
   # @case_id OCP-9709
   @admin
-  Scenario: secret volume security check
+  Scenario: OCP-9709 secret volume security check
     Given I have a project
     When I run the :create client command with:
       | filename | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/secret/secret.yaml |

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -257,7 +257,7 @@ Feature: storageClass related feature
   # @author chaoyang@redhat.com
   # @case_id OCP-10159
   @admin
-  Scenario: PVC with storage class won't provisioned pv if no storage class or wrong storage class object
+  Scenario: OCP-10159 PVC with storage class won't provisioned pv if no storage class or wrong storage class object
     Given I have a project
     # No sc exists
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
@@ -277,7 +277,7 @@ Feature: storageClass related feature
 
   # @author chaoyang@redhat.com
   # @case_id OCP-10228
-  Scenario: AWS ebs volume is dynamic provisioned with default storageclass
+  Scenario: OCP-10228 AWS ebs volume is dynamic provisioned with default storageclass
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/ebs/pvc-retain.json" replacing paths:
       | ["metadata"]["name"]                         | pvc-<%= project.name %> |

--- a/features/storage/storage_object_in_use_protection.feature
+++ b/features/storage/storage_object_in_use_protection.feature
@@ -2,7 +2,7 @@ Feature: Storage object in use protection
 
   # @author lxia@redhat.com
   # @case_id OCP-17253
-  Scenario: Delete pvc which is not in active use by pod should be deleted immediately
+  Scenario: OCP-17253 Delete pvc which is not in active use by pod should be deleted immediately
     Given I have a project
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
       | ["metadata"]["name"] | pvc-<%= project.name %> |
@@ -13,7 +13,7 @@ Feature: Storage object in use protection
 
   # @author lxia@redhat.com
   # @case_id OCP-17254
-  Scenario: Delete pvc which is in active use by pod should postpone deletion
+  Scenario: OCP-17254 Delete pvc which is in active use by pod should postpone deletion
     Given I have a project
     When I create a dynamic pvc from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/misc/pvc.json" replacing paths:
       | ["metadata"]["name"] | pvc-<%= project.name %> |
@@ -48,7 +48,7 @@ Feature: Storage object in use protection
   # @author lxia@redhat.com
   # @case_id OCP-18796
   @admin
-  Scenario: Delete pv which is bind with pvc should postpone deletion
+  Scenario: OCP-18796 Delete pv which is bind with pvc should postpone deletion
     Given I have a project
     When admin creates a PV from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/auto/pv-template.json" where:
       | ["metadata"]["name"] | pv-<%= project.name %> |

--- a/features/storage/vsphere.feature
+++ b/features/storage/vsphere.feature
@@ -59,7 +59,7 @@ Feature: vSphere test scenarios
   # @author jhou@redhat.com
   # @case_id OCP-13389
   @admin
-  Scenario: Dynamically provision a vSphere volume with invalid disk format
+  Scenario: OCP-13389 Dynamically provision a vSphere volume with invalid disk format
     Given I have a project
     When admin creates a StorageClass from "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/vsphere/storageclass.yml" where:
       | ["metadata"]["name"]         | storageclass-<%= project.name %> |

--- a/features/svc-catalog_asb/asb.feature
+++ b/features/svc-catalog_asb/asb.feature
@@ -145,7 +145,7 @@ Feature: Ansible-service-broker related scenarios
   # @author zitang@redhat.com
   # @case_id OCP-15354
   @admin
-  Scenario: Check multiple broker support for service catalog
+  Scenario: OCP-15354 Check multiple broker support for service catalog
     Given admin checks that the "ansible-service-broker" cluster_service_broker exists
     And admin checks that the "template-service-broker" cluster_service_broker exists
 

--- a/features/svc-catalog_asb/svc-catalog.feature
+++ b/features/svc-catalog_asb/svc-catalog.feature
@@ -4,7 +4,7 @@ Feature: Service-catalog related scenarios
   # @case_id OCP-15600
   @admin
   @destructive
-  Scenario: service-catalog walkthrough example
+  Scenario: OCP-15600 service-catalog walkthrough example
     Given I have a project
     And evaluation of `project.name` is stored in the :ups_broker_project clipboard
     And I create a new project
@@ -92,7 +92,7 @@ Feature: Service-catalog related scenarios
   # @author chezhang@redhat.com
   # @case_id OCP-14833
   @admin
-  Scenario: Confirm service-catalog image working well
+  Scenario: OCP-14833 Confirm service-catalog image working well
     When I switch to cluster admin pseudo user
     And I use the "kube-service-catalog" project
     Given 1 pods become ready with labels:
@@ -131,7 +131,7 @@ Feature: Service-catalog related scenarios
   # @case_id OCP-15604
   @admin
   @destructive
-  Scenario: Create/get/update/delete for ClusterServiceBroker resource	
+  Scenario: OCP-15604 Create/get/update/delete for ClusterServiceBroker resource	
     Given I have a project
     And evaluation of `project.name` is stored in the :ups_broker_project clipboard
 
@@ -211,7 +211,7 @@ Feature: Service-catalog related scenarios
   # @case_id OCP-15602
   @admin
   @destructive
-  Scenario: Create/get/update/delete for Clusterserviceclass/Clusterserviceplan resource
+  Scenario: OCP-15602 Create/get/update/delete for Clusterserviceclass/Clusterserviceplan resource
     Given I have a project
 
     # Deploy ups broker

--- a/features/test/admin.feature
+++ b/features/test/admin.feature
@@ -1,4 +1,5 @@
 Feature: Testing Admin Scenarios
+
   @admin
   Scenario: simple create project admin scenario
     When I run the :oadm_new_project admin command with:
@@ -32,7 +33,7 @@ Feature: Testing Admin Scenarios
   # @author yinzhou@redhat.com
   # @case_id OCP-9748
   @admin
-  Scenario: Use options minify/raw/flatten to check the output of kubeconfig setting
+  Scenario: OCP-9748 Use options minify/raw/flatten to check the output of kubeconfig setting
     When I run the :oadm_config_view admin command with:
       | flatten | |
     Then the step should succeed

--- a/features/test/build.feature
+++ b/features/test/build.feature
@@ -1,4 +1,5 @@
 Feature: build test related
+
   Scenario: Print build logs when buid failed
     Given I have a project
     When I create a new application with:

--- a/features/test/clean_up.feature
+++ b/features/test/clean_up.feature
@@ -1,4 +1,5 @@
 Feature: some clean up steps testing
+
   Scenario: define clean-up in different ways
     Given I register clean-up steps:
       |I log the message> Message 1  |

--- a/features/test/cli.feature
+++ b/features/test/cli.feature
@@ -1,4 +1,5 @@
 Feature: Testing CLI Scenarios
+
   Scenario: simple create project
     When I run the :new_project client command with:
       | project_name | demo |

--- a/features/test/collections.feature
+++ b/features/test/collections.feature
@@ -1,4 +1,5 @@
 Feature: some collection operations verification
+
   Scenario: substructs
     Given the expression should be true> cb.h1 = {metadata:{labels:{labelname: nil}}}
     And   the expression should be true> cb.h2 = {metadata:{labels:nil}}

--- a/features/test/containers.feature
+++ b/features/test/containers.feature
@@ -1,4 +1,5 @@
 Feature: test container related support
+
   Scenario: container support
     Given I have a project
     And I have a pod-for-ping in the project

--- a/features/test/daemonset.feature
+++ b/features/test/daemonset.feature
@@ -1,4 +1,5 @@
 Feature: test daemonset methods
+
   @admin
   Scenario: Test daemonset support in the framework
     Given I have a project

--- a/features/test/endpoint.feature
+++ b/features/test/endpoint.feature
@@ -1,4 +1,5 @@
 Feature: test endpoint methods
+
   @admin
   Scenario: Test endpoint support in the framework
     Given I switch to cluster admin pseudo user

--- a/features/test/file.feature
+++ b/features/test/file.feature
@@ -1,4 +1,5 @@
 Feature: test files related steps
+
   Scenario: test directory creation
     Given I create the "tc512258" directory
     And I pry

--- a/features/test/git.feature
+++ b/features/test/git.feature
@@ -1,4 +1,5 @@
 Feature: test git steps
+
   Scenario: git test
     And I git clone the repo "https://github.com/openshift/ruby-hello-world"
     And I git clone the repo "https://github.com/openshift/ruby-hello-world" to "dummy"

--- a/features/test/logging_metrics.feature
+++ b/features/test/logging_metrics.feature
@@ -1,4 +1,5 @@
 Feature: test logging and metrics related steps
+
   @admin
   @destructive
   Scenario: test uninstall

--- a/features/test/meta.feature
+++ b/features/test/meta.feature
@@ -1,4 +1,5 @@
 Feature: some meta step tests
+
   Scenario: Loop over the clipboard
     Given expression should be true> cb.testvars = [1,2,3,4]
     When I repeat the following steps for each :testvar in cb.testvars:

--- a/features/test/metering.feature
+++ b/features/test/metering.feature
@@ -1,4 +1,5 @@
 Feature: test metering related steps
+
   @admin
   @destructive
   Scenario: test metering install

--- a/features/test/node.feature
+++ b/features/test/node.feature
@@ -1,4 +1,5 @@
 Feature: test nodes relates steps
+
   @admin
   @destructive
   Scenario: nodes test

--- a/features/test/node_config.feature
+++ b/features/test/node_config.feature
@@ -1,4 +1,5 @@
 Feature: test node config related steps
+
   Background:
     Given I select a random node's host
     And the value with path " " in node config is stored into the :original_cfg clipboard

--- a/features/test/obsolete_update_from_api_object.feature
+++ b/features/test/obsolete_update_from_api_object.feature
@@ -1,4 +1,5 @@
 Feature: test refactor of update_from_api_object to use raw_resource
+
   Scenario: test image_stream_tag
     Given I have a project
     And I run the :tag client command with:

--- a/features/test/output.feature
+++ b/features/test/output.feature
@@ -1,4 +1,5 @@
 Feature: Output inspections
+
   Scenario: the output by order should contain/match
     When I log the messages:
       | string 1 |

--- a/features/test/parse_ini.feature
+++ b/features/test/parse_ini.feature
@@ -1,4 +1,5 @@
 Feature: test ini files
+
   @admin
   Scenario: parse ini formated file
     Given I parse the INI file "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/logging_metrics/default_inventory_prometheus"

--- a/features/test/policy.feature
+++ b/features/test/policy.feature
@@ -1,4 +1,5 @@
 Feature: Add admin user to current project
+
   Scenario: Add admin user to current project
     When I create a new project
     Then the step should succeed

--- a/features/test/pvc.feature
+++ b/features/test/pvc.feature
@@ -1,4 +1,5 @@
 Feature: pvc testing scenarios
+
   Scenario: fetch pvc detail when got wrong status
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/nfs/auto/pvc-template.json" replacing paths:

--- a/features/test/rc.feature
+++ b/features/test/rc.feature
@@ -1,4 +1,5 @@
 Feature: rc related test
+
   Scenario: test new rc ready method
     Given I have a project
     When I run the :create client command with:

--- a/features/test/rest.feature
+++ b/features/test/rest.feature
@@ -1,4 +1,5 @@
 Feature: Testing REST Scenarios
+
   Scenario: simple rest scenario
     When I perform the :create_project_request rest request with:
       | project name | demo |

--- a/features/test/storage_class.feature
+++ b/features/test/storage_class.feature
@@ -1,4 +1,5 @@
 Feature: StorageClass testing scenarios
+
   @admin
   Scenario: admin creates a StorageClass
     Given I have a project

--- a/features/test/transformations.feature
+++ b/features/test/transformations.feature
@@ -1,4 +1,5 @@
 Feature: test some transformations
+
   Scenario: Some Transformations
     Given I log the message> some <%= "message" %> with double <%= "expand" %>
     Then the output should contain:

--- a/features/test/upgrade.feature
+++ b/features/test/upgrade.feature
@@ -3,7 +3,7 @@ Feature: basic verification for upgrade testing
   # note that upuser1 and 2 need to be defined for the environement
   @upgrade-prepare
   @users=upuserX
-  Scenario: cakephp example works well after upgrade - prepare
+  Scenario: OCP-10017 cakephp example works well after upgrade - prepare
     When I run the :new_project client command with:
       | project_name | project-ocp10017 |
     Then the step should succeed
@@ -13,7 +13,7 @@ Feature: basic verification for upgrade testing
   # @case_id OCP-10017
   @admin
   @users=upuserX
-  Scenario: cakephp example works well after upgrade
+  Scenario: OCP-10017 cakephp example works well after upgrade
     Given I switch to cluster admin pseudo user
     Given I use the "project-ocp10017" project
 
@@ -21,7 +21,7 @@ Feature: basic verification for upgrade testing
   @upgrade-prepare
   @users=upuserY
   @admin
-  Scenario: etcd-operator and cluster work well after upgrade - prepare
+  Scenario: OCP-22606 etcd-operator and cluster work well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/admin/subscription.yaml |
@@ -41,7 +41,7 @@ Feature: basic verification for upgrade testing
   # @case_id OCP-22606
   @admin
   @users=upuserY
-  Scenario: etcd-operator and cluster work well after upgrade
+  Scenario: OCP-22606 etcd-operator and cluster work well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "openshift-operators" project
     Then status becomes :running of exactly 1 pods labeled:
@@ -52,9 +52,9 @@ Feature: basic verification for upgrade testing
 
   # @case_id OCP-26309
   @upgrade-check
-  Scenario: simple selector upgrade test case
+  Scenario: OCP-26309 simple selector upgrade test case
     Given I log the message> Hi Check!
 
   @upgrade-prepare
-  Scenario: simple selector upgrade test case - prepare
+  Scenario: OCP-26309 simple selector upgrade test case - prepare
     Given I log the message> Hi Prepare!

--- a/features/test/version_compare.feature
+++ b/features/test/version_compare.feature
@@ -1,4 +1,5 @@
 Feature: test version compare
+
   Scenario: test version compare
     Given the master version >= "3.11"
     Given the master version >= "3.5"

--- a/features/web/build.feature
+++ b/features/web/build.feature
@@ -2,7 +2,7 @@ Feature: build related feature on web console
 
   # @author yapei@redhat.com
   # @case_id OCP-11773
-  Scenario: Modify buildconfig settings for Dockerfile source
+  Scenario: OCP-11773 Modify buildconfig settings for Dockerfile source
     Given I have a project
     When I run the :new_build client command with:
       | D     | FROM centos:7\nRUN yum install -y httpd |
@@ -42,7 +42,7 @@ Feature: build related feature on web console
 
   # @author xxia@redhat.com
   # @case_id OCP-12494
-  Scenario: Check build trigger info when the trigger is ImageChange on web
+  Scenario: OCP-12494 Check build trigger info when the trigger is ImageChange on web
     Given I have a project
     When I run the :create client command with:
       | f    | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/build/tc528954/bc_imagechange.yaml |

--- a/features/web/catalog.feature
+++ b/features/web/catalog.feature
@@ -2,7 +2,7 @@ Feature: scenarios related to catalog page
 
   # @author chali@redhat.com
   # @case_id OCP-10989
-  Scenario: Check the browse catalog tab on "Add to Project" page
+  Scenario: OCP-10989 Check the browse catalog tab on "Add to Project" page
     Given the master version <= "3.6"
     Given I create a new project
     When I perform the :goto_overview_page web console action with:

--- a/features/web/check_link.feature
+++ b/features/web/check_link.feature
@@ -2,7 +2,7 @@ Feature: Check links in Openshift
 
   # @author yapei@redhat.com
   # @case_id OCP-9770
-  Scenario: check doc links in web
+  Scenario: OCP-9770 check doc links in web
     Given I store master major version in the clipboard
     # check documentation link in getting started instructions
     When I perform the :check_default_documentation_link_in_get_started web console action with:

--- a/features/web/check_page.feature
+++ b/features/web/check_page.feature
@@ -3,7 +3,7 @@ Feature: check page info related
   # @author wsun@redhat.com
   # @case_id OCP-10605
   @smoke
-  Scenario: Check Events page
+  Scenario: OCP-10605 Check Events page
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/nodejs:latest                |
@@ -23,7 +23,7 @@ Feature: check page info related
 
   # @author yapei@redhat.com
   # @case_id OCP-12625
-  Scenario: Check home page to list user projects
+  Scenario: OCP-12625 Check home page to list user projects
     Given I login via web console
     When I run the :check_instructions_on_home_page web console action
     Then the step should succeed
@@ -37,7 +37,7 @@ Feature: check page info related
 
   # @author yanpzhan@redhat.com
   # @case_id OCP-11219
-  Scenario: Check storage page on web console
+  Scenario: OCP-11219 Check storage page on web console
     Given I have a project
     When I perform the :check_empty_storage_page web console action with:
       | project_name | <%= project.name %> |

--- a/features/web/configmap.feature
+++ b/features/web/configmap.feature
@@ -2,7 +2,7 @@ Feature: ConfigMap related features
 
   # @author xxing@redhat.com
   # @case_id OCP-12006
-  Scenario: Edit ConfigMap on web console
+  Scenario: OCP-12006 Edit ConfigMap on web console
     Given the master version >= "3.5"
     Given I have a project
     When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/configmap/configmap.yaml" replacing paths:
@@ -60,7 +60,7 @@ Feature: ConfigMap related features
 
   # @author etrott@redhat.com
   # @case_id OCP-11052
-  Scenario: Add/Edit env vars from config maps
+  Scenario: OCP-11052 Add/Edit env vars from config maps
     Given the master version >= "3.6"
     Given I have a project
     When I run the :new_app client command with:

--- a/features/web/create.feature
+++ b/features/web/create.feature
@@ -3,7 +3,7 @@ Feature: create app on web console related
   # @author xxing@redhat.com
   # @case_id OCP-11171
   @smoke
-  Scenario: Create application from image on web console
+  Scenario: OCP-11171 Create application from image on web console
     Given I have a project
     Given I wait for the :create_app_from_image web console action to succeed with:
       | project_name | <%= project.name %>                        |
@@ -18,7 +18,7 @@ Feature: create app on web console related
 
   # @author xxing@redhat.com
   # @case_id OCP-11445
-  Scenario: Create application from template with invalid parameters on web console
+  Scenario: OCP-11445 Create application from template with invalid parameters on web console
     Given I have a project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/templates/ui/application-template-stibuild-without-customize-route.json |
@@ -35,7 +35,7 @@ Feature: create app on web console related
 
   # @author wsun@redhat.com
   # @case_id OCP-12596
-  Scenario: Create the app with invalid name
+  Scenario: OCP-12596 Create the app with invalid name
     Given I have a project
     When I perform the :create_app_from_image web console action with:
       | project_name | <%= project.name %>                        |
@@ -107,7 +107,7 @@ Feature: create app on web console related
 
   # @author etrott@redhat.com
   # @case_id OCP-10920
-  Scenario: Environment variables and label management in create app from image on web console
+  Scenario: OCP-10920 Environment variables and label management in create app from image on web console
     Given I have a project
     When I perform the :create_app_from_image_check_label web console action with:
       | project_name | <%= project.name %>                         |
@@ -253,7 +253,7 @@ Feature: create app on web console related
 
   # @author yapei@redhat.com
   # @case_id OCP-15062
-  Scenario: Check Deploy Image and Import YAML from new landing page
+  Scenario: OCP-15062 Check Deploy Image and Import YAML from new landing page
     Given the master version >= "3.7"
     Given I have a project
     # deploy from image stream tag with customized env and labels

--- a/features/web/deployments.feature
+++ b/features/web/deployments.feature
@@ -3,7 +3,7 @@ Feature: Check deployments function
   # @author yapei@redhat.com
   # @case_id OCP-10679
   @smoke
-  Scenario: make deployment from web console
+  Scenario: OCP-10679 make deployment from web console
     Given I have a project
     # create dc
     When I run the :create client command with:
@@ -39,7 +39,7 @@ Feature: Check deployments function
 
   # @author yapei@redhat.com
   # @case_id OCP-12417
-  Scenario: Check deployment info on web console
+  Scenario: OCP-12417 Check deployment info on web console
     Given I create a new project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment1.json |
@@ -97,7 +97,7 @@ Feature: Check deployments function
 
   # @author yanpzhan@redhat.com
   # @case_id OCP-11198
-  Scenario: View deployments streaming logs
+  Scenario: OCP-11198 View deployments streaming logs
     Given I have a project
     When I run the :new_app client command with:
       | name  | mytest                |
@@ -139,7 +139,7 @@ Feature: Check deployments function
 
   # @author yapei@redhat.com
   # @case_id OCP-10937
-  Scenario: Idled DC handling on web console
+  Scenario: OCP-10937 Idled DC handling on web console
     Given I create a new project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/deployment/deployment-with-service.yaml |
@@ -197,7 +197,7 @@ Feature: Check deployments function
 
   # @author yapei@redhat.com
   # @case_id OCP-11593
-  Scenario: Create,Edit and Delete HPA from the deployment config page
+  Scenario: OCP-11593 Create,Edit and Delete HPA from the deployment config page
     Given the master version >= "3.3"
     Given I have a project
     When I run the :run client command with:
@@ -302,7 +302,7 @@ Feature: Check deployments function
 
   # @author etrott@redhat.com
   # @case_id OCP-12375
-  Scenario: Check ReplicaSet on Overview and ReplicaSet page
+  Scenario: OCP-12375 Check ReplicaSet on Overview and ReplicaSet page
     Given the master version >= "3.4"
     Given I have a project
     When I run the :create client command with:

--- a/features/web/environments.feature
+++ b/features/web/environments.feature
@@ -2,7 +2,7 @@ Feature: env related feature
 
   # @author yanpzhan@redhat.com
   # @case_id OCP-15442
-  Scenario: Support add configmap/secret with EnvForm format on env page
+  Scenario: OCP-15442 Support add configmap/secret with EnvForm format on env page
     Given I have a project
     When I run the :secrets client command with:
       | action | new        |

--- a/features/web/filter.feature
+++ b/features/web/filter.feature
@@ -2,7 +2,7 @@ Feature: filter on create page
 
   # @author yanpzhan@redhat.com
   # @case_id OCP-11077
-  Scenario: Filter resources by labels under Browse page
+  Scenario: OCP-11077 Filter resources by labels under Browse page
     Given I have a project
     When I perform the :create_app_from_image web console action with:
       | project_name | <%= project.name %>                        |
@@ -206,7 +206,7 @@ Feature: filter on create page
 
   # @author yanpzhan@redhat.com
   # @case_id OCP-11698
-  Scenario: Display existing labels in label suggestion list according to different resources
+  Scenario: OCP-11698 Display existing labels in label suggestion list according to different resources
     Given I have a project
     When I run the :new_app client command with:
       | image_stream | openshift/python:latest                |

--- a/features/web/hooks.feature
+++ b/features/web/hooks.feature
@@ -2,7 +2,7 @@ Feature: bc/dc hooks related
 
   # @author xxing@redhat.com
   # @case_id OCP-11033
-  Scenario: Show hooks of recreate strategy DC
+  Scenario: OCP-11033 Show hooks of recreate strategy DC
     Given the master version > "3.4"
     Given I have a project
     When I run the :new_app client command with:

--- a/features/web/imagestreams.feature
+++ b/features/web/imagestreams.feature
@@ -3,7 +3,7 @@ Feature: check image streams page
   # @author yapei@redhat.com
   # @case_id OCP-10738
   @smoke
-  Scenario: check image stream page
+  Scenario: OCP-10738 check image stream page
     Given I have a project
     When I perform the :check_empty_image_streams_page web console action with:
       | project_name | <%= project.name %> |

--- a/features/web/k8s-deployments.feature
+++ b/features/web/k8s-deployments.feature
@@ -2,7 +2,7 @@ Feature: Features about k8s deployments
 
 # @author etrott@redhat.com
   # @case_id OCP-12329
-  Scenario: Check k8s deployments on Deployments page
+  Scenario: OCP-12329 Check k8s deployments on Deployments page
     Given the master version >= "3.4"
     Given I create a new project
     When I perform the :goto_deployments_page web console action with:

--- a/features/web/limits.feature
+++ b/features/web/limits.feature
@@ -3,7 +3,7 @@ Feature: functions about resource limits on pod
   # @author yapei@redhat.com
   # @case_id OCP-10773
   @admin
-  Scenario: Specify resource constraints for standalone rc and dc in web console with project limits already set
+  Scenario: OCP-10773 Specify resource constraints for standalone rc and dc in web console with project limits already set
     Given I create a new project
     # create limits and DC
     When I run the :create admin command with:

--- a/features/web/login.feature
+++ b/features/web/login.feature
@@ -3,7 +3,7 @@ Feature: login related scenario
   # @author wjiang@redhat.com
   # @case_id OCP-12239
   @smoke
-  Scenario: login and logout via web
+  Scenario: OCP-12239 login and logout via web
     Given I login via web console
     Given I run the :logout web console action
     Then the step should succeed
@@ -13,7 +13,7 @@ Feature: login related scenario
 
   # @author xxing@redhat.com
   # @case_id OCP-9771
-  Scenario: User could not access pages directly without login first
+  Scenario: OCP-9771 User could not access pages directly without login first
     Given I have a project
     # Disable default login
     When I perform the :new_project_navigate web console action with:
@@ -27,7 +27,7 @@ Feature: login related scenario
 
   # @author xxing@redhat.com
   # @case_id OCP-12189
-  Scenario: The page should redirect to login page when access session protected pages after session expired
+  Scenario: OCP-12189 The page should redirect to login page when access session protected pages after session expired
     When I create a new project via web
     Then the step should succeed
     #make token expired

--- a/features/web/membership.feature
+++ b/features/web/membership.feature
@@ -2,7 +2,7 @@ Feature: memberships related features via web
 
   # @author etrott@redhat.com
   # @case_id OCP-11843
-  Scenario: Manage project membership about users
+  Scenario: OCP-11843 Manage project membership about users
     Given the master version >= "3.4"
     Given I have a project
     When I perform the :check_entry_content_on_membership web console action with:

--- a/features/web/notification_drawer.feature
+++ b/features/web/notification_drawer.feature
@@ -2,7 +2,7 @@
 
   # @author yapei@redhat.com
   # @case_id OCP-15231
-  Scenario: Check notification goes into drawer in its own project
+  Scenario: OCP-15231 Check notification goes into drawer in its own project
     Given the master version >= "3.7"
     # Create 2 projects, add 'python' app to 1st project, add 'php' app to 2nd project
     Given I have a project

--- a/features/web/overview.feature
+++ b/features/web/overview.feature
@@ -2,7 +2,7 @@ Feature: Check overview page
 
   # @author xiaocwan@redhat.com
   # @case_id OCP-10101
-  Scenario: Check overview page
+  Scenario: OCP-10101 Check overview page
     Given the master version <= "3.5"
     Given I have a project
     When I perform the :check_project_overview_without_resource web console action with:
@@ -178,7 +178,7 @@ Feature: Check overview page
 
   # @author hasha@redhat.com
   # @case_id OCP-13641
-  Scenario: Check app resources on overview page
+  Scenario: OCP-13641 Check app resources on overview page
     Given the master version >= "3.6"
     Given I have a project
     When I run the :new_app client command with:

--- a/features/web/pod.feature
+++ b/features/web/pod.feature
@@ -2,7 +2,7 @@ Feature: Pod related features on web console
 
   # @author yanpzhan@redhat.com
   # @case_id OCP-11534
-  Scenario: View streaming logs for a running pod
+  Scenario: OCP-11534 View streaming logs for a running pod
     Given I have a project
     #Create a pod
     And I run the :run client command with:

--- a/features/web/project.feature
+++ b/features/web/project.feature
@@ -2,7 +2,7 @@ Feature: projects related features via web
 
   # @author wsun@redhat.com
   # @case_id OCP-12440
-  Scenario: Could list all projects based on the user's authorization on web console
+  Scenario: OCP-12440 Could list all projects based on the user's authorization on web console
     Given an 8 characters random string of type :dns is stored into the :project1 clipboard
     Given an 8 characters random string of type :dns is stored into the :project2 clipboard
     Given an 8 characters random string of type :dns is stored into the :project3 clipboard
@@ -53,7 +53,7 @@ Feature: projects related features via web
 
   # @author yapei@redhat.com
   # @case_id OCP-10014
-  Scenario: Delete project from web console
+  Scenario: OCP-10014 Delete project from web console
     # delete project with project name on projects page
     When I create a project via web with:
       | display_name | testing project one |

--- a/features/web/pvc.feature
+++ b/features/web/pvc.feature
@@ -4,7 +4,7 @@ Feature: Add pvc to pod from web related
   # @case_id OCP-10752
   @admin
   @destructive
-  Scenario: Attach pvc to pod with multiple containers from web console
+  Scenario: OCP-10752 Attach pvc to pod with multiple containers from web console
     Given I have a project
     And I have a NFS service in the project
     And default storage class is deleted
@@ -86,7 +86,7 @@ Feature: Add pvc to pod from web related
 
   # @author yanpzhan@redhat.com
   # @case_id OCP-10126
-  Scenario: Create persist volume claim from web console
+  Scenario: OCP-10126 Create persist volume claim from web console
     Given I have a project
 
     # Create ROX type pvc

--- a/features/web/registry.feature
+++ b/features/web/registry.feature
@@ -3,7 +3,7 @@ Feature: Testing registry
   # @author etrott@redhat.com
   # @case_id OCP-10224
   @admin
-  Scenario: Login and logout of standalone registry console
+  Scenario: OCP-10224 Login and logout of standalone registry console
     Given I have a project
     And I open registry console in a browser
 

--- a/features/web/routes.feature
+++ b/features/web/routes.feature
@@ -2,7 +2,7 @@ Feature: Routes related features on web console
 
   # @author yapei@redhat.com
   # @case_id OCP-12294
-  Scenario: Create route with invalid name and hostname on web console
+  Scenario: OCP-12294 Create route with invalid name and hostname on web console
     Given I create a new project
     When I run the :create client command with:
       | f | https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/authorization/scc/pod_requests_nothing.json |
@@ -34,7 +34,7 @@ Feature: Routes related features on web console
 
   # @author yapei@redhat.com
   # @case_id OCP-11210
-  Scenario: Add path when creating edge terminated route on web console
+  Scenario: OCP-11210 Add path when creating edge terminated route on web console
     Given I create a new project
 
     # create pod, service and pod used for curl command

--- a/features/web/scale.feature
+++ b/features/web/scale.feature
@@ -2,7 +2,7 @@ Feature: scale related features
 
   # @author yanpzhan@redhat.com
   # @case_id OCP-11196
-  Scenario: Could scale up and down on overview page
+  Scenario: OCP-11196 Could scale up and down on overview page
     Given I have a project
     #Create pod with dc
     When I run the :run client command with:

--- a/features/web/secrets.feature
+++ b/features/web/secrets.feature
@@ -2,7 +2,7 @@ Feature: web secrets related
 
   # @author xxing@redhat.com
   # @case_id OCP-11386
-  Scenario: Add secret on Create From Image page
+  Scenario: OCP-11386 Add secret on Create From Image page
     Given I have a project
     When I run the :oc_secrets_new_basicauth client command with:
       | secret_name | gitsecret |
@@ -28,7 +28,7 @@ Feature: web secrets related
 
   # @author yanpzhan@redhat.com
   # @case_id OCP-15549
-  Scenario: Add secret to application from the secret page
+  Scenario: OCP-15549 Add secret to application from the secret page
     Given I have a project
     When I run the :secrets client command with:
       | action | new        |

--- a/features/web/service-catalog/create.feature
+++ b/features/web/service-catalog/create.feature
@@ -2,7 +2,7 @@ Feature: create app on web console related
 
   # @author hasha@redhat.com
   # @case_id OCP-13718
-  Scenario: Create and view advanced options while creating/selecting project from homepage
+  Scenario: OCP-13718 Create and view advanced options while creating/selecting project from homepage
     # since it's 3.6 tech preview, no scripts for 3.6
     Given the master version >= "3.6"
     When I run the :goto_home_page web console action

--- a/features/web/service-catalog/project.feature
+++ b/features/web/service-catalog/project.feature
@@ -2,7 +2,7 @@ Feature: projects related features via homepage
 
   # @author hasha@redhat.com
   # @case_id OCP-13717
-  Scenario: Manage project in popup panel on home page
+  Scenario: OCP-13717 Manage project in popup panel on home page
     Given the master version >= "3.6"
     Given I have a project
     Given a 5 characters random string of type :dns is stored into the :proj_name clipboard

--- a/features/web/service.feature
+++ b/features/web/service.feature
@@ -2,7 +2,7 @@ Feature: services related feature on web console
 
   # @author wsun@redhat.com
   # @case_id OCP-10602
-  Scenario: Access service pages from web console
+  Scenario: OCP-10602 Access service pages from web console
     Given I have a project
     # oc process -f file | oc create -f -
     When I process and create "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/tc/tc477695/hello.json"
@@ -72,7 +72,7 @@ Feature: services related feature on web console
 
   # @author etrott@redhat.com
   # @case_id OCP-10359
-  Scenario: Group services on overview page
+  Scenario: OCP-10359 Group services on overview page
     # Given the master version >= "3.4"
     Given I create a new project
     When I run the :create client command with:

--- a/features/web/settings.feature
+++ b/features/web/settings.feature
@@ -3,7 +3,7 @@ Feature: check settings page on web console
   # @author yapei@redhat.com
   # @case_id OCP-12631
   @admin
-  Scenario: create project limit and quota, check settings on web console
+  Scenario: OCP-12631 create project limit and quota, check settings on web console
     Given I have a project
     # create limit and quota via CLI
     Given I use the "<%= project.name %>" project
@@ -142,7 +142,7 @@ Feature: check settings page on web console
 
   # @author xxing@redhat.com
   # @case_id OCP-10351
-  Scenario: Check Openshift Master and Kubernetes Master version on About page
+  Scenario: OCP-10351 Check Openshift Master and Kubernetes Master version on About page
     Given the master version >= "3.3"
     When I run the :version client command
     Then the step should succeed
@@ -161,7 +161,7 @@ Feature: check settings page on web console
 
   # @author hasha@redhat.com
   # @case_id OCP-16826
-  Scenario: User could set console home page
+  Scenario: OCP-16826 User could set console home page
     Given the master version >= "3.9"
 
     # not able to set homepage as project overview when user has no project


### PR DESCRIPTION
We've add ID to scenario names for master branch, then we sync those changes to polarion.

But when testing for v3, they do not have ID in scenario names, cause mismatch from polarion, then runner job will show scenario as not found.