### PR TITLE
OCPQE-13027: More retries when create_run fail, and sleep before retry

### DIFF
--- a/lib/polarshift/request.rb
+++ b/lib/polarshift/request.rb
@@ -176,7 +176,7 @@ module BushSlicer
       end
 
       def create_run_smart(timeout: 360, **opts)
-        for retries in 1..5 do
+        for retries in 1..10 do
           res = create_run(**opts)
           if res[:exitstatus] == 202
             op_url = JSON.load(res[:response])["operation_result_url"]
@@ -189,6 +189,7 @@ module BushSlicer
           unless pr["status"] == "failed"
             break
           end
+          sleep 60
         end
 
         unless pr.dig("properties", "run_id")


### PR DESCRIPTION
After we bring in the retry logic, we got two failed jobs due to create_run failed, the others works good. So bump up the retry times a little bit, and wait 60 seconds before retry.

/cc @jhou1 @pruan-rht @chengzhang1016 @Xia-Zhao-rh 