### PR TITLE
Fix issue for OCPQE-12378

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -79,10 +79,8 @@ require_relative 'chrome_extension'
       chrome_switches = []
       if ENV.has_key?("http_proxy") || @http_proxy
         # get rid of the heading "http://" that breaks the profile
-        proxy_raw = @http_proxy || ENV["http_proxy"]
-        logger.warn "For UI team to debug proxy_raw value: #{proxy_raw}"
+        proxy_raw = (@http_proxy || ENV["http_proxy"]).sub(/(\/)+$/, '')
         proxy = proxy_raw.sub(%r{^.+?://}, "")
-        logger.warn "For UI team to debug proxy value: #{proxy}"
         proxy_bypass = "localhost,127.0.0.1"
         firefox_profile.proxy = chrome_caps.proxy = safari_caps.proxy = Selenium::WebDriver::Proxy.new({:http => proxy.sub(%r{^.+?@}, ""), :ssl => proxy.sub(%r{^.+?@}, "")})
         firefox_profile['network.proxy.no_proxies_on'] = proxy_bypass


### PR DESCRIPTION
Pass log on different env:
ipi-on-gcp/versioned-installer-filestore-CSI-ci: Runner/680138/
ipi-on-aws/versioned-installer-arm-ovn-efs-sts-ci: Runner/680153/
upi-on-vsphere/versioned-installer-vmc7-secureboot_enabled-static_network:Runner/680163/
Pass log on local:
[pass.log](https://github.com/openshift/verification-tests/files/10109681/pass.log)
![Pass](https://user-images.githubusercontent.com/78589509/204438008-4b797cbf-b2a2-459b-9dfe-98e99ef752b2.png)