### PR TITLE
update response to stdout

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -42,11 +42,11 @@ Feature: Multus-CNI related scenarios
     When I execute on the pod:
       | bash | -c | ip -f inet addr show net1 |
     Then the output should match "10.1.1.\d{1,3}"
-    And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod1_multus_ip clipboard
+    And evaluation of `@result[:stdout].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod1_multus_ip clipboard
     When I execute on the pod:
       | bash | -c | ip -f inet addr show eth0 |
     Then the step should succeed
-    And evaluation of `@result[:response].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod1_sdn_ip clipboard
+    And evaluation of `@result[:stdout].match(/\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/)[0]` is stored in the :pod1_sdn_ip clipboard
 
     # Create the second pod which consumes the macvlan cr
     Given I obtain test data file "networking/multus-cni/Pods/1interface-macvlan-bridge.yaml"


### PR DESCRIPTION
due to https://s3.upshift.redhat.com/cucushift-html-logs/logs/2022/10/12/06%3A50%3A32/OCP-21151_SDN_Create_pods_with_multus-cni_-_macvlan_bridge_mode?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20221012%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20221012T071343Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1e632c35010c0936a00476c9ec3d34c7795f5bfbb5611eb168f68afe122c2baf

```
 INFO> Shell Commands: http_proxy=http://packetproxy:r3dh4t22@packet-aux-server-ext.qe.devcluster.openshift.com:3128
https_proxy=http://packetproxy:r3dh4t22@packet-aux-server-ext.qe.devcluster.openshift.com:3128
oc exec macvlan-bridge-pod-fsbdf  --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_testuser-47.kubeconfig -n guzlg  -i -- curl --connect-timeout 5 00.255171:8080

STDERR:
E1012 07:04:07.197208   28215 v2.go:105] read /dev/stdin: resource temporarily unavailable
curl: (7) Couldn't connect to server
command terminated with exit code 7
07:04:07 INFO> Exit Status: 7
```

@openshift/team-sdn-qe ^^