### PR TITLE
Update OCP-40569

### DIFF
--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -210,9 +210,9 @@ Feature: OVNKubernetes IPsec related networking scenarios
     # Enable ipsec through CNO
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":{}}}}} |
+    Given I select a random node's host
     Given I wait up to 60 seconds for the steps to pass:
     """
-    Given I select a random node's host
     And I run commands on the host:
       | ip x s \| grep -i "mode transport" |
     Then the step should succeed
@@ -223,7 +223,6 @@ Feature: OVNKubernetes IPsec related networking scenarios
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":null}}}} |
     Given I wait up to 90 seconds for the steps to pass:
     """
-    Given I select a random node's host
     And I run commands on the host:
       | ip x s \| grep -i "mode transport" |
     Then the step should fail

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -210,23 +210,21 @@ Feature: OVNKubernetes IPsec related networking scenarios
     # Enable ipsec through CNO
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":{}}}}} |
-    Given I select a random node's host
-    Given I wait up to 60 seconds for the steps to pass:
+    Given I store the ovnkube-master "north" leader pod in the clipboard
+    Given I wait up to 90 seconds for the steps to pass:
     """
-    And I run commands on the host:
-      | ip x s \| grep -i "mode transport" |
-    Then the step should succeed
-    And the output should contain "mode transport"
+    And admin executes on the pod "northd" container:
+      | bash | -c | ovn-nbctl --no-leader-only get nb_global . ipsec \| grep true |
+    And the output should contain "true"
     """
     # Disable ipsec through CNO
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":null}}}} |
     Given I wait up to 90 seconds for the steps to pass:
     """
-    And I run commands on the host:
-      | ip x s \| grep -i "mode transport" |
-    Then the step should fail
-    Then the output should not contain "mode transport"
+    And admin executes on the pod "northd" container:
+      | bash | -c | ovn-nbctl --no-leader-only get nb_global . ipsec \| grep false |
+    And the output should contain "false"
     """
 
    

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -198,9 +198,8 @@ Feature: OVNKubernetes IPsec related networking scenarios
   # @case_id OCP-40569
   @admin
   @destructive
-  @network-ovnkubernetes @network-openshiftsdn
+  @network-ovnkubernetes
   @4.12 @4.11
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @singlenode

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -198,8 +198,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   # @case_id OCP-40569
   @admin
   @destructive
-  @inactive
-  @network-ovnkubernetes @network-openshiftsdn @ipsec
+  @network-ovnkubernetes @network-openshiftsdn
   @4.12 @4.11
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
@@ -207,61 +206,28 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @singlenode
   Scenario: OCP-40569:SDN Allow enablement/disablement ipsec at runtime
     Given the env is using "OVNKubernetes" networkType
