### PR TITLE
Adding the missing descheduler version

### DIFF
--- a/features/step_definitions/descheduler.rb
+++ b/features/step_definitions/descheduler.rb
@@ -42,7 +42,7 @@ Given /^(cluster-kube-descheduler-operator) channel name is stored in the#{OPT_S
   if (descheduler_envs.empty?) || (envs.nil?) || (envs[:channel].nil?)
     version = cluster_version('version').version.split('-')[0].split('.').take(2).join('.')
     case version
-    when '4.6','4.7','4.8','4.9','4.10'
+    when '4.6','4.7','4.8','4.9','4.10','4.11'
       cb[cb_name] = version
     else
       cb[cb_name] = "stable"
@@ -153,7 +153,7 @@ Given /^I upgrade the descheduler operator with:$/ do | table |
   # wait till new csv to be installed
   success = wait_for(180, interval: 10) {
     if channel != "stable"
-      (subscription(subscription).installplan_csv.include? channel) || (subscription(subscription).installplan_csv.include? (channel.split('-')[1]))
+      (subscription(subscription).installplan_csv.include? channel)
     else
       subscription(subscription).installplan_csv != pre_csv
     end


### PR DESCRIPTION
PR fixes two issues here:
=======================
1. I see that upgrades from 4.11.y to 4.11.z are failing to create csv version with out the version 4.11 present in here, so fixing the same.
2. I see that descheduler channels does not have '-' in its channel name and when using the existing code it fails with error **no implicit conversion of nil into String**, so fixing the same.