### PR TITLE
Fix tags for scenario outlines in storage

### DIFF
--- a/features/storage/cloud_provider.feature
+++ b/features/storage/cloud_provider.feature
@@ -4,6 +4,10 @@ Feature: kubelet restart and node restart
   @admin
   @destructive
   @inactive
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: kubelet restart should not affect attached/mounted volumes
     Given I have a project
@@ -49,10 +53,6 @@ Feature: kubelet restart and node restart
 
     @vsphere-ipi
     @vsphere-upi
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | platform       |
       | OCP-13631:Storage | vsphere-volume | # @case_id OCP-13631

--- a/features/storage/csi.feature
+++ b/features/storage/csi.feature
@@ -40,6 +40,12 @@ Feature: CSI testing related feature
 
   # @author chaoyang@redhat.com
   @admin
+  @upgrade-sanity
+  @qeci
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Configure 'Retain' reclaim policy
     Given I have a project
@@ -80,12 +86,6 @@ Feature: CSI testing related feature
 
     @openstack-ipi
     @openstack-upi
-    @upgrade-sanity
-    @qeci
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | sc_name      |
       | OCP-37572:Storage | standard-csi | # @case_id OCP-37572
@@ -94,6 +94,11 @@ Feature: CSI testing related feature
   # @author wduan@redhat.com
   @admin
   @smoke
+  @upgrade-sanity
+  @qeci
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   Scenario Outline: CSI dynamic provisioning with default fstype
     Given I have a project
@@ -166,11 +171,6 @@ Feature: CSI testing related feature
 
     @openstack-ipi
     @openstack-upi
-    @upgrade-sanity
-    @qeci
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | sc_name      |
       | OCP-37562:Storage | standard-csi | # @case_id OCP-37562
@@ -179,6 +179,11 @@ Feature: CSI testing related feature
   # @author wduan@redhat.com
   @admin
   @smoke
+  @upgrade-sanity
+  @qeci
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   Scenario Outline: CSI dynamic provisioning with fstype
     Given I have a project
@@ -222,11 +227,6 @@ Feature: CSI testing related feature
 
     @openstack-ipi
     @openstack-upi
-    @upgrade-sanity
-    @qeci
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | sc_name      | fstype |
       | OCP-37560:Storage | standard-csi | xfs    | # @case_id OCP-37560
@@ -234,6 +234,11 @@ Feature: CSI testing related feature
 
 
   # @author wduan@redhat.com
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   Scenario Outline: CSI dynamic provisioning with block
     Given I have a project
@@ -275,11 +280,6 @@ Feature: CSI testing related feature
       | case_id           | sc_name      |
       | OCP-37564:Storage | standard-csi | # @case_id OCP-37564
 
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | sc_name      |
       | OCP-37511:Storage | standard-csi | # @case_id OCP-37511
@@ -287,6 +287,10 @@ Feature: CSI testing related feature
 
   # @author wduan@redhat.com
   @admin
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: CSI dynamic provisioning with different type
     Given I have a project
@@ -329,10 +333,6 @@ Feature: CSI testing related feature
       | OCP-24546:Storage | gp2-csi | sc1  | 125Gi | # @case_id OCP-24546
       | OCP-24572:Storage | gp2-csi | st1  | 125Gi | # @case_id OCP-24572
 
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | sc_name      | type   | size |
       | OCP-37478:Storage | standard-csi | pd-ssd | 1Gi  | # @case_id OCP-37478
@@ -340,6 +340,11 @@ Feature: CSI testing related feature
 
   # @author wduan@redhat.com
   @admin
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Check CSI Driver Operator installation
     When I run the :get admin command with:
@@ -383,11 +388,6 @@ Feature: CSI testing related feature
       | case_id           | provisioner     | sc_name | deployment_operator         | deployment_controller         | daemonset_node          |
       | OCP-34144:Storage | ebs.csi.aws.com | gp2-csi | aws-ebs-csi-driver-operator | aws-ebs-csi-driver-controller | aws-ebs-csi-driver-node | # @case_id OCP-34144
 
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | provisioner           | sc_name      | deployment_operator        | deployment_controller        | daemonset_node         |
       | OCP-37474:Storage | pd.csi.storage.gke.io | standard-csi | gcp-pd-csi-driver-operator | gcp-pd-csi-driver-controller | gcp-pd-csi-driver-node | # @case_id OCP-37474

