### PR TITLE
storage-fixplatformname

### DIFF
--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -235,7 +235,7 @@ When /^admin creates new in-tree storageclass with:$/ do |table|
   ensure_admin_tagged
   project_name = project.name
 
-  iaas_type = env.iaas[:type] rescue nil 
+  iaas_type = env.iaas[:type].downcase rescue nil 
   if iaas_type == "aws"   
     provisioner = 'aws-ebs'
   elsif iaas_type == "gcp"
@@ -244,7 +244,7 @@ When /^admin creates new in-tree storageclass with:$/ do |table|
     provisioner = 'azure-disk'
   elsif iaas_type == "vsphere"
     provisioner = 'vsphere-volume'
-  elsif iaas_type == "cinder"
+  elsif iaas_type == "openstack"
     provisioner = 'cinder'
   else
     raise "Unsupported iass_type `#{iaas_type}`"


### PR DESCRIPTION
Hi Team, 

Kindly PTAL,

Payload: 4.10.43
Platform: OSP 
Issue: #<RuntimeError: Unsupported iass_type `openstack`> 
PR about: Fix platform name + to small letters, we are not hitting Unsupported iass_type. 

Logs: 
Openstack: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5239/console 
      storageclass.storage.k8s.io/sc-33sqm created
      [04:47:38] INFO> Exit Status: 0
      Error about: ImagePullBackOff in pod container creation

GCP: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5241/console
AWS https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5240/console

/assign @chao007 @duanwei33 @Phaow 