### PR TITLE
OCPQE-10970, OCPQE-10931: Add handler for skip_this_scenario

### DIFF
--- a/lib/test_case_manager.rb
+++ b/lib/test_case_manager.rb
@@ -47,6 +47,8 @@ module BushSlicer
         attachments = handle_current_artifacts(test_suite.artifacts_format)
         test_suite.test_case_execute_finish!(finish_event, attach: attachments)
         reset_hooks_status
+      when :skip_case
+        test_suite.current_test_record = nil
       when :finish_before_hook
         test_case = args[0]
         err = args[1]

--- a/lib/test_case_manager_filter.rb
+++ b/lib/test_case_manager_filter.rb
@@ -42,6 +42,9 @@ module BushSlicer
       config.on_event :test_case_finished do |event|
         puts "test_case_finished: #{event}"
         puts "#{event.inspect}\n"
+        if event.result.skipped?
+          tc_manager.signal(:skip_case, event)
+        end
         unless event.result.skipped?
           tc_manager.signal(:end_case, event)
         end


### PR DESCRIPTION
The error is,
```
07-05 19:59:18.365    Scenario: OCP-24691 Defined Multiple allowedCIDRs                                                 # features/networking/service.feature:353
07-05 19:59:18.365  [11:59:18] WARN> logic error
07-05 19:59:18.365  [11:59:18] WARN> trying to start Cucumber scenario for test case #<Cucumber::Core::Test::Case:0x0000000018c22078>: OCP-24691 Defined Multiple allowedCIDRs
07-05 19:59:18.365  [11:59:18] WARN> but we are using test record from: OCP-30057 OVN DB should be updated correctly if a resource only exist in NB db but not in Kube API
```
The issue is that
let's assume we have two test cases, caseA and caseB. caseA has skip_this_scenario in one of its steps due to conditions can not met (e.g, scenario requires at least two nodes, but we are on SNO, which has only one node).
When starting the execution on caseB after caseA is skipped, Cucumber::Core::Test::Case is set to caseB, and BushSlicer::PolarShift::ScenarioWrapper still points to caseA, which cause logic error in start_scenario_for, and caseB is skipped due to the logic error/mismatch.
If we have caseC, caseD, ... followed, it will be skipped, too, due to the same logic error/mismatch.

Several days earlier we tried to removed the skip check, so when caseA is skipped, we send a signal to indicate we have reached the end of case of caseA, so Cucumber::Core::Test::Case and BushSlicer::PolarShift::ScenarioWrapper match again.
It works for the skip_this_scenario, but later we found it cause issue when the test scenario is skipped at the very beginning due to 409 conflict (which indicates the test case have been reserved by another build).

In this PR, for the skipped scenarios, we explicitly set the current_test_record to nil, to indicate the test has finished.


/cc @jhou1 @pruan-rht @JianLi-RH @dis016 