### PR TITLE
Revert "OCPQE-10931: skip scenario properly"

### DIFF
--- a/lib/polarshift/test_suite.rb
+++ b/lib/polarshift/test_suite.rb
@@ -107,8 +107,10 @@ module BushSlicer
 
         if self.current_test_record.start_scenario_for! test_case
           return true
+        else
+          puts "logic error: starting test case '#{test_case}' that is not part of current test record\n"
+          #raise "logic error: starting test case that is not part of current test record"
         end
-        return false
       end
 
       # @param test_case [Cucumber::Core::Test::Case]

--- a/lib/test_case_manager_filter.rb
+++ b/lib/test_case_manager_filter.rb
@@ -40,7 +40,9 @@ module BushSlicer
       end
 
       config.on_event :test_case_finished do |event|
-        tc_manager.signal(:end_case, event)
+        unless event.result.skipped?
+          tc_manager.signal(:end_case, event)
+        end
       end
 
       config.on_event :test_run_finished do |event|


### PR DESCRIPTION
Reverts openshift/verification-tests#2920

It cause issue when the test case is already reserved in other jobs.
```
06-27 15:03:20.318  [07:03:19] INFO> Updating PolarShift test case OCP-12652 with Running status and duration of 0.0 seconds
06-27 15:03:20.318  [07:03:19] INFO> HTTP POST user@[https://polarshift-api-*.com/project/OSE/run/20220627-0652/records](https://polarshift-api-*.com/project/OSE/run/20220627-0652/records%1B[0m)
06-27 15:03:20.318  [07:03:19] INFO> HTTP POST took 0.026 sec: 409 Conflict
06-27 15:03:20.318      Given I have a project              # features/step_definitions/project.rb:7
......
06-27 15:03:20.318  undefined method `in_progress?' for nil:NilClass (NoMethodError)
06-27 15:03:20.318  /home/jenkins/ws/workspace/ocp-common/Runner/lib/polarshift/test_suite.rb:154:in `test_case_expected?'
06-27 15:03:20.319  /home/jenkins/ws/workspace/ocp-common/Runner/lib/polarshift/test_suite.rb:127:in `test_case_execute_finish!'
06-27 15:03:20.319  /home/jenkins/ws/workspace/ocp-common/Runner/lib/test_case_manager.rb:48:in `signal'
06-27 15:03:20.319  /home/jenkins/ws/workspace/ocp-common/Runner/lib/test_case_manager_filter.rb:43:in `block in done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/event_bus.rb:34:in `block in broadcast'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/event_bus.rb:34:in `each'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/event_bus.rb:34:in `broadcast'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/event_bus.rb:40:in `method_missing'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/test/runner.rb:22:in `test_case'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/test/case.rb:28:in `describe_to'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-5.3.0/lib/cucumber/filters/prepare_world.rb:11:in `test_case'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/test/case.rb:28:in `describe_to'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/filter.rb:57:in `test_case'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-5.3.0/lib/cucumber/filters/retry.rb:18:in `test_case'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/test/case.rb:28:in `describe_to'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-5.3.0/lib/cucumber/filters/quit.rb:11:in `test_case'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/test/case.rb:28:in `describe_to'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-5.3.0/lib/cucumber/filters/broadcast_test_run_started_event.rb:21:in `block in done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-5.3.0/lib/cucumber/filters/broadcast_test_run_started_event.rb:20:in `map'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-5.3.0/lib/cucumber/filters/broadcast_test_run_started_event.rb:20:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/filter.rb:62:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/filter.rb:62:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/filter.rb:62:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/filter.rb:62:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/filter.rb:62:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/filter.rb:62:in `done'
06-27 15:03:20.319  /home/jenkins/ws/workspace/ocp-common/Runner/lib/test_case_manager_filter.rb:53:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/filter.rb:62:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-5.3.0/lib/cucumber/filters/randomizer.rb:24:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/test/filters/locations_filter.rb:20:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/filter.rb:62:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/test/filters/tag_filter.rb:18:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/compiler.rb:31:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core/gherkin/parser.rb:46:in `done'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core.rb:35:in `parse'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-core-8.0.1/lib/cucumber/core.rb:24:in `compile'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-5.3.0/lib/cucumber/runtime.rb:79:in `run!'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-5.3.0/lib/cucumber/cli/main.rb:29:in `execute!'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/gems/cucumber-5.3.0/bin/cucumber:9:in `<top (required)>'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/bin/cucumber:23:in `load'
06-27 15:03:20.319  /home/jenkins/.gem/bundler/ruby/2.7.0/bin/cucumber:23:in `<top (required)>'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli/exec.rb:63:in `load'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli/exec.rb:63:in `kernel_load'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli/exec.rb:28:in `run'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli.rb:475:in `exec'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli.rb:31:in `dispatch'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli.rb:25:in `start'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/libexec/bundle:46:in `block in <top (required)>'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/share/gems/gems/bundler-2.2.24/libexec/bundle:34:in `<top (required)>'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/bin/bundle:23:in `load'
06-27 15:03:20.319  /opt/rh/rh-ruby27/root/usr/bin/bundle:23:in `<main>'
06-27 15:03:20.319  [07:03:19] INFO> === After Scenario: OCP-12652 The later route should be HostAlreadyClaimed when there is a same host exist ===
06-27 15:03:20.319  [07:03:19] INFO> === End After Scenario: OCP-12652 The later route should be HostAlreadyClaimed when there is a same host exist ===
06-27 15:03:20.319  [07:03:19] INFO> obj_key: logs/2022/06/27/06:53:42/OCP-12652_The_later_route_should_be_HostAlreadyClaimed_when_there_is_a_same_host_exist
06-27 15:03:20.319  [07:03:19] INFO> URL: [http://*/url/generate?key=logs/2022/06/27/06:53:42/OCP-12652_The_later_route_should_be_HostAlreadyClaimed_when_there_is_a_same_host_exist](http://10.14.89.4:3000/url/generate?key=logs/2022/06/27/06:53:42/OCP-12652_The_later_route_should_be_HostAlreadyClaimed_when_there_is_a_same_host_exist%1B[0m)
06-27 15:03:20.319  Bug in test case management - current test record is not set but we finished scenario 'OCP-12652 The later route should be HostAlreadyClaimed when there is a same host exist'
06-27 15:03:20.319  logic error: expected to have current test record but we do not
06-27 15:03:20.319  Skipping testcase due to lacking testrecord for #<Cucumber::Core::Test::Case:0x000000001c29c590>
06-27 15:03:20.319  [07:03:19] INFO> Using /home/jenkins/ws/workspace/ocp-common/Runner/private/config/openshift-ci/.datahub_cred credentials file.
06-27 15:03:20.319  [07:03:19] INFO> === At Exit ===
```