-    Given I store all worker nodes to the :workers clipboard
-    Given the default interface on nodes is stored in the :default_interface clipboard
-    #Enable ipsec through CNO
+    
+    # Enable ipsec through CNO
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":{}}}}} |
-    Given I have a project
-    Given I obtain test data file "networking/pod-for-ping.json"
-    When I run oc create over "pod-for-ping.json" replacing paths:
-      | ["spec"]["nodeName"] | <%= cb.workers[1].name %> |
-      | ["metadata"]["name"] | pod-worker1               |
-    Then the step should succeed
-    And a pod becomes ready with labels:
-      | name=hello-pod |
-    And evaluation of `pod.ip_url` is stored in the :test_pod_worker1 clipboard
-
-    Given I obtain test data file "networking/pod-for-ping.json"
-    When I run oc create over "pod-for-ping.json" replacing paths:
-      | ["spec"]["nodeName"]                 | <%= cb.workers[0].name %>                                                                                          |
-      | ["metadata"]["name"]                 | pod-worker0                                                                                                        |
-      | ["spec"]["containers"][0]["command"] | ["bash", "-c", "for f in {0..3600}; do curl <%= cb.test_pod_worker1 %>:8080 ; --connect-timeout 5; sleep 1; done"] |
-    Then the step should succeed
-    #Above command will curl "hello openshift" traffic every 1 second to worker1 test pod which is expected to cause ESP traffic generation across those nodes
-    And a pod becomes ready with labels:
-      | name=hello-pod |
-    #Make sure you are receiving ESP packets at the destination node. For that we will simulate a prviledged pod to allow tcpdumping
-    Given I obtain test data file "networking/net_admin_cap_pod.yaml"
-    When I run oc create as admin over "net_admin_cap_pod.yaml" replacing paths:
-      | ["spec"]["nodeName"]                                       | <%= cb.workers[1].name %> |
-      | ["metadata"]["namespace"]                                  | <%= project.name %>       |
-      | ["metadata"]["name"]                                       | hostnw-pod-worker1        |
-      | ["spec"]["containers"][0]["securityContext"]["privileged"] | true                      |
-    Then the step should succeed
-    And a pod becomes ready with labels:
-      | name=network-pod |
-    And evaluation of `pod.name` is stored in the :hostnw_pod_worker1 clipboard
-    #capturing tcpdump for 2 seconds
     Given I wait up to 60 seconds for the steps to pass:
     """
-    When admin executes on the "<%= cb.hostnw_pod_worker1 %>" pod:
-      | bash | -c | timeout  --preserve-status 2 tcpdump -i <%= cb.default_interface %> esp |
+    Given I select a random node's host
+    And I run commands on the host:
+      | ip x s \| grep -i "mode transport" |
     Then the step should succeed
-    # Example ESP packet un-encrypted will look like 16:37:16.309297 IP ip-10-0-x-x.us-east-2.compute.internal > ip-10-0-x-x.us-east-2.compute.internal: ESP(spi=0xf50c771c,seq=0xfaad)
-    And the output should match:
-      | <%= cb.workers[0].name %>.* > <%= cb.workers[1].name %>.*: ESP |
+    And the output should contain "mode transport"
     """
-
-    #Disable ipsec through CNO
+    # Disable ipsec through CNO
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":null}}}} |
-    Given I wait up to 60 seconds for the steps to pass:
+    Given I wait up to 90 seconds for the steps to pass:
     """
-    When admin executes on the "<%= cb.hostnw_pod_worker1 %>" pod:
-      | bash | -c | timeout  --preserve-status 2 tcpdump -i <%= cb.default_interface %> esp |
-    Then the step should succeed
-    # Example ESP packet un-encrypted will look like 16:37:16.309297 IP ip-10-0-x-x.us-east-2.compute.internal > ip-10-0-x-x.us-east-2.compute.internal: ESP(spi=0xf50c771c,seq=0xfaad)
-    And the output should not match:
-      | <%= cb.workers[0].name %>.* > <%= cb.workers[1].name %>.*: ESP |
+    Given I select a random node's host
+    And I run commands on the host:
+      | ip x s \| grep -i "mode transport" |
+    Then the step should fail
+    Then the output should not contain "mode transport"
     """
+
+   

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -200,6 +200,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @destructive
   @network-ovnkubernetes
   @4.12 @4.11
+  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
   @singlenode

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -206,25 +206,90 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @singlenode
   Scenario: OCP-40569:SDN Allow enablement/disablement ipsec at runtime
     Given the env is using "OVNKubernetes" networkType
