### PR TITLE
Remove 22595 from 4.12

### DIFF
--- a/features/images/rhel8_images.feature
+++ b/features/images/rhel8_images.feature
@@ -75,7 +75,7 @@ Feature: rhel8images.feature
   # @case_id OCP-22595
   @admin
   @proxy
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode


### PR DESCRIPTION
@liangxia 
https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-22595 is deprecated since 4.7, I update this case, please help review, thanks