### PR TITLE
fix OCPQE-3947

### DIFF
--- a/features/upgrade/logging/upgrade.feature
+++ b/features/upgrade/logging/upgrade.feature
@@ -15,7 +15,8 @@ Feature: Logging upgrading related features
   @network-ovnkubernetes @network-openshiftsdn
   @amd64
   Scenario: Cluster logging checking during cluster upgrade - prepare
-    Given I check if the remaining_resources in woker nodes meet the requirements for logging stack
+    Given logging service is removed successfully
+    And I check if the remaining_resources in woker nodes meet the requirements for logging stack
     Given I switch to the first user
     Given I have "json" log pod in project "logging-upg-prep-1"
     And I have "json" log pod in project "logging-upg-prep-share"


### PR DESCRIPTION
To fix [OCPQE-3947](https://issues.redhat.com//browse/OCPQE-3947), remove namespaces `openshift-logging` and `openshift-operators-redhat`, let upgrade-prepare deploys logging operators.

/cc @anpingli 