### PR TITLE
Fix SA "I find a bearer token ..." step def

### DIFF
--- a/features/step_definitions/user.rb
+++ b/features/step_definitions/user.rb
@@ -27,6 +27,7 @@ Given /^I find a bearer token of the(?: (.+?))? service account$/ do |acc|
   if service_account(acc).cached_tokens == []
     # Starting with kube 1.24, i.e. OCP 4.11, serviceaccount's YAML does not have an automatically-generated secret-based token
     # So we explicitly create token here
+    acc = service_account(acc).name if acc.include? ":" # when the arg uses format "system:serviceaccount:projectname:default"
     @result = user.cli_exec(:create_token, [[:serviceaccount, acc]])
     raise "Could not create token for the serviceaccount #{acc}" unless @result[:success]
     service_account(acc).add_str_token(@result[:response], protect: true)


### PR DESCRIPTION
A couple of SA cases failed due to last fix not fully considering all argument formats of this step.
Failures like: [OCP-11135](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2022/06/21/13%3A28%3A39/OCP-11135_Could_grant_admin_permission_for_the_service_account_username_to_access_to_other_project?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20220623%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20220623T015042Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=5a9eacf85545932797227f3f282267f2e227bac7248240f85704cf0bdd4c7c27), [OCP-12643](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2022/06/21/13%3A28%3A56/OCP-12643_Could_grant_edit_permission_for_the_service_account_username_to_access_to_its_own_project?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20220623%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20220623T014921Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=b8bfed1f036c390b6e19e2be5283773a23aa588aca10a469056c07c5a8004b1e)
Pass logs: /job/ocp-common/job/Runner/480623/console
@y4sht since it affects a couple of cases, please have a quick review to make it merge, thanks!