### PR TITLE
Use updated image that permission on /var/log/messages to make it readable

### DIFF
--- a/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_deployment.yaml
+++ b/testdata/logging/clusterlogforwarder/rsyslog/insecure/rsyslogserver_deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - "-n"
         command:
         - "/usr/sbin/rsyslogd"
-        image: quay.io/openshifttest/rsyslogd-container@sha256:e806eb41f05d7cc6eec96bf09c7bcb692f97562d4a983cb019289bd048d9aee2
+        image: quay.io/openshifttest/rsyslogd-container@sha256:11b619f2ed0dba2bdb43d6c2f506b1ccb92e27052bb773123937b22c917c06bb
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6514


### PR DESCRIPTION
@anpingli @zhaozhanqi PTAL



bundle exec cucumber features/upgrade/sdn/policy-upgrade.feature:534 fails with error message.

14:48:25] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@bastion.vmc.ci.openshift.org:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@bastion.vmc.ci.openshift.org:3128
      oc exec rsyslogserver-568959987b-9m7k9  --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig -n rsyslog-server  -i -- grep -w verdict\=allow /var/log/messages
      
      STDERR:
      E1109 09:48:26.925162  256314 v2.go:105] read /dev/stdin: resource temporarily unavailable
      grep: /var/log/messages: Permission denied

oc -n rsyslog-server exec -it rsyslogserver-568959987b-9m7k9 -- bash
bash-5.1$ ls -l /var/log/messages
-rw-------. 1 root root 0 Oct  9 13:59 /var/log/messages
bash-5.1$ exit
exit

With updated image (https://gitlab.cee.redhat.com/aosqe/tests-images/-/merge_requests/69)

oc -n rsyslog-server exec -it rsyslogserver-778d4f89cc-plrkx -- bash
bash-5.1$ ls -l /var/log/messages
-rw-rw-r--. 1 root root 1092 Nov  9 15:19 /var/log/messages

 oc -n rsyslog-server exec -it rsyslogserver-778d4f89cc-plrkx -- bash -c "tail -f /var/log/messages"
2022-11-09T15:19:10.915750+00:00 100.64.0.2 ovs|00035|lflow_cache|INFO|Detected cache inactivity (last active 30012 ms ago): trimming cache
2022-11-09T15:19:10.915968+00:00 100.64.0.3 ovs|00091|lflow_cache|INFO|Detected cache inactivity (last active 30015 ms ago): trimming cache
2022-11-09T15:19:10.923683+00:00 100.64.0.6 ovs|00044|lflow_cache|INFO|Detected cache inactivity (last active 30022 ms ago): trimming cache
2022-11-09T15:19:10.925867+00:00 100.64.0.5 ovs|00059|lflow_cache|INFO|Detected cache inactivity (last active 30024 ms ago): trimming cache
2022-11-09T15:21:28.974936+00:00 100.64.0.5 ovs|00010|acl_log(ovn_pinctrl0)|INFO|name="policy-acl-upgrade1_allow-ns-and-pod_0", verdict=allow, severity=alert, direction=to-lport: tcp,vlan_tci=0x0000,dl_src=0a:58:0a:83:00:01,dl_dst=0a:58:0a:83:00:10,nw_src=10.128.2.10,nw_dst=10.131.0.16,nw_tos=0,nw_ecn=0,nw_ttl=63,tp_src=52558,tp_dst=8080,tcp_flags=syn
2022-11-09T15:21:28.975794+00:00 100.64.0.5 ovs|00011|acl_log(ovn_pinctrl0)|INFO|name="policy-acl-upgrade1_allow-ns-and-pod_0", verdict=allow, severity=alert, direction=to-lport: tcp,vlan_tci=0x0000,dl_src=0a:58:0a:83:00:01,dl_dst=0a:58:0a:83:00:10,nw_src=10.128.2.10,nw_dst=10.131.0.16,nw_tos=0,nw_ecn=0,nw_ttl=63,tp_src=52558,tp_dst=8080,tcp_flags=ack
2022-11-09T15:21:28.975794+00:00 100.64.0.5 ovs|00012|acl_log(ovn_pinctrl0)|INFO|name="policy-acl-upgrade1_allow-ns-and-pod_0", verdict=allow, severity=alert, direction=to-lport: tcp,vlan_tci=0x0000,dl_src=0a:58:0a:83:00:01,dl_dst=0a:58:0a:83:00:10,nw_src=10.128.2.10,nw_dst=10.131.0.16,nw_tos=0,nw_ecn=0,nw_ttl=63,tp_src=52558,tp_dst=8080,tcp_flags=psh|ack
2022-11-09T15:21:28.976687+00:00 100.64.0.5 ovs|00013|acl_log(ovn_pinctrl0)|INFO|name="policy-acl-upgrade1_allow-ns-and-pod_0", verdict=allow, severity=alert, direction=to-lport: tcp,vlan_tci=0x0000,dl_src=0a:58:0a:83:00:01,dl_dst=0a:58:0a:83:00:10,nw_src=10.128.2.10,nw_dst=10.131.0.16,nw_tos=0,nw_ecn=0,nw_ttl=63,tp_src=52558,tp_dst=8080,tcp_flags=ack
2022-11-09T15:21:28.976687+00:00 100.64.0.5 ovs|00014|acl_log(ovn_pinctrl0)|INFO|name="policy-acl-upgrade1_allow-ns-and-pod_0", verdict=allow, severity=alert, direction=to-lport: tcp,vlan_tci=0x0000,dl_src=0a:58:0a:83:00:01,dl_dst=0a:58:0a:83:00:10,nw_src=10.128.2.10,nw_dst=10.131.0.16,nw_tos=0,nw_ecn=0,nw_ttl=63,tp_src=52558,tp_dst=8080,tcp_flags=fin|ack
2022-11-09T15:21:28.976687+00:00 100.64.0.5 ovs|00015|acl_log(ovn_pinctrl0)|INFO|name="policy-acl-upgrade1_allow-ns-and-pod_0", verdict=allow, severity=alert, direction=to-lport: tcp,vlan_tci=0x0000,dl_src=0a:58:0a:83:00:01,dl_dst=0a:58:0a:83:00:10,nw_src=10.128.2.10,nw_dst=10.131.0.16,nw_tos=0,nw_ecn=0,nw_ttl=63,tp_src=52558,tp_dst=8080,tcp_flags=ack

