### PR TITLE
fix rules for OCP-27586

### DIFF
--- a/lib/rules/web/admin_console/4.10/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.10/dashboards.xyaml
@@ -178,47 +178,50 @@ check_resources_pod_dashboard:
 check_cluster_utilization_items:
   elements:
   - selector:
-      xpath: //div[contains(@class, "pf-c-card__title") and text()='Cluster utilization']
+      xpath: //div[text()='Cluster utilization']
     timeout: 30
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='CPU']
+      xpath: //h4[text()='CPU']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Memory']
+      xpath: //h4[text()='Memory']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Filesystem']
+      xpath: //h4[text()='Filesystem']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Network transfer']
+      xpath: //h4[text()='Network transfer']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Pod count']
+      xpath: //h4[text()='Pod count']
+  scripts:
+  - command: return document.querySelectorAll('h4[data-test="utilization-item-title"]')[4].scrollIntoView(true)
+    expect_result: ~
 click_cpu_data:
   element:
     selector:
-      xpath: //h4[text()='CPU']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='CPU']/following::button[1]
     op: click
 click_memory_data:
   element:
     selector:
-      xpath: //h4[text()='Memory']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='Memory']/following::button[1]
     op: click
 click_filesystem_data:
   element:
     selector:
-      xpath: //h4[text()='Filesystem']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='Filesystem']/following::button[1]
     op: click
 click_pod_count_data:
   element:
     selector:
-      xpath: //h4[text()='Pod count']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='Pod count']/following::button[1]
     op: click
 click_network_in_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'pf-c-button')][1]
+      xpath: //h4[text()='Network transfer']/following::button[1]
     op: click
 click_network_out_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'pf-c-button')][2]
+      xpath: //h4[text()='Network transfer']/following::button[2]
     op: click
     timeout: 60
 choose_consumer_measure:

--- a/lib/rules/web/admin_console/4.11/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.11/dashboards.xyaml
@@ -178,47 +178,50 @@ check_resources_pod_dashboard:
 check_cluster_utilization_items:
   elements:
   - selector:
-      xpath: //div[contains(@class, "pf-c-card__title") and text()='Cluster utilization']
+      xpath: //div[text()='Cluster utilization']
     timeout: 30
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='CPU']
+      xpath: //h4[text()='CPU']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Memory']
+      xpath: //h4[text()='Memory']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Filesystem']
+      xpath: //h4[text()='Filesystem']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Network transfer']
+      xpath: //h4[text()='Network transfer']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Pod count']
+      xpath: //h4[text()='Pod count']
+  scripts:
+  - command: return document.querySelectorAll('h4[data-test="utilization-item-title"]')[4].scrollIntoView(true)
+    expect_result: ~
 click_cpu_data:
   element:
     selector:
-      xpath: //h4[text()='CPU']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='CPU']/following::button[1]
     op: click
 click_memory_data:
   element:
     selector:
-      xpath: //h4[text()='Memory']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='Memory']/following::button[1]
     op: click
 click_filesystem_data:
   element:
     selector:
-      xpath: //h4[text()='Filesystem']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='Filesystem']/following::button[1]
     op: click
 click_pod_count_data:
   element:
     selector:
-      xpath: //h4[text()='Pod count']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='Pod count']/following::button[1]
     op: click
 click_network_in_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'pf-c-button')][1]
+      xpath: //h4[text()='Network transfer']/following::button[1]
     op: click
 click_network_out_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'pf-c-button')][2]
+      xpath: //h4[text()='Network transfer']/following::button[2]
     op: click
     timeout: 60
 choose_consumer_measure:

--- a/lib/rules/web/admin_console/4.12/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.12/dashboards.xyaml
@@ -178,47 +178,50 @@ check_resources_pod_dashboard:
 check_cluster_utilization_items:
   elements:
   - selector:
-      xpath: //div[contains(@class, "pf-c-card__title") and text()='Cluster utilization']
+      xpath: //div[text()='Cluster utilization']
     timeout: 30
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='CPU']
+      xpath: //h4[text()='CPU']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Memory']
+      xpath: //h4[text()='Memory']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Filesystem']
+      xpath: //h4[text()='Filesystem']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Network transfer']
+      xpath: //h4[text()='Network transfer']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Pod count']
+      xpath: //h4[text()='Pod count']
+  scripts:
+  - command: return document.querySelectorAll('h4[data-test="utilization-item-title"]')[4].scrollIntoView(true)
+    expect_result: ~
 click_cpu_data:
   element:
     selector:
