### PR TITLE
fix OCP-11255, remove label of < 4.11

### DIFF
--- a/features/cli/configmap.feature
+++ b/features/cli/configmap.feature
@@ -44,7 +44,7 @@ Feature: configMap
   # @author chezhang@redhat.com
   # @case_id OCP-11255
   @smoke
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.13 @4.12 @4.11
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity


### PR DESCRIPTION
due to this pr(https://github.com/openshift/verification-tests/pull/3079/files) add seccomp, will lead to failure of OCP-11255 in version < 4.11, so remove label of < 4.11