### PR TITLE
Add @users back to test case

### DIFF
--- a/features/upgrade/sdn/multus-upgrade.feature
+++ b/features/upgrade/sdn/multus-upgrade.feature
@@ -3,6 +3,7 @@
   # @author weliang@redhat.com
   @admin
   @upgrade-prepare
+  @users=upuser1,upuser2
   @4.12 @4.11 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
@@ -46,6 +47,7 @@
   # @case_id OCP-44898
   @admin
   @upgrade-check
+  @users=upuser1,upuser2
   @4.12 @4.11 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi


### PR DESCRIPTION
Removing @users in `https://github.com/openshift/verification-tests/pull/3097/files#diff-deed1f9aea2eaeda53415aa72219c9479601c89758c737e506fa090d5cf65248L6` cause test failed in `https://gcsweb-qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/qe-private-deck/pr-logs/pull/openshift_release/33684/rehearse-33684-periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-nightly-e2e-vsphere-ipi-sdn-migration-ovn-p2/1587822254731825152/artifacts/e2e-vsphere-ipi-sdn-migration-ovn-p2/cucushift-upgrade-prepare/build-log.txt` 

`https://github.com/openshift/verification-tests/pull/3097/files#diff-deed1f9aea2eaeda53415aa72219c9479601c89758c737e506fa090d5cf65248L6` passed in the local run without those @users, seems e2e env still need those tags.

Add @users back to the code now.

@openshift/team-sdn-qe PTAL


