### PR TITLE
Fix ocp-12292 message check issue

### DIFF
--- a/features/admin/quota.feature
+++ b/features/admin/quota.feature
@@ -78,7 +78,7 @@ Feature: Quota related scenarios
       | f | pod-request-limit-invalid-1.yaml |
     Then the step should fail
     And the output should match:
-      | (?i)Failed quota: myquota: must specify cpu,memory |
+      | (?i)Failed quota: myquota: must specify cpu.*memory |
     When I run the :describe client command with:
       | resource | quota   |
       | name     | myquota |

--- a/features/admin/quota.feature
+++ b/features/admin/quota.feature
@@ -46,8 +46,8 @@ Feature: Quota related scenarios
       | OCP-12145:Node | ocp12145 | pod-request-limit-valid-2.yaml | pod-request-limit-valid-2 | cpu\\s+200m\\s+30 | memory\\s+(268435456\|256Mi)\\s+16Gi | # @case_id OCP-12145
 
   # @author qwang@redhat.com
+  # @author weinliu@redhat.com
   # @case_id OCP-12292
-  @flaky
   @admin
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi


### PR DESCRIPTION
Fix ocp-12292 message check issue


log:

```[weinliu@rhel8 verification-tests]$ cucumber features/admin/quota.feature:60
Using the default, devel and _devel profiles...
Feature: Quota related scenarios

  # @author qwang@redhat.com
  # @author qwang@redhat.com
  # @case_id OCP-12292
  @flaky @admin @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6 @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @upgrade-sanity @singlenode @proxy @noproxy @disconnected @connected @network-ovnkubernetes @network-openshiftsdn @heterogeneous @arm64 @amd64
  Scenario: OCP-12292:Node The quota usage should NOT be incremented if Requests and Limits aren't specified # features/admin/quota.feature:60
waiting for operation up to 3600 seconds..
      [08:01:55] INFO> === Before Scenario: OCP-12292:Node The quota usage should NOT be incremented if Requests and Limits aren't specified ===
      [08:01:55] INFO> Shell Commands: mkdir -v -p '/home/weinliu/workdir/rhel8-weinliux'
      mkdir: created directory '/home/weinliu/workdir/rhel8-weinliux'
      [08:01:56] INFO> Exit Status: 0
      [08:01:56] INFO> === End Before Scenario: OCP-12292:Node The quota usage should NOT be incremented if Requests and Limits aren't specified ===
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    Given I have a project                                                                                   # features/step_definitions/project.rb:7
      [08:01:57] INFO> HTTP GET https://console-openshift-console.apps.weinliu4120901.qe.devcluster.openshift.com
      [08:01:57] INFO> HTTP GET took 0.706 sec: 200 OK | text/html 3875 bytes
      [08:01:57] INFO> HTTP GET https://api.weinliu4120901.qe.devcluster.openshift.com:6443/.well-known/oauth-authorization-server
      [08:01:58] INFO> HTTP GET took 0.662 sec: 200 OK | application/json 666 bytes
      [08:01:58] INFO> HTTP GET testuser-0@https://oauth-openshift.apps.weinliu4120901.qe.devcluster.openshift.com/oauth/authorize
      [08:01:59] INFO> HTTP GET took 0.740 sec: 302 Found
      [08:01:59] INFO> HTTP GET https://api.weinliu4120901.qe.devcluster.openshift.com:6443/apis/user.openshift.io/v1/users/~
      [08:01:59] INFO> HTTP GET took 0.711 sec: 200 OK | application/json 501 bytes
      [08:01:59] INFO> cleaning-up user testuser-0 projects
      [08:01:59] INFO> Shell Commands: rm  -f -- /home/weinliu/workdir/rhel8-weinliux/ocp4_testuser-0.kubeconfig

      [08:02:00] INFO> Exit Status: 0
      [08:02:01] INFO> Shell Commands: oc version -o yaml --client --kubeconfig=/tmp/kubeconfig20220901-1833-1pd2ir6
      clientVersion:
        buildDate: "2021-10-19T00:35:40Z"
        compiler: gc
        gitCommit: 96e95cef877ba04872b88e4e2597eabb0174d182
        gitTreeState: clean
        gitVersion: 4.9.0-202110182323.p0.git.96e95ce.assembly.stream-96e95ce
        goVersion: go1.16.6
        major: ""
        minor: ""
        platform: linux/amd64
      releaseClientVersion: 4.9.5
      [08:02:02] INFO> Exit Status: 0
      Logged into "https://api.weinliu4120901.qe.devcluster.openshift.com:6443" as "testuser-0" using the token provided.

      You don't have any projects. You can try to create a new project, by running

          oc new-project <projectname>
      [08:02:05] INFO> Exit Status: 0
      [08:02:08] INFO> Shell Commands: oc new-project i613j --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_testuser-0.kubeconfig
      Now using project "i613j" on server "https://api.weinliu4120901.qe.devcluster.openshift.com:6443".

      You can add applications to this project with the 'new-app' command. For example, try:

          oc new-app rails-postgresql-example

      to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:

          kubectl create deployment hello-node --image=k8s.gcr.io/serve_hostname
      [08:02:10] INFO> Exit Status: 0
      [08:02:10] INFO> Shell Commands: oc get namespace i613j --template=\{\{\ index\ .metadata.annotations\ \"openshift.io/sa.scc.uid-range\"\ \}\} --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_testuser-0.kubeconfig
      1000750000/10000
      [08:02:11] INFO> Exit Status: 0
      [08:02:12] INFO> oc get projects i613j --output=yaml --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_testuser-0.kubeconfig
      [08:02:12] INFO> After 1 iterations and 1 seconds:
      apiVersion: project.openshift.io/v1
      kind: Project
      metadata:
        annotations:
          openshift.io/description: ""
          openshift.io/display-name: ""
          openshift.io/requester: testuser-0
          openshift.io/sa.scc.mcs: s0:c27,c24
          openshift.io/sa.scc.supplemental-groups: 1000750000/10000
          openshift.io/sa.scc.uid-range: 1000750000/10000
        creationTimestamp: "2022-09-01T08:02:08Z"
        labels:
          kubernetes.io/metadata.name: i613j
          pod-security.kubernetes.io/enforce: restricted
          pod-security.kubernetes.io/enforce-version: v1.24
        name: i613j
        resourceVersion: "67027"
        uid: 043efe67-fec2-4037-82ba-c14593060927
      spec:
        finalizers:
        - kubernetes
      status:
        phase: Active
cp /home/weinliu/new_git/verification-tests/testdata/quota/myquota.yaml myquota.yaml
    Given I obtain test data file "quota/myquota.yaml"                                                       # features/step_definitions/file.rb:1
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    When I run the :create admin command with:                                                               # features/step_definitions/cli.rb:31
      | f | myquota.yaml |
      | n | <%= project.name %>                                                                   |
      [08:02:12] INFO> HTTP GET https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/134885/artifact/workdir/install-dir/auth/kubeconfig/
      [08:02:12] INFO> HTTP GET took 0.894 sec: 200 OK | application/octet-stream 12260 bytes
      [08:02:12] INFO> Shell Commands: rm  -f -- /home/weinliu/workdir/rhel8-weinliux/ocp4_admin.kubeconfig

      [08:02:13] INFO> Exit Status: 0
      [08:02:14] INFO> Shell Commands: oc config set-credentials admin --client-certificate=/home/weinliu/workdir/rhel8-weinliux/clcert20220901-1833-yvec12 --client-key=/home/weinliu/workdir/rhel8-weinliux/clkey20220901-1833-i1f8cu --embed-certs=true --server=https://api.weinliu4120901.qe.devcluster.openshift.com:6443 --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      User "admin" set.
      [08:02:15] INFO> Exit Status: 0
      [08:02:15] INFO> Shell Commands: oc config set-cluster generated-cluster --server=https://api.weinliu4120901.qe.devcluster.openshift.com:6443 --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Cluster "generated-cluster" set.
      [08:02:16] INFO> Exit Status: 0
      [08:02:16] INFO> Shell Commands: oc config set-context generated --cluster=generated-cluster --user=admin --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Context "generated" created.
      [08:02:17] INFO> Exit Status: 0
      [08:02:17] INFO> Shell Commands: oc config use-context generated --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Switched to context "generated".
      [08:02:18] INFO> Exit Status: 0
      [08:02:18] INFO> Shell Commands: oc create -f myquota.yaml --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_admin.kubeconfig -n i613j
      resourcequota/myquota created
      [08:02:19] INFO> Exit Status: 0
    Then the step should succeed                                                                             # features/step_definitions/common.rb:4
waiting for operation up to 3600 seconds..
    And I wait up to 60 seconds for the steps to pass:                                                       # features/step_definitions/meta_steps.rb:33
      """
      When I run the :describe client command with:
        | resource | quota   |
        | name     | myquota |
      Then the output should match:
        | cpu\\s+0\\s+30      |
        | memory\\s+0\\s+16Gi |
      """
      [08:02:19] INFO> Shell Commands: oc describe quota myquota --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_testuser-0.kubeconfig
      Name:                   myquota
      Namespace:              i613j
      Resource                Used  Hard
      --------                ----  ----
      configmaps              2     15
      cpu                     0     30
      memory                  0     16Gi
      persistentvolumeclaims  0     20
      pods                    0     20
      replicationcontrollers  0     30
      resourcequotas          1     1
      secrets                 6     15
      services                0     10
      [08:02:20] INFO> Exit Status: 0
cp /home/weinliu/new_git/verification-tests/testdata/quota/ocp12292/pod-request-limit-invalid-1.yaml pod-request-limit-invalid-1.yaml
    Given I obtain test data file "quota/ocp12292/pod-request-limit-invalid-1.yaml"                          # features/step_definitions/file.rb:1
waiting for operation up to 3600 seconds..
    When I run the :create client command with:                                                              # features/step_definitions/cli.rb:13
      | f | pod-request-limit-invalid-1.yaml |
      [08:02:21] INFO> Shell Commands: oc create -f pod-request-limit-invalid-1.yaml --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_testuser-0.kubeconfig

      STDERR:
      Error from server (Forbidden): error when creating "pod-request-limit-invalid-1.yaml": pods "pod-request-limit-invalid-1" is forbidden: failed quota: myquota: must specify cpu for: pod-request-limit-invalid-1; memory for: pod-request-limit-invalid-1
      [08:02:22] INFO> Exit Status: 1
    Then the step should fail                                                                                # features/step_definitions/common.rb:4
    And the output should match:                                                                             # features/step_definitions/common.rb:33
      | (?i)Failed quota: myquota: must specify cpu.*memory |
waiting for operation up to 3600 seconds..
    When I run the :describe client command with:                                                            # features/step_definitions/cli.rb:13
      | resource | quota   |
      | name     | myquota |
      [08:02:22] INFO> Shell Commands: oc describe quota myquota --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_testuser-0.kubeconfig
      Name:                   myquota
      Namespace:              i613j
      Resource                Used  Hard
      --------                ----  ----
      configmaps              2     15
      cpu                     0     30
      memory                  0     16Gi
      persistentvolumeclaims  0     20
      pods                    0     20
      replicationcontrollers  0     30
      resourcequotas          1     1
      secrets                 6     15
      services                0     10
      [08:02:23] INFO> Exit Status: 0
    Then the output should match:                                                                            # features/step_definitions/common.rb:33
      | cpu\\s+0\\s+30      |
      | memory\\s+0\\s+16Gi |
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [08:02:23] INFO> === After Scenario: OCP-12292:Node The quota usage should NOT be incremented if Requests and Limits aren't specified ===
      [08:02:23] INFO> cleaning-up user testuser-0 projects
      [08:02:24] INFO> Shell Commands: oc delete projects --all --kubeconfig=/home/weinliu/workdir/rhel8-weinliux/ocp4_testuser-0.kubeconfig
      project.project.openshift.io "i613j" deleted
      [08:02:32] INFO> Exit Status: 0
      [08:02:32] INFO> waiting up to 30 seconds for user clean-up to take place
      [08:02:33] INFO> HTTP DELETE https://api.weinliu4120901.qe.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthaccesstokens/sha256~pTrFiMXQXZGodrEHDVmuweDNutCEplyKAdaXqxatR9M
      [08:02:33] INFO> HTTP DELETE took 0.671 sec: 200 OK | application/json 788 bytes
      [08:02:33] INFO> Shell Commands: rm -r -f -- /home/weinliu/workdir/rhel8-weinliux

      [08:02:34] INFO> Exit Status: 0
      [08:02:35] INFO> === End After Scenario: OCP-12292:Node The quota usage should NOT be incremented if Requests and Limits aren't specified ===
# @author qwang@redhat.com
# @case_id OCP-12256
# @author qwang@redhat.com
# @case_id OCP-12206
# @author qwang@redhat.com
# @case_id OCP-11566
# @author qwang@redhat.com
# @case_id OCP-10801
# For BestEffort pod
# Because quota optimation is under way, leave time gap to wait for operation completed
# For Bustable pod
# @author qwang@redhat.com
# @case_id OCP-11251
# For Bustable pod
# Because quota optimation is under way, leave time gap to wait for operation completed
# For BestEffort pod
# @author qwang@redhat.com
# @case_id OCP-11568
# For NotTerminating pod
# Because quota optimation is under way, leave time gap to wait for operation completed
# For Terminating pod
# @author qwang@redhat.com
# @case_id OCP-11780
# For Terminating pod
# activeDeadlineSeconds=60s, after 60s, used quota returns to the original state
# For NotTerminating pod
# @author chezhang@redhat.com
# @case_id OCP-10706
# @author chezhang@redhat.com
# @case_id OCP-11779
# @author cryan@redhat.com
# @case_id OCP-10033
# @bug_id 1333122
# @author qwang@redhat.com
# @case_id OCP-11247
# Add correct quota
# @author qwang@redhat.com
# @case_id OCP-11927
# @author chezhang@redhat.com
# @case_id OCP-10945
# @author chezhang@redhat.com
# @case_id OCP-11983
# @author chezhang@redhat.com
# @case_id OCP-12086
# @author chezhang@redhat.com
# @author weinliu@redhat.com
# @case_id OCP-11348
# @author qwang@redhat.com
# @case_id OCP-11636
# @author qwang@redhat.com
# @case_id OCP-11827
# @author qwang@redhat.com
# @case_id OCP-11000
# @author qwang@redhat.com
# @case_id OCP-10283
# @author qwang@redhat.com
# @case_id OCP-11660
# Create requests.storage of quota < existing PVC capacity
# Create requests.storage of quota > existing PVC capacity
# @author qwang@redhat.com
# @case_id OCP-11389
# Only quota requests.storage < 5Gi
# Create PVC (here request 5Gi storage)
# Quota covers requests.storage > 5Gi and PVC
# Create PVC (here request 5Gi storage)
# Create PVC again (here request 5Gi storage > avaliable quota 3Gi)

1 scenario (1 passed)
11 steps (11 passed)
0m40.454s
[08:02:35] INFO> === At Exit ===
[weinliu@rhel8 verification-tests]$```
