### PR TITLE
Add other labels to avoid alert

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -505,10 +505,8 @@ Given /^I have a iSCSI setup in the environment$/ do
     @result = admin.cli_exec(:create_namespace, name: 'iscsi-target')
     raise 'failed to create "iscsi-target" project' unless @result[:success]
     if env.version_ge("4.12", user: user)
-      @result = admin.cli_exec(:label, resource: 'ns/iscsi-target', key_val: 'security.openshift.io/scc.podSecurityLabelSync=false', overwrite: 'true')
-      raise 'failed to add label "security.openshift.io/scc.podSecurityLabelSync=false" to "iscsi-target" namespace' unless @result[:success]
-      @result = admin.cli_exec(:label, resource: 'ns/iscsi-target', key_val: 'pod-security.kubernetes.io/enforce=privileged', overwrite: 'true')
-      raise 'failed to add label "pod-security.kubernetes.io/enforce=privileged" to "iscsi-target" namespace' unless @result[:success]
+      @result = admin.cli_exec(:label, [[:resource, "ns/iscsi-target"], [:overwrite, "true"], [:key_val, "security.openshift.io/scc.podSecurityLabelSync=false"], [:key_val, "pod-security.kubernetes.io/enforce=privileged"], [:key_val, "pod-security.kubernetes.io/audit=privileged"], [:key_val, "pod-security.kubernetes.io/warn=privileged"]])
+      raise 'failed to add pod security labels to "iscsi-target" namespace' unless @result[:success]
     end
   end
 


### PR DESCRIPTION
@Phaow @duanwei33 @liangxia I forgot to say previous https://github.com/openshift/verification-tests/pull/2999 will fire one important alert on cluster due to https://github.com/openshift/cluster-kube-apiserver-operator/pull/1362 alert definition. We must add other labels to avoid the alert for pod creation. The audit label must be added. The warn label is optional, but why not make the warn output gone.
Pass log: job/Runner/575626/console
@Phaow @duanwei33 @liangxia help review and merge, thanks!