### PR TITLE
Adding extra timeout here because the current one is not sufficient

### DIFF
--- a/features/upgrade/workloads/descheduler-upgrade.feature
+++ b/features/upgrade/workloads/descheduler-upgrade.feature
@@ -63,8 +63,11 @@ Feature: Descheduler major upgrade should work fine
     And I use the "openshift-kube-descheduler-operator" project
     And status becomes :running of exactly 1 pods labeled:
       | name=descheduler-operator |
+    Given I wait up to 180 seconds for the steps to pass:
+    """
     And status becomes :running of exactly 1 pods labeled:
       | app=descheduler |
+    """
     When I run the :get client command with:
       | resource     | csv                                 |
       | n            | openshift-kube-descheduler-operator |


### PR DESCRIPTION
Eventhough Step status becomes :running of exactly 1 pods labeled already contains wait logic,  i see that the test is failing, so wrapped the statement in another wait.

```
And status becomes :running of exactly 1 pods labeled:                                            # features/step_definitions/pod.rb:88
      | name=descheduler-operator |
      [12:00:56] INFO> oc get pods --output=yaml -l name\=descheduler-operator --kubeconfig=/home/knarra/workdir/knarra-knarrax/ocp4_admin.kubeconfig -n openshift-kube-descheduler-operator
      [12:00:56] INFO> 1 iterations for 2 sec, returned 1 pods, 1 matching
waiting for operation up to 900 seconds..
waiting for operation up to 3600 seconds..
    And status becomes :running of exactly 1 pods labeled:                                            # features/step_definitions/pod.rb:88
      | app=descheduler |
      [12:00:58] INFO> oc get pods --output=yaml -l app\=descheduler --kubeconfig=/home/knarra/workdir/knarra-knarrax/ocp4_admin.kubeconfig -n openshift-kube-descheduler-operator
      [12:00:58] INFO> 1 iterations for 2 sec, returned 3 pods, 3 matching
      desired num of pods did not become running (RuntimeError)
      /home/knarra/automation/Openshift/verification-tests/features/step_definitions/pod.rb:102:in `/^status becomes :([^\s]*?) of( exactly)? ([0-9]+) pods? labeled:$/'
      features/upgrade/workloads/descheduler-upgrade.feature:66:in `status becomes :running of exactly 1 pods labeled:'
```
pod gets updated:
```

[knarra@knarra verification-tests]$ oc get pods --show-labels -n openshift-kube-descheduler-operator
NAME                                    READY   STATUS    RESTARTS   AGE   LABELS
cluster-c85fc6578-vpbw8                 1/1     Running   0          10m   app=descheduler,pod-template-hash=c85fc6578
descheduler-operator-76dfb78d84-7cx9p   1/1     Running   0          10m   name=descheduler-operator,pod-template-hash=76dfb78d84
```
