### PR TITLE
fix OCP-25765

### DIFF
--- a/lib/rules/web/admin_console/4.10/user_management.xyaml
+++ b/lib/rules/web/admin_console/4.10/user_management.xyaml
@@ -35,7 +35,10 @@ check_rolebinding_of_user:
 impersonate_one_user:
   params:
     kebab_item: Impersonate User <resource_name>
+    test_id_value: item-filter
+    filter_text: <resource_name>
   action: goto_users_list_page
+  action: set_strings_in_filter_box
   action: click_one_operation_in_kebab
 check_impersonate_notifications:
   elements:

--- a/lib/rules/web/admin_console/4.11/user_management.xyaml
+++ b/lib/rules/web/admin_console/4.11/user_management.xyaml
@@ -35,7 +35,10 @@ check_rolebinding_of_user:
 impersonate_one_user:
   params:
     kebab_item: Impersonate User <resource_name>
+    test_id_value: item-filter
+    filter_text: <resource_name>
   action: goto_users_list_page
+  action: set_strings_in_filter_box
   action: click_one_operation_in_kebab
 check_impersonate_notifications:
   elements:

--- a/lib/rules/web/admin_console/4.12/user_management.xyaml
+++ b/lib/rules/web/admin_console/4.12/user_management.xyaml
@@ -35,7 +35,10 @@ check_rolebinding_of_user:
 impersonate_one_user:
   params:
     kebab_item: Impersonate User <resource_name>
+    test_id_value: item-filter
+    filter_text: <resource_name>
   action: goto_users_list_page
+  action: set_strings_in_filter_box
   action: click_one_operation_in_kebab
 check_impersonate_notifications:
   elements:

--- a/lib/rules/web/admin_console/4.6/user_management.xyaml
+++ b/lib/rules/web/admin_console/4.6/user_management.xyaml
@@ -26,7 +26,10 @@ check_rolebinding_of_user:
 impersonate_one_user:
   params:
     kebab_item: Impersonate User "<resource_name>"
+    test_id_value: item-filter
+    filter_text: <resource_name>
   action: goto_users_list_page
+  action: set_strings_in_filter_box
   action: click_one_operation_in_kebab
 check_impersonate_notifications:
   elements:

--- a/lib/rules/web/admin_console/4.7/user_management.xyaml
+++ b/lib/rules/web/admin_console/4.7/user_management.xyaml
@@ -35,7 +35,10 @@ check_rolebinding_of_user:
 impersonate_one_user:
   params:
     kebab_item: Impersonate User <resource_name>
+    test_id_value: item-filter
+    filter_text: <resource_name>
   action: goto_users_list_page
+  action: set_strings_in_filter_box
   action: click_one_operation_in_kebab
 check_impersonate_notifications:
   elements:

--- a/lib/rules/web/admin_console/4.8/user_management.xyaml
+++ b/lib/rules/web/admin_console/4.8/user_management.xyaml
@@ -35,7 +35,10 @@ check_rolebinding_of_user:
 impersonate_one_user:
   params:
     kebab_item: Impersonate User <resource_name>
+    test_id_value: item-filter
+    filter_text: <resource_name>
   action: goto_users_list_page
+  action: set_strings_in_filter_box
   action: click_one_operation_in_kebab
 check_impersonate_notifications:
   elements:

--- a/lib/rules/web/admin_console/4.9/user_management.xyaml
+++ b/lib/rules/web/admin_console/4.9/user_management.xyaml
@@ -35,7 +35,10 @@ check_rolebinding_of_user:
 impersonate_one_user:
   params:
     kebab_item: Impersonate User <resource_name>
+    test_id_value: item-filter
+    filter_text: <resource_name>
   action: goto_users_list_page
+  action: set_strings_in_filter_box
   action: click_one_operation_in_kebab
 check_impersonate_notifications:
   elements:


### PR DESCRIPTION
added one step to filter user name to reduce the failures when there are many users
```
 INFO> found 0 element elements with selector: {:xpath=>"//a[text()='testuser-36']//ancestor::tr//button[@data-test-id='kebab-button']"}
```
![download](https://user-images.githubusercontent.com/12692381/194686868-c8b6ece4-8160-45a9-8298-dd88f5e78469.png)


4.10 pass log https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/639104/console 
4.12 pass log https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/639114/console
4.6 pass log https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/639115/console
4.8 pass log https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/639116/console