### PR TITLE
Rollback the hello-pod yaml file for OCP-19695

### DIFF
--- a/testdata/infrastructure/hpa/hello-pod.yaml
+++ b/testdata/infrastructure/hpa/hello-pod.yaml
@@ -5,19 +5,10 @@ metadata:
     name: hello-pod
   name: hello-pod
 spec:
-  securityContext:
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   containers:
     - image: "quay.io/openshifttest/hello-openshift@sha256:4200f438cf2e9446f6bcff9d67ceea1f69ed07a2f83363b7fb52529f7ddd8a83"
       imagePullPolicy: IfNotPresent
       name: hello-pod
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-          - ALL
       ports:
         - containerPort: 8080
           protocol: TCP


### PR DESCRIPTION
This test case is affected by the changes in PR: https://github.com/openshift/verification-tests/pull/3079
Since there is no sufficient pass log to support the changes, so decided to roll back the file, and has been left a message to the owner to do more updates.

Pass log: /Runner/662476/console