### PR TITLE
Podsecurity issue fix for OCP-14665 and OCP-14673

### DIFF
--- a/features/step_definitions/project.rb
+++ b/features/step_definitions/project.rb
@@ -205,6 +205,16 @@ Given /^admin creates a project with a random schedulable node selector$/ do
     })
   step %Q/I store the ready and schedulable workers in the :nodes clipboard/
   step %Q/label "<%= project.name %>=label" is added to the "<%= node.name %>" node/
+  if env.version_ge("4.12", user: user)
+    step %Q/I run the :label admin command with:/, table(%{
+      | resource  | namespace/<%= project.name %>                        |
+      | overwrite | true                                                 |
+      | key_val   | security.openshift.io/scc.podSecurityLabelSync=false |
+      | key_val   | pod-security.kubernetes.io/enforce=privileged        |
+      | key_val   | pod-security.kubernetes.io/audit=privileged          |
+      | key_val   | pod-security.kubernetes.io/warn=privileged           |
+      })
+  end
   step %Q/I switch to cluster admin pseudo user/
   step %Q/I use the "<%= project.name %>" project/
 end


### PR DESCRIPTION
To fix [OCPQE-11935](https://issues.redhat.com//browse/OCPQE-11935):
Checked this step "admin creates a project with a random schedulable node selector" is only used by storage team, and adding the namespace label.

[Failed in CI](https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/396/219006?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED%26page.page%3D4)
[pass log ](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/600542/console)

@Phaow PTAL, thanks