### PR TITLE
use normal deployment instead of new-app

### DIFF
--- a/features/storage/cloud_provider.feature
+++ b/features/storage/cloud_provider.feature
@@ -3,7 +3,6 @@ Feature: kubelet restart and node restart
   # @author lxia@redhat.com
   @admin
   @destructive
-  @inactive
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @disconnected @connected
@@ -11,25 +10,36 @@ Feature: kubelet restart and node restart
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: kubelet restart should not affect attached/mounted volumes
     Given I have a project
-    When I run the :new_app client command with:
-      | template | mysql-persistent |
+    Given I obtain test data file "storage/misc/pvc.json"
+    When I create a dynamic pvc from "pvc.json" replacing paths:
+      | ["metadata"]["name"] | mypvc |
     Then the step should succeed
+    Given I obtain test data file "storage/misc/deployment.yaml"
+    When I run oc create over "deployment.yaml" replacing paths:
+      | ["metadata"]["name"]                                                             | mydep        |
+      | ["spec"]["template"]["metadata"]["labels"]["action"]                             | storage      |
+      | ["spec"]["template"]["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | mypvc        |
+      | ["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/storage |
+    Then the step should succeed
+    And the "mypvc" PVC becomes :bound
     And a pod becomes ready with labels:
-      | name=mysql |
+      | action=storage |
 
     When I execute on the pod:
-      | touch | /var/lib/mysql/data/testfile_before_restart |
+      | touch | /mnt/storage/testfile_before_restart |
     Then the step should succeed
     # restart kubelet on the node
     Given I use the "<%= pod.node_name %>" node
     And the node service is restarted on the host
+    # wait some time in case pod becomes to Terminating
+    And 30 seconds have passed
     And I wait up to 120 seconds for the steps to pass:
     """
     When I execute on the pod:
-      | ls | /var/lib/mysql/data/testfile_before_restart |
+      | ls | /mnt/storage/testfile_before_restart |
     Then the step should succeed
     When I execute on the pod:
-      | touch | /var/lib/mysql/data/testfile_after_restart |
+      | touch | /mnt/storage/testfile_after_restart |
     Then the step should succeed
     """
 


### PR DESCRIPTION
1. These cases are not deactivated from Polarion and cases have a good pass rate in Jenkins CI, so remove "@inactive" tag to bring them back
2. Use normal deployment instead of new-app
3. Adding waiting time for expected behavior

[pass log](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/676851/console)

@chao007 @Phaow @ropatil010 PTAL, thanks.

