### PR TITLE
fix premature exit for s3 upload

### DIFF
--- a/lib/launchers/amz.rb
+++ b/lib/launchers/amz.rb
@@ -160,9 +160,10 @@ module BushSlicer
     # 2021/09/04/12:11:12 and 2021/09/04/23:11:12 as differnt directories
     def s3_upload_file(bucket:, file:, target: nil, content_type: 'text/html')
       target ||= File.basename file
-      res = s3.bucket(bucket).object(target).upload_file(file, content_type: content_type)
-      logger.info("S3 upload file status: #{res}")
-      unless res
+      begin 
+        res = s3.bucket(bucket).object(target).upload_file(file, content_type: content_type)
+        logger.info("S3 upload file status: #{res}")
+      rescue
         # XXX: don't raise exception to avoid premature exit of long test runs
         logger.error("Failed to upload file '#{file}' to '#{target}'")
       end


### PR DESCRIPTION
This should fix the premature exit for jenkins run when the html file is missing.  @jhou1 @liangxia  @dis016 @JianLi-RH PTAL
```
06-17 08:22:15.869  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/aws-sdk-s3-1.114.0/lib/aws-sdk-s3/file_uploader.rb:40:in `size': No such file or directory @ rb_file_s_size - /home/jenkins/ws/workspace/ocp-common/Runner/workdir_cucu_formatter/OCP-30356_Normal_User_can_only_view_project_owned_by_himself/console.html (Errno::ENOENT)
06-17 08:22:15.870  	from /home/jenkins/.gem/bundler/ruby/2.7.0/gems/aws-sdk-s3-1.114.0/lib/aws-sdk-s3/file_uploader.rb:40:in `upload'
06-17 08:22:15.870  	from /home/jenkins/.gem/bundler/ruby/2.7.0/gems/aws-sdk-s3-1.114.0/lib/aws-sdk-s3/customizations/object.rb:440:in `upload_file'
06-17 08:22:15.870  	from /home/jenkins/ws/workspace/ocp-common/Runner/lib/launchers/amz.rb:163:in `s3_upload_file'
06-17 08:22:15.870  	from /home/jenkins/ws/workspace/ocp-common/Runner/lib/launchers/amz.rb:177:in `upload_cucushift_html'
06-17 08:22:15.870  	from /home/jenkins/ws/workspace/ocp-common/Runner/lib/test_case_manager.rb:235:in `handle_attach'
06-17 08:22:15.870  	from /home/jenkins/ws/workspace/ocp-common/Runner/lib/test_case_manager.rb:26:in `block in initialize'
06-17 08:22:15.870  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/headless-2.3.1/lib/headless.rb:251:in `exit': exit (SystemExit)
```