### PR TITLE
add step to make sure the scearios running correct cluster

### DIFF
--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -366,6 +366,7 @@ Feature: Egress-ingress related networking scenarios
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-19615:SDN Iptables should be updated with correct endpoints when egress DNS policy was used
+    Given the env is using "OpenShiftSDN" networkType	
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
     When I run oc create over "list_for_pods.json" replacing paths:
@@ -421,6 +422,7 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33530:SDN EgressFirewall allows traffic to destination ports
+    Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -462,6 +464,7 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33531:SDN EgressFirewall rules take effect in order
+    Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -487,6 +490,7 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33539:SDN EgressFirewall policy should not take effect for traffic between pods and pods to service
+    Given the env is using "OVNKubernetes" networkType
     Given I have a project
     # Create EgressFirewall policy to deny all outbound traffic
     When I obtain test data file "networking/ovn-egressfirewall/limit_policy.json"
@@ -526,6 +530,7 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33565:SDN EgressFirewall policy take effect for multiple port
+    Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -557,6 +562,7 @@ Feature: Egress-ingress related networking scenarios
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-35341:SDN EgressNetworkPolicy maxItems is 1000
+    Given the env is using "OpenShiftSDN" networkType
     Given I have a project
     Given I obtain test data file "networking/egressnetworkpolicy/egressnetworkpolicy_1000.yaml"
     When I run the :create admin command with:
@@ -585,6 +591,7 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
   Scenario: OCP-37491:SDN EgressFirewall allows traffic to destination dnsName
+    Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -621,6 +628,7 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
   Scenario: OCP-37495:SDN EgressFirewall denys traffic to destination dnsName
+    Given the env is using "OVNKubernetes" networkType
     Given I have a project
 
     When I obtain test data file "networking/ovn-egressfirewall/egressfirewall-policy4.yaml"
@@ -657,6 +665,7 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
   Scenario: OCP-37496:SDN Edit EgressFirewall should take effect
+    Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -695,6 +704,7 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
   Scenario: OCP-41179:SDN bug1947917 Egress Firewall should reliably apply firewall rules
+    Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
 

--- a/features/networking/egress-ip.feature
+++ b/features/networking/egress-ip.feature
@@ -11,6 +11,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-15465:SDN Only cluster admin can add/remove egressIPs on hostsubnet
+    Given the env is using "OpenShiftSDN" networkType
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
 
@@ -32,6 +33,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-15466:SDN Only cluster admin can add/remove egressIPs on netnamespaces
+    Given the env is using "OpenShiftSDN" networkType
     # Try to add the egress ip to the netnamespace with normal user
     Given I have a project
     And evaluation of `project.name` is stored in the :project clipboard
@@ -54,6 +56,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-15471:SDN All the pods egress connection will get out through the egress IP if the egress IP is set to netns and egress node can host the IP
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given I select a random node's host
     # create project with pods
@@ -114,6 +117,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-15472:SDN The egressIPs will be added to the node's primary NIC when it gets set on hostsubnet and will be removed after gets unset
+    Given the env is using "OpenShiftSDN" networkType
     # add the egress ip to the hostsubnet
     Given  the valid egress IP is added to the node
     And evaluation of `node.name` is stored in the :egress_node clipboard
@@ -154,6 +158,7 @@ Feature: Egress IP related features
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-21812:SDN Should remove the egressIP from the array if it was not being used
+    Given the env is using "OpenShiftSDN" networkType
     Given I store a random unused IP address from the reserved range to the clipboard
     And evaluation of `IPAddr.new("<%= cb.subnet_range %>").to_s+"/"+IPAddr.new("<%= cb.subnet_range %>").prefix.to_s` is stored in the :valid_subnet clipboard
 
@@ -207,6 +212,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-15992:SDN The EgressNetworkPolicy should work well with egressIP
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given the valid egress IP is added to the node
     And I have a project
