### PR TITLE
change workload

### DIFF
--- a/testdata/cloud/autoscaler-auto-tmpl.yml
+++ b/testdata/cloud/autoscaler-auto-tmpl.yml
@@ -13,7 +13,7 @@ spec:
         resources:
           requests:
             memory: 500Mi
-            cpu: 500m
+            cpu: 1100m
       restartPolicy: Never
       tolerations:
       - key: mapi


### PR DESCRIPTION
Change the workload request cpu from `500m` to `1100m`, as the previous value `500m` cannot work on vsphere autoscaler, we already reported bug to dev https://bugzilla.redhat.com/show_bug.cgi?id=2111721, but dev will not fix this, so we can only use workaround which is increasing the workload cpu resource request. @sunzhaohua2 @miyadav @jhou1 PTAL, thanks!
test result on aws:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/536818/console
test result on azure:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/536817/console
test result on vsphere:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/536956/console