--- a/features/storage/csi_resize.feature
+++ b/features/storage/csi_resize.feature
@@ -2,6 +2,11 @@ Feature: CSI Resizing related feature
 
   # @author chaoyang@redhat.com
   @admin
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Resize online volume from 1Gi to 2Gi
     Given I have a project
@@ -53,16 +58,15 @@ Feature: CSI Resizing related feature
 
     @openstack-ipi
     @openstack-upi
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | sc_name      |
       | OCP-37559:Storage | standard-csi | # @case_id OCP-37559
 
   # @author wduan@redhat.com
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Resize negative test
     Given I have a project
@@ -90,10 +94,6 @@ Feature: CSI Resizing related feature
     And the output should match:
       | Forbidden.*field can not be less than previous value |
 
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
     @aws-ipi
     @aws-upi
     Examples:

--- a/features/storage/csi_snapshot.feature
+++ b/features/storage/csi_snapshot.feature
@@ -2,6 +2,12 @@ Feature: Volume snapshot test
 
   # @author wduan@redhat.com
   @admin
+  @upgrade-sanity
+  @qeci
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   Scenario Outline: Volume snapshot create and restore test
     Given I have a project
@@ -67,18 +73,17 @@ Feature: Volume snapshot test
 
     @openstack-ipi
     @openstack-upi
-    @upgrade-sanity
-    @qeci
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | csi-sc       | csi-vsc      |
       | OCP-37568:Storage | standard-csi | standard-csi | # @case_id OCP-37568
 
   # @author wduan@redhat.com
   @admin
+  @upgrade-sanity
+  @qeci
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   Scenario Outline: Volume snapshot create and restore test with block
     Given I have a project
@@ -141,11 +146,6 @@ Feature: Volume snapshot test
 
     @openstack-ipi
     @openstack-upi
-    @upgrade-sanity
-    @qeci
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | csi-sc       | csi-vsc      |
       | OCP-37569:Storage | standard-csi | standard-csi | # @case_id OCP-37569

--- a/features/storage/dynamic_provisioning.feature
+++ b/features/storage/dynamic_provisioning.feature
@@ -3,6 +3,10 @@ Feature: Dynamic provisioning
   # @author lxia@redhat.com
   @admin
   @smoke
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: dynamic provisioning
     Given I have a project
@@ -77,10 +81,6 @@ Feature: Dynamic provisioning
 
     @openstack-ipi
     @openstack-upi
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id          | cloud_provider |
       | OCP-9656:Storage | cinder         | # @case_id OCP-9656

--- a/features/storage/fsType.feature
+++ b/features/storage/fsType.feature
@@ -3,6 +3,10 @@ Feature: testing for parameter fsType
   # @author chaoyang@redhat.com
   @admin
   @smoke
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: persistent volume formated with fsType
     Given I have a project
@@ -32,24 +36,24 @@ Feature: testing for parameter fsType
       | ls | /mnt/testfile |
     Then the step should succeed
 
-    @openstack-ipi @gcp-ipi @aws-ipi
-    @openstack-upi @gcp-upi @aws-upi
+    @gcp-ipi
+    @gcp-upi
     Examples:
       | case_id           | fsType | type |
       | OCP-10095:Storage | ext3   | gce  | # @case_id OCP-10095
       | OCP-10094:Storage | ext4   | gce  | # @case_id OCP-10094
       | OCP-10096:Storage | xfs    | gce  | # @case_id OCP-10096
 
+    @aws-ipi
+    @aws-upi
     Examples:
       | case_id           | fsType | type |
       | OCP-10048:Storage | ext3   | ebs  | # @case_id OCP-10048
       | OCP-9612:Storage  | ext4   | ebs  | # @case_id OCP-9612
       | OCP-10049:Storage | xfs    | ebs  | # @case_id OCP-10049
 
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
+    @openstack-ipi
+    @openstack-upi
     Examples:
       | case_id           | fsType | type   |
       | OCP-10097:Storage | ext3   | cinder | # @case_id OCP-10097

--- a/features/storage/hostpath.feature
+++ b/features/storage/hostpath.feature
@@ -3,6 +3,10 @@ Feature: Storage of Hostpath plugin testing
   # @author chaoyang@redhat.com
   # @author lxia@redhat.com
   @admin
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Create hostpath pv with access mode and reclaim policy
     Given I have a project
