### PR TITLE
update hello-pod.json

### DIFF
--- a/testdata/pods/hello-pod.json
+++ b/testdata/pods/hello-pod.json
@@ -9,6 +9,12 @@
     }
   },
   "spec": {
+    "securityContext": {
+      "runAsNonRoot": true,
+      "seccompProfile": {
+        "type": "RuntimeDefault"
+      }
+    },
     "containers": [
       {
         "name": "hello-openshift",
@@ -29,8 +35,10 @@
         "terminationMessagePath": "/dev/termination-log",
         "imagePullPolicy": "IfNotPresent",
         "securityContext": {
-          "capabilities": {},
-          "privileged": false
+          "allowPrivilegeEscalation": false,
+          "capabilities": {
+            "drop": ["ALL"]
+          }
         }
       }
     ],


### PR DESCRIPTION
before the fix
```
09-27 14:26:47.858      Given I obtain test data file "pods/hello-pod.json"                                                        # features/step_definitions/file.rb:1
09-27 14:26:48.815      When I run the :create client command with:                                                                # features/step_definitions/cli.rb:13
09-27 14:26:48.815        | f | hello-pod.json |
09-27 14:26:48.815        | n | <%= project.name %> |
09-27 14:26:48.815        [06:26:47] INFO> Shell Commands: oc create -f hello-pod.json --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_testuser-18.kubeconfig -n 8rr2n
09-27 14:26:48.815        
09-27 14:26:48.815        STDERR:
09-27 14:26:48.816        Error from server (Forbidden): error when creating "hello-pod.json": pods "hello-openshift" is forbidden: violates PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "hello-openshift" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "hello-openshift" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "hello-openshift" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "hello-openshift" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
09-27 14:26:48.816        [06:26:48] INFO> Exit Status: 1
09-27 14:26:48.816      Then the step should succeed                                                                               # features/step_definitions/common.rb:4
09-27 14:26:48.816        the step failed (RuntimeError)
```

after the fix
```
09-27 16:21:03.139      Given I obtain test data file "pods/hello-pod.json"                                                        # features/step_definitions/file.rb:1
09-27 16:21:04.061      When I run the :create client command with:                                                                # features/step_definitions/cli.rb:13
09-27 16:21:04.061        | f | hello-pod.json |
09-27 16:21:04.061        | n | <%= project.name %> |
09-27 16:21:04.061        [08:21:02] INFO> Shell Commands: oc create -f hello-pod.json --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_testuser-18.kubeconfig -n nfx57
09-27 16:21:04.061        pod/hello-openshift created
09-27 16:21:04.061        [08:21:03] INFO> Exit Status: 0
09-27 16:21:04.061      Then the step should succeed    
```