### PR TITLE
update response to stdout

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -228,23 +228,23 @@ Feature: SDN related networking scenarios
     When I run commands on the host:
       | iptables-save --version |
     Then the step should succeed
-    And evaluation of `@result[:response].scan(/\d\.\d.\d/)` is stored in the :iptables_version_host clipboard
+    And evaluation of `@result[:stdout].scan(/\d\.\d.\d/)` is stored in the :iptables_version_host clipboard
     #Comparing host and sdn container version for iptables binary
     When I run command on the node's sdn pod:
       | iptables-save | --version |
     Then the step should succeed
-    And evaluation of `@result[:response].scan(/\d\.\d.\d/)` is stored in the :iptables_version_pod clipboard
+    And evaluation of `@result[:stdout].scan(/\d\.\d.\d/)` is stored in the :iptables_version_pod clipboard
     Then the expression should be true> cb.iptables_version_host == cb.iptables_version_pod
 
     When I run commands on the host:
       | iptables -S \| wc -l |
     Then the step should succeed
-    And evaluation of `@result[:response].split("\n")[0]` is stored in the :host_rules clipboard
+    And evaluation of `@result[:stdout].split("\n")[0]` is stored in the :host_rules clipboard
     #Comparing host and sdn container rules for iptables
     When I run command on the node's sdn pod:
       | bash | -c | iptables -S \| wc -l |
     Then the step should succeed
-    And evaluation of `@result[:response].split("\n")[0]` is stored in the :sdn_pod_rules clipboard
+    And evaluation of `@result[:stdout].split("\n")[0]` is stored in the :sdn_pod_rules clipboard
     Then the expression should be true> cb.host_rules == cb.sdn_pod_rules
 
   # @author huirwang@redhat.com


### PR DESCRIPTION
for fix this issue 

