### PR TITLE
Fix permission issue for chrome launch

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -33,3 +33,8 @@ RUN set -x && \
     /verification-tests/tools/hack_bundle.rb && \
     yum clean all -y && \
     rm -rf /var/cache/yum /var/tmp/* /tmp/* /verification-tests/Gemfile.lock
+
+# Fixing OCPQE-11756
+RUN set -x && \
+    mkdir /verification-tests/.local && \
+    chmod -R 777 /verification-tests/.local


### PR DESCRIPTION
# Before Granting Permission
```
bash-4.4$ /usr/bin/google-chrome-stable --help
mkdir: cannot create directory '/.local': Permission denied
touch: cannot touch '/.local/share/applications/mimeapps.list': No such file or directory
[0909/093802.341461:FATAL:chrome_main_delegate.cc(419)] execlp failed: No such file or directory (2)
Trace/breakpoint trap (core dumped)
```

# Granted Permission
```
[root@e1c884393f98 /]# mkdir .local
[root@e1c884393f98 /]# chmod -R 777 .local
```

# After Granting Permission
No longer seeing permission problem
```
bash-4.4$  /usr/bin/google-chrome-stable --no-sandbox
[296:296:0909/094042.030243:ERROR:ozone_platform_x11.cc(240)] Missing X server or $DISPLAY
[296:296:0909/094042.033301:ERROR:env.cc(255)] The platform failed to initialize.  Exiting.
[0909/094042.051325:ERROR:nacl_helper_linux.cc(315)] NaCl helper process running without a sandbox!
Most likely you need to configure your SUID sandbox correctly
```

This is an attempt to fix [OCPQE-11756](https://issues.redhat.com//browse/OCPQE-11756)

@liangxia @pruan-rht @chengzhang1016 @yapei PTAL