### PR TITLE
Output the test_case_finished event to help debug OCPQE-10970

### DIFF
--- a/lib/test_case_manager_filter.rb
+++ b/lib/test_case_manager_filter.rb
@@ -40,6 +40,8 @@ module BushSlicer
       end
 
       config.on_event :test_case_finished do |event|
+        puts "test_case_finished: #{event}"
+        puts "#{event.inspect}\n"
         unless event.result.skipped?
           tc_manager.signal(:end_case, event)
         end


### PR DESCRIPTION
We've tried https://github.com/openshift/verification-tests/pull/2920 to fix the skip scenario issue. But revert the change later as it caused issue when the test case is already reserved.

Before making another fix, I'd like to check those test_case_finished events in detail, especially for the "HTTP POST took 0.036 sec: 409 Conflict" which is hard to simulate manually.

/cc @jhou1 @pruan-rht @JianLi-RH @dis016 