### PR TITLE
fixed prometeus sa token issues

### DIFF
--- a/features/networking/metrics.feature
+++ b/features/networking/metrics.feature
@@ -11,28 +11,11 @@ Feature: SDN/OVN metrics related networking scenarios
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-28519:SDN Prometheus should be able to monitor kubeproxy metrics
+    Given I select a random node's host
     Given I switch to cluster admin pseudo user
     And I use the "openshift-sdn" project
-    And evaluation of `endpoints('sdn').subsets.first.addresses.first.ip.to_s` is stored in the :metrics_ep_ip clipboard
-    And evaluation of `endpoints('sdn').subsets.first.ports.first.port.to_s` is stored in the :metrics_ep_port clipboard
-    And evaluation of `cb.metrics_ep_ip + ':' +cb.metrics_ep_port` is stored in the :metrics_ep clipboard
-
-    Given I use the "openshift-monitoring" project
-    And evaluation of `secret(service_account('prometheus-k8s').get_secret_names.find {|s| s.match('token')}).token` is stored in the :sa_token clipboard
-
-    #Running curl -k http://<%= cb.metrics_ep %>/metrics if version is < 4.6
-    #Running curl -k -H "Authorization: Bearer <%= cb.sa_token %>" https://<%= cb.metrics_ep %>/metrics if version is > 4.5 as sdn mmetrics should be using https scheme
-    Given evaluation of `%Q{curl -k http://<%= cb.metrics_ep %>/metrics}` is stored in the :curl_query_le_4_5 clipboard
-    Given evaluation of `%Q{curl -k -H \"Authorization: Bearer <%= cb.sa_token %>\" https://<%= cb.metrics_ep %>/metrics}` is stored in the :curl_query_ge_4_6 clipboard
-    Given evaluation of `env.version_le("4.5", user: user) ? "#{cb.curl_query_le_4_5}" : "#{cb.curl_query_ge_4_6}"` is stored in the :curl_query clipboard
-    When I run the :exec admin command with:
-      | n                | openshift-monitoring |
-      | pod              | prometheus-k8s-0     |
-      | c                | prometheus           |
-      | oc_opts_end      |                      |
-      | exec_command     | bash                 |
-      | exec_command_arg | -c                   |
-      | exec_command_arg | <%= cb.curl_query %> |
+    When I run command on the node's sdn pod:
+      | bash | -c | curl 127.0.0.1:29101/metrics  |
     Then the step should succeed
     #The idea is to check whether these metrics are being relayed on the port 9101
     And the output should contain:
@@ -49,34 +32,19 @@ Feature: SDN/OVN metrics related networking scenarios
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-16016:SDN Should be able to monitor the openshift-sdn related metrics by prometheus
+    Given I select a random node's host
     Given I switch to cluster admin pseudo user
     And I use the "openshift-sdn" project
-    And evaluation of `endpoints('sdn').subsets.first.addresses.first.ip.to_s` is stored in the :metrics_ep_ip clipboard
-    And evaluation of `endpoints('sdn').subsets.first.ports.first.port.to_s` is stored in the :metrics_ep_port clipboard
-    And evaluation of `cb.metrics_ep_ip + ':' +cb.metrics_ep_port` is stored in the :metrics_ep clipboard
-
-    Given I use the "openshift-monitoring" project
-    And evaluation of `secret(service_account('prometheus-k8s').get_secret_names.find {|s| s.match('token')}).token` is stored in the :sa_token clipboard
-
-    #Running curl -k http://<%= cb.metrics_ep %>/metrics if version is < 4.6
-    #Running curl -k -H "Authorization: Bearer <%= cb.sa_token %>" https://<%= cb.metrics_ep %>/metrics if version is > 4.5 as sdn metrics should be using https scheme
-    Given evaluation of `%Q{curl -k http://<%= cb.metrics_ep %>/metrics}` is stored in the :curl_query_le_4_5 clipboard
-    Given evaluation of `%Q{curl -k -H \"Authorization: Bearer <%= cb.sa_token %>\" https://<%= cb.metrics_ep %>/metrics}` is stored in the :curl_query_ge_4_6 clipboard
-    Given evaluation of `env.version_le("4.5", user: user) ? "#{cb.curl_query_le_4_5}" : "#{cb.curl_query_ge_4_6}"` is stored in the :curl_query clipboard
-    When I run the :exec admin command with:
-      | n                | openshift-monitoring |
-      | pod              | prometheus-k8s-0     |
-      | c                | prometheus           |
-      | oc_opts_end      |                      |
-      | exec_command     | bash                 |
-      | exec_command_arg | -c                   |
-      | exec_command_arg | <%= cb.curl_query %> |
+    When I run command on the node's sdn pod:
+      | bash | -c | curl 127.0.0.1:29101/metrics |
     Then the step should succeed
     #The idea is to check whether these metrics are being relayed on the port 9101
     And the output should contain:
-      | kubeproxy_sync_proxy_rules_duration       |
-      | kubeproxy_sync_proxy_rules_last_timestamp |
-  
+      | openshift_sdn_arp  |
+      | openshift_sdn_pod  |
+      | openshift_sdn_vnid |
+      | openshift_sdn_ovs  |
+      
   # @author anusaxen@redhat.com
   # @case_id OCP-37704
   @admin


### PR DESCRIPTION
Due to recent sa token behavior change, replacing prometheus sa token logic.Instead we can get metrics relayed on port 9109 via sdn pods only. FYI In case of SDN we relay metrics on all sdn network pods irrespctive of controller, master or worker pod

Logs: http://pastebin.test.redhat.com/1068170

@openshift/team-sdn-qe 