@@ -254,6 +260,7 @@ Feature: Egress IP related features
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-15473:SDN The related iptables/openflow rules will be removed once the egressIP gets removed from netnamespace
+    Given the env is using "OpenShiftSDN" networkType
     Given the valid egress IP is added to the node
     And I have a project
 
@@ -306,6 +313,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-19973:SDN The egressIP should still work fine after the node or network service restarted
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given the valid egress IP is added to the node
     And I have a project
@@ -347,6 +355,7 @@ Feature: Egress IP related features
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   Scenario: OCP-15998:SDN Invalid egressIP should not be acceptable
+    Given the env is using "OpenShiftSDN" networkType
     Given I select a random node's host
     Given evaluation of `["fe80::5054:ff:fedd:3698", "a.b.c.d", "10.10.10.-1", "10.0.0.1/64", "10.1.1/24", "A008696"]` is stored in the :ips clipboard
     And I repeat the following steps for each :ip in cb.ips:
@@ -372,6 +381,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-25694:SDN Random outages with egressIP
+    Given the env is using "OpenShiftSDN" networkType
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
     And I have a project
@@ -409,6 +419,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-25640:SDN Should be able to access to the service's externalIP with egressIP
+    Given the env is using "OpenShiftSDN" networkType
     Given I have a project
     Given I store the schedulable nodes in the :nodes clipboard
     And the Internal IP of node "<%= cb.nodes[0].name %>" is stored in the :hostip clipboard
@@ -468,6 +479,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-18316:SDN The egressIPs should work well when re-using the egressIP which is holding by a deleted project
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
@@ -504,6 +516,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-18315:SDN Add the removed egressIP back to the netnamespace would work well
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
@@ -546,6 +559,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-19785:SDN The pod should be able to access outside with the node source IP after the egressIP removed
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
@@ -596,6 +610,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-15989:SDN Pods will not be affected by the egressIP set on other netnamespace
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     # create project with pods
     Given I have a project
@@ -629,6 +644,7 @@ Feature: Egress IP related features
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
   Scenario: OCP-15987:SDN The egressIP will be unavailable if it was set to multiple hostsubnets
+    Given the env is using "OpenShiftSDN" networkType
     Given I store the schedulable workers in the :nodes clipboard
     And the valid egress IP is added to the "<%= cb.nodes[0].name %>" node
     Given as admin I successfully merge patch resource "hostsubnet/<%= cb.nodes[1].name %>" with:
@@ -666,6 +682,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @heterogeneous @arm64 @amd64
   Scenario: OCP-18586:SDN The same egressIP will not be assigned to different netnamespace
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     Given I store a random unused IP address from the reserved range to the clipboard
@@ -711,6 +728,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-40928:SDN Manually EgressIPs assignments:if a pod is on a node that is hosting an egressIP that pod will always use the egressIP of the node it is on
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     Given I store a random unused IP address from the reserved range to the clipboard
@@ -761,6 +779,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-40933:SDN Manually EgressIPs assignments: if a pod is not on a node hosting an egressIP it is random which egressIP it will use
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given I store the masters in the :masters clipboard
     Given I store the schedulable workers in the :workers clipboard
@@ -812,6 +831,7 @@ Feature: Egress IP related features
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-40957:SDN Auto EgressIPs assignments: if a pod is not on a node hosting an egressIP it is random which egressIP it will use
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given I store the masters in the :masters clipboard
     Given I store the schedulable workers in the :workers clipboard
@@ -864,6 +884,7 @@ Feature: Egress IP related features
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-40956:SDN Auto EgressIPs assignments:if a pod is on a node that is hosting an egressIP that pod will always use the egressIP of the node
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :workers clipboard
     Given I store a random unused IP address from the reserved range to the clipboard
@@ -923,6 +944,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-46244:SDN Bug1926662 NodePort works when configuring an EgressIP address
+    Given the env is using "OpenShiftSDN" networkType
     Given I store the schedulable workers in the :workers clipboard
     And I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.workers[0].name %>" is stored in the :worker0_ip clipboard
