### PR TITLE
pod security for hostnw pods

### DIFF
--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -18,6 +18,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
     #Using socat tool to send ESP packets to host worker1 from worker0. Port 50 is for ESP protocol. Simulating a hostnetwork pod on worker0 with privileged mode to allow socat tool leverage
     Given evaluation of `50` is stored in the :protocol clipboard
     Given I have a project
+    And the appropriate pod security labels are applied to the "<%= project.name %>" namespace
     Given I obtain test data file "networking/net_admin_cap_pod.yaml"
     When I run oc create as admin over "net_admin_cap_pod.yaml" replacing paths:
        | ["spec"]["nodeName"]                                       | <%= cb.workers[0].name %>                                                          |

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -18,7 +18,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
     #Using socat tool to send ESP packets to host worker1 from worker0. Port 50 is for ESP protocol. Simulating a hostnetwork pod on worker0 with privileged mode to allow socat tool leverage
     Given evaluation of `50` is stored in the :protocol clipboard
     Given I have a project
-    And the appropriate pod security labels are applied to the "<%= project.name %>" namespace
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/net_admin_cap_pod.yaml"
     When I run oc create as admin over "net_admin_cap_pod.yaml" replacing paths:
        | ["spec"]["nodeName"]                                       | <%= cb.workers[0].name %>                                                          |

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -353,7 +353,7 @@ Feature: Pod related networking scenarios
     Given I have a project
     #privileges are needed to support network-pod as hostnetwork pod creation later
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
-    And the appropriate pod security labels are applied to the "<%= project.name %>" namespace
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/pod_with_udp_port_4789_nodename.json"
     When I run oc create over "pod_with_udp_port_4789_nodename.json" replacing paths:
       | ["items"][0]["spec"]["template"]["spec"]["nodeName"] | <%= cb.nodes[0].name %> |

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -353,6 +353,7 @@ Feature: Pod related networking scenarios
     Given I have a project
     #privileges are needed to support network-pod as hostnetwork pod creation later
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
+    And the appropriate pod security labels are applied to the "<%= project.name %>" namespace
     Given I obtain test data file "networking/pod_with_udp_port_4789_nodename.json"
     When I run oc create over "pod_with_udp_port_4789_nodename.json" replacing paths:
       | ["items"][0]["spec"]["template"]["spec"]["nodeName"] | <%= cb.nodes[0].name %> |

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1599,16 +1599,3 @@ Given /^the cluster is dual stack network type$/ do
     skip_this_scenario
   end
 end
-
-Given /^the appropriate pod security labels are applied to the#{OPT_QUOTED} namespace$/ do | project_name |
-  ensure_admin_tagged
-  project_name ||= project.name
-  if env.version_ge("4.12", user: user)
-    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'security.openshift.io/scc.podSecurityLabelSync=false', overwrite: true)
-    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'pod-security.kubernetes.io/enforce=privileged', overwrite: true)
-    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'pod-security.kubernetes.io/audit=privileged', overwrite: true)
-    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'pod-security.kubernetes.io/warn=privileged', overwrite: true)
-  else
-    nil  
-  end
-end

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1599,3 +1599,15 @@ Given /^the cluster is dual stack network type$/ do
     skip_this_scenario
   end
 end
+
+Given /^the appropriate pod security labels are applied to the "(.+?)" namespace$/ do | project_name |
+  ensure_admin_tagged
+  if env.version_ge("4.12", user: user)
+    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'security.openshift.io/scc.podSecurityLabelSync=false', overwrite: true)
+    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'pod-security.kubernetes.io/enforce=privileged', overwrite: true)
+    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'pod-security.kubernetes.io/audit=privileged', overwrite: true)
+    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'pod-security.kubernetes.io/warn=privileged', overwrite: true)
+  else
+    nil  
+  end
+end

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1600,8 +1600,9 @@ Given /^the cluster is dual stack network type$/ do
   end
 end
 
-Given /^the appropriate pod security labels are applied to the "(.+?)" namespace$/ do | project_name |
+Given /^the appropriate pod security labels are applied to the#{OPT_QUOTED} namespace$/ do | project_name |
   ensure_admin_tagged
+  project_name ||= project.name
   if env.version_ge("4.12", user: user)
     admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'security.openshift.io/scc.podSecurityLabelSync=false', overwrite: true)
     admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'pod-security.kubernetes.io/enforce=privileged', overwrite: true)

--- a/features/step_definitions/project.rb
+++ b/features/step_definitions/project.rb
@@ -49,6 +49,17 @@ Given /^I have a project with proper privilege$/ do
   end
 end
 
+Given /^the appropriate pod security labels are applied to the#{OPT_QUOTED} namespace$/ do | project_name |
+  ensure_admin_tagged
+  project_name ||= project.name
+  if env.version_ge("4.12", user: user)
+    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'security.openshift.io/scc.podSecurityLabelSync=false', overwrite: true)
+    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'pod-security.kubernetes.io/enforce=privileged', overwrite: true)
+    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'pod-security.kubernetes.io/audit=privileged', overwrite: true)
+    admin.cli_exec(:label, resource: "namespace", name: project_name, key_val: 'pod-security.kubernetes.io/warn=privileged', overwrite: true)
+  end
+end
+
 # try to create a new project with current user
 When /^I create a new project(?: via (.*?))?$/ do |via|
   @result = BushSlicer::Project.create(by: user, name: rand_str(5, :dns), _via: (via.to_sym if via))

--- a/features/upgrade/sdn/ipsec-upgrade.feature
+++ b/features/upgrade/sdn/ipsec-upgrade.feature
@@ -19,6 +19,7 @@ Feature: IPsec upgrade scenarios
     When I run the :new_project client command with:
       | project_name | ipsec-upgrade |
     Then the step should succeed
+    And the appropriate pod security labels are applied to the "ipsec-upgrade" namespace
     When I use the "ipsec-upgrade" project
     Given I obtain test data file "networking/list_for_pods.json"
     #Creating two test pods for pod-pod encryption check. Pods needs to be deployment/rc backed so that they can be migrate successfuly to the upgraded cluster.Creating each separat as they need to be on diff

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -420,6 +420,7 @@ Feature: SDN compoment upgrade testing
     When I run the :new_project client command with:
       | project_name | conntrack-upgrade |
     Then the step should succeed
+    And the appropriate pod security labels are applied to the "conntrack-upgrade" namespace
     Given I use the "conntrack-upgrade" project
     And I obtain test data file "networking/pod_with_udp_port_4789_nodename.json"
     When I run oc create over "pod_with_udp_port_4789_nodename.json" replacing paths:

--- a/testdata/networking/net_admin_cap_pod.yaml
+++ b/testdata/networking/net_admin_cap_pod.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   generateName: network-pod-
   labels:
-          name: network-pod
+    name: network-pod
 spec:
   containers:
   - name: network-pod


### PR DESCRIPTION
Simlar to https://github.com/openshift/verification-tests/pull/3001/files (as debug pod is also hostnw pod), we also need a def under our networking.rb to support various host network pod usecases which are failing on 4.12

we  pass `nil` the logic if env < 4.12
Logs: https://privatebin.corp.redhat.com/?cdaa9fa5248e2208#236gaH3wzHKBX4c77p1xvgL43DiUvMot9L5iQnKYPxs9

@openshift/team-sdn-qe PTAL