### PR TITLE
fix OCPQE-8932

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -386,7 +386,7 @@ Given /^(cluster-logging|elasticsearch-operator) channel name is stored in the#{
     version = cluster_version('version').version.split('-')[0].split('.').take(2).join('.')
     case version
     when '4.12'
-      cb[cb_name] = "stable"
+      cb[cb_name] = "stable-5.6"
     when '4.11'
       cb[cb_name] = "stable-5.5"
     when '4.10'


### PR DESCRIPTION
To fix failure in [OCPQE-8932](https://issues.redhat.com//browse/OCPQE-8932):
From https://gitlab.cee.redhat.com/aosqe/jenkins-jcasc-n/-/blob/master/scripts/OCPQE-11466/upgrade_cluster_logging.sh#L9-10, in OCP 4.12 the channel is `stable-5.6`.
As the `catsrc/qe-app-registry` is enabled in [Prow CI](https://github.com/openshift/release/tree/master/ci-operator/step-registry/enable-qe-catalogsource), we should always have channel `stable-5.6` in our test clusters, here change the default channel name to `stable-5.6` when testing in OCP 4.12. 

/cc @anpingli 