### PR TITLE
fixing iptables usecase OCP-24543

### DIFF
--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -228,13 +228,13 @@ Feature: SDN related networking scenarios
     When I run commands on the host:
       | iptables-save --version |
     Then the step should succeed
-    And evaluation of `@result[:stdout].scan(/\d\.\d.\d/)` is stored in the :iptables_version_host clipboard
+    And evaluation of `@result[:stdout].scan(/\d\.\d.\d/)[0]` is stored in the :iptables_version_host clipboard
     #Comparing host and sdn container version for iptables binary
     When I run command on the node's sdn pod:
       | iptables-save | --version |
     Then the step should succeed
-    And evaluation of `@result[:stdout].scan(/\d\.\d.\d/)` is stored in the :iptables_version_pod clipboard
-    Then the expression should be true> cb.iptables_version_host == cb.iptables_version_pod
+    And the output should contain:
+      | <%= cb.iptables_version_host %> |
 
     When I run commands on the host:
       | iptables -S \| wc -l |
@@ -245,7 +245,7 @@ Feature: SDN related networking scenarios
       | bash | -c | iptables -S \| wc -l |
     Then the step should succeed
     And evaluation of `@result[:stdout].split("\n")[0]` is stored in the :sdn_pod_rules clipboard
-    Then the expression should be true> cb.host_rules == cb.sdn_pod_rules
+    Then the expression should be true> cb.sdn_pod_rules >= cb.host_rules
 
   # @author huirwang@redhat.com
   # @case_id OCP-25707


### PR DESCRIPTION
Quick fix: This usecase was initially created keeping RHCOS nodes in mind. Howver it was noticed in recent prow failures that it might behave a bit different if a RHEL node is chosen. Confirmed with dev, its  not a product issue but some RPMs etc used on RHEL/RHCOS are certainly different and responsible for those

Whats changed
- The RHEL node vs sdn pod on same RHEL node might same version of nftables but pod might add additional sub version suffix to it due the fact that sdn containers are adding extra RPMS later during installation
For e.g
The node might contain main version as "1.8.4" but pod might dump "1.8.4", "1.512". We want to make sure 1.8.4 should sync across both at least

Node says <main_version>
pod says <main_version, sub_version>

- Also SDN containers sometime in rare cases add extra fw rule on container which is specific to sdn container on rhel but not necessarily sync to node. We just need to make sure rules on pod should always >= node. Shouldn't be less than node which ensures node rules are in perfectly sync with pod.

Logs: https://privatebin.corp.redhat.com/?d9413681ab683a68#6o6Jq9oWfKiCeKhaLwBHH5aYqz1ETFwcp7cTy2ZevFWS 

@openshift/team-sdn-qe 