### PR TITLE
fix the apiVersion of scc

### DIFF
--- a/testdata/node/scc.yaml
+++ b/testdata/node/scc.yaml
@@ -5,7 +5,7 @@ allowHostPID: false
 allowHostPorts: false
 allowPrivilegedContainer: false
 allowedCapabilities: null
-apiVersion: v1
+apiVersion: security.openshift.io/v1
 defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny


### PR DESCRIPTION
now the apiVersion of 'v1' has been deprecated in scc,  so we need to update it to : security.openshift.io/v1