### PR TITLE
OCPQE-11571: Add tags for low priority test cases

### DIFF
--- a/features/admin/quota.feature
+++ b/features/admin/quota.feature
@@ -38,6 +38,7 @@ Feature: Quota related scenarios
     @proxy @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
     @heterogeneous @arm64 @amd64
+    @inactive
     Examples:
       | case_id        | path     | file                           | pod_name                  | expr1             | expr2                                |
       | OCP-11754:Node | ocp11754 | pod-request-limit-valid-3.yaml | pod-request-limit-valid-3 | cpu\\s+100m\\s+30 | memory\\s+(134217728\|128Mi)\\s+16Gi | # @case_id OCP-11754

--- a/features/build/metrics.feature
+++ b/features/build/metrics.feature
@@ -163,6 +163,8 @@ Feature: Builds and samples related metrics test
   @4.6
   @network-ovnkubernetes @network-openshiftsdn
   @inactive
+  @openstack-ipi @baremetal-ipi
+  @openstack-upi @baremetal-upi
   Scenario: OCP-33770:BuildAPI Adding metric for registry v1 protocol imports
     Given I have a project
     #Importing a image with regsitry v1 api

--- a/features/cli/create.feature
+++ b/features/cli/create.feature
@@ -163,6 +163,7 @@ Feature: creating 'apps' with CLI
   @singlenode
   @proxy @noproxy @connected
   @arm64 @amd64
+  @inactive
   Scenario: OCP-22515:Authentication 4.x Could not create any context in non-existent project
     Given I create a new application with:
       | docker image | openshift/ruby-20-centos7~https://github.com/openshift/ruby-hello-world |

--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -827,6 +827,7 @@ Feature: deployment related features
   # @author yinzhou@redhat.com
   # @case_id OCP-11326
   @smoke
+  @inactive
   Scenario: OCP-11326:Workloads Support verbs of Deployment in OpenShift
     Given I have a project
     Given I obtain test data file "deployment/extensions/deployment.yaml"

--- a/features/cli/pod.feature
+++ b/features/cli/pod.feature
@@ -113,6 +113,8 @@ Feature: pods related scenarios
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-11753:Workloads Pod should be immediately deleted if it's not scheduled even if graceful termination period is set
     Given I have a project
     Given I obtain test data file "pods/graceful-delete/10.json"

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -7,6 +7,8 @@ Feature: Check status via oc status, wait etc
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-11147:Workloads Show RC info and indicate bad secrets reference in 'oc status'
     Given I have a project
 

--- a/features/images/rhel8_images.feature
+++ b/features/images/rhel8_images.feature
@@ -8,6 +8,8 @@ Feature: rhel8images.feature
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @inactive
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-22950:BuildAPI Using new-app cmd to create app with ruby rhel8 image
     Given I have a project
     When I run the :tag admin command with:

--- a/features/logging/cluster_log_forwarder.feature
+++ b/features/logging/cluster_log_forwarder.feature
@@ -143,7 +143,7 @@ Feature: cluster log forwarder features
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  @heterogeneous
+  @arm64 @amd64 @heterogeneous
   Scenario: OCP-29843:Logging ClusterLogForwarder: Forward logs to fluentd as insecure
     Given I switch to the first user
     And I have a project
@@ -235,7 +235,7 @@ Feature: cluster log forwarder features
     @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
     @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
     @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous
+    @arm64 @amd64 @heterogeneous
     Examples:
       | case_id           | auth_type         |
       | OCP-29844:Logging | mTLS_share        | # @case_id OCP-29844

--- a/features/logging/eventrouter.feature
+++ b/features/logging/eventrouter.feature
@@ -5,7 +5,7 @@ Feature: eventrouter related test
   # @author qitang@redhat.com
   @admin
   @destructive
-  @4.6
+  @4.12 @4.11 @4.10 @4.6
   Scenario Outline: The Openshift Events be parsed
     Given I switch to the first user
     Given I create a project with non-leading digit name

--- a/features/logging/forward_logs_to_external_elasticsearch.feature
+++ b/features/logging/forward_logs_to_external_elasticsearch.feature
@@ -91,7 +91,7 @@ Feature: Cases to test forward logs to external elasticsearch
     @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
     @network-ovnkubernetes @network-openshiftsdn
     @proxy @noproxy @disconnected @connected
-    @heterogeneous
+    @arm64 @amd64 @heterogeneous
     Examples:
       | case_id           | scheme | client_auth | file                 |
       | OCP-29845:Logging | https  | true        | clf-with-secret.yaml | # @case_id OCP-29845
