### PR TITLE
Fix flakes of 19110|19150

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -504,10 +504,12 @@ Given /^I have a iSCSI setup in the environment$/ do
   if !_project.exists?(user:admin, quiet: true)
     @result = admin.cli_exec(:create_namespace, name: 'iscsi-target')
     raise 'failed to create "iscsi-target" project' unless @result[:success]
-    @result = admin.cli_exec(:label, resource: 'ns/iscsi-target', key_val: 'security.openshift.io/scc.podSecurityLabelSync=false', overwrite: 'true')
-    raise 'failed to add label "security.openshift.io/scc.podSecurityLabelSync=false" to "iscsi-target" namespace' unless @result[:success]
-    @result = admin.cli_exec(:label, resource: 'ns/iscsi-target', key_val: 'pod-security.kubernetes.io/enforce=privileged', overwrite: 'true')
-    raise 'failed to add label "pod-security.kubernetes.io/enforce=privileged" to "iscsi-target" namespace' unless @result[:success]
+    if env.version_ge("4.12", user: user)
+      @result = admin.cli_exec(:label, resource: 'ns/iscsi-target', key_val: 'security.openshift.io/scc.podSecurityLabelSync=false', overwrite: 'true')
+      raise 'failed to add label "security.openshift.io/scc.podSecurityLabelSync=false" to "iscsi-target" namespace' unless @result[:success]
+      @result = admin.cli_exec(:label, resource: 'ns/iscsi-target', key_val: 'pod-security.kubernetes.io/enforce=privileged', overwrite: 'true')
+      raise 'failed to add label "pod-security.kubernetes.io/enforce=privileged" to "iscsi-target" namespace' unless @result[:success]
+    end
   end
 
   _pod = cb.iscsi_pod = pod("iscsi-target", _project)

--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -500,9 +500,9 @@ end
 Given /^I have a iSCSI setup in the environment$/ do
   ensure_admin_tagged
 
-  _project = project("iscsi-target", switch: false)
+  _project = project("openshift-iscsi-target", switch: false)
   if !_project.exists?(user:admin, quiet: true)
-    @result = admin.cli_exec(:create_namespace, name: 'iscsi-target')
+    @result = admin.cli_exec(:create_namespace, name: 'openshift-iscsi-target')
     raise 'failed to "iscsi-target" project' unless @result[:success]
   end
 

--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -500,10 +500,14 @@ end
 Given /^I have a iSCSI setup in the environment$/ do
   ensure_admin_tagged
 
-  _project = project("openshift-iscsi-target", switch: false)
+  _project = project("iscsi-target", switch: false)
   if !_project.exists?(user:admin, quiet: true)
-    @result = admin.cli_exec(:create_namespace, name: 'openshift-iscsi-target')
-    raise 'failed to "iscsi-target" project' unless @result[:success]
+    @result = admin.cli_exec(:create_namespace, name: 'iscsi-target')
+    raise 'failed to create "iscsi-target" project' unless @result[:success]
+    @result = admin.cli_exec(:label, resource: 'ns/iscsi-target', key_val: 'security.openshift.io/scc.podSecurityLabelSync=false', overwrite: 'true')
+    raise 'failed to add label "security.openshift.io/scc.podSecurityLabelSync=false" to "iscsi-target" namespace' unless @result[:success]
+    @result = admin.cli_exec(:label, resource: 'ns/iscsi-target', key_val: 'pod-security.kubernetes.io/enforce=privileged', overwrite: 'true')
+    raise 'failed to add label "pod-security.kubernetes.io/enforce=privileged" to "iscsi-target" namespace' unless @result[:success]
   end
 
   _pod = cb.iscsi_pod = pod("iscsi-target", _project)


### PR DESCRIPTION
## Fix flakes of 19110|19150
When using "oc apply/create -f" to create iscsi-target server pods violates PodSecurity on 4.12, it used hostpath so need ns privilieged. Modify the default create ns of the iscsi-target server to openshift-iscsi-target solve the issue. And it should also work on previously releases.

**[Flake record](https://${report-portal-Domain}/ui/#prow/launches/all/204729?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED%26page.page%3D2)**
**[Test record ](https://${jenkins-Domain}/job/ocp-common/job/Runner/572210/console)**