### PR TITLE
Reverted changes as that was causing confusion about disconnected and…

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -613,16 +613,8 @@ Feature: Machine features testing
       | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %> |
       | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | disconnected-azure-36489                    |
       | ["spec"]["template"]["spec"]["providerSpec"]["value"]["publicIP"]                         | true                                        |
-    
-    And admin ensures "disconnected-azure-36489" machine_set_machine_openshift_io is deleted after scenario
-    Then I store the last provisioned machine in the :machine_latest clipboard 
-    
-    When I run the :describe admin command with:
-      | resource | machines.machine.openshift.io |
-      | name     | <%= cb.machine_latest %>      |
-    Then the step should succeed
     And the output should contain:
-      | InvalidConfiguration |
+      | providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation |
 
   # @author miyadav@redhat.com
   # @case_id OCP-47658


### PR DESCRIPTION
… private clusters

@sunzhaohua2 @huali9 @jhou1  PTAL , when time permits 

https://issues.redhat.com/browse/OCPBUGS-519
```
Automation validation :
      [05:35:49] INFO> Exit Status: 0
      [05:35:49] INFO> {"apiVersion":"machine.openshift.io/v1beta1","kind":"MachineSet","metadata":{"labels":{"machine.openshift.io/cluster-api-cluster":null,"machine.openshift.io/cluster-api-machine-role":"worker","machine.openshift.io/cluster-api-machine-type":"worker"},"name":"disconnected-azure-36489"},"spec":{"replicas":1,"selector":{"matchLabels":{"machine.openshift.io/cluster-api-cluster":"miyadav-0809az-g6qbl","machine.openshift.io/cluster-api-machineset":"disconnected-azure-36489"}},"template":{"metadata":{"labels":{"machine.openshift.io/cluster-api-cluster":"miyadav-0809az-g6qbl","machine.openshift.io/cluster-api-machine-role":"worker","machine.openshift.io/cluster-api-machine-type":"worker","machine.openshift.io/cluster-api-machineset":"disconnected-azure-36489"}},"spec":{"metadata":{},"taints":[{"effect":"NoSchedule","key":"mapi","value":"mapi_test"}],"providerSpec":{"value":{"publicIP":true,"location":null,"osDisk":{"diskSizeGB":128}}}}}}}
      [05:35:49] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@23.98.149.217:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@23.98.149.217:3128
      oc create -f - --kubeconfig=/home/miyadav/workdir/miyadav-miyadavx/ocp4_admin.kubeconfig
      

      STDERR:
      Error from server (providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation): error when creating "STDIN": admission webhook "validation.machineset.machine.openshift.io" denied the request: providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation
      [05:35:51] INFO> Exit Status: 1
    And the output should contain:                                                                                               # features/step_definitions/common.rb:33
      | providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation |
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [05:35:51] INFO> === After Scenario: OCP-36489:ClusterInfrastructure Machineset should not be created when publicIP:true in disconnected Azure enviroment ===
      [05:35:51] INFO> Shell Commands: rm -r -f -- /home/miyadav/workdir/miyadav-miyadavx
      
      [05:35:52] INFO> Exit Status: 0
      [05:35:53] INFO> === End After Scenario: OCP-36489:ClusterInfrastructure Machineset should not be created when publicIP:true in disconnected Azure enviroment ===
# @author miyadav@redhat.com
# @case_id OCP-47658
# @author miyadav@redhat.com
# @case_id OCP-47989
# @author miyadav@redhat.com

1 scenario (1 passed)
6 steps (6 passed)
0m25.132s
```
Manual validation :
`[miyadav@miyadav azure]$ oc create -f publicIP.yaml --kubeconfig kk 
Error from server (providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation): error when creating "publicIP.yaml": admission webhook "validation.machineset.machine.openshift.io" denied the request: providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation
[miyadav@miyadav azure]$ `


