### PR TITLE
fix failure in OCP-41179

### DIFF
--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -726,9 +726,12 @@ Feature: Egress-ingress related networking scenarios
     """
 
     #Check the last dns name in yaml file should be allowed
+    And I wait up to 60 seconds for the steps to pass:
+    """
     When I execute on the pod:
       | curl | --connect-timeout | 5 | --head | www.amihealthy.com |
     Then the step should succeed
+    """
 
     # Check another dnsname not in the yaml file should be blocked.
     When I execute on the pod:


### PR DESCRIPTION
Resolve ticket, https://issues.redhat.com/browse/OCPQE-12619
Curling immediately after the egressfirewall applied may got failed sometimes especially when it contains many rules, adding timeout to avoid this.

Test log on sno cluster:  https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5121/console