@@ -49,10 +53,6 @@ Feature: Storage of Hostpath plugin testing
 
     @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
     @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id          | access_mode   | reclaim_policy | pv_status | step_status |
       | OCP-9639:Storage | ReadWriteOnce | Retain         | released  | succeed     | # @case_id OCP-9639

--- a/features/storage/negative.feature
+++ b/features/storage/negative.feature
@@ -3,6 +3,9 @@ Feature: negative testing
   # @author jhou@redhat.com
   # @author lxia@redhat.com
   @admin
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.8 @4.7 @4.6
   Scenario Outline: PV with invalid volume id should be prevented from creating
     Given admin ensures "mypv" pv is deleted after scenario
@@ -13,9 +16,6 @@ Feature: negative testing
     And the output should contain:
       | <error> |
 
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     @gcp-ipi
     @gcp-upi
     Examples:

--- a/features/storage/node_operations.feature
+++ b/features/storage/node_operations.feature
@@ -3,6 +3,9 @@ Feature: Node operations test scenarios
   # @author jhou@redhat.com
   @admin
   @destructive
+  @upgrade-sanity
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Drain a node that has cloud vendor volumes
     Given environment has at least 2 schedulable nodes
@@ -59,9 +62,6 @@ Feature: Node operations test scenarios
       | case_id           | cloud_provider |
       | OCP-15276:Storage | cinder         | # @case_id OCP-15276
 
-    @upgrade-sanity
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | cloud_provider |
       | OCP-15283:Storage | aws-ebs        | # @case_id OCP-15283

--- a/features/storage/persistent_volume.feature
+++ b/features/storage/persistent_volume.feature
@@ -4,6 +4,10 @@ Feature: Persistent Volume Claim binding policies
   # @author lxia@redhat.com
   # @author chaoyang@redhat.com
   @admin
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: PVC with one accessMode can bind PV with all accessMode
     Given I have a project
@@ -37,10 +41,6 @@ Feature: Persistent Volume Claim binding policies
 
     @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
     @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | accessMode1   | accessMode2   | accessMode3   |
       | OCP-9702:Storage  | ReadOnlyMany  | ReadWriteMany | ReadWriteOnce | # @case_id OCP-9702
@@ -75,6 +75,11 @@ Feature: Persistent Volume Claim binding policies
 
   # @author lxia@redhat.com
   @admin
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: PV can not bind PVC which request more storage
     Given I have a project
@@ -97,11 +102,6 @@ Feature: Persistent Volume Claim binding policies
 
     @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
     @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | access_mode   |
       | OCP-26880:Storage | ReadOnlyMany  | # @case_id OCP-26880
@@ -111,6 +111,11 @@ Feature: Persistent Volume Claim binding policies
 
   # @author lxia@redhat.com
   @admin
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: PV can not bind PVC with mismatched accessMode
     Given I have a project
@@ -138,11 +143,6 @@ Feature: Persistent Volume Claim binding policies
 
     @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
     @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | pv_access_mode | pvc_access_mode1 | pvc_access_mode2 |
       | OCP-26882:Storage | ReadOnlyMany   | ReadWriteMany    | ReadWriteOnce    | # @case_id OCP-26882

--- a/features/storage/pre-bind.feature
+++ b/features/storage/pre-bind.feature
@@ -200,6 +200,9 @@ Feature: Testing for pv and pvc pre-bind feature
   # @author chaoyang@redhat.com
   # @author lxia@redhat.com
   @admin
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Prebound pv/pvc is availabe/pending due to requested pvc/pv prebound to other pv/pvc
     Given I create a project with non-leading digit name
@@ -218,13 +221,10 @@ Feature: Testing for pv and pvc pre-bind feature
       | ["spec"]["storageClassName"] | sc-<%= project.name %> |
     And the "mypvc" PVC becomes :pending
     And the "pv-<%= project.name %>" PV status is :available
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
+
     @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
     @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
     Examples:
       | case_id           | pre-bind-pvc | pre-bind-pv                |
       | OCP-10108:Storage | nfsc         | nfspv1-<%= project.name %> | # @case_id OCP-10108
       | OCP-10112:Storage | nfsc1        | nfspv-<%= project.name %>  | # @case_id OCP-10112
-

--- a/features/storage/reclaim_policy.feature
+++ b/features/storage/reclaim_policy.feature
@@ -2,6 +2,9 @@ Feature: Persistent Volume reclaim policy tests
 
   # @author lxia@redhat.com
   @admin
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Persistent volume with RWO access mode and Delete policy
     Given I have a project
