### PR TITLE
Add wait time so that descheduler operator pod comes up fine

### DIFF
--- a/features/upgrade/workloads/descheduler-upgrade.feature
+++ b/features/upgrade/workloads/descheduler-upgrade.feature
@@ -63,8 +63,11 @@ Feature: Descheduler major upgrade should work fine
       | app=descheduler |
     Given I make sure the descheduler operator gets updated successfully if needed
     And I use the "openshift-kube-descheduler-operator" project
+    Given I wait up to 180 seconds for the steps to pass:
+    """
     And status becomes :running of exactly 1 pods labeled:
       | name=descheduler-operator |
+    """
     Given I wait up to 180 seconds for the steps to pass:
     """
     And status becomes :running of exactly 1 pods labeled:


### PR DESCRIPTION
sometimes i see that test is failing with error that there are two pods existing and none of them in running state, one could be in containercreating and another could be in terminating state. So adding wait time to make sure that old pod dies completely and new pod comes up fine.

11-20 06:04:24.487      And status becomes :running of exactly 1 pods labeled:                                            # features/step_definitions/pod.rb:88
11-20 06:04:24.487        | name=descheduler-operator |
11-20 06:04:24.487        [00:34:24] INFO> oc get pods --output=yaml -l name\=descheduler-operator --kubeconfig=/home/jenkins/ws/workspace/ocp-upgrade/upgrade-consumer/workdir/ocp4_admin.kubeconfig -n openshift-kube-descheduler-operator
11-20 06:04:24.487        [00:34:24] INFO> 1 iterations for 1 sec, returned 2 pods, 2 matching
11-20 06:04:24.487        desired num of pods did not become running (RuntimeError)
11-20 06:04:24.487        /home/jenkins/ws/workspace/ocp-upgrade/upgrade-consumer/features/step_definitions/pod.rb:102:in `/^status becomes :([^\s]*?) of( exactly)? ([0-9]+) pods? labeled:$/'
11-20 06:04:24.487        features/upgrade/workloads/descheduler-upgrade.feature:66:in `status becomes :running of exactly 1 pods labeled:'