### PR TITLE
Fixing code to log appropriate error instead of nameerror

### DIFF
--- a/features/step_definitions/descheduler.rb
+++ b/features/step_definitions/descheduler.rb
@@ -118,6 +118,7 @@ Given /^kubedescheduler operator has been installed successfully$/ do
     end
   end
   # check csv existense
+  csv = nil
   success = wait_for(300, interval: 10) {
     csv = subscription('cluster-kube-descheduler-operator').current_csv
     !(csv.nil?) && cluster_service_version(csv).exists?


### PR DESCRIPTION
With out the fix here code here raises a Namerror which is not very clear to ci-watchers. Fixing the same so that it will log something as "CSV #{csv} isn't created"