### PR TITLE
update the configmap of rsyslogserver

### DIFF
--- a/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_configmap.yaml
+++ b/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_configmap.yaml
@@ -21,7 +21,9 @@ data:
     :programname, contains, "openshift-audit.log" /var/log/custom/audit.log
     :msg, contains, "docker"{
       if $msg contains "infra-write" then /var/log/clf/infra-container.log
+      if $msg contains "infrastructure" then /var/log/clf/infra-container.log
       if $msg contains "app-write" then /var/log/clf/app-container.log
+      if $msg contains "application" then /var/log/clf/app-container.log
     }
     :msg, contains, "_STREAM_ID" /var/log/clf/infra.log
     :msg, contains, "auditID" /var/log/clf/audit.log

--- a/testdata/logging/logforwarding/rsyslog/insecure/rsyslogserver_configmap.yaml
+++ b/testdata/logging/logforwarding/rsyslog/insecure/rsyslogserver_configmap.yaml
@@ -20,8 +20,10 @@ data:
     :programname, contains, "k8s-audit.log" /var/log/custom/audit.log
     :programname, contains, "openshift-audit.log" /var/log/custom/audit.log 
     :msg, contains, "docker"{
-      if $msg contains "viaq_index_name:infra-write" then /var/log/clf/infra-container.log
-      if $msg contains "viaq_index_name:app-write" then /var/log/clf/app-container.log
+      if $msg contains "infrastructure" then /var/log/clf/infra-container.log
+      if $msg contains "infra-write" then /var/log/clf/infra-container.log
+      if $msg contains "application" then /var/log/clf/app-container.log
+      if $msg contains "app-write" then /var/log/clf/app-container.log
     }
     :msg, contains, "_STREAM_ID" /var/log/clf/infra.log
     :msg, contains, "auditID" /var/log/clf/audit.log


### PR DESCRIPTION
The keyword infra-write,app-write are dropped from Logging 5.4 update syslog.conf filter to match this change.
version <=5.1:  [infra-write,app-write, audit-write]  present
version = 5.2,5.3:  both [infra-write,app-write, audit-write]  and [logType:  applicaiton,logType:  infrastructure,  logType audit] present,
version >=5.4  only  [logType:  applicaiton,logType:  infrastructure,  logType audit]  present