### PR TITLE
resolve OCPQE-10816

### DIFF
--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -131,8 +131,8 @@ Feature: SCTP related scenarios
   @heterogeneous @arm64 @amd64
   Scenario: OCP-28759 Expose SCTP NodePort Services
     Given I store the ready and schedulable workers in the :workers clipboard
-    And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ip clipboard
     Given I install machineconfigs load-sctp-module
+    And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ip clipboard
     Given I have a project
     And I wait up to 800 seconds for the steps to pass:
     """

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1256,6 +1256,12 @@ end
 Given /^I install machineconfigs load-sctp-module$/ do
   ensure_admin_tagged
   _admin = admin
+  @result = _admin.cli_exec(:get, resource: "nodes")
+    if @result[:response].include?("SchedulingDisabled") || @result[:response].include?("NotReady")
+      logger.warn "There are some nodes already in not normal status."
+      logger.warn "We will skip this scenario"
+      skip_this_scenario
+    end
   if cb.workers.count > 1
     @result = _admin.cli_exec(:get, resource: "machineconfigs", output: 'jsonpath={.items[?(@.metadata.name=="load-sctp-module")].metadata.name}')
     if @result[:response] != "load-sctp-module"


### PR DESCRIPTION
1. Resolved below failure for OCP-28759, sometimes cluster doesn't have 2 available workers which caused the below error happening.  Move it after the step `Given I install machineconfigs load-sctp-module` as it has the checking workers step.
```
the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ip clipboard ==>@  [features/step_definitions/networking.rb:990](https://github.com/openshift/verification-tests/blob/edd90951b465c880dc41d371073263c4321615c9/features/step_definitions/networking.rb#L990)
#<NoMethodError: undefined method `name' for nil:NilClass>
```
2. Sometimes before executing the SCTP cases, the nodes are already in not correct status, to avoid this kind of failures, add one more step checking before the load sctp module. 

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4575/console

@openshift/team-sdn-qe
