### PR TITLE
update for ipv6 dual stack scenarios

### DIFF
--- a/features/networking/ipv6_dualstack.feature
+++ b/features/networking/ipv6_dualstack.feature
@@ -12,6 +12,7 @@ Feature: ipv6 dual stack cluster test scenarios
   @heterogeneous @arm64 @amd64
   Scenario: OCP-40581:SDN Project should be in isolation when using multitenant policy for ipv6 dual stack
     # create project and pods
+    Given the cluster is dual stack network type
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
     Given I obtain test data file "networking/list_for_pods_ipv6.json"
@@ -94,6 +95,7 @@ Feature: ipv6 dual stack cluster test scenarios
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @heterogeneous @arm64 @amd64
   Scenario: OCP-46816:SDN ipv6 for nodeport service
+    Given the cluster is dual stack network type
     Given I store the workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[1].name %>" is stored in the :worker1_ipv4 clipboard    
     And the Internal IPv6 of node "<%= cb.workers[0].name %>" is stored in the :worker0_ipv6 clipboard

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1590,3 +1590,12 @@ Given /^the egressfirewall policy is applied to the "(.+?)" namespace$/ do | pro
   end
   logger.info "The egressfirewall type is applied."
 end
+
+Given /^the cluster is dual stack network type$/ do
+  ensure_admin_tagged
+  @result = admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.serviceNetwork}")
+  unless @result[:response].count(":") >= 2 && @result[:response].count(".") >= 2  
+    logger.warn "the cluster is not dual stack cluster, will skip this scenario"
+    skip_this_scenario
+  end
+end


### PR DESCRIPTION

      [05:12:51] INFO> === After Scenario: OCP-40581:SDN Project should be in isolation when using multitenant policy for ipv6 dual stack ===
      [05:12:51] INFO> Shell Commands: rm -r -f -- /root/workdir/preserve-zzhao-rootx
      
      [05:12:52] INFO> Exit Status: 0
      [05:12:53] INFO> === End After Scenario: OCP-40581:SDN Project should be in isolation when using multitenant policy for ipv6 dual stack ===
# @author zzhao@redhat.com
# @case_id OCP-46816

1 scenario (1 skipped)
42 steps (42 skipped)
0m25.399s


skip those two scenarios for that not ipv6 dual stack cluster. 

@openshift/team-sdn-qe ^^