### PR TITLE
Fix error message+logic to pick the latest machine name

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -638,9 +638,19 @@ Feature: Machine features testing
       | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %> |
       | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | disconnected-azure-36489                    |
       | ["spec"]["template"]["spec"]["providerSpec"]["value"]["publicIP"]                         | true                                        |
-
+    
+    And admin ensures "disconnected-azure-36489" machine_set_machine_openshift_io is deleted after scenario
+    Then I store the last machine name in the :machine_latest clipboard 
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    Then the expression should be true> machine_machine_openshift_io(cb.machine_latest).phase(cached: false) == "Failed"
+    """
+    When I run the :describe admin command with:
+      | resource | machines.machine.openshift.io |
+      | name     | <%= cb.machine_latest %>      |
+    Then the step should succeed
     And the output should contain:
-      | Forbidden: publicIP is not allowed in Azure disconnected installation |
+      | InvalidConfiguration |
 
   # @author miyadav@redhat.com
   # @case_id OCP-47658

--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -640,11 +640,8 @@ Feature: Machine features testing
       | ["spec"]["template"]["spec"]["providerSpec"]["value"]["publicIP"]                         | true                                        |
     
     And admin ensures "disconnected-azure-36489" machine_set_machine_openshift_io is deleted after scenario
-    Then I store the last machine name in the :machine_latest clipboard 
-    And I wait up to 30 seconds for the steps to pass:
-    """
-    Then the expression should be true> machine_machine_openshift_io(cb.machine_latest).phase(cached: false) == "Failed"
-    """
+    Then I store the last provisioned machine in the :machine_latest clipboard 
+    
     When I run the :describe admin command with:
       | resource | machines.machine.openshift.io |
       | name     | <%= cb.machine_latest %>      |

--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -53,6 +53,11 @@ Given(/^I store the last provisioned machine in the#{OPT_SYM} clipboard$/) do | 
   cb[cb_name] = machines.max_by(&:created_at).name
 end
 
+Given(/^I store the last machine name in the#{OPT_SYM} clipboard$/) do | cb_name |
+  machine = BushSlicer::MachineMachineOpenshiftIo.list(user: admin, project: project("openshift-machine-api"))[0].name
+  cb[cb_name] = machine
+end
+
 Given(/^I wait for the node of machine_machine_openshift_io(?: named "(.+)")? to appear/) do | machine_name |
   machines = BushSlicer::MachineMachineOpenshiftIo.list(user: admin, project: project("openshift-machine-api"))
   cache_resources *machines

--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -53,11 +53,6 @@ Given(/^I store the last provisioned machine in the#{OPT_SYM} clipboard$/) do | 
   cb[cb_name] = machines.max_by(&:created_at).name
 end
 
-Given(/^I store the last machine name in the#{OPT_SYM} clipboard$/) do | cb_name |
-  machine = BushSlicer::MachineMachineOpenshiftIo.list(user: admin, project: project("openshift-machine-api"))[0].name
-  cb[cb_name] = machine
-end
-
 Given(/^I wait for the node of machine_machine_openshift_io(?: named "(.+)")? to appear/) do | machine_name |
   machines = BushSlicer::MachineMachineOpenshiftIo.list(user: admin, project: project("openshift-machine-api"))
   cache_resources *machines


### PR DESCRIPTION
@sunzhaohua2 @huali9 PTAL .

This test fails consistently due to error message changed(Forbidden error is no more , it gives invalid configuration and machineset is created successfully )  , more details can be found here - https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/396/200732/11501975

[Error](https://gcsweb-qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-nightly-e2e-azure-ipi-resourcegroup-p1/1559570771666276352/artifacts/e2e-azure-ipi-resourcegroup-p1/cucushift-e2e/build-log.txt) log 

Validation results - https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/563832/console