-    
-    # Enable ipsec through CNO
+    Given I store all worker nodes to the :workers clipboard
+    Given the default interface on nodes is stored in the :default_interface clipboard
+
+    #Enable ipsec through CNO
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":{}}}}} |
+
+    Given I have a project with proper privilege
+    And evaluation of `project.name` is stored in the :hello_pod_project clipboard
+    Given I obtain test data file "networking/pod-for-ping.json"
+    When I run oc create over "pod-for-ping.json" replacing paths:
+      | ["spec"]["nodeName"] | <%= cb.workers[1].name %> |
+      | ["metadata"]["name"] | pod-worker1               |
+    Then the step should succeed
+    And a pod becomes ready with labels:
+      | name=hello-pod |
+    And evaluation of `pod.ip_url` is stored in the :test_pod_worker1 clipboard
+
+    Given I obtain test data file "networking/pod-for-ping.json"
+    When I run oc create over "pod-for-ping.json" replacing paths:
+      | ["spec"]["nodeName"]                 | <%= cb.workers[0].name %>                                                                                          |
+      | ["metadata"]["name"]                 | pod-worker0                                                                                                        |
+      | ["spec"]["containers"][0]["command"] | ["bash", "-c", "for f in {0..3600}; do curl <%= cb.test_pod_worker1 %>:8080 ; --connect-timeout 5; sleep 1; done"] |
+    Then the step should succeed
+    #Above command will curl "hello openshift" traffic every 1 second to worker1 test pod which is expected to cause ESP traffic generation across those nodes
+    And a pod becomes ready with labels:
+      | name=hello-pod |
+
+    Given I obtain test data file "networking/net_admin_cap_pod.yaml"
+    When I run oc create as admin over "net_admin_cap_pod.yaml" replacing paths:
+      | ["spec"]["nodeName"]                                       | <%= cb.workers[1].name %>   |
+      | ["metadata"]["namespace"]                                  | <%= cb.hello_pod_project %> |
+      | ["metadata"]["name"]                                       | hostnw-pod-worker1          |
+      | ["spec"]["containers"][0]["securityContext"]["privileged"] | true                        |
+    Then the step should succeed
+    And a pod becomes ready with labels:
+      | name=network-pod |
+    And evaluation of `pod.name` is stored in the :hello_pod_worker1 clipboard
+
+    #Check ESP traffic between two pods crossing nodes after enabling IPsec
+    Given I wait up to 90 seconds for the steps to pass:
+    """
+    When admin executes on the "<%= cb.hello_pod_worker1 %>" pod:
+      | bash | -c | timeout  --preserve-status 2 tcpdump -v -i <%= cb.default_interface %> esp |
+    Then the step should succeed
+    And the output should contain "ESP"
+    """
+
+    #Need to restart ovnkube-master "north" leader after enabling ipsec to make sure use correct "north" leader
     Given I store the ovnkube-master "north" leader pod in the clipboard
+    Given admin ensures "<%= cb.north_leader.name %>" pod is deleted from the "openshift-ovn-kubernetes" project    
+    Given I store the ovnkube-master "north" leader pod in the clipboard
+    #Check "north" leader return ipsec enabled/ture information
     Given I wait up to 90 seconds for the steps to pass:
     """
     And admin executes on the pod "northd" container:
       | bash | -c | ovn-nbctl --no-leader-only get nb_global . ipsec \| grep true |
     And the output should contain "true"
     """
+    
     # Disable ipsec through CNO
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":null}}}} |
+
+    Given I switch to the first user
+    And I use the "<%= cb.hello_pod_project %>" project
+    #Check NO ESP traffic between two pods crossing nodes after enabling IPsec
+    Given I wait up to 90 seconds for the steps to pass:
+    """
+    When admin executes on the "<%= cb.hello_pod_worker1 %>" pod:
+      | bash | -c | timeout  --preserve-status 2 tcpdump -v -i <%= cb.default_interface %> esp |
+    Then the step should succeed
+    And the output should not contain "ESP"
+    """
+    
+    #Need to restart ovnkube-master "north" leader after enabling ipsec to make sure use correct "north" leader
+    Given I store the ovnkube-master "north" leader pod in the clipboard
+    Given admin ensures "<%= cb.north_leader.name %>" pod is deleted from the "openshift-ovn-kubernetes" project    
+    Given I store the ovnkube-master "north" leader pod in the clipboard
+    #Check "north" leader return ipsec disabled/false information
     Given I wait up to 90 seconds for the steps to pass:
     """
     And admin executes on the pod "northd" container:
       | bash | -c | ovn-nbctl --no-leader-only get nb_global . ipsec \| grep false |
     And the output should contain "false"
     """
-
    


### PR DESCRIPTION
As reported in https://issues.redhat.com/browse/OCPQE-11648, the test case OCP-40569: "Allow enablement/disablement ipsec at runtime" failed randomly because checking ESP traffic not always return as expected.

Other ipsec test cases have more steps to check ESP traffic crossing the nodes in the cluster. For this case, checking enable and disable ipsec state at run time will be enough for this testing. Update case to see ipsec has correct ipsec transport mode when enable and disable.

Test log: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/4823/console

@anuragthehatter @openshift/team-sdn-qe  PTAL