### PR TITLE
OCPQE-8870: wait for project annotation "openshift.io/sa.scc.uid-range"

### DIFF
--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -464,13 +464,6 @@ module BushSlicer
           admin.cli_exec(:annotate, resource: "namespace", resourcename: project_name, keyval: 'openshift.io/node-selector=', overwrite: true)
           # we must update the cache, since we just waited for the previously active project to disappear
           project.reload
-          success = wait_for(60, interval: 5) {
-            uid_range = admin.cli_exec(:get, resource: "namespace", resource_name: project_name, template: '{{ index .metadata.annotations "openshift.io/sa.scc.uid-range" }}')
-            !uid_range.nil? && !uid_range.empty? && uid_range !~ /no value/
-          }
-          unless success
-            raise "timeout waiting for project #{project_name} to get annotation openshift.io/sa.scc.uid-range"
-          end
         end
         @service_project = project
       end


### PR DESCRIPTION
After https://github.com/openshift/verification-tests/pull/2928 merged, I'm searching the CI logs to verify the fix do works or not.
Then found the issue not only exist for `oc debug`, but also exist for normal operations. E.g,
```
490594/log-[2022-06-29T23:24:15.947Z]     Given I obtain test data file "quota/pod-completed.yaml"                # features/step_definitions/file.rb:1
490594/log-[2022-06-29T23:24:28.091Z]     When I run the :create client command with:                             # features/step_definitions/cli.rb:13
490594/log-[2022-06-29T23:24:28.091Z]       | f | pod-completed.yaml |
490594/log-[2022-06-29T23:24:28.091Z]       [23:24:15] INFO> Shell Commands: oc create -f pod-completed.yaml --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_testuser-28.kubeconfig
490594/log-[2022-06-29T23:24:28.091Z]       
490594/log-[2022-06-29T23:24:28.091Z]       STDERR:
490594/log:[2022-06-29T23:24:28.091Z]       Error from server (Forbidden): error when creating "pod-completed.yaml": pods "podtocomplete" is forbidden: error fetching namespace "etj28": unable to find annotation openshift.io/sa.scc.uid-range
```
```
490625/log-[2022-06-30T00:53:59.053Z]     Given I obtain test data file "networking/iperf_nodeport_service.json"                                   # features/step_definitions/file.rb:1
490625/log-[2022-06-30T00:54:11.299Z]     When I run the :create admin command with:                                                               # features/step_definitions/cli.rb:31
490625/log-[2022-06-30T00:54:11.299Z]       | f | iperf_nodeport_service.json |
490625/log-[2022-06-30T00:54:11.299Z]       [00:53:59] INFO> Shell Commands: oc create -f iperf_nodeport_service.json --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_admin.kubeconfig
490625/log-[2022-06-30T00:54:11.299Z]       service/iperf-server created
490625/log-[2022-06-30T00:54:11.299Z]       
490625/log-[2022-06-30T00:54:11.299Z]       STDERR:
490625/log:[2022-06-30T00:54:11.299Z]       Error from server (Forbidden): pods "iperf-server" is forbidden: error fetching namespace "ss5gy": unable to find annotation openshift.io/sa.scc.uid-range
```
Thus move the hack to a more proper place to fix them all.

/cc @kasturinarra @xingxingxia @xiaojiey @qiliRedHat