### PR TITLE
Bypass the premature exit of case or execution due to kube-apiserver operator roll out in SNO cases.

### DIFF
--- a/lib/openshift/resource.rb
+++ b/lib/openshift/resource.rb
@@ -51,7 +51,7 @@ module BushSlicer
         return false
       elsif result[:response] =~ /connection to the server \S+ was refused - did you specify the right host or port/ && env.nodes.length == 1
         logger.info(result[:response])
-        return false
+        return true
       else
         # e.g. when called by user without rights to list Resource
         raise "error getting #{self.class.name} '#{name}' existence: #{result[:response]}"


### PR DESCRIPTION
In [OCPQE-8433](https://issues.redhat.com/browse/OCPQE-8433?focusedCommentId=20220756&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-20220756), we have seen that , SNO case had been prematurely exited from test execution during a destructive case i.e. when new revision rolled out for kube-apiserver operator, SNO reports as "connection to the server xyz was refused - did you specify the right host or port?" till the operator becomes available. Currently the framework is not able to handle this properly and it raise exception [here](https://github.com/openshift/verification-tests/blob/70f9b2a5affb5764837df23b38169817ca3dd5d9/lib/openshift/resource.rb#L66). To avoid this situation i.e allowing SNO cases to retry and proceed further, we need to change the return response where we capture the failure in resource file end.
Please find the execution result references below.
Current failing execution is [here](http://pastebin.test.redhat.com/1066232)
Execution after the fix is [here](http://pastebin.test.redhat.com/1066237)

@liangxia @wangke19 Kindly review the change and let me know your feedback. Thank you.