### PR TITLE
update rsyslogd-container images

### DIFF
--- a/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - "-n"
         command:
         - "/usr/sbin/rsyslogd"
-        image: quay.io/openshifttest/rsyslogd-container@sha256:0404787721bed7d07199281cc3545e6948ae070ec25328e3fd5fe7f3d0e6458d
+        image: quay.io/openshifttest/rsyslogd-container@sha256:e806eb41f05d7cc6eec96bf09c7bcb692f97562d4a983cb019289bd048d9aee2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6514

--- a/testdata/logging/logforwarding/rsyslog/insecure/rsyslogserver_deployment.yaml
+++ b/testdata/logging/logforwarding/rsyslog/insecure/rsyslogserver_deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - "-n"
         command:
         - "/usr/sbin/rsyslogd"
-        image: quay.io/openshifttest/rsyslogd-container@sha256:7cd0b9cc0e77747899330656a732cac7bba3af5c445e55baa51d5885397042d0
+        image: quay.io/openshifttest/rsyslogd-container@sha256:e806eb41f05d7cc6eec96bf09c7bcb692f97562d4a983cb019289bd048d9aee2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6514


### PR DESCRIPTION
- use one image to support both TLS and none tls cases

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/640767/console