-      xpath: //h4[text()='CPU']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='CPU']/following::button[1]
     op: click
 click_memory_data:
   element:
     selector:
-      xpath: //h4[text()='Memory']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='Memory']/following::button[1]
     op: click
 click_filesystem_data:
   element:
     selector:
-      xpath: //h4[text()='Filesystem']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='Filesystem']/following::button[1]
     op: click
 click_pod_count_data:
   element:
     selector:
-      xpath: //h4[text()='Pod count']/..//button[contains(@class,'pf-c-button')]
+      xpath: //h4[text()='Pod count']/following::button[1]
     op: click
 click_network_in_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'pf-c-button')][1]
+      xpath: //h4[text()='Network transfer']/following::button[1]
     op: click
 click_network_out_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'pf-c-button')][2]
+      xpath: //h4[text()='Network transfer']/following::button[2]
     op: click
     timeout: 60
 choose_consumer_measure:

--- a/lib/rules/web/admin_console/4.6/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.6/dashboards.xyaml
@@ -168,47 +168,50 @@ check_resources_pod_dashboard:
 check_cluster_utilization_items:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-dashboard-card__title') and text()='Cluster Utilization']
+      xpath: //h2[text()='Cluster Utilization']
     timeout: 30 
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='CPU']
+      xpath: //h4[text()='CPU']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Memory']
+      xpath: //h4[text()='Memory']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Filesystem']
+      xpath: //h4[text()='Filesystem']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Network Transfer']
+      xpath: //h4[text()='Network Transfer']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Pod count']
+      xpath: //h4[text()='Pod count']
+  scripts:
+  - command: return document.querySelectorAll('h4[data-test="utilization-item-title"]')[4].scrollIntoView(true)
+    expect_result: ~
 click_cpu_data:
   element:
     selector:
-      xpath: //h4[text()='CPU']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='CPU']/following::button[1]
     op: click
 click_memory_data:
   element:
     selector:
-      xpath: //h4[text()='Memory']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Memory']/following::button[1]
     op: click
 click_filesystem_data:
   element:
     selector:
-      xpath: //h4[text()='Filesystem']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Filesystem']/following::button[1]
     op: click
 click_pod_count_data:
   element:
     selector:
-      xpath: //h4[text()='Pod count']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Pod count']/following::button[1]
     op: click
 click_network_in_data:
   element:
     selector:
-      xpath: //h4[text()='Network Transfer']/..//button[contains(@class,'co-dashboard-card__button-link')][1]
+      xpath: //h4[text()='Network Transfer']/following::button[1]
     op: click
 click_network_out_data:
   element:
     selector:
-      xpath: //h4[text()='Network Transfer']/..//button[contains(@class,'co-dashboard-card__button-link')][2]
+      xpath: //h4[text()='Network Transfer']/following::button[2]
     op: click
     timeout: 60
 choose_consumer_measure:

--- a/lib/rules/web/admin_console/4.7/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.7/dashboards.xyaml
@@ -168,47 +168,50 @@ check_resources_pod_dashboard:
 check_cluster_utilization_items:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-dashboard-card__title') and text()='Cluster utilization']
+      xpath: //h2[text()='Cluster utilization']
     timeout: 30 
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='CPU']
+      xpath: //h4[text()='CPU']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Memory']
+      xpath: //h4[text()='Memory']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Filesystem']
+      xpath: //h4[text()='Filesystem']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Network transfer']
+      xpath: //h4[text()='Network transfer']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Pod count']
+      xpath: //h4[text()='Pod count']
+  scripts:
+  - command: return document.querySelectorAll('h4[data-test="utilization-item-title"]')[4].scrollIntoView(true)
+    expect_result: ~
 click_cpu_data:
   element:
     selector:
-      xpath: //h4[text()='CPU']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='CPU']/following::button[1]
     op: click
 click_memory_data:
   element:
     selector:
-      xpath: //h4[text()='Memory']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Memory']/following::button[1]
     op: click
 click_filesystem_data:
   element:
     selector:
-      xpath: //h4[text()='Filesystem']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Filesystem']/following::button[1]
     op: click
 click_pod_count_data:
   element:
     selector:
