### PR TITLE
Add osd_ccs @aro @rosa tags for Auth

### DIFF
--- a/features/cli/oc_secrets.feature
+++ b/features/cli/oc_secrets.feature
@@ -63,6 +63,7 @@ Feature: oc_secrets.feature
   @singlenode
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-10631:Authentication Project admin can process local directory or files and convert it to kubernetes secret
     Given I have a project
     When the "tmpfoo" file is created with the following lines:

--- a/features/cli/pod.feature
+++ b/features/cli/pod.feature
@@ -233,6 +233,7 @@ Feature: pods related scenarios
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-22283:Authentication 4.0 Oauth provider info should be consumed in a pod
     Given I have a project
     When I run the :new_app client command with:

--- a/features/cli/policy.feature
+++ b/features/cli/policy.feature
@@ -10,6 +10,7 @@ Feature: change the policy of user/service account
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-11074:Authentication User can view ,add, remove and modify roleBinding via admin role user
     Given I have a project
     When I run the :get client command with:
@@ -65,6 +66,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-12430:Authentication Could get projects for new role which has permission to get projects
     Given an 8 characters random string of type :dns is stored into the :random clipboard
     And admin ensures "clusterrole-12430-<%= cb.random %>" cluster_role is deleted after scenario
@@ -89,6 +91,7 @@ Feature: change the policy of user/service account
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-11442:Authentication User can view, add , modify and delete specific role to/from new added project via admin role user
     Given I have a project
     Given I obtain test data file "authorization/policy/projectviewservice.json"
@@ -430,6 +433,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-9551:Authentication User can know if he can create podspec against the current scc rules via CLI
     Given I have a project
     Given I obtain test data file "authorization/scc/PodSecurityPolicySubjectReview_privileged_false.json"
@@ -468,6 +472,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-9552:Authentication User can know which serviceaccount and SA groups can create the podspec against the current sccs by CLI
     Given I have a project
     Given I obtain test data file "authorization/scc/PodSecurityPolicyReview.json"
@@ -512,6 +517,7 @@ Feature: change the policy of user/service account
   @singlenode
   @proxy @noproxy @connected
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-9553:Authentication User can know whether the PodSpec he's describing will actually be allowed by the current SCC rules via CLI
     Given I have a project
     Given I obtain test data file "authorization/scc/PodSecurityPolicySubjectReview.json"

--- a/features/cli/projects.feature
+++ b/features/cli/projects.feature
@@ -119,6 +119,7 @@ Feature: projects related features via cli
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-12561:Authentication Could remove user and group from the current project
     Given I have a project
     When I run the :oadm_policy_add_role_to_user client command with:
@@ -162,6 +163,7 @@ Feature: projects related features via cli
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-11201:Authentication Process with default FSGroup id can be ran when using the default MustRunAs as the RunAsGroupStrategy
     Given I have a project
     Given I obtain test data file "pods/hello-pod.json"

--- a/features/cli/serviceaccount.feature
+++ b/features/cli/serviceaccount.feature
@@ -10,6 +10,7 @@ Feature: ServiceAccount and Policy Managerment
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-10642:Authentication Could grant admin permission for the service account username to access to its own project
     Given I have a project
     When I create a new application with:
@@ -47,6 +48,7 @@ Feature: ServiceAccount and Policy Managerment
   @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-11494:Authentication Could grant admin permission for the service account group to access to its own project
     Given I have a project
     When I run the :new_app client command with:
@@ -91,6 +93,7 @@ Feature: ServiceAccount and Policy Managerment
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
+  @osd_ccs @aro @rosa
   Scenario: OCP-11249:Authentication User can get the serviceaccount token via client
     Given I have a project
     When I run the :create_token client command with:


### PR DESCRIPTION
Selected Auth 4.10 ~ 4.12 valid non-destructive cases for these tags:
```
$ cd verification-tests
$ cucumber --dry-run --name Authentication --tags 'not @destructive' --tags '(@4.12 or @4.11 or @4.10)' --tags 'not @inactive' -f summary | tee ~/my/rosa-aro-osd.scenarios
oc_secrets.feature
  OCP-10631:Authentication Project admin can process local directory or files and convert it to kubernetes secret -
...

$ ALL=`grep -o 'OCP-[0-9]*' ~/my/rosa-aro-osd.scenarios`
$ for CaseID in $ALL
do
  FileName=`grep --include "*.feature" -HlR $CaseID`
  sed -i "/Scenario: $CaseID"':Authentication/i \
  @osd_ccs @aro @rosa' "$FileName"
done
```
@zhouying7780 @liangxia please help review/merge, thanks!