### PR TITLE
update idling case for upgrade testing

### DIFF
--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -253,7 +253,7 @@ Feature: Routing and DNS related scenarios
   # @author mjoseph@redhat.com
   @upgrade-prepare
   @users=upuser1,upuser2
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.12 @4.11 @4.10 @4.9 @4.8
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode
@@ -293,7 +293,7 @@ Feature: Routing and DNS related scenarios
   # @case_id OCP-45955
   @upgrade-check
   @users=upuser1,upuser2
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.12 @4.11 @4.10 @4.9 @4.8
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode


### PR DESCRIPTION
Since idling is not functional with OVN on 4.6/4.7, but we don't want remove tag `@network-ovnkubernetes` from this case, so the alternative solution is remove the old release tag.

@melvinjoseph86 @quarterpin @ShudiLi please help take a look, thanks, 