### PR TITLE
fix OCPQE-11756

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -112,8 +112,8 @@ require_relative 'chrome_extension'
       client.open_timeout = 180
       client.read_timeout = 600
       headless
-      Selenium::WebDriver.logger.level = :debug
-      Watir.logger.level = :debug
+      #Selenium::WebDriver.logger.level = :debug
+      #Watir.logger.level = :debug
       if @browser_type == :firefox
         logger.info "Launching Firefox Marionette/Geckodriver"
         raise "auth proxy not implemented for Firefox" if proxy_pass
@@ -148,7 +148,7 @@ require_relative 'chrome_extension'
           chrome_caps[:element_scroll_behavior] = @scroll_strategy
         end
         if self.class.container?
-          chrome_switches.concat %w[--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-infobars --disable-dev-shm-usage --disable-extensions]
+          chrome_switches.concat %w[--headless --no-sandbox --disable-setuid-sandbox --disable-gpu --disable-infobars --disable-dev-shm-usage]
         end
         options = {
           browser_name: 'chrome',
@@ -162,7 +162,7 @@ require_relative 'chrome_extension'
         if @selenium_url
           @browser = Watir::Browser.new :chrome, :http_client=>client, options: options, url: @selenium_url
         else
-          options["goog:chromeOptions"][:args] = chrome_switches
+          options[:args] = chrome_switches
           @browser = Watir::Browser.new :chrome, :http_client=>client, options: options
         end
         logger.info "#{browser.driver.capabilities[:browser_name]} version is #{browser.driver.capabilities[:browser_version]}"


### PR DESCRIPTION
Before this change, I can see errors in local container
```
      unknown error: Chrome failed to start: exited abnormally.
        (unknown error: DevToolsActivePort file doesn't exist)
        (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.) (Selenium::WebDriver::Error::UnknownError)
      #0 0x56406407b693 <unknown>
      #1 0x564063e74b0a <unknown>
```