-      xpath: //h4[text()='Pod count']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Pod count']/following::button[1]
     op: click
 click_network_in_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'co-dashboard-card__button-link')][1]
+      xpath: //h4[text()='Network transfer']/following::button[1]
     op: click
 click_network_out_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'co-dashboard-card__button-link')][2]
+      xpath: //h4[text()='Network transfer']/following::button[2]
     op: click
     timeout: 60
 choose_consumer_measure:

--- a/lib/rules/web/admin_console/4.8/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.8/dashboards.xyaml
@@ -168,47 +168,50 @@ check_resources_pod_dashboard:
 check_cluster_utilization_items:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-dashboard-card__title') and text()='Cluster utilization']
+      xpath: //h2[text()='Cluster utilization']
     timeout: 30
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='CPU']
+      xpath: //h4[text()='CPU']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Memory']
+      xpath: //h4[text()='Memory']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Filesystem']
+      xpath: //h4[text()='Filesystem']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Network transfer']
+      xpath: //h4[text()='Network transfer']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Pod count']
+      xpath: //h4[text()='Pod count']
+  scripts:
+  - command: return document.querySelectorAll('h4[data-test="utilization-item-title"]')[4].scrollIntoView(true)
+    expect_result: ~
 click_cpu_data:
   element:
     selector:
-      xpath: //h4[text()='CPU']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='CPU']/following::button[1]
     op: click
 click_memory_data:
   element:
     selector:
-      xpath: //h4[text()='Memory']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Memory']/following::button[1]
     op: click
 click_filesystem_data:
   element:
     selector:
-      xpath: //h4[text()='Filesystem']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Filesystem']/following::button[1]
     op: click
 click_pod_count_data:
   element:
     selector:
-      xpath: //h4[text()='Pod count']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Pod count']/following::button[1]
     op: click
 click_network_in_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'co-dashboard-card__button-link')][1]
+      xpath: //h4[text()='Network transfer']/following::button[1]
     op: click
 click_network_out_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'co-dashboard-card__button-link')][2]
+      xpath: //h4[text()='Network transfer']/following::button[2]
     op: click
     timeout: 60
 choose_consumer_measure:

--- a/lib/rules/web/admin_console/4.9/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.9/dashboards.xyaml
@@ -178,47 +178,50 @@ check_resources_pod_dashboard:
 check_cluster_utilization_items:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-dashboard-card__title') and text()='Cluster utilization']
+      xpath: //h2[text()='Cluster utilization']
     timeout: 30
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='CPU']
+      xpath: //h4[text()='CPU']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Memory']
+      xpath: //h4[text()='Memory']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Filesystem']
+      xpath: //h4[text()='Filesystem']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Network transfer']
+      xpath: //h4[text()='Network transfer']
   - selector:
-      xpath: //div[contains(@class,'co-utilization-card__item')]//h4[text()='Pod count']
+      xpath: //h4[text()='Pod count']
+  scripts:
+  - command: return document.querySelectorAll('h4[data-test="utilization-item-title"]')[4].scrollIntoView(true)
+    expect_result: ~
 click_cpu_data:
   element:
     selector:
-      xpath: //h4[text()='CPU']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='CPU']/following::button[1]
     op: click
 click_memory_data:
   element:
     selector:
-      xpath: //h4[text()='Memory']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Memory']/following::button[1]
     op: click
 click_filesystem_data:
   element:
     selector:
-      xpath: //h4[text()='Filesystem']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Filesystem']/following::button[1]
     op: click
 click_pod_count_data:
   element:
     selector:
-      xpath: //h4[text()='Pod count']/..//button[contains(@class,'co-dashboard-card__button-link')]
+      xpath: //h4[text()='Pod count']/following::button[1]
     op: click
 click_network_in_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'co-dashboard-card__button-link')][1]
+      xpath: //h4[text()='Network transfer']/following::button[1]
     op: click
 click_network_out_data:
   element:
     selector:
-      xpath: //h4[text()='Network transfer']/..//button[contains(@class,'co-dashboard-card__button-link')][2]
+      xpath: //h4[text()='Network transfer']/following::button[2]
     op: click
     timeout: 60
 choose_consumer_measure:


### PR DESCRIPTION
1. button class can easily change so removed class from xpath expression
2. `Cluster Utilization` card has 5 categories, most times not all categories are viewable so updated to scroll all into view before further checking