### PR TITLE
Update multus upgrade test

### DIFF
--- a/features/upgrade/sdn/multus-upgrade.feature
+++ b/features/upgrade/sdn/multus-upgrade.feature
@@ -54,8 +54,7 @@
   Scenario: Check the multus works well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "multus-upgrade" project
-    Given a pod becomes ready with labels:
-      | multus-default-route-pod |
+    Given the pod named "multus-default-route-pod" becomes ready
     # Check created pod has correct ip address on interface net1
     When I execute on the pod:
       | ip | a |

--- a/features/upgrade/sdn/multus-upgrade.feature
+++ b/features/upgrade/sdn/multus-upgrade.feature
@@ -34,12 +34,6 @@
     Then the step should succeed
     And the pod named "multus-default-route-pod" becomes ready
 
-    # Check pod1 has correct macvlan mode on interface net1
-    When I execute on the pod:
-      | ip | -d | link |
-    Then the output should contain:
-      | net1                |
-      | macvlan mode bridge |
     # Check created pod has correct ip address on interface net1
     When I execute on the pod:
       | ip | a |
@@ -62,12 +56,6 @@
     When I use the "multus-upgrade" project
     Given a pod becomes ready with labels:
       | multus-default-route-pod |
-    # Check pod1 has correct macvlan mode on interface net1
-    When I execute on the pod:
-      | ip | -d | link |
-    Then the output should contain:
-      | net1                |
-      | macvlan mode bridge |
     # Check created pod has correct ip address on interface net1
     When I execute on the pod:
       | ip | a |

--- a/features/upgrade/sdn/multus-upgrade.feature
+++ b/features/upgrade/sdn/multus-upgrade.feature
@@ -22,7 +22,7 @@
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml"
     When I run oc create as admin over "whereabouts-macvlan.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                      |
-      | ["spec"]["config"]        | '{ "cniVersion": "0.3.1", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/30"} }' |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.1", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/32"} }' |
     Then the step should succeed
 
     # Create a pod absorbing above net-attach-def


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPQE-10840: Upgrade testing will reboot all the nodes. The root cause for this issue is the dynamic address may be changed after nodes get rebooting, use static IP for pod’s secondary interface instead of dynamic, the IP should keep same before and after rebooting the nodes 

@openshift/team-sdn-qe PTAL

Test Log:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4646/console
After rebooting nodes:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4647/console
