### PR TITLE
Revert "Update multus upgrade test (#2964)"

### DIFF
--- a/features/upgrade/sdn/multus-upgrade.feature
+++ b/features/upgrade/sdn/multus-upgrade.feature
@@ -19,26 +19,34 @@
       | project_name | multus-upgrade |
     Then the step should succeed
     When I use the "multus-upgrade" project
-    Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/ipam-static.yaml"
-    When I run oc create as admin over "ipam-static.yaml" replacing paths:
-      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                      |
-      | ["metadata"]["name"]      | bridge-static                                                                                                                            |
-      | ["spec"]["config"]        | '{ "cniVersion": "0.3.1", "type": "bridge", "ipam": {"type":"static","addresses": [{"address": "22.2.2.22/24","gateway": "22.2.2.1"}]}}' |
+    Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml"
+    When I run oc create as admin over "whereabouts-macvlan.yaml" replacing paths:
+      | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                      |
+      | ["spec"]["config"]        | '{ "cniVersion": "0.3.1", "type": "macvlan", "master": "<%= cb.default_interface %>","mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.22.100/30"} }' |
     Then the step should succeed
 
     # Create a pod absorbing above net-attach-def
-    Given I obtain test data file "networking/multus-cni/Pods/multus-default-route-pod.yaml"
-    When I run the :create client command with:
-      | f | multus-default-route-pod.yaml |
-      | n | <%= project.name %>           |
+    Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod_upgrade.yaml"
+    When I run oc create over "generic_multus_pod_upgrade.yaml" replacing paths:
+      | ["items"][0]["spec"]["template"]["metadata"]["labels"]["name"]                             | test-pod1                       |
+      | ["items"][0]["metadata"]["name"]                                                           | macvlan-bridge-whereabouts-pod1 |
+      | ["items"][0]["spec"]["template"]["metadata"]["annotations"]["k8s.v1.cni.cncf.io/networks"] | macvlan-bridge-whereabouts      |
+      | ["items"][0]["spec"]["template"]["spec"]["containers"][0]["name"]                          | macvlan-bridge-whereabouts      |
     Then the step should succeed
-    And the pod named "multus-default-route-pod" becomes ready
+    Given a pod becomes ready with labels:
+      | name=test-pod1 |
 
+    # Check pod1 has correct macvlan mode on interface net1
+    When I execute on the pod:
+      | ip | -d | link |
+    Then the output should contain:
+      | net1                |
+      | macvlan mode bridge |
     # Check created pod has correct ip address on interface net1
     When I execute on the pod:
       | ip | a |
-    Then the output should contain:
-      | 22.2.2.22 |
+    Then the output should match:
+      | 192.168.22.10[12] |
 
   # @author weliang@redhat.com
   # @case_id OCP-44898
@@ -54,12 +62,19 @@
   Scenario: Check the multus works well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "multus-upgrade" project
-    Given the pod named "multus-default-route-pod" becomes ready
+    Given a pod becomes ready with labels:
+      | name=test-pod1 |
+    # Check pod1 has correct macvlan mode on interface net1
+    When I execute on the pod:
+      | ip | -d | link |
+    Then the output should contain:
+      | net1                |
+      | macvlan mode bridge |
     # Check created pod has correct ip address on interface net1
     When I execute on the pod:
       | ip | a |
-    Then the output should contain:
-      | 22.2.2.22 |
+    Then the output should match:
+      | 192.168.22.10[12] |
 
     # Delete the created project from testing cluster
     Given the "multus-upgrade" project is deleted


### PR DESCRIPTION
This reverts commit 61cbd59d3b36a6b606eaf9a58a165f69a55bf182.

@weliang1 I revered your changes since networking/multus-cni/Pods/multus-default-route-pod.yaml is not rc or deployment, the pod will be deleted after upgrade the cluster. 

and I just checked 192.168.22.100/30 only two ips (192.168.22.101 and 192.168.22.102)
so here only update to match with ip 101 and 102

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4652/console
