### PR TITLE
resolve failure: undefined method for nil class

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -717,8 +717,10 @@ Given /^I upgrade the operator with:$/ do | table |
       # wait for the ES cluster to be ready
       success = wait_for(600, interval: 10) {
         esPods = BushSlicer::Pod.get_labeled("component=elasticsearch", project: project, user: user, quiet: true).map(&:name)
-        readyPods = (elasticsearch('elasticsearch').es_master_ready_pod_names + elasticsearch('elasticsearch').es_client_ready_pod_names(cached: true) + elasticsearch('elasticsearch').es_data_ready_pod_names(cached:true)).uniq
-        elasticsearch('elasticsearch').cluster_health == "green" && (esPods - readyPods).blank? && (readyPods - esPods).blank?
+        unless (elasticsearch('elasticsearch').es_master_ready_pod_names.nil?) || (elasticsearch('elasticsearch').es_client_ready_pod_names.nil?) || (elasticsearch('elasticsearch').es_data_ready_pod_names.nil?)
+          readyPods = (elasticsearch('elasticsearch').es_master_ready_pod_names + elasticsearch('elasticsearch').es_client_ready_pod_names(cached: true) + elasticsearch('elasticsearch').es_data_ready_pod_names(cached:true)).uniq
+          elasticsearch('elasticsearch').cluster_health == "green" && (esPods - readyPods).blank? && (readyPods - esPods).blank?
+        end
       }
       raise "ES cluster isn't in a good status" unless success
       # check pvc count

--- a/lib/openshift/elasticsearch.rb
+++ b/lib/openshift/elasticsearch.rb
@@ -92,7 +92,7 @@ module BushSlicer
     end
 
     def cluster_status(user: nil, quiet: false, cached: false)
-      return status(user: nil, quiet: false, cached: false).dig('cluster') unless status.nil?
+      return status(user: user, quiet: quiet, cached: cached).dig('cluster') unless status.nil?
     end
 
     def cluster_health(user: nil, cached: false, quiet: false)

--- a/lib/openshift/elasticsearch.rb
+++ b/lib/openshift/elasticsearch.rb
@@ -88,11 +88,11 @@ module BushSlicer
     end
 
     def status(user: nil, quiet: true, cached: false)
-      return raw_resource(user: user, cached: cached, quiet: quiet).dig('status')
+      return raw_resource(user: user, cached: cached, quiet: quiet).dig('status') unless raw_resource.nil?
     end
 
     def cluster_status(user: nil, quiet: false, cached: false)
-      return status.dig('cluster')
+      return status(user: nil, quiet: false, cached: false).dig('cluster') unless status.nil?
     end
 
     def cluster_health(user: nil, cached: false, quiet: false)
@@ -129,67 +129,67 @@ module BushSlicer
     end
 
     def nodes_status(user: nil, cached: false, quiet: true)
-      return status(user: user, cached: cached, quiet: quiet).dig('nodes')
+      return status(user: user, cached: cached, quiet: quiet).dig('nodes') unless status.nil?
     end
 
     def nodes_conditions(user: nil, cached: false, quiet: true)
-      return nodes_status(user: user, cached: cached, quiet: quiet).first['conditions']
+      return nodes_status(user: user, cached: cached, quiet: quiet).first['conditions'] unless nodes_status.nil?
     end
 
     def cluster_conditions(user: nil, cached: false, quiet: true)
-      return status(user: user, cached: cached, quiet: quiet).dig('conditions')
+      return status(user: user, cached: cached, quiet: quiet).dig('conditions') unless status.nil?
     end
 
     def es_pods(user: nil, cached: false, quiet: true)
-      return status(user: user, cached: cached, quiet: quiet).dig('pods')
+      return status(user: user, cached: cached, quiet: quiet).dig('pods') unless status.nil?
     end
 
     def es_master_pods(user: nil, cached: false, quiet: true)
