### PR TITLE
converted to ginkgo no longer needed

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -593,38 +593,6 @@ Feature: Machine features testing
       | OCP-35421:ClusterInfrastructure | default-valued-windows-35421 | openshift-qe-template-windows-2019 | 135               | # @case_id OCP-35421
 
   # @author miyadav@redhat.com
-  # @case_id OCP-36489
-  @admin
-  @aro
-  @proxy @noproxy @disconnected
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @network-ovnkubernetes @network-openshiftsdn
-  @heterogeneous @arm64 @amd64
-  @azure-ipi
-  Scenario: OCP-36489:ClusterInfrastructure Machineset should not be created when publicIP:true in disconnected Azure enviroment
-    Given I have an IPI deployment
-    And I switch to cluster admin pseudo user
-    Then I use the "openshift-machine-api" project
-
-    Given I obtain test data file "cloud/ms-azure/ms_disconnected_env.yaml"
-    When I run oc create over "ms_disconnected_env.yaml" replacing paths:
-      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %> |
-      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | disconnected-azure-36489                    |
-      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %> |
-      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | disconnected-azure-36489                    |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["publicIP"]                         | true                                        |
-    
-    And admin ensures "disconnected-azure-36489" machine_set_machine_openshift_io is deleted after scenario
-    Then I store the last provisioned machine in the :machine_latest clipboard 
-    
-    When I run the :describe admin command with:
-      | resource | machines.machine.openshift.io |
-      | name     | <%= cb.machine_latest %>      |
-    Then the step should succeed
-    And the output should contain:
-      | InvalidConfiguration |
-
-  # @author miyadav@redhat.com
   # @case_id OCP-47658
   @admin
   @aro


### PR DESCRIPTION
As we have converted it to ginkgo  , there were issues related to test selection and it was selected in disconnect=no also 
https://github.com/openshift/openshift-tests-private/blob/master/test/extended/clusterinfrastructure/machines.go#L539
backport merged as well till 4.10 

@sunzhaohua2 @huali9 @jhou1 , it looks safe to remove it . 
example [failure](https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/396/235764/15828076/15828446/log?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.issueType%3Dti001%252Cti_1hrghcxlbgshc%252Cti_s4scyws6guht%252Cti_sok676b1k8j5%252Cti_r1ifkmkw19o1) 