### PR TITLE
remove outdated case

### DIFF
--- a/features/logging/eventrouter.feature
+++ b/features/logging/eventrouter.feature
@@ -47,5 +47,4 @@ Feature: eventrouter related test
     @hypershift-hosted
     Examples:
     | case_id           | index_name  |
-    | OCP-25899:Logging | .operations | # @case_id OCP-25899
     | OCP-29738:Logging | infra       | # @case_id OCP-29738


### PR DESCRIPTION
When debugging https://url.corp.redhat.com/9efeb20, I found the case OCP-25899 was tested, and it's outdated, here remove it from the test scenario. 