-      return es_pods(user: user, cached: cached, quiet: quiet)['master']
+      return es_pods(user: user, cached: cached, quiet: quiet)['master'] unless es_pods.nil?
     end
 
     def es_master_ready_pod_names(user: nil, cached: false, quiet: true)
-      return es_master_pods(user: user, cached: cached, quiet: quiet)['ready']
+      return es_master_pods(user: user, cached: cached, quiet: quiet)['ready'] unless es_master_pods.nil?
     end
 
     def es_master_not_ready_pod_names(user: nil, cached: false, quiet: true)
-      return es_master_pods(user: user, cached: cached, quiet: quiet)['notReady']
+      return es_master_pods(user: user, cached: cached, quiet: quiet)['notReady'] unless es_master_pods.nil?
     end
 
     def es_master_failed_pod_names(user: nil, cached: false, quiet: true)
-      return es_master_pods(user: user, cached: cached, quiet: quiet)['failed']
+      return es_master_pods(user: user, cached: cached, quiet: quiet)['failed'] unless es_master_pods.nil?
     end
 
     def es_client_pods(user: nil, cached: false, quiet: true)
-      return es_pods(user: user, cached: cached, quiet: quiet)['client']
+      return es_pods(user: user, cached: cached, quiet: quiet)['client'] unless es_pods.nil?
     end
 
     def es_client_ready_pod_names(user: nil, cached: false, quiet: true)
-      return es_client_pods(user: user, cached: cached, quiet: quiet)['ready']
+      return es_client_pods(user: user, cached: cached, quiet: quiet)['ready'] unless es_client_pods.nil?
     end
 
     def es_client_not_ready_pod_names(user: nil, cached: false, quiet: true)
-      return es_client_pods(user: user, cached: cached, quiet: quiet)['notReady']
+      return es_client_pods(user: user, cached: cached, quiet: quiet)['notReady'] unless es_client_pods.nil?
     end
 
     def es_client_failed_pod_names(user: nil, cached: false, quiet: true)
-      return es_client_pods(user: user, cached: cached, quiet: quiet)['failed']
+      return es_client_pods(user: user, cached: cached, quiet: quiet)['failed'] unless es_client_pods.nil?
     end
 
     def es_data_pods(user: nil, cached: false, quiet: true)
-      return es_pods(user: user, cached: cached, quiet: quiet)['data']
+      return es_pods(user: user, cached: cached, quiet: quiet)['data'] unless es_pods.nil?
     end
 
     def es_data_ready_pod_names(user: nil, cached: false, quiet: true)
-      return es_data_pods(user: user, cached: cached, quiet: quiet)['ready']
+      return es_data_pods(user: user, cached: cached, quiet: quiet)['ready'] unless es_data_pods.nil?
     end
 
     def es_data_not_ready_pod_names(user: nil, cached: false, quiet: true)
-      return es_data_pods(user: user, cached: cached, quiet: quiet)['notReady']
+      return es_data_pods(user: user, cached: cached, quiet: quiet)['notReady'] unless es_data_pods.nil?
     end
 
     def es_data_failed_pod_names(user: nil, cached: false, quiet: true)
-      return es_data_pods(user: user, cached: cached, quiet: quiet)['failed']
+      return es_data_pods(user: user, cached: cached, quiet: quiet)['failed'] unless es_data_pods.nil?
     end
 
   end


### PR DESCRIPTION
To resolve below failure:
```
07-28 23:27:44.846        undefined method `dig' for nil:NilClass (NoMethodError)
07-28 23:27:44.846        /home/jenkins/ws/workspace/ocp-upgrade/upgrade-consumer/lib/openshift/elasticsearch.rb:144:in `es_pods'
07-28 23:27:44.846        /home/jenkins/ws/workspace/ocp-upgrade/upgrade-consumer/lib/openshift/elasticsearch.rb:148:in `es_master_pods'
07-28 23:27:44.846        /home/jenkins/ws/workspace/ocp-upgrade/upgrade-consumer/lib/openshift/elasticsearch.rb:152:in `es_master_ready_pod_names'
```