### PR TITLE
Adding @inactive tags to tests

### DIFF
--- a/features/kata/install_uninstall.feature
+++ b/features/kata/install_uninstall.feature
@@ -22,6 +22,7 @@ Feature: kata related features
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @inactive
   Scenario: OCP-36509:Kata test delete kata installation
     Given I remove kata operator from the namespace
 

--- a/features/kata/pod.feature
+++ b/features/kata/pod.feature
@@ -9,6 +9,7 @@ Feature: kata and pod related scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @inactive
   Scenario: OCP-38468:Kata Pod using kata runtime can have an initcontainer
     Given I have a project
     And I obtain test data file "kata/OCP-38468/pod_with_init_container.yaml"

--- a/features/kata/smoke_tests.feature
+++ b/features/kata/smoke_tests.feature
@@ -11,6 +11,7 @@ Feature: kata smoke tests
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @inactive
   Scenario: OCP-41263:Kata Namespace installed by operator
     Given kata container has been installed successfully
     Then the expression should be true> project.name == 'openshift-sandboxed-containers-operator'


### PR DESCRIPTION
The below tests are not reqd and are covered in our golang tests. Removing them by adding the inactive tag.
The respective polarion work items have also been marked inactive

cc @pruan @cpmeadors @dis016 