### PR TITLE
OCP-37704 should point to kubernetes elected ovn master pod to fetch ovn exposed metrics

### DIFF
--- a/features/networking/metrics.feature
+++ b/features/networking/metrics.feature
@@ -92,11 +92,10 @@ Feature: SDN/OVN metrics related networking scenarios
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
   Scenario: OCP-37704:SDN Should be able to monitor various ovnkube-master and ovnkube-node metrics via prometheus
-    Given I switch to cluster admin pseudo user
-    And I use the "openshift-ovn-kubernetes" project
-    And evaluation of `endpoints('ovn-kubernetes-master').subsets.first.addresses.first.ip.to_s` is stored in the :ovn_master_metrics_ep_ip clipboard
+    Given I store kubernetes elected leader pod for ovnkube-master in the :leader_pod clipboard
+    And evaluation of `cb.leader_pod.ip` is stored in the :leader_pod_ip clipboard
     And evaluation of `endpoints('ovn-kubernetes-master').subsets.first.ports.first.port.to_s` is stored in the :ovn_master_metrics_ep_port clipboard
-    And evaluation of `cb.ovn_master_metrics_ep_ip + ':' +cb.ovn_master_metrics_ep_port` is stored in the :ovn_master_metrics_ep clipboard
+    And evaluation of `cb.leader_pod_ip + ':' +cb.ovn_master_metrics_ep_port` is stored in the :ovn_master_metrics_ep clipboard
     
     And evaluation of `endpoints('ovn-kubernetes-node').subsets.first.addresses.first.ip.to_s` is stored in the :ovn_node_metrics_ep_ip clipboard
     And evaluation of `endpoints('ovn-kubernetes-node').subsets.flat_map{ |i| i.ports }.select{ |p| p.name == "metrics" }.first.port.to_s` is stored in the :ovn_node_metrics_ep_port clipboard


### PR DESCRIPTION
Since 4.11+ OVN master metrics are now being exposed to kubernetes elected OVN master pod instead earlier they were exposed to all OVN masters. This case was passing most of the time as co-incidentally it was selecting right master..heh.

This is already implemented in right way in `openshift-tests-private` repo but needed fix here. Also https://github.com/openshift/verification-tests/pull/3043 introduced a new helper function, thanks @pruan-rht for that which we can use here and in long run to use kube elected ovn master wherever needed in fixes

@openshift/team-sdn-qe 

Logs: https://privatebin.corp.redhat.com/?e17d1275802e6bd1#3tfTyUskQ9u3DNvx3ueWfPM2jtLnR3UvXk3BSd9Uge2f