### PR TITLE
Add setup privileged project util

### DIFF
--- a/features/step_definitions/project.rb
+++ b/features/step_definitions/project.rb
@@ -34,34 +34,8 @@ Given /^I have a project$/ do
   end
 end
 
-Given /^I have a privileged project$/ do
-  # system projects should not be selected by default
-  sys_projects = BushSlicer::Project::SYSTEM_PROJECTS
-
-  project = @projects.reverse.find {|p|
-    !sys_projects.include?(p.name) &&
-      p.is_user_admin?(user: user, cached: true) &&
-      p.active?(user: user, cached: true)
-  }
-  if project
-    # project does exist as visible is doing an actual query
-    # also move project up the stack
-    @projects << @projects.delete(project)
-  else
-    projects = (user.projects - sys_projects).select {|p|
-      p.is_user_admin?(user: user, cached: true) &&
-      p.active?(user: user, cached: true)
-    }
-    if projects.empty?
-      step 'I create a new project'
-      unless @result[:success]
-        logger.error(@result[:response])
-        raise "unable to create project, see log"
-      end
-    else
-      cache_resources *projects
-    end
-  end
+Given /^I have a project with proper privilege$/ do
+  step %Q/I have a project/
   if env.version_ge("4.12", user: user)
     step %Q/I run the :label admin command with:/, table(%{
       | resource  | namespace/<%= project.name %>                        |


### PR DESCRIPTION
## Add setup privileged project util
PodSecurity restricted enabled by default on 4.12, used hostpath cases need namespace set to privilieged. Add setup privileged project util for using privilieged namespace scenarios.

**[Flake record](https://${report-portal-Domain}/ui/#prow/launches/454/207510/12395570/12395797/log?item1Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED)**
**[Test record ](https://${jenkins-Domain}/job/ocp-common/job/Runner/577369/console)**