### PR TITLE
increase memory for ES pods and set default channel to stable

### DIFF
--- a/features/logging/logging_acceptance.feature
+++ b/features/logging/logging_acceptance.feature
@@ -6,7 +6,7 @@ Feature: Logging smoke test case
   @serial
   @console
   @rosa
-  @aro 
+  @aro
   @osd_ccs
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi

--- a/testdata/logging/clusterlogging/cl-storage-with-im-template.yaml
+++ b/testdata/logging/clusterlogging/cl-storage-with-im-template.yaml
@@ -26,8 +26,7 @@ objects:
             nodeCount: ${{ES_NODE_COUNT}}
             resources:
               requests:
-                cpu: 100m
-                memory: 1Gi
+                memory: ${ES_REQUESTS_MEMORY}
             storage:
               storageClassName: "${STORAGE_CLASS}"
               size: "${PVC_SIZE}"
@@ -50,3 +49,5 @@ parameters:
     value: "1"
   - name: REDUNDANCY_POLICY
     value: "ZeroRedundancy"
+  - name: ES_REQUESTS_MEMORY
+    value: "2Gi"

--- a/testdata/logging/clusterlogging/cl_fluentd-buffer.yaml
+++ b/testdata/logging/clusterlogging/cl_fluentd-buffer.yaml
@@ -26,11 +26,8 @@ spec:
       nodeCount: 1
       redundancyPolicy: ZeroRedundancy
       resources:
-        limits:
-          memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 1Gi
+          memory: 2Gi
       storage: {}
     type: elasticsearch
   managementState: Managed

--- a/testdata/logging/clusterlogging/cl_fluentd-buffer_Invalid.yaml
+++ b/testdata/logging/clusterlogging/cl_fluentd-buffer_Invalid.yaml
@@ -26,11 +26,8 @@ spec:
       nodeCount: 1
       redundancyPolicy: ZeroRedundancy
       resources:
-        limits:
-          memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 1Gi
+          memory: 2Gi
       storage: {}
     type: elasticsearch
   managementState: Managed

--- a/testdata/logging/clusterlogging/cl_fluentd-buffer_default.yaml
+++ b/testdata/logging/clusterlogging/cl_fluentd-buffer_default.yaml
@@ -16,11 +16,8 @@ spec:
       nodeCount: 1
       redundancyPolicy: ZeroRedundancy
       resources:
-        limits:
-          memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 1Gi
+          memory: 2Gi
       storage: {}
     type: elasticsearch
   managementState: Managed

--- a/testdata/logging/clusterlogging/clusterlogging-storage-template.yaml
+++ b/testdata/logging/clusterlogging/clusterlogging-storage-template.yaml
@@ -19,8 +19,7 @@ objects:
             nodeCount: ${{ES_NODE_COUNT}}
             resources:
               requests:
-                cpu: 100m
-                memory: 1Gi
+                memory: 2Gi
             storage:
               storageClassName: "${STORAGE_CLASS}"
               size: "${PVC_SIZE}"

--- a/testdata/logging/clusterlogging/example.yaml
+++ b/testdata/logging/clusterlogging/example.yaml
@@ -10,11 +10,8 @@ spec:
     elasticsearch:
       nodeCount: 1
       resources:
-        limits:
-          memory: 2Gi
         requests:
-          cpu: 100m
-          memory: 1Gi
+          memory: 2Gi
       storage: {}
       redundancyPolicy: "ZeroRedundancy"
   visualization:

--- a/testdata/logging/clusterlogging/example_indexmanagement.yaml
+++ b/testdata/logging/clusterlogging/example_indexmanagement.yaml
@@ -7,7 +7,7 @@ spec:
   managementState: "Managed"
   logStore:
     type: "elasticsearch"
-    retentionPolicy: 
+    retentionPolicy:
       application:
         maxAge: 60m
       infra:
@@ -19,8 +19,7 @@ spec:
       redundancyPolicy: "ZeroRedundancy"
       resources:
         requests:
-          cpu: 100m
-          memory: "1Gi"
+          memory: "2Gi"
       storage: {}
   visualization:
     type: "kibana"

--- a/testdata/logging/clusterlogging/example_unmanaged.yaml
+++ b/testdata/logging/clusterlogging/example_unmanaged.yaml
@@ -11,8 +11,7 @@ spec:
       nodeCount: 1
       resources:
         requests:
-          cpu: 100m
-          memory: 1Gi
+          memory: 2Gi
       storage:
         storageClassName: "gp2"
         size: "10Gi"
@@ -21,10 +20,6 @@ spec:
     type: "kibana"
     kibana:
       replicas: 1
-  curation:
-    type: "curator"
-    curator:
-      schedule: "*/10 * * * *"
   collection:
     logs:
       type: "fluentd"

--- a/testdata/logging/clusterlogging/index_management_test.yaml
+++ b/testdata/logging/clusterlogging/index_management_test.yaml
@@ -7,7 +7,7 @@ spec:
   managementState: "Managed"
   logStore:
     type: "elasticsearch"
-    retentionPolicy: 
+    retentionPolicy:
       application:
         maxAge: 9m
       infra:
@@ -19,8 +19,7 @@ spec:
       redundancyPolicy: "ZeroRedundancy"
       resources:
         requests:
-          cpu: 100m
-          memory: "1Gi"
+          memory: "2Gi"
       storage: {}
   visualization:
     type: "kibana"

--- a/testdata/logging/clusterlogging/scalebase.yaml
+++ b/testdata/logging/clusterlogging/scalebase.yaml
@@ -11,17 +11,12 @@ spec:
       nodeCount: 2
       resources:
         requests:
-          cpu: 100m
-          memory: 1Gi
+          memory: 2Gi
       redundancyPolicy: "SingleRedundancy"
   visualization:
     type: "kibana"
     kibana:
       replicas: 1
-  curation:
-    type: "curator"
-    curator:
-      schedule: "*/30 * * * *"
   collection:
     logs:
       type: "fluentd"


### PR DESCRIPTION
This PR:
1. set default requests memory to `2Gi` for ES
2. set channel to `stable` when testing on OCP 4.12 to avoid below issue:
```
 [36mspec:[0m
      [36m  channel: stable-5.6[0m
      [36m  installPlanApproval: Automatic[0m
      [36m  name: elasticsearch-operator[0m
      [36m  source: redhat-operators[0m
      [36m  sourceNamespace: openshift-marketplace[0m
```