### PR TITLE
Revert pr3042

### DIFF
--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -367,6 +367,7 @@ Feature: Egress-ingress related networking scenarios
   Scenario: OCP-19615:SDN Iptables should be updated with correct endpoints when egress DNS policy was used
     Given the env is using "OpenShiftSDN" networkType	
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/list_for_pods.json"
     When I run oc create over "list_for_pods.json" replacing paths:
       | ["items"][0]["spec"]["replicas"] | 1 |

--- a/testdata/networking/aosqe-pod-for-ping.json
+++ b/testdata/networking/aosqe-pod-for-ping.json
@@ -8,12 +8,6 @@
         }
   },
   "spec": {
-      "securityContext":{
-         "runAsNonRoot": true,
-         "seccompProfile":{
-            "type":"RuntimeDefault"
-	 }
-       },
       "containers": [{
         "name": "hello-pod",
         "image": "quay.io/openshifttest/hello-sdn@sha256:c89445416459e7adea9a5a416b3365ed3d74f2491beb904d61dc8d1eb89a72a4",
@@ -21,12 +15,6 @@
           "limits":{
             "memory":"340Mi"
           }
-        },
-        "securityContext": {
-           "capabilities": {
-             "drop": ["ALL"]
-           },
-           "allowPrivilegeEscalation": false
         }
       }]
   }


### PR DESCRIPTION
1. Revert https://github.com/openshift/verification-tests/pull/3042, as that change failed in 4.10,the pod couldn't be created successfully.
2. Fix original issue OCP-19615 by adding "And the appropriate pod security labels are applied to the namespace"

Test logs:
4.10: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5021/console 
4.12: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5022/console

@openshift/team-sdn-qe 