### PR TITLE
Fix the test to run on Singlestack IPv6 cluster

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -545,7 +545,7 @@ Feature: SDN compoment upgrade testing
       | configmap_file  | config-map.yaml               |
       | deployment_file | rsyslogserver_deployment.yaml |
       | pod_label       | component=rsyslogserver       |
-    And evaluation of `service("rsyslogserver").ip` is stored in the :svc_ip clipboard
+    And evaluation of `service("rsyslogserver").ip_url` is stored in the :svc_ip clipboard
     And evaluation of `pod(0).name` is stored in the :rsyslog_server_pod clipboard
     Then the step should succeed
 
@@ -653,7 +653,7 @@ Feature: SDN compoment upgrade testing
     Given I wait for the "rsyslogserver" service to become ready
     Given a pod becomes ready with labels:
       | appname=rsyslogserver |
-    And evaluation of `service("rsyslogserver").ip` is stored in the :svc_ip clipboard
+    And evaluation of `service("rsyslogserver").ip_url` is stored in the :svc_ip clipboard
     And evaluation of `pod(0).name` is stored in the :rsyslog_server_pod clipboard
     Then the step should succeed
 


### PR DESCRIPTION
Fix to enable test to run on SingleStack IPv6 cluster.

Tested on the following profiles:-
private-templates/functionality-testing/aos-4_11/upi-on-baremetal/versioned-installer-packet-dual_stack
private-templates/functionality-testing/aos-4_10/upi-on-baremetal/versioned-installer-packet-single_stack-http_proxy-fips-ipsec-ci

@openshift/team-sdn-qe PTAL
