### PR TITLE
Removing flaky tag plus updating the code to upgrade minor versions as well

### DIFF
--- a/features/step_definitions/descheduler.rb
+++ b/features/step_definitions/descheduler.rb
@@ -134,3 +134,59 @@ Given /^cluster descheduler operator is ready$/ do
     | name=descheduler-operator |
   })
 end
+
+# upgrade operator and check the descheduler pods status
+Given /^I upgrade the descheduler operator with:$/ do | table |
+  opts = opts_array_to_hash(table.raw)
+  subscription = opts[:subscription]
+  channel = opts[:channel]
+  catsrc = opts[:catsrc]
+  namespace = opts[:namespace]
+  step %Q/I use the "#{namespace}" project/
+
+  pre_csv = subscription(subscription).current_csv
+  # upgrade operator
+  patch_json = {"spec": {"channel": "#{channel}", "source": "#{catsrc}"}}
+  patch_opts = {resource: "subscription", resource_name: subscription, p: patch_json.to_json, n: namespace, type: "merge"}
+  @result = admin.cli_exec(:patch, **patch_opts)
+  raise "Patch failed with #{@result[:response]}" unless @result[:success]
+  # wait till new csv to be installed
+  success = wait_for(180, interval: 10) {
+    if channel != "stable"
+      (subscription(subscription).installplan_csv.include? channel) || (subscription(subscription).installplan_csv.include? (channel.split('-')[1]))
+    else
+      subscription(subscription).installplan_csv != pre_csv
+    end
+  }
+  raise "the new CSV can't be installed" unless success
+  # wait till new csv is ready
+  success = wait_for(600, interval: 10) {
+    new_csv = subscription(subscription).current_csv(cached: false)
+    cluster_service_version(new_csv).ready?[:success]
+  }
+  raise "can't upgrade operator #{subscription}" unless success
+end
+
+# only check the major version, such as 4.4, 4.5, 4.6, don't care about versions like 4.6.0-2020xxxxxxxx
+Given /^I make sure the descheduler operator gets updated successfully if needed$/ do
+  step %Q/I switch to cluster admin pseudo user/
+  # check if channel name in subscription is same to the target channel
+  step %Q/cluster-kube-descheduler-operator channel name is stored in the :kdo_channel clipboard/
+  step %Q/cluster-kube-descheduler-operator catalog source name is stored in the :kdo_catsrc clipboard/
+  # check DO
+  step %Q/I use the "openshift-kube-descheduler-operator" project/
+  kdo_current_channel = subscription("cluster-kube-descheduler-operator").channel(cached: false)
+  kdo_current_catsrc = subscription("cluster-kube-descheduler-operator").source
+  if cb.kdo_channel != kdo_current_channel || cb.kdo_catsrc != kdo_current_catsrc
+    upgrade_kdo = true
+    step %Q/I upgrade the descheduler operator with:/, table(%{
+      | namespace    | openshift-kube-descheduler-operator |
+      | subscription | cluster-kube-descheduler-operator   |
+      | channel      | #{cb.kdo_channel}                   |
+      | catsrc       | #{cb.kdo_catsrc}                    |
+    })
+    step %Q/the step should succeed/
+  else
+    upgrade_kdo = false
+  end
+end

--- a/features/upgrade/workloads/descheduler-upgrade.feature
+++ b/features/upgrade/workloads/descheduler-upgrade.feature
@@ -5,7 +5,6 @@ Feature: Descheduler major upgrade should work fine
   @upgrade-prepare
   @users=upuser1,upuser2
   @destructive
-  @flaky
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
@@ -47,7 +46,6 @@ Feature: Descheduler major upgrade should work fine
   @upgrade-check
   @users=upuser1,upuser2
   @destructive
-  @flaky
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
@@ -61,16 +59,8 @@ Feature: Descheduler major upgrade should work fine
     Given I store master major version in the clipboard
     Given a pod becomes ready with labels:
       | app=descheduler |
-    Given cluster-kube-descheduler-operator channel name is stored in the :kdo_channel clipboard
-    When I run the :patch client command with:
-      | resource      | subscription                                                                   |
-      | resource_name | cluster-kube-descheduler-operator                                              |
-      | p             | [{"op": "replace", "path": "/spec/channel", "value": "<%= cb.kdo_channel %>"}] |
-      | type          | json                                                                           |
-      | n             | openshift-kube-descheduler-operator                                            |
-    Then the step should succeed
+    Given I make sure the descheduler operator gets updated successfully if needed
     And I use the "openshift-kube-descheduler-operator" project
-    Given I wait for the resource "pod" named "<%= pod.name %>" to disappear
     And status becomes :running of exactly 1 pods labeled:
       | name=descheduler-operator |
     And status becomes :running of exactly 1 pods labeled:


### PR DESCRIPTION
Previously only upgrading major versions of descheduler was working with the existing code i.e (4.7 -> 4.8, 4.8 -> 4.9) and post upgrade check was always failing when upgrade was happening with in the same version i.e (4.7.rc -> 4.7.rc2). With this PR it should be fixed and we should not be seeing any failures with respect to post upgrade check for descheduler case.