@@ -199,6 +199,11 @@ Feature: Cases to test forward logs to external elasticsearch
     And the expression should be true> JSON.parse(@result[:stdout])['count'] > 0
     """
 
+    @heterogeneous @arm64 @amd64
+    @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+    @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+    @proxy @noproxy @disconnected @connected
+    @network-ovnkubernetes @network-openshiftsdn
     Examples:
       | case_id           | version | scheme | client_auth | username | password | secret_name |
       | OCP-41807:Logging | 7.16    | https  | true        | test1    | redhat   | test1       | # @case_id OCP-41807

--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -161,6 +161,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @gcp-ipi @azure-ipi @aws-ipi
   Scenario: OCP-27627:ClusterInfrastructure Verify all machine instance-state should be consistent with their providerStats.instanceState
     Given I have an IPI deployment
     And evaluation of `BushSlicer::MachineMachineOpenshiftIo.list(user: admin, project: project('openshift-machine-api'))` is stored in the :machines clipboard
@@ -314,6 +315,8 @@ Feature: Machine features testing
 
     @gcp-ipi
     @heterogeneous @arm64 @amd64
+    @proxy @noproxy @disconnected @connected
+    @network-ovnkubernetes @network-openshiftsdn
     Examples:
       | case_id                         | iaas_type | machineset_name        |
       | OCP-32126:ClusterInfrastructure | gcp       | machineset-clone-32126 | # @case_id OCP-32126
@@ -498,6 +501,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   Scenario: OCP-33455:ClusterInfrastructure Run machine api Controllers using leader election
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -527,6 +531,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   Scenario: OCP-34718:ClusterInfrastructure Node labels and Affinity definition in PV should match
     Given I have a project
 
@@ -620,6 +625,7 @@ Feature: Machine features testing
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
+  @azure-ipi
   Scenario: OCP-36489:ClusterInfrastructure Machineset should not be created when publicIP:true in disconnected Azure enviroment
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -643,6 +649,8 @@ Feature: Machine features testing
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-47658:ClusterInfrastructure Operator cloud-controller-manager should not show empty version
     Given I switch to cluster admin pseudo user
     Then evaluation of `cluster_operator('cloud-controller-manager').versions` is stored in the :versions clipboard

--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -168,6 +168,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   Scenario: OCP-28718:ClusterInfrastructure Machine Node startup timeout should be configurable
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -236,6 +237,7 @@ Feature: MachineHealthCheck Test Scenarios
   @admin
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   Scenario: OCP-29857:ClusterInfrastructure MaxUnhealthy should not allow malformed values
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -308,6 +310,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   Scenario: OCP-33714:ClusterInfrastructure Leverage OpenAPI validation within MHC
     Given I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project
@@ -329,6 +332,7 @@ Feature: MachineHealthCheck Test Scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   Scenario: OCP-34095:ClusterInfrastructure timeout field without units(h,m,s) shoud not be allowed to be stored
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user

--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -171,6 +171,8 @@ Feature: Machine misc features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi
+  @vsphere-upi
   Scenario: OCP-37180:ClusterInfrastructure Report vCenter version to telemetry
     Given I switch to cluster admin pseudo user
     When I perform the GET prometheus rest client with:

--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -9,7 +9,7 @@ Feature: Egress-ingress related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @upgrade-sanity
   @noproxy @connected
-  @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
   Scenario: OCP-11639:SDN EgressNetworkPolicy will not take effect after delete it
     Given I have a project
@@ -733,6 +733,8 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn	
   @singlenode
   @proxy @noproxy @disconnected @connected
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-44940:SDN bug2000057 No segmentation error occurs in ovnkube-master after egressfirewall resource that references a DNS name is deleted
     Given the env is using "OVNKubernetes" networkType
     And I have a project

--- a/features/networking/egress-ip.feature
+++ b/features/networking/egress-ip.feature
@@ -344,6 +344,8 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-15998:SDN Invalid egressIP should not be acceptable
     Given I select a random node's host
     Given evaluation of `["fe80::5054:ff:fedd:3698", "a.b.c.d", "10.10.10.-1", "10.0.0.1/64", "10.1.1/24", "A008696"]` is stored in the :ips clipboard
@@ -958,10 +960,13 @@ Feature: Egress IP related features
   # @case_id OCP-46637
   @admin
   @destructive
-  @4.12 @4.10 @4.9
+  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   @vsphere-ipi
   @vsphere-upi
   @qeci
+  @heterogeneous @arm64 @amd64
+  @network-openshiftsdn
+  @noproxy
   Scenario: OCP-46637:SDN Bug2024880 EgressIP should work when configuring networkpolicy
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :workers clipboard

--- a/features/networking/isolation.feature
+++ b/features/networking/isolation.feature
@@ -146,8 +146,12 @@ Feature: networking isolation related scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-9641
   @admin
-  @network-multitenant
-  @4.12
+  @network-openshiftsdn @network-multitenant
+  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @proxy @noproxy
   Scenario: OCP-9641:SDN Make the network of given project be accessible to other projects
     # Create 3 projects and each contains 1 pod and 1 service
     Given the env is using multitenant network

--- a/features/networking/multus-ipv6.feature
+++ b/features/networking/multus-ipv6.feature
@@ -135,6 +135,8 @@ Feature: Multus-CNI ipv6 related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-44941:SDN Whereabouts IPv6 should be calculated if first hextet of IPv6 has leading zeros	
   # Bug https://bugzilla.redhat.com/show_bug.cgi?id=1919048
   # Make sure that the multus is enabled

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -664,6 +664,7 @@ Feature: Multus-CNI related scenarios
   # @author anusaxen@redhat.com
   # @case_id OCP-21949
   @admin
+  @inactive
   Scenario: OCP-21949:SDN The multus admission controller should be able to detect the issue in the pod template
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
@@ -1822,6 +1823,8 @@ Feature: Multus-CNI related scenarios
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-46116:SDN BZ1897431 CIDR support for additional network attachment with the bridge CNI plug-in
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -29,6 +29,8 @@ Feature: Operator related networking scenarios
   @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-22706:SDN The clusteroperator should be able to reflect the correct version field post bad network operator config
 
     Given the master version >= "4.1"

--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -208,6 +208,8 @@ Feature: OVN related networking scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-32184:SDN ovnkube-masters should allocate pod IP and mac addresses
     Given the env is using "OVNKubernetes" networkType
     And I have a project

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -199,8 +199,12 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @admin
   @destructive
   @inactive
-  @network-ovnkubernetes @ipsec
-  @4.12
+  @network-ovnkubernetes @network-openshiftsdn @ipsec
+  @4.12 @4.11
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @proxy @noproxy @disconnected @connected
+  @singlenode
   Scenario: OCP-40569:SDN Allow enablement/disablement ipsec at runtime
     Given the env is using "OVNKubernetes" networkType
     Given I store all worker nodes to the :workers clipboard

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -430,7 +430,7 @@ Feature: Pod related networking scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  @4.12
+  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario: OCP-25294:SDN Pod should be accesible via node ip and host port
     Given I store the workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[0].name %>" is stored in the :worker0_ip clipboard

--- a/features/storage/NoDiskConflict.feature
+++ b/features/storage/NoDiskConflict.feature
@@ -7,6 +7,8 @@ Feature: NoDiskConflict
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @aws-ipi
+  @aws-upi
   Scenario: OCP-9929:Storage Only one pod with the same persistent volume can be scheduled when NoDiskConflicts policy is enabled
     Given a 5 characters random string of type :dns is stored into the :proj_name clipboard
     When I run the :oadm_new_project admin command with:

--- a/features/storage/cinder.feature
+++ b/features/storage/cinder.feature
@@ -7,6 +7,8 @@ Feature: Cinder Persistent Volume
   @singlenode
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @openstack-ipi
+  @openstack-upi
   Scenario: OCP-9643:Storage Persistent Volume with cinder volume plugin
     Given I have a project
     And I have a 1 GB volume and save volume id in the :vid clipboard

--- a/features/storage/csi_clone.feature
+++ b/features/storage/csi_clone.feature
@@ -224,7 +224,7 @@ Feature: CSI clone testing related feature
   # @case_id OCP-27617
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @openstack-ipi
   @openstack-upi
   @qeci

--- a/features/storage/csi_resize.feature
+++ b/features/storage/csi_resize.feature
@@ -94,6 +94,8 @@ Feature: CSI Resizing related feature
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
     @heterogeneous @arm64 @amd64
+    @aws-ipi
+    @aws-upi
     Examples:
       | case_id           | sc_name |
       | OCP-25809:Storage | gp2-csi | # @case_id OCP-25809

--- a/features/storage/negative.feature
+++ b/features/storage/negative.feature
@@ -16,6 +16,8 @@ Feature: negative testing
     @singlenode
     @proxy @noproxy @disconnected @connected
     @heterogeneous @arm64 @amd64
+    @gcp-ipi
+    @gcp-upi
     Examples:
       | case_id           | dir | file               | error                        |
       | OCP-10310:Storage | gce | pv-retain-rwx.json | error querying GCE PD volume | # @case_id OCP-10310

--- a/features/storage/pre-bind.feature
+++ b/features/storage/pre-bind.feature
@@ -7,6 +7,8 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-10107:Storage Prebound pv is availabe due to requested pvc status is bound
     Given I create a project with non-leading digit name
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -34,6 +36,8 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-10109:Storage Prebound pv is availabe due to mismatched accessmode with requested pvc
     Given I create a project with non-leading digit name
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
@@ -60,6 +64,8 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-10111:Storage Prebound pvc is pending due to requested pv status is bound
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -86,6 +92,8 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-10113:Storage Prebound PVC is pending due to mismatched accessmode with requested PV
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -111,6 +119,8 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-10114:Storage Prebound PVC is pending due to mismatched volume size with requested PV
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -136,6 +146,8 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-9941:Storage PV and PVC bound successfully when pvc created prebound to pv
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -164,6 +176,8 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-9940:Storage PV and PVC bound successfully when pv created prebound to pvc
     Given I create a project with non-leading digit name
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
@@ -207,6 +221,8 @@ Feature: Testing for pv and pvc pre-bind feature
     @singlenode
     @proxy @noproxy @disconnected @connected
     @heterogeneous @arm64 @amd64
+    @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+    @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
     Examples:
       | case_id           | pre-bind-pvc | pre-bind-pv                |
       | OCP-10108:Storage | nfsc         | nfspv1-<%= project.name %> | # @case_id OCP-10108

--- a/features/upgrade/build/build-upgrade.feature
+++ b/features/upgrade/build/build-upgrade.feature
@@ -11,6 +11,8 @@ Feature: build related upgrade check
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   @inactive
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: Check docker and sti build works well before and after upgrade - prepare
     Given I switch to the first user
     When I run the :new_project client command with:
@@ -39,6 +41,8 @@ Feature: build related upgrade check
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   @inactive
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: Check docker and sti build works well before and after upgrade
     Given I switch to the first user
     When I use the "build-upgrade" project

--- a/features/upgrade/logging/upgrade_with_clf.feature
+++ b/features/upgrade/logging/upgrade_with_clf.feature
@@ -7,8 +7,10 @@ Feature: Upgrade Logging with ClusterLogForwarder
   @users=upuser1,upuser2
   @stage-only
   @singlenode
-  @connected
-  @4.6
+  @4.7 @4.6
+  @gcp-ipi
+  @gcp-upi
+  @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @connected
   Scenario: Upgrade clusterlogging with mulitple external log store enabled - prepare
     Given the master version >= "4.6"
@@ -111,7 +113,10 @@ Feature: Upgrade Logging with ClusterLogForwarder
   @stage-only
   @singlenode
   @proxy @noproxy @connected
-  @4.6
+  @4.7 @4.6
+  @gcp-ipi
+  @gcp-upi
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: Upgrade clusterlogging with mulitple external log store enabled
     Given the master version >= "4.6"
     #check data

--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -153,7 +153,10 @@ Feature: Machine-api components upgrade tests
   @upgrade-prepare
   @admin
   @destructive
-  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @arm64 @amd64 @heterogeneous
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario Outline: Spot/preemptible instances should not block upgrade - prepare
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -200,6 +203,9 @@ Feature: Machine-api components upgrade tests
   @admin
   @destructive
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @arm64 @amd64 @heterogeneous
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario Outline: Spot/preemptible instances should not block upgrade
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -227,7 +233,6 @@ Feature: Machine-api components upgrade tests
       | OCP-41175:ClusterInfrastructure | aws       | machineset-clone-41175 | "spotMarketOptions": {} | # @case_id OCP-41175
 
     @gcp-ipi
-    @heterogeneous
     Examples:
       | case_id                         | iaas_type | machineset_name        | value               |
       | OCP-41803:ClusterInfrastructure | gcp       | machineset-clone-41803 | "preemptible": true | # @case_id OCP-41803

--- a/features/upgrade/sdn/service-upgrade.feature
+++ b/features/upgrade/sdn/service-upgrade.feature
@@ -3,7 +3,7 @@ Feature: service upgrade scenarios
   # @author zzhao@redhat.com
   @admin
   @upgrade-prepare
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
@@ -36,7 +36,7 @@ Feature: service upgrade scenarios
   # @case_id OCP-44259
   @admin
   @upgrade-check
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected


### PR DESCRIPTION
When adapting to Prow CI, we add our tests step by step. First add all test with priority Critical, then followed by High, then medium. And now comes to the last stage, to add priority Low test cases