### PR TITLE
Fix OCP-11348

### DIFF
--- a/features/admin/quota.feature
+++ b/features/admin/quota.feature
@@ -974,8 +974,8 @@ Feature: Quota related scenarios
       | pods\\s+0\\s+10  |
 
   # @author chezhang@redhat.com
+  # @author weinliu@redhat.com
   # @case_id OCP-11348
-  @flaky
   @admin
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
@@ -1063,8 +1063,11 @@ Feature: Quota related scenarios
       | name=pod-besteffort-terminating |
     And I wait up to 70 seconds for the steps to pass:
     """
-    When I get project pods
-    Then the output should match "pod-besteffort-terminating.*DeadlineExceeded"
+      When I run the :describe client command with:
+        | resource | pod                        |
+        | name     | pod-besteffort-terminating |
+       Then the output should match:
+        | DeadlineExceeded |
     """
     When I run the :describe client command with:
       | resource | quota |


### PR DESCRIPTION
Using `oc describe` to check DeadlineExceeded, instead of `oc get`