### PR TITLE
Increased default wait timeout from 60s to 120s while checking secret in OCP-41198

### DIFF
--- a/features/upgrade/api_auth/upgrade.feature
+++ b/features/upgrade/api_auth/upgrade.feature
@@ -271,7 +271,7 @@ Feature: apiserver and auth related upgrade check
       | f | headless-services.yaml |
     Then the step should succeed
     Given I use the "service-ca-upgrade" project
-    And I wait for the "test-serving-cert" secret to appear
+    And I wait for the "test-serving-cert" secret to appear up to 120 seconds
     And I run the :extract client command with:
       | resource | secret/test-serving-cert |
       | confirm  | true                     |


### PR DESCRIPTION
In upgrade CI pipeline jobs, it has been reported multiple times that , prepare case of OCP-41198 i.e. "apiserver and auth related upgrade check.Upgrade action will cause re-generation of certificates for headless services to include the wildcard subjects - prepare" has failed with timeout while checking the secret object created in test step. Hence I would like to increase the wait timeout to 120s to see how it works in execution ( This would not make any difference in already passing scenario execution only it would wait additional 60s before it fails with timeout in failing cases.)
Please note that, with same profile ,in multiple isolated test executions, we weren't reproduced this error.
Reference ticket  :  [OCPQE-10514](https://issues.redhat.com/browse/OCPQE-10514), [OCPQE-10956](https://issues.redhat.com/browse/OCPQE-10956)
Jenkins execution report could find [here](http://pastebin.test.redhat.com/1063284)
@wangke19  Kindly review the same.