### PR TITLE
Make those "could not find all scenarios" more clearly

### DIFF
--- a/lib/common.rb
+++ b/lib/common.rb
@@ -175,7 +175,7 @@ module BushSlicer
 
     module Setup
       def self.handle_signals
-        # Cucumber traps SIGINT anf SIGTERM to allow graceful shutdown
+        # Cucumber traps SIGINT and SIGTERM to allow graceful shutdown
         # see https://github.com/cucumber/cucumber/issues/27
         Signal.trap('SIGINT') { exit(false) }
         #Signal.trap('SIGTERM') { exit(false) } # it works like that already

--- a/lib/manager.rb
+++ b/lib/manager.rb
@@ -30,7 +30,7 @@ module BushSlicer
     def clean_up
       if @world
         begin
-          # this is likely not going to work in at_exit pahse with
+          # this is likely not going to work in at_exit phase with
           # cucumber 2.4 because builtin methods like `#step` are messed up
           # at that stage. Should we continue on failures in `#at_exit`?
           @world.after_scenario

--- a/lib/test_case_manager.rb
+++ b/lib/test_case_manager.rb
@@ -70,7 +70,7 @@ module BushSlicer
             Kernel.puts("#{job.human_id} - already reserved")
           end
           test_suite.incomplete.each do |job|
-            Kernel.puts("#{job.human_id} - could not find all scenarios")
+            Kernel.puts("#{job.human_id} - could not find scenario, or scenario not suitable for current TEST_MODE")
           end
           test_suite.non_runnable.each do |job|
             Kernel.puts("#{job.human_id} - not runnable")


### PR DESCRIPTION
```
Randomized with seed 11921
[16:55:25] INFO> === At Exit ===
OCP-29199 - could not find all scenarios
OCP-33053 - could not find all scenarios
```

Most of the times, those "could not find all scenarios" are due to scenarios are not suitable for the current TEST_MODE set in Runner job

/cc @jhou1 @JianLi-RH @dis016 @pruan-rht 