### PR TITLE
fix OCPQE-11446

### DIFF
--- a/lib/openshift/cluster_network.rb
+++ b/lib/openshift/cluster_network.rb
@@ -1,0 +1,11 @@
+require 'openshift/cluster_resource'
+
+module BushSlicer
+    class ClusterNetwork < ClusterResource
+        RESOURCE = "clusternetworks"
+        def plugin_name(user: nil, cached: true, quiet: false)
+            rr = raw_resource(user: user, cached: cached, quiet: quiet)
+            return rr.dig('pluginName')
+        end
+    end
+end


### PR DESCRIPTION
When the cluster has `network_plugin_mode: "multitenant"`, EO can't update the ES status as they're not in the same project, here add a step to make project/openshift-operators-redhat network global in these clusters. 