### PR TITLE
Fix flake OCP-9700

### DIFF
--- a/features/storage/security.feature
+++ b/features/storage/security.feature
@@ -10,7 +10,7 @@ Feature: storage security check
   @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: volume security testing
-    Given I have a project
+    Given I have a project with proper privilege
     Given I obtain test data file "storage/misc/pvc.json"
     When I run oc create over "pvc.json" replacing paths:
       | ["metadata"]["name"] | mypvc1 |
@@ -141,7 +141,7 @@ Feature: storage security check
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-9709:Storage secret volume security check
-    Given I have a project
+    Given I have a project with proper privilege
     Given I obtain test data file "storage/secret/secret.yaml"
     When I run the :create client command with:
       | filename | secret.yaml |


### PR DESCRIPTION
PodSecurity restriction enabled by default on 4.12, updated test script to use new step definition for Project setup with privileged namespace.

[**Flake record**](https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/all/212125/13089063/13090011/log?item1Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED)

[**Jenkins test record**](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/587000/)

