### PR TITLE
improved fetch logic for pod IPs

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -494,10 +494,9 @@ Feature: SDN compoment upgrade testing
     Given I wait up to 20 seconds for the steps to pass:
     """
     And I execute on the pod:
-      | bash | -c | conntrack -L \| grep "<%= cb.host_pod1.ip %>" |
+      | bash | -c | conntrack -L \| grep -w "<%= cb.host_pod1.ip %>" |
     Then the step should succeed
-    And the output should match:
-      |<%= cb.host_pod1.ip %>|
+    And the output should match "<%= cb.host_pod1.ip %> "
     """
     #Deleting the udp listener pod which will trigger a new udp listener pod with new IP
     Given I ensure "<%= cb.host_pod1.name %>" pod is deleted
@@ -517,11 +516,11 @@ Feature: SDN compoment upgrade testing
     Given I wait up to 20 seconds for the steps to pass:
     """
     When I execute on the "<%= cb.network_pod %>" pod:
-      | bash | -c | conntrack -L \| grep "<%= cb.host_pod2.ip %>" |
-    Then the output should match "<%= cb.host_pod2.ip %>"
-    And the output should not match "<%= cb.host_pod1.ip %>"
+      | bash | -c | conntrack -L \| grep -w "<%= cb.host_pod2.ip %>" |
+    Then the output should match "<%= cb.host_pod2.ip %> "
+    And the output should not match "<%= cb.host_pod1.ip %> "
     """
-
+    
   # @author asood@redhat.com
   @admin
   @upgrade-prepare


### PR DESCRIPTION
In rare circumstances if output dump is say
```udp      17 29 src=10.129.2.133 dst=10.129.2.134 sport=47249 dport=8080 src=10.129.2.134 dst=10.129.2.133 sport=8080 dport=47249 mark=0 secctx=system_u:object_r:unlabeled_t:s0 zone=22 use=2 ```
and pod IP to search is ```10.129.2.13``` , the logic would pass assuming pod IP being a subset of ```10.129.2.133```.

Improved grep logic to add w flag to dump output just matching with those IPs and adding a white space in match expression to fix that subset logic

@openshift/team-sdn-qe 