@@ -54,9 +57,6 @@ Feature: Persistent Volume reclaim policy tests
 
     @openstack-ipi
     @openstack-upi
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id          | storage_type | volume_name | path   | file                |
       | OCP-9944:Storage | cinder       | volumeID    | cinder | pv-rwx-default.json | # @case_id OCP-9944

--- a/features/storage/security.feature
+++ b/features/storage/security.feature
@@ -4,6 +4,10 @@ Feature: storage security check
   # @author piqin@redhat.com
   @admin
   @smoke
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: volume security testing
     Given I have a project
@@ -121,10 +125,6 @@ Feature: storage security check
 
     @openstack-ipi
     @openstack-upi
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id          | storage_type | volume_name | type   |
       | OCP-9721:Storage | cinder       | volumeID    | cinder | # @case_id OCP-9721

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -2,6 +2,9 @@ Feature: storageClass related feature
 
   # @author lxia@redhat.com
   @admin
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: PVC modification after creating storage class
     Given I have a project
@@ -46,9 +49,6 @@ Feature: storageClass related feature
 
     @azure-ipi
     @azure-upi
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | storage-class-name |
       | OCP-13488:Storage | managed-premium    | # @case_id OCP-13488
@@ -57,6 +57,10 @@ Feature: storageClass related feature
   # @author chaoyang@redhat.com
   @admin
   @smoke
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: storage class provisioner
     Given I have a project
@@ -102,10 +106,6 @@ Feature: storageClass related feature
 
     @aws-ipi
     @aws-upi
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | provisioner | type | zone       | is-default | size  |
       | OCP-10160:Storage | aws-ebs     | gp2  | us-east-1d | false      | 1Gi   | # @case_id OCP-10160
@@ -115,6 +115,10 @@ Feature: storageClass related feature
   # @author lxia@redhat.com
   @admin
   @destructive
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: New creation PVC failed when multiple classes are set as default
     Given I have a project
@@ -177,10 +181,6 @@ Feature: storageClass related feature
 
     @vsphere-ipi
     @vsphere-upi
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | provisioner    |
       | OCP-24259:Storage | vsphere-volume | # @case_id OCP-24259
@@ -205,6 +205,9 @@ Feature: storageClass related feature
 
   # @author chaoyang@redhat.com
   @admin
+  @singlenode
+  @proxy @noproxy @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: PVC with storage class will provision pv with io1 type and 100/20000 iops ebs volume
     Given I have a project
@@ -245,9 +248,6 @@ Feature: storageClass related feature
 
     @aws-ipi
     @aws-upi
-    @singlenode
-    @proxy @noproxy @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | size  |
       | OCP-10158:Storage | 4Gi   | # @case_id OCP-10158
@@ -255,6 +255,9 @@ Feature: storageClass related feature
 
   # @author chaoyang@redhat.com
   @admin
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: PVC with storage class will not provision pv with st1/sc1 type ebs volume if request size is wrong
     Given I have a project
@@ -284,9 +287,6 @@ Feature: storageClass related feature
 
     @aws-ipi
     @aws-upi
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | type | size | errorMessage                  |
       | OCP-10164:Storage | sc1  | 5Gi  | at least 125 GiB              | # @case_id OCP-10164
@@ -345,6 +345,3 @@ Feature: storageClass related feature
       | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/iaas               |
     Then the step should succeed
     And the pod named "mypod" becomes ready
-
-
-

--- a/features/storage/vsphere.feature
+++ b/features/storage/vsphere.feature
@@ -3,6 +3,10 @@ Feature: vSphere test scenarios
   # @author jhou@redhat.com
   @admin
   @smoke
+  @upgrade-sanity
+  @singlenode
+  @proxy @noproxy @disconnected @connected
+  @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Dynamically provision a vSphere volume with different disk formats
     Given I have a project
@@ -57,10 +61,6 @@ Feature: vSphere test scenarios
 
     @vsphere-ipi
     @vsphere-upi
-    @upgrade-sanity
-    @singlenode
-    @proxy @noproxy @disconnected @connected
-    @heterogeneous @arm64 @amd64
     Examples:
       | case_id           | disk_format      |
       | OCP-13386:Storage | thin             | # @case_id OCP-13386


### PR DESCRIPTION
When there are multiple `Examples` for scenario outlines, some of the tags are shared across those examples, which need to put ahead of the scenario outline.

/cc @duanwei33 @chao007 @Phaow 