### PR TITLE
Increase time for the step to succeed

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -221,7 +221,7 @@ Feature: SDN compoment upgrade testing
       | name=hello-idle |
     And evaluation of `pod(2).name` is stored in the :pod3 clipboard
     And evaluation of `pod(2).ip_url` is stored in the :pod3ip clipboard
-    And I wait up to 10 seconds for the steps to pass:
+    And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.pod1 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |
@@ -238,7 +238,7 @@ Feature: SDN compoment upgrade testing
     Given a pod becomes ready with labels:
       | name=hello-idle |
     And evaluation of `pod(4).name` is stored in the :pod5 clipboard
-    And I wait up to 10 seconds for the steps to pass:
+    And I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.pod4 %>" pod:
       | curl | -s | --connect-timeout | 5 | <%= cb.pod2ip %>:8080 |


### PR DESCRIPTION
@openhift/team-sdn-qe PTAL

https://issues.redhat.com/browse/OCPQE-11801

Increase the time for step to succeed. It was just 10sec, most of the test steps have 30 secs.

Tested on cluster private-templates/functionality-testing/aos-4_7/ipi-on-gcp/versioned-installer-restricted_network-private_cluster-ci

[asood@asood verification-tests]$ oc version
Client Version: 4.12.0-0.nightly-2022-07-25-055755
Kustomize Version: v4.5.4
Server Version: 4.7.0-0.nightly-2022-08-27-004627
Kubernetes Version: v1.20.15+98b2293
