### PR TITLE
Remove duplicate error info

### DIFF
--- a/lib/polarshift/test_suite.rb
+++ b/lib/polarshift/test_suite.rb
@@ -108,7 +108,6 @@ module BushSlicer
         if self.current_test_record.start_scenario_for! test_case
           return true
         else
-          puts "logic error: starting test case '#{test_case}' that is not part of current test record\n"
           return false
         end
       end


### PR DESCRIPTION
We have error message as below,
```
07-05 21:27:14.144  [13:27:13] WARN> logic error
07-05 21:27:14.144  [13:27:13] WARN> trying to start Cucumber scenario for test case #<Cucumber::Core::Test::Case:0x0000000017584b40>: OCP-26139 Traffic flow shouldn't be interrupted when master switches the leader positions
07-05 21:27:14.144  [13:27:13] WARN> but we are using test record from: OCP-32205 Thrashing ovnkube master IPAM allocator by creating and deleting various pods on a specific node
07-05 21:27:14.144  logic error: starting test case '#<Cucumber::Core::Test::Case:0x0000000017584b40>' that is not part of current test record
```