### PR TITLE
Add pod security labels to namespaces

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -161,6 +161,17 @@ Given /^I have LDAP service in my project$/ do
     # So take the second one since this one can be implemented currently
     ###
     stats = {}
+    if env.version_ge("4.12", user: user)
+      step %Q/I run the :label admin command with:/, table(%{
+        | resource  | namespace/<%= project.name %>                        |
+        | overwrite | true                                                 |
+        | key_val   | security.openshift.io/scc.podSecurityLabelSync=false |
+        | key_val   | pod-security.kubernetes.io/enforce=privileged        |
+        | key_val   | pod-security.kubernetes.io/audit=privileged          |
+        | key_val   | pod-security.kubernetes.io/warn=privileged           |
+        })
+      step %Q/the step should succeed/
+    end
     step 'I obtain test data file "pods/ldapserver.yaml"'
     step %Q/I run the :create admin command with:/, table(%{
       | f | ldapserver.yaml      |


### PR DESCRIPTION
Failure log: https://url.corp.redhat.com/e73923f due to error:
Error from server (Forbidden): error when creating "ldapserver.yaml": pods "ldapserver" is forbidden: violates PodSecurity "restricted:v1.24": unrestricted capabilities (container "ldapserver" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "ldapserver" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "ldapserver" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")


Pass log: job/ocp-common/job/Runner/575624/console
@zhouying7780 @liangxia help review / merge, thanks!