```
tests/blob/7647a55fff682d249b4c65bbb36c19a57a8fa5a6/features/step_definitions/common.rb#L141)
#<RuntimeError: expression returned non-positive status: false left_operand: ["1.8.4"], right_operand: ["1.8.4", "8.460"] >
[features/step_definitions/common.rb:168](https://github.com/openshift/verification-tests/blob/7647a55fff682d249b4c65bbb36c19a57a8fa5a6/features/step_definitions/common.rb#L168):in `/^(?:the )?expression should be true> (.+)$/'
[features/networking/sdn.feature:237](https://github.com/openshift/verification-tests/blob/7647a55fff682d249b4c65bbb36c19a57a8fa5a6/features/networking/sdn.feature#L237):in `the expression should be true> cb.iptables_version_host == cb.iptables_version_pod'
When
```

@openshift/team-sdn-qe 


test pass

```
      [10:24:51] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      oc exec sdn-v9fhd  --kubeconfig=/root/workdir/preserve-zzhao-rootx/ocp4_admin.kubeconfig -n openshift-sdn  --container=sdn -i -- iptables-save --version
      iptables-save v1.8.4 (nf_tables)
      
      STDERR:
      E0908 04:24:52.871690   14893 v2.go:105] read /dev/stdin: resource temporarily unavailable
      [10:24:53] INFO> Exit Status: 0
    Then the step should succeed                                                                             # features/step_definitions/common.rb:4
    And evaluation of `@result[:stdout].scan(/\d\.\d.\d/)` is stored in the :iptables_version_pod clipboard  # features/step_definitions/common.rb:128
    Then the expression should be true> cb.iptables_version_host == cb.iptables_version_pod                  # features/step_definitions/common.rb:141
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    When I run commands on the host:                                                                         # features/step_definitions/node.rb:98
      | iptables -S \| wc -l |
      [10:24:54] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      oc debug  --kubeconfig=/root/workdir/preserve-zzhao-rootx/ocp4_admin.kubeconfig -n prj-preserve-zzhao-rootx-9s1o --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:24f33c4258d6177a3bdb1a7c859b1c199a7afffa4e04f5c7dc21149b9c2dc9d8 node/yanyang-0908b-tv9xc-worker-westus-nzwhf -- chroot /host/ bash -c cd\ \'/tmp/workdir/preserve-zzhao-rootx\''
      'iptables\ -S\ \|\ wc\ -l
      61
      
      STDERR:
      Starting pod/yanyang-0908b-tv9xc-worker-westus-nzwhf-debug ...
      To use host binaries, run `chroot /host`
      
      Removing debug pod ...
      [10:24:56] INFO> Exit Status: 0
    Then the step should succeed                                                                             # features/step_definitions/common.rb:4
    And evaluation of `@result[:stdout].split("\n")[0]` is stored in the :host_rules clipboard               # features/step_definitions/common.rb:128
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    #Comparing host and sdn container rules for iptables
    When I run command on the node's sdn pod:                                                                # features/step_definitions/networking.rb:649
      | bash | -c | iptables -S \| wc -l |
      [10:24:56] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      oc get network.operator cluster --output=yaml --kubeconfig=/root/workdir/preserve-zzhao-rootx/ocp4_admin.kubeconfig
      apiVersion: operator.openshift.io/v1
      kind: Network
      metadata:
        creationTimestamp: "2022-09-08T03:22:14Z"
        generation: 83
        name: cluster
        resourceVersion: "47665"
        uid: 81703e45-62fd-4886-b593-0bc285828e0e
      spec:
        clusterNetwork:
        - cidr: 10.128.0.0/14
          hostPrefix: 23
        defaultNetwork:
          type: OpenShiftSDN
        disableNetworkDiagnostics: false
        logLevel: Normal
        managementState: Managed
        observedConfig: null
        operatorLogLevel: Normal
        serviceNetwork:
        - 172.30.0.0/16
        unsupportedConfigOverrides: null
      status:
        conditions:
        - lastTransitionTime: "2022-09-08T03:22:14Z"
          status: "False"
          type: ManagementStateDegraded
        - lastTransitionTime: "2022-09-08T03:42:02Z"
          status: "False"
          type: Degraded
        - lastTransitionTime: "2022-09-08T03:22:14Z"
          status: "True"
          type: Upgradeable
        - lastTransitionTime: "2022-09-08T04:23:17Z"
          status: "False"
          type: Progressing
        - lastTransitionTime: "2022-09-08T03:22:45Z"
          status: "True"
          type: Available
        readyReplicas: 0
        version: 4.10.0-0.nightly-2022-09-06-195243
      [10:24:57] INFO> Exit Status: 0
      [10:24:58] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      oc exec sdn-v9fhd  --kubeconfig=/root/workdir/preserve-zzhao-rootx/ocp4_admin.kubeconfig -n openshift-sdn  --container=sdn -i -- bash -c iptables\ -S\ \|\ wc\ -l
      61
      
      STDERR:
      E0908 04:25:00.001536   14924 v2.go:105] read /dev/stdin: resource temporarily unavailable
      [10:25:00] INFO> Exit Status: 0
    Then the step should succeed                                                                             # features/step_definitions/common.rb:4
    And evaluation of `@result[:stdout].split("\n")[0]` is stored in the :sdn_pod_rules clipboard            # features/step_definitions/common.rb:128
    Then the expression should be true> cb.host_rules == cb.sdn_pod_rules                                    # features/step_definitions/common.rb:141
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [10:25:00] INFO> === After Scenario: OCP-23543:SDN The iptables binary and rules on sdn containers should be the same as host ===
      [10:25:01] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      oc debug  --kubeconfig=/root/workdir/preserve-zzhao-rootx/ocp4_admin.kubeconfig -n prj-preserve-zzhao-rootx-9s1o --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:24f33c4258d6177a3bdb1a7c859b1c199a7afffa4e04f5c7dc21149b9c2dc9d8 node/yanyang-0908b-tv9xc-worker-westus-nzwhf -- chroot /host/ bash -c rm\ -r\ -f\ --\ /tmp/workdir/preserve-zzhao-rootx
      
      STDERR:
      Starting pod/yanyang-0908b-tv9xc-worker-westus-nzwhf-debug ...
      To use host binaries, run `chroot /host`
      
      Removing debug pod ...
      [10:25:03] INFO> Exit Status: 0
      [10:25:04] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      oc debug  --kubeconfig=/root/workdir/preserve-zzhao-rootx/ocp4_admin.kubeconfig -n prj-preserve-zzhao-rootx-9s1o --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:24f33c4258d6177a3bdb1a7c859b1c199a7afffa4e04f5c7dc21149b9c2dc9d8 node/yanyang-0908b-tv9xc-worker-westus-nzwhf -- chroot /host/ bash -c ls\ -d\ --\ /tmp/workdir/preserve-zzhao-rootx
      ls: cannot access '/tmp/workdir/preserve-zzhao-rootx': No such file or directory
      
      STDERR:
      Starting pod/yanyang-0908b-tv9xc-worker-westus-nzwhf-debug ...
      To use host binaries, run `chroot /host`
      
      Removing debug pod ...
      error: non-zero exit code from debug container
      [10:25:07] INFO> Exit Status: 1
      [10:25:07] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.66.71.222:3128
      oc delete projects prj-preserve-zzhao-rootx-9s1o --wait=false --kubeconfig=/root/workdir/preserve-zzhao-rootx/ocp4_admin.kubeconfig
      project.project.openshift.io "prj-preserve-zzhao-rootx-9s1o" deleted
      [10:25:08] INFO> Exit Status: 0
      [10:25:08] INFO> Shell Commands: rm -r -f -- /root/workdir/preserve-zzhao-rootx
      
      [10:25:09] INFO> Exit Status: 0
      [10:25:10] INFO> === End After Scenario: OCP-23543:SDN The iptables binary and rules on sdn containers should be the same as host ===
# @author huirwang@redhat.com
# @case_id OCP-25707
# @author huirwang@redhat.com
# @case_id OCP-25706
# @bug_id 1669311
# Kill ovs process
#Check sdn works
# @author weliang@redhat.com
# @case_id OCP-27655
#Test for bug https://bugzilla.redhat.com/show_bug.cgi?id=1800324 and https://bugzilla.redhat.com/show_bug.cgi?id=1796157
#add checkpopint from work to access the service
# @author anusaxen@redhat.com
# @case_id OCP-25787
#Fetching ovn master pod name to be used later
#Checking controller iteration 1. Need to execute under ovn-contoller container
#Checking controller iteration 2
#Checking controller iteration 3
#Checking controller iteration 4
#Checking final iteration post all above iterations passed. In this iteration we expect CNI file to be created
# @author anusaxen@redhat.com
# @case_id OCP-25933
#bridge interfaces needs to be unmanaged
# And veths ovs interfaces also needs to be unmanaged
# @author huirwang@redhat.com
# @case_id OCP-29299
# Check the network operator logs
# @author zzhao@redhat.com
# @case_id OCP-36287
# @author huirwang@redhat.com
# @case_id OCP-41132
# @author zzhao@redhat.com
# @case_id OCP-43146

1 scenario (1 passed)
15 steps (15 passed)
0m44.823s

```