### PR TITLE
update rules for OCP-32152

### DIFF
--- a/lib/rules/web/admin_console/4.10/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.10/common_ui_elements.xyaml
@@ -766,16 +766,31 @@ check_deploymentconfig_secondary_menu_link:
   params:
     secondary_menu: DeploymentConfigs
     text: DeploymentConfigs
+    link_url: all-namespaces/deploymentconfigs
+  action: check_secondary_menu_link
+check_job_secondary_menu_link:
+  params:
+    secondary_menu: Jobs
+    text: Jobs
+    link_url: all-namespaces/jobs
   action: check_secondary_menu_link
 check_replicaset_secondary_menu_link:
   params:
     secondary_menu: ReplicaSets
     text: ReplicaSets
+    link_url: all-namespaces/replicasets
   action: check_secondary_menu_link
 check_replicationcontroller_secondary_menu_link:
   params:
     secondary_menu: ReplicationControllers
     text: ReplicationControllers
+    link_url: all-namespaces/replicationcontrollers
+  action: check_secondary_menu_link
+check_secret_secondary_menu_link:
+  params:
+    secondary_menu: Secrets
+    text: Secrets
+    link_url: all-namespaces/secrets
   action: check_secondary_menu_link
 click_dropdown:
   element:

--- a/lib/rules/web/admin_console/4.11/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.11/common_ui_elements.xyaml
@@ -766,16 +766,31 @@ check_deploymentconfig_secondary_menu_link:
   params:
     secondary_menu: DeploymentConfigs
     text: DeploymentConfigs
+    link_url: all-namespaces/deploymentconfigs
+  action: check_secondary_menu_link
+check_job_secondary_menu_link:
+  params:
+    secondary_menu: Jobs
+    text: Jobs
+    link_url: all-namespaces/jobs
   action: check_secondary_menu_link
 check_replicaset_secondary_menu_link:
   params:
     secondary_menu: ReplicaSets
     text: ReplicaSets
+    link_url: all-namespaces/replicasets
   action: check_secondary_menu_link
 check_replicationcontroller_secondary_menu_link:
   params:
     secondary_menu: ReplicationControllers
     text: ReplicationControllers
+    link_url: all-namespaces/replicationcontrollers
+  action: check_secondary_menu_link
+check_secret_secondary_menu_link:
+  params:
+    secondary_menu: Secrets
+    text: Secrets
+    link_url: all-namespaces/secrets
   action: check_secondary_menu_link
 click_dropdown:
   element:

--- a/lib/rules/web/admin_console/4.12/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.12/common_ui_elements.xyaml
@@ -766,16 +766,31 @@ check_deploymentconfig_secondary_menu_link:
   params:
     secondary_menu: DeploymentConfigs
     text: DeploymentConfigs
+    link_url: all-namespaces/apps.openshift.io~v1~DeploymentConfig
+  action: check_secondary_menu_link
+check_job_secondary_menu_link:
+  params:
+    secondary_menu: Jobs
+    text: Jobs
+    link_url: all-namespaces/batch~v1~Job
   action: check_secondary_menu_link
 check_replicaset_secondary_menu_link:
   params:
     secondary_menu: ReplicaSets
     text: ReplicaSets
+    link_url: all-namespaces/apps~v1~ReplicaSet
   action: check_secondary_menu_link
 check_replicationcontroller_secondary_menu_link:
   params:
     secondary_menu: ReplicationControllers
     text: ReplicationControllers
+    link_url: all-namespaces/core~v1~ReplicationController
+  action: check_secondary_menu_link
+check_secret_secondary_menu_link:
+  params:
+    secondary_menu: Secrets
+    text: Secrets
+    link_url: all-namespaces/core~v1~Secret
   action: check_secondary_menu_link
 click_dropdown:
   element:

--- a/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
@@ -738,18 +738,33 @@ check_secondary_menu_link:
   action: check_link_and_text
 check_deploymentconfig_secondary_menu_link:
   params:
-    secondary_menu: Deployment Configs
-    text: Deployment Configs
+    secondary_menu: DeploymentConfigs
+    text: DeploymentConfigs
+    link_url: all-namespaces/deploymentconfigs
+  action: check_secondary_menu_link
+check_job_secondary_menu_link:
+  params:
+    secondary_menu: Jobs
+    text: Jobs
+    link_url: all-namespaces/jobs
   action: check_secondary_menu_link
 check_replicaset_secondary_menu_link:
   params:
-    secondary_menu: Replica Sets
-    text: Replica Sets
+    secondary_menu: ReplicaSets
+    text: ReplicaSets
+    link_url: all-namespaces/replicasets
   action: check_secondary_menu_link
 check_replicationcontroller_secondary_menu_link:
   params:
-    secondary_menu: Replication Controllers
-    text: Replication Controllers
+    secondary_menu: ReplicationControllers
+    text: ReplicationControllers
+    link_url: all-namespaces/replicationcontrollers
+  action: check_secondary_menu_link
+check_secret_secondary_menu_link:
+  params:
+    secondary_menu: Secrets
+    text: Secrets
+    link_url: all-namespaces/secrets
   action: check_secondary_menu_link
 click_dropdown:
   element:

--- a/lib/rules/web/admin_console/4.7/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.7/common_ui_elements.xyaml
@@ -747,16 +747,31 @@ check_deploymentconfig_secondary_menu_link:
   params:
     secondary_menu: DeploymentConfigs
     text: DeploymentConfigs
+    link_url: all-namespaces/deploymentconfigs
+  action: check_secondary_menu_link
+check_job_secondary_menu_link:
+  params:
+    secondary_menu: Jobs
+    text: Jobs
+    link_url: all-namespaces/jobs
   action: check_secondary_menu_link
 check_replicaset_secondary_menu_link:
   params:
     secondary_menu: ReplicaSets
     text: ReplicaSets
+    link_url: all-namespaces/replicasets
   action: check_secondary_menu_link
 check_replicationcontroller_secondary_menu_link:
   params:
     secondary_menu: ReplicationControllers
     text: ReplicationControllers
+    link_url: all-namespaces/replicationcontrollers
+  action: check_secondary_menu_link
+check_secret_secondary_menu_link:
+  params:
+    secondary_menu: Secrets
+    text: Secrets
+    link_url: all-namespaces/secrets
   action: check_secondary_menu_link
 click_dropdown:
   element:

--- a/lib/rules/web/admin_console/4.8/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.8/common_ui_elements.xyaml
@@ -756,16 +756,31 @@ check_deploymentconfig_secondary_menu_link:
   params:
     secondary_menu: DeploymentConfigs
     text: DeploymentConfigs
+    link_url: all-namespaces/deploymentconfigs
+  action: check_secondary_menu_link
+check_job_secondary_menu_link:
+  params:
+    secondary_menu: Jobs
+    text: Jobs
+    link_url: all-namespaces/jobs
   action: check_secondary_menu_link
 check_replicaset_secondary_menu_link:
   params:
     secondary_menu: ReplicaSets
     text: ReplicaSets
+    link_url: all-namespaces/replicasets
   action: check_secondary_menu_link
 check_replicationcontroller_secondary_menu_link:
   params:
     secondary_menu: ReplicationControllers
     text: ReplicationControllers
+    link_url: all-namespaces/replicationcontrollers
+  action: check_secondary_menu_link
+check_secret_secondary_menu_link:
+  params:
+    secondary_menu: Secrets
+    text: Secrets
+    link_url: all-namespaces/secrets
   action: check_secondary_menu_link
 click_dropdown:
   element:

--- a/lib/rules/web/admin_console/4.9/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.9/common_ui_elements.xyaml
@@ -765,16 +765,31 @@ check_deploymentconfig_secondary_menu_link:
   params:
     secondary_menu: DeploymentConfigs
     text: DeploymentConfigs
+    link_url: all-namespaces/deploymentconfigs
+  action: check_secondary_menu_link
+check_job_secondary_menu_link:
+  params:
+    secondary_menu: Jobs
+    text: Jobs
+    link_url: all-namespaces/jobs
   action: check_secondary_menu_link
 check_replicaset_secondary_menu_link:
   params:
     secondary_menu: ReplicaSets
     text: ReplicaSets
+    link_url: all-namespaces/replicasets
   action: check_secondary_menu_link
 check_replicationcontroller_secondary_menu_link:
   params:
     secondary_menu: ReplicationControllers
     text: ReplicationControllers
+    link_url: all-namespaces/replicationcontrollers
+  action: check_secondary_menu_link
+check_secret_secondary_menu_link:
+  params:
+    secondary_menu: Secrets
+    text: Secrets
+    link_url: all-namespaces/secrets
   action: check_secondary_menu_link
 click_dropdown:
   element:


### PR DESCRIPTION
workloads list page URL has been updated from `kind` to `group-version-kind` format, so move all changing text to rules 

take all namespace deploymentconfig list page URL as example, it was `all-namespaces/deploymentconfigs` but now it is `all-namespaces/apps.openshift.io~v1~DeploymentConfig`