### PR TITLE
remove 4.6 and 4.7 version since there is known issue

### DIFF
--- a/features/upgrade/sdn/service-upgrade.feature
+++ b/features/upgrade/sdn/service-upgrade.feature
@@ -3,7 +3,7 @@ Feature: service upgrade scenarios
   # @author zzhao@redhat.com
   @admin
   @upgrade-prepare
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.12 @4.11 @4.10 @4.9 @4.8
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected
@@ -36,7 +36,7 @@ Feature: service upgrade scenarios
   # @case_id OCP-44259
   @admin
   @upgrade-check
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.12 @4.11 @4.10 @4.9 @4.8
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @proxy @noproxy @disconnected @connected


### PR DESCRIPTION
Since there is known issue for idle https://bugzilla.redhat.com/show_bug.cgi?id=2041307 and this will not be fixed before 4.8 version, and only document mention this issue and workaround

So remove 4.6 and 4.7 version in order to always failed cases in CI
@openshift/team-sdn-qe 