### PR TITLE
testdata/networking/aosqe-pod-for-ping.json

### DIFF
--- a/testdata/networking/aosqe-pod-for-ping.json
+++ b/testdata/networking/aosqe-pod-for-ping.json
@@ -8,6 +8,12 @@
         }
   },
   "spec": {
+      "securityContext":{
+         "runAsNonRoot": true,
+         "seccompProfile":{
+            "type":"RuntimeDefault"
+	 }
+       },
       "containers": [{
         "name": "hello-pod",
         "image": "quay.io/openshifttest/hello-sdn@sha256:c89445416459e7adea9a5a416b3365ed3d74f2491beb904d61dc8d1eb89a72a4",
@@ -15,6 +21,12 @@
           "limits":{
             "memory":"340Mi"
           }
+        },
+        "securityContext": {
+           "capabilities": {
+             "drop": ["ALL"]
+           },
+           "allowPrivilegeEscalation": false
         }
       }]
   }


### PR DESCRIPTION
Quick fix for case OCP-19615.
Case failed as below error.
```
[07:13:39] INFO> Shell Commands: oc create -f /Users/hrwang/Code/verification-tests/testdata/networking/aosqe-pod-for-ping.json --kubeconfig=/Users//workdir/mac-hrwangx/ocp4_admin.kubeconfig
      
      STDERR:
      Error from server (Forbidden): error when creating "/Users/hrwang/Code/verification-tests/testdata/networking/aosqe-pod-for-ping.json": pods "hello-pod" is forbidden: violates PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "hello-pod" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "hello-pod" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "hello-pod" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "hello-pod" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
      [07:13:40] INFO> Exit Status: 1
```


Test log:
https://privatebin.corp.redhat.com/?8cce18182039fe7e#5aek1X1VMJDB6fkHtuh6iSQbF9N2JN8AcKNeeWVzmmsn

@openshift/team-sdn-qe 