### PR TITLE
search pod ip intead of nodeport

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -394,7 +394,7 @@ Feature: Pod related networking scenarios
     Given I wait up to 20 seconds for the steps to pass:
     """
     And I execute on the pod:
-      | bash | -c | conntrack -L \| grep "<%= cb.nodeport %>" |
+      | bash | -c | conntrack -L \| grep "<%= cb.host_pod1.ip %>" |
     Then the step should succeed
     And the output should contain:
       |<%= cb.host_pod1.ip %>|
@@ -418,7 +418,7 @@ Feature: Pod related networking scenarios
     Given I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.network_pod %>" pod:
-      | bash | -c | conntrack -L \| grep "<%= cb.nodeport %>" |
+      | bash | -c | conntrack -L \| grep "<%= cb.host_pod2.ip %>" |
     Then the output should contain "<%= cb.host_pod2.ip %>"
     And the output should not contain "<%= cb.host_pod1.ip %>"
     """


### PR DESCRIPTION
The aim of this conntrack case is to make sure entries related to pod which no more exist shouldn't be present in conntrack table. We were searching that since beginning on our clusters grepping nodeport value casually but why not using podIP which is the aim here.

The existing logic will work fine if we dont have external gateway configured on cluster else breaks

On VZ IPI BM cluster conntrack rules are complicated involving gateways/spk and transalate nodeport, IP/port to differnet values confusing this individual case to fail on such.

I have run case on both clusters now and it works as expected

Normal AWS cluster: https://privatebin.corp.redhat.com/?a9738e9d8729e098#DxeQ4w5aPG1M3VyY4tFxp615phueCXwqpaBeFk2qz3aW

IPI BM vz cluster: https://privatebin.corp.redhat.com/?0d3850858d941345#F3fJoW1nLsfXsvgrgoTBTaLZZmSbJGzjxvo8hqe7FAA7

@openshift/team-sdn-qe PTAL