### PR TITLE
fix OCPQE-11171

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -362,6 +362,9 @@ Given /^I delete the clusterlogging instance$/ do
     end
       step %Q/logging collector name is stored in the :collector_name clipboard/
     unless cluster_logging('instance').collection_spec(cached: true).nil?
+      if daemon_set(collector_name).exists?
+        @result = admin.cli_exec(:delete, object_type: 'daemonset', object_name_or_id: collector_name, n: 'openshift-logging')
+      end
       step %Q/I wait for the resource "daemonset" named "#{cb.collector_name}" to disappear/
     end
   end

--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -362,10 +362,7 @@ Given /^I delete the clusterlogging instance$/ do
     end
       step %Q/logging collector name is stored in the :collector_name clipboard/
     unless cluster_logging('instance').collection_spec(cached: true).nil?
-      if daemon_set(collector_name).exists?
-        @result = admin.cli_exec(:delete, object_type: 'daemonset', object_name_or_id: collector_name, n: 'openshift-logging')
-      end
-      step %Q/I wait for the resource "daemonset" named "#{cb.collector_name}" to disappear/
+      step %Q/admin ensures "#{cb.collector_name}" ds is deleted/
     end
   end
 end


### PR DESCRIPTION
Sometimes the ds/collector is not removed automatically after removing clusterlogging, and the step `I wait for the resource "daemonset" named "#{cb.collector_name}" to disappear` causes premature test execution termination. Here add a step to remove the ds if it's not removed automatically.