### PR TITLE
Add @inactive tag

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -312,7 +312,7 @@ Feature: SDN related networking scenarios
   # @author weliang@redhat.com
   # @case_id OCP-27655
   @admin
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @upgrade-sanity


### PR DESCRIPTION
Due to https://issues.redhat.com/browse/OCPBUGS-994, admin should not run any pods under default ns. Update case to be inactive. 

@openshift/team-sdn-qe PTAL
