### PR TITLE
OCPQE-10970: Fix RuntimeError: unsetting current test record while it is already unset

### DIFF
--- a/lib/test_case_manager.rb
+++ b/lib/test_case_manager.rb
@@ -48,7 +48,7 @@ module BushSlicer
         test_suite.test_case_execute_finish!(finish_event, attach: attachments)
         reset_hooks_status
       when :skip_case
-        test_suite.current_test_record = nil
+        test_suite.current_test_record = nil unless test_suite.current_test_record.nil?
       when :finish_before_hook
         test_case = args[0]
         err = args[1]


### PR DESCRIPTION
We only allow change current_test_record from nil to non-nil, and vice versa.
```
      # for logic validation reasons, allow changes only from nil to non-nil
      #   and vice versa
      # @param value [PolarShift::TestCase]
      def current_test_record=(value)
        if @current_test_record.nil? && value ||
            @current_test_record && value.nil?
          @current_test_record = value
        elsif @current_test_record
          raise "current test record not cleared before setting new one"
        else
          raise "unsetting current test record while it is already unset"
        end
      end
```
so add a check before set it to nil.

/cc @jhou1 @pruan-rht @dis016 @JianLi-RH 