### PR TITLE
Project name must be no more than 63 chars

### DIFF
--- a/lib/bushslicer.rb
+++ b/lib/bushslicer.rb
@@ -61,7 +61,7 @@ module BushSlicer
   # EXECUTOR_NAME is used as part of project name and workdir,
   # truncate it as the project name is limited to 63 chars,
   # apppend "x" to make sure it always ends with proper char
-  EXECUTOR_NAME = "#{EXECUTOR_NAME_TEMP[0..55]}x".freeze
+  EXECUTOR_NAME = "#{EXECUTOR_NAME_TEMP[0..50]}x".freeze
 
   START_TIME = Time.now
   TIME_SUFFIX = [


### PR DESCRIPTION
`project_name = "prj-" + EXECUTOR_NAME.downcase + "-" + project_suffix.sample(4).join`
4 + x + 1 + 4, while x = 56 + 1, cause project name to be 66 chars, exceed the max length of 63 chars for project.

/cc @duanwei33 @jhou1 @pruan-rht 