### PR TITLE
Fixed OCP-10873 failure

### DIFF
--- a/features/cli/oc_expose.feature
+++ b/features/cli/oc_expose.feature
@@ -15,6 +15,7 @@ Feature: oc_expose.feature
   Scenario: OCP-10873:APIServer Access app througth secure service and regenerate service serving certs if it about to expire
     Given the master version >= "3.3"
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     And SCC "privileged" is added to the "system:serviceaccounts:<%= project.name %>" group
     Given I obtain test data file "deployment/OCP-10873/svc.json"
     When I run the :create client command with:


### PR DESCRIPTION
Fixed securityContext & seccompProfile issue for test OCP-10873 failure.

Execution Result : [642779](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/642779/console)

