### PR TITLE
add label to logging namespaces

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -31,7 +31,10 @@ Given /^logging operators are installed successfully$/ do
   step %Q/I switch to cluster admin pseudo user/
   step %Q/evaluation of `cluster_version('version').version` is stored in the :ocp_cluster_version clipboard/
 
-  unless project('openshift-operators-redhat').exists?
+  if project('openshift-operators-redhat').exists?
+    @result = admin.cli_exec(:label, resource: "namespace", name: "openshift-operators-redhat", key_val: 'openshift.io/cluster-monitoring=true', overwrite: true)
+    raise "Can't add label openshift.io/cluster-monitoring=true to namespace openshift-operators-redhat" unless @result[:success]
+  else
     eo_namespace_yaml = "#{BushSlicer::HOME}/testdata/logging/eleasticsearch/deploy_via_olm/01_eo-project.yaml"
     @result = admin.cli_exec(:create, f: eo_namespace_yaml)
     raise "Error creating namespace" unless @result[:success]
@@ -96,7 +99,10 @@ Given /^logging operators are installed successfully$/ do
   step %Q/elasticsearch operator is ready/
 
   # Create namespace
-  unless project('openshift-logging').exists?
+  if project('openshift-logging').exists?
+    @result = admin.cli_exec(:label, resource: "namespace", name: "openshift-logging", key_val: 'openshift.io/cluster-monitoring=true', overwrite: true)
+    raise "Can't add label openshift.io/cluster-monitoring=true to namespace openshift-logging" unless @result[:success]
+  else
     namespace_yaml = "#{BushSlicer::HOME}/testdata/logging/clusterlogging/deploy_clo_via_olm/01_clo_ns.yaml"
     @result = admin.cli_exec(:create, f: namespace_yaml)
     raise "Error creating namespace" unless @result[:success]


### PR DESCRIPTION
When debugging test results on ROSA and OSD, alway seeing below failure:
```
Message: failed OCP-37508:Logging One logging acceptance case for all cluster
Type: failed

Text:

Scenario: OCP-37508:Logging One logging acceptance case for all cluster
Given I wait up to 360 seconds for the steps to pass:

Message:

undefined method `[]' for nil:NilClass (NoMethodError)
(eval):1:in block in <top (required)>'
./features/step_definitions/common.rb:142:ineval'
./features/step_definitions/common.rb:142:in /^(?:the )?expression should be true> (.+)$/'
./features/step_definitions/transform.rb:33:incall'
./features/step_definitions/transform.rb:33:in block in singleton class'
./features/step_definitions/meta_steps.rb:48:inblock (2 levels) in <top (required)>'
./lib/base_helper.rb:160:in wait_for'
./features/step_definitions/meta_steps.rb:43:in/^I wait(?: up to ([0-9]+|<%=.+?%>) seconds)? for the steps to pass:$/'
features/logging/logging_acceptance.feature:129:in `I wait up to 360 seconds for the steps to pass:'
```
In OSD/ROSA, the namespace openshift-logging and openshift-operators-redhat are created before running logging case, and they don't have label `openshift.io/cluster-monitoring=true`, thus the metrics in these 2 projects are not gathered by prometheus, here adding label to logging projects manually if the projects already exist in cluster.
```
$ oc get ns openshift-logging -oyaml
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"openshift.io/node-selector":""},"labels":{"hive.openshift.io/managed":"true","openshift.io/cluster-logging":"true"},"name":"openshift-logging"}}
    openshift.io/node-selector: ""
    openshift.io/sa.scc.mcs: s0:c30,c15
    openshift.io/sa.scc.supplemental-groups: 1000900000/10000
    openshift.io/sa.scc.uid-range: 1000900000/10000
  creationTimestamp: "2022-12-02T01:02:09Z"
  labels:
    hive.openshift.io/managed: "true"
    kubernetes.io/metadata.name: openshift-logging
    olm.operatorgroup.uid/b9094957-8942-463e-9d57-ed0bdb2311b6: ""
    openshift.io/cluster-logging: "true"
    pod-security.kubernetes.io/audit: privileged
    pod-security.kubernetes.io/audit-version: v1.24
    pod-security.kubernetes.io/enforce: privileged
    pod-security.kubernetes.io/warn: privileged
    pod-security.kubernetes.io/warn-version: v1.24
    security.openshift.io/scc.podSecurityLabelSync: "true"
  name: openshift-logging
  resourceVersion: "78691"
  uid: 876d5d61-d460-48a8-bb60-ee64fb61e4e3
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```