### PR TITLE
Recreate the iSCSI pod after deleting

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -528,8 +528,9 @@ Given /^I have a iSCSI setup in the environment$/ do
     logger.info "found existing iSCSI pod, skipping config"
   elsif _pod.exists?(user: admin, quiet: true)
     logger.warn "broken iSCSI pod, will try to recreate keeping other config"
-    @result = admin.cli_exec(:delete, n: _project.name, object_type: "pod", object_name_or_id: _pod.name)
-    raise "could not delete broken iSCSI pod" unless @result[:success]
+    step %Q{admin ensures "#{_pod.name}" pod is deleted from the "#{_project.name}" project}
+    @result = admin.cli_exec(:create, n: _project.name, f: "#{BushSlicer::HOME}/testdata/storage/iscsi/iscsi-target.json")
+    raise "could not create iSCSI pod" unless @result[:success]
   else
     @result = admin.cli_exec(:create, n: _project.name, f: "#{BushSlicer::HOME}/testdata/storage/iscsi/iscsi-target.json")
     raise "could not create iSCSI pod" unless @result[:success]


### PR DESCRIPTION
PR to fix [OCPQE-11977](https://issues.redhat.com/browse/OCPQE-11977) and [OCPQE-11976](https://issues.redhat.com/browse/OCPQE-11976).
Before the fix, when there is a unhealthy iscsi-target pod, it only remove but not create a new one like [failed job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/667401/console).

This is the [successful job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/667402/console). 

@radeore @Phaow @chao007 @ropatil010 PTAL.