@@ -968,6 +990,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @noproxy
   Scenario: OCP-46637:SDN Bug2024880 EgressIP should work when configuring networkpolicy
+    Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :workers clipboard
     And the valid egress IP is added to the "<%= cb.workers[0].name %>" node

--- a/features/networking/ovn-egress-ip.feature
+++ b/features/networking/ovn-egress-ip.feature
@@ -13,6 +13,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33618:SDN EgressIP works for all pods in the matched namespace when only configure namespaceSelector
+    Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
@@ -84,6 +85,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33723:SDN Multiple EgressIP objects can have multiple Egress IPs
+    Given the env is using "OVNKubernetes" networkType		
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -158,6 +160,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33641:SDN Multi-project can share same EgressIP
+    Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -233,6 +236,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33699:SDN Removed matched labels from project will not use EgressIP
+    Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -290,6 +294,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33700:SDN Removed matched labels from pods will not use EgressIP
+    Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -355,6 +360,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33631:SDN EgressIP was removed after delete egressIP object
+    Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -408,6 +414,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33704:SDN After reboot node or reboot OVN services EgressIP still work
+    Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -472,6 +479,7 @@ Feature: OVN Egress IP related features
   @heterogeneous @arm64 @amd64
   Scenario: OCP-34938:SDN Warning event will be triggered if apply EgressIP object but no EgressIP nodes
     #Get unused IP as egress ip
+    Given the env is using "OVNKubernetes" networkType
     Given I store a random unused IP address from the reserved range to the clipboard
 
     #Create egress ip object
@@ -507,6 +515,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33706:SDN The pod located on different node than EgressIP nodes
+    Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
@@ -561,6 +570,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33718:SDN Deleting EgressIP object and recreating it will work
+    Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
 
     #Get unused IP as egress ip
@@ -626,6 +636,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33710:SDN An EgressIP object can not have multiple egress IP assignments on the same node
+    Given the env is using "OVNKubernetes" networkType
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
 
@@ -660,6 +671,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33617:SDN Common user cannot tag the nodes by labelling them as egressIP nodes
+    Given the env is using "OVNKubernetes" networkType
     Given I select a random node's host
     And evaluation of `node.name` is stored in the :egress_node clipboard
 
@@ -683,6 +695,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-33719:SDN Any egress IP can only be assigned to one node only
+    Given the env is using "OVNKubernetes" networkType
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
     And label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[1].name %>" node
@@ -733,6 +746,7 @@ Feature: OVN Egress IP related features
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-44250:SDN lr-policy-list and snat should be updated correctly after remove pods
+    Given the env is using "OVNKubernetes" networkType
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
 
@@ -846,6 +860,7 @@ Feature: OVN Egress IP related features
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-44251:SDN lr-policy-list and snat should be updated correctly after remove egressip objects 
+    Given the env is using "OVNKubernetes" networkType	
     Given I store the schedulable workers in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node
 
@@ -941,6 +956,7 @@ Feature: OVN Egress IP related features
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-42925:SDN Traffic is load balanced between egress nodes in OVN cluster
+    Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
     Given I store the schedulable nodes in the :nodes clipboard
     Then label "k8s.ovn.org/egress-assignable=true" is added to the "<%= cb.nodes[0].name %>" node

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -11,6 +11,7 @@ Feature: Pod related networking scenarios
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-9747:SDN Pod cannot claim UDP port 4789 on the node as part of a port mapping
+    Given the env is using "OpenShiftSDN" networkType
     Given I have a project
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I obtain test data file "networking/pod_with_udp_port_4789.json"
@@ -36,6 +37,7 @@ Feature: Pod related networking scenarios
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-10031:SDN Container could reach the dns server
+    Given the env is using "OpenShiftSDN" networkType
     Given I have a project
     Given I obtain test data file "pods/ocp10031/pod.json"
     When I run the :create client command with:
@@ -60,6 +62,7 @@ Feature: Pod related networking scenarios
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-14986:SDN The openflow list will be cleaned after delete the pods
+    Given the env is using "OpenShiftSDN" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
     Then evaluation of `pod.node_name` is stored in the :node_name clipboard
@@ -95,6 +98,7 @@ Feature: Pod related networking scenarios
   @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   Scenario: OCP-10817:SDN Check QoS after creating pod
+    Given the env is using "OpenShiftSDN" networkType
     Given I have a project
     # setup iperf server to receive the traffic
     Given I obtain test data file "networking/egress-ingress/qos/iperf-server.json"
@@ -602,6 +606,7 @@ Feature: Pod related networking scenarios
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-22034:SDN Check the unused ip are released after node reboot
+    Given the env is using "OpenShiftSDN" networkType
     Given I store the workers in the :workers clipboard
     Given I use the "<%= cb.workers[0].name %>" node
     And I run commands on the host:
@@ -621,6 +626,7 @@ Feature: Pod related networking scenarios
   @admin
   @destructive
   Scenario: OCP-41666:SDN Pod stuck in container creating - failed to run CNI IPAM ADD: failed to allocate for range 0: no IP addresses available in range set
+    Given the env is using "OpenShiftSDN" networkType
     Given I switch to cluster admin pseudo user
     When I run the :label admin command with:
       | resource  | machineconfigpool         |

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -52,6 +52,7 @@ Feature: SDN related networking scenarios
     # we do not detect incomplete rule removal since ~4.3, BZ-1810316
     # so only test on >= 4.3
     Given the master version >= "4.3"
+    Given the env is using "OpenShiftSDN" networkType
     Given I select a random node's host
     And the node iptables config is checked
     And the step succeeded
@@ -91,6 +92,7 @@ Feature: SDN related networking scenarios
   @heterogeneous @arm64 @amd64
   Scenario: OCP-13847:SDN an empty OPENSHIFT-ADMIN-OUTPUT-RULES chain is created in filter table at startup
     Given the master version >= "3.6"
+    Given the env is using "OpenShiftSDN" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
     Then evaluation of `pod.node_name` is stored in the :node_name clipboard
@@ -518,6 +520,7 @@ Feature: SDN related networking scenarios
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-41132:SDN UDP offloads were disabled on vsphere platform
+    Given the env is using "OpenShiftSDN" networkType
     Given I select a random node's host
     Given the default interface on nodes is stored in the :default_interface clipboard
     And I run commands on the host:

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -508,6 +508,7 @@ Feature: Service related networking scenarios
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
   Scenario: OCP-24694:SDN Taint node with too small MTU value
+    Given the env is using "OpenShiftSDN" networkType
     Given the default interface on nodes is stored in the :default_interface clipboard
     And the node's MTU value is stored in the :mtu_actual clipboard
     And the node's active nmcli connection is stored in the :nmcli_active_con_uuid clipboard
@@ -765,6 +766,7 @@ Feature: Service related networking scenarios
   @network-ovnkubernetes
   @heterogeneous @arm64 @amd64
   Scenario: OCP-47087:SDN Other node cannot be accessed for nodePort when externalTrafficPolicy is Local
+    Given the env is using "OVNKubernetes" networkType
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard
     And the Internal IP of node "<%= cb.masters[1].name %>" is stored in the :master1_ip clipboard


### PR DESCRIPTION
OVN will be default network type in 4.12 version,  so the default workflow will be OVN. so here enhance the step to make sure scenarios are working on correct cluster in case. 

thus in Prow CI config, we do not need to specified the network type tag
before:

```
      E2E_RUN_TAGS: '@aws-ipi and @network-openshiftsdn and not @fips'
```

after :

```
E2E_RUN_TAGS: '@aws-ipi and  not @fips'
```

and another in cucushift repo https://github.com/openshift/cucushift/pull/9250

@openshift/team-sdn-qe ^^