### PR TITLE
update NE testdata for hypershift testing

### DIFF
--- a/testdata/routing/operator/ingressctl-nsowner.yaml
+++ b/testdata/routing/operator/ingressctl-nsowner.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nsowner
   namespace: openshift-ingress-operator
 spec:
-  defaultCertificate:
-    name: router-certs-default
   domain: nsowner.example.com
   replicas: 1
   endpointPublishingStrategy:


### PR DESCRIPTION
remove `router-certs-default` setting since hypershift host cluster uses another secret.