### PR TITLE
Fix issue: e2e CI watcher modify ns

### DIFF
--- a/features/storage/pre-bind.feature
+++ b/features/storage/pre-bind.feature
@@ -21,7 +21,7 @@ Feature: Testing for pv and pvc pre-bind feature
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
     Then admin creates a PV from "preboundpv-rwo.yaml" where:
       | ["metadata"]["name"]              | pv2-<%= project.name %> |
-      | ["spec"]["claimRef"]["namespace"] | <%= project.name %>     |
+      | ["spec"]["claimRef"]["namespace"] | "<%= project.name %>"   |
       | ["spec"]["claimRef"]["name"]      | mypvc                   |
       | ["spec"]["storageClassName"]      | sc-<%= project.name %>  |
     And the "pv2-<%= project.name %>" PV status is :available
@@ -39,7 +39,7 @@ Feature: Testing for pv and pvc pre-bind feature
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
     Given admin creates a PV from "preboundpv-rwo.yaml" where:
       | ["metadata"]["name"]              | pv-<%= project.name %> |
-      | ["spec"]["claimRef"]["namespace"] | <%= project.name %>    |
+      | ["spec"]["claimRef"]["namespace"] | "<%= project.name %>"  |
       | ["spec"]["claimRef"]["name"]      | mypvc                  |
       | ["spec"]["storageClassName"]      | sc-<%= project.name %> |
     Then the step should succeed
@@ -169,7 +169,7 @@ Feature: Testing for pv and pvc pre-bind feature
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
     Given admin creates a PV from "preboundpv-rwo.yaml" where:
       | ["metadata"]["name"]              | pv-<%= project.name %> |
-      | ["spec"]["claimRef"]["namespace"] | <%= project.name %>    |
+      | ["spec"]["claimRef"]["namespace"] | "<%= project.name %>"  |
       | ["spec"]["claimRef"]["name"]      | mypvc2                 |
       | ["spec"]["storageClassName"]      | sc-<%= project.name %> |
     Given I obtain test data file "storage/nfs/claim-rwo.json"
@@ -192,7 +192,7 @@ Feature: Testing for pv and pvc pre-bind feature
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
     Given admin creates a PV from "preboundpv-rwo.yaml" where:
       | ["metadata"]["name"]              | pv-<%= project.name %> |
-      | ["spec"]["claimRef"]["namespace"] | <%= project.name %>    |
+      | ["spec"]["claimRef"]["namespace"] | "<%= project.name %>"  |
       | ["spec"]["claimRef"]["name"]      | <pre-bind-pvc>         |
       | ["spec"]["storageClassName"]      | sc-<%= project.name %> |
     Then the step should succeed


### PR DESCRIPTION
Hi, 

kindly PTAL, 

Issue: 
https://issues.redhat.com/browse/OCPQE-11283
Explanation: When ever there is namespace generated with no characters in it(a-z), have only numbers(0-9). will throw error. 

Manual execution when ns have only numbers, 
oc create -f pv.yaml 
Error from server (BadRequest): error when creating "pv.yaml": PersistentVolume in version "v1" cannot be handled as a PersistentVolume: json: cannot unmarshal number into Go struct field ObjectReference.spec.claimRef.namespace of type string

Manual execution when ns have only numbers but considering as string, 
 oc create -f pv.yaml
persistentvolume/pv-12345 created
pv.yaml
  claimRef:
    namespace: "12345"
    name: nfsc1
  storageClassName: sc-12345
  rohitpatil@ropatil-mac Downloads % oc get pv
NAME       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM         STORAGECLASS   REASON   AGE
pv-12345   1Gi        RWO            Retain           Available   12345/nfsc1   sc-12345                11m
  
  Runner job with fix: 
  https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/519185/console