### PR TITLE
storage-intreetests-verificationtests

### DIFF
--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -255,6 +255,7 @@ When /^admin creates new in-tree storageclass with:$/ do |table|
   sc_hash = YAML.load_file file
 
   # replace paths from table
+  sc_hash["parameters"] ||= {}
   table.raw.each do |path, value|
       eval "sc_hash#{path} = YAML.load value" unless path == ''
   end

--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -251,7 +251,7 @@ When /^admin creates new in-tree storageclass with:$/ do |table|
   end
 
   # load file 
-  file = "#{BushSlicer::HOME}/testdata/storage/misc/storageClass-with-stable-annotations.yaml"
+  file = "#{BushSlicer::HOME}/testdata/storage/misc/in-tree-storageClass-template.yaml"
   sc_hash = YAML.load_file file
 
   # replace paths from table

--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -230,3 +230,50 @@ Given /^default storageclass is stored in the#{OPT_SYM} clipboard$/ do | cb_name
   cb[cb_name] = _sc
   cache_resources _sc
 end
+
+When /^admin creates new in-tree storageclass with:$/ do |table|
+  ensure_admin_tagged
+  project_name = project.name
+
+  iaas_type = env.iaas[:type] rescue nil 
+  if iaas_type == "aws"   
+    provisioner = 'aws-ebs'
+  elsif iaas_type == "gcp"
+    provisioner = 'gce-pd'
+  elsif iaas_type == "azure"
+    provisioner = 'azure-disk'
+  elsif iaas_type == "vsphere"
+    provisioner = 'vsphere-volume'
+  elsif iaas_type == "cinder"
+    provisioner = 'cinder'
+  else
+    raise "Unsupported iass_type `#{iaas_type}`"
+  end
+
+  # load file 
+  file = "#{BushSlicer::HOME}/testdata/storage/misc/storageClass-with-stable-annotations.yaml"
+  sc_hash = YAML.load_file file
+
+  # replace paths from table
+  table.raw.each do |path, value|
+      eval "sc_hash#{path} = YAML.load value" unless path == ''
+  end
+
+  # replace the provisioner value according to platform wise 
+  sc_hash["provisioner"] = "kubernetes.io/#{provisioner}"
+  
+  logger.info("Creating StorageClass:\n#{sc_hash.to_yaml}")
+  @result = BushSlicer::StorageClass.create(by: admin, spec: sc_hash)
+
+  if @result[:success]
+    cache_resources *@result[:resource]
+
+    # register mandatory clean-up
+    _sc = @result[:resource]
+    _admin = admin
+    teardown_add { _sc.ensure_deleted(user: _admin) }
+  else
+    logger.error(@result[:response])
+    raise "failed to clone StorageClass from: #{src_sc}"
+  end  
+end

--- a/features/storage/fsType.feature
+++ b/features/storage/fsType.feature
@@ -10,8 +10,9 @@ Feature: testing for parameter fsType
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: persistent volume formated with fsType
     Given I have a project
-    And admin clones storage class "sc-<%= project.name %>" from ":default" with:
-      | ["parameters"]["fsType"] | <fsType> |
+    And admin creates new in-tree storageclass with:
+      | ["metadata"]["name"]     | sc-<%= project.name %> |
+      | ["parameters"]["fsType"] | <fsType>               |
     Given I obtain test data file "storage/misc/pvc-with-storageClassName.json"
     When I run oc create over "pvc-with-storageClassName.json" replacing paths:
       | ["metadata"]["name"]         | mypvc                  |

--- a/testdata/storage/misc/in-tree-storageClass-template.yaml
+++ b/testdata/storage/misc/in-tree-storageClass-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: slow
+  name: in-tree
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
 provisioner: kubernetes.io/#PROVISIONER#

--- a/testdata/storage/misc/storageClass-with-stable-annotations.yaml
+++ b/testdata/storage/misc/storageClass-with-stable-annotations.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: slow
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: kubernetes.io/#PROVISIONER#


### PR DESCRIPTION
Hi Team,

kindly PTAL.
Issue: https://issues.redhat.com/browse/OCPQE-12840
Problem statement: Test cases impacted wrt intree tc after CSI Migration.
4.11: Azure, Cinder
4.12: GCP, AWS

Fix: Making all cucushift related tc wrt intree instead of doubling them in ginkgo by adding 1 function definition.
Calling this function definition will fix most of the issues related to CSI Migration.

Scenario Outline: Setting mountOptions for StorageClass
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5206/console 412 GCP
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5207/console 412 AWS
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5208/console 412 Az

Scenario: OCP-19886:Storage Display allowVolumeExpansion field in oc describe storage class
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5210/console 412 AZ
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5211/console 412 GCP
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5212/console 412 AWS

/assign @chao007 @duanwei33 @Phaow @radeore 