### PR TITLE
Update three cases supported in sdn2ovn migration

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1528,11 +1528,13 @@ end
 Given /^the cluster is not migration from sdn plugin$/ do
   ensure_admin_tagged
   _admin = admin
-  @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration}")
-  if @result[:stdout]["networkType"]
-    logger.warn "the cluster is migration from sdn plugin"
-    logger.warn "We will skip this scenario"
-    skip_this_scenario
+  if env.version_le("4.11", user: user)
+    @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration}")
+    if @result[:stdout]["networkType"]
+      logger.warn "the cluster is migration from sdn plugin"
+      logger.warn "We will skip this scenario"
+      skip_this_scenario
+    end
   end
 end
 

--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -53,6 +53,7 @@ Feature: Egress compoment upgrade testing
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: Check egressfirewall is functional post upgrade
+    Given the cluster is not migration from sdn plugin
     Given I switch to cluster admin pseudo user
     And I save egress type to the clipboard
     When I run the :get admin command with:
@@ -263,6 +264,7 @@ Feature: Egress compoment upgrade testing
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: Check sdn egressip is functional post upgrade
+    Given the cluster is not migration from sdn plugin
     Given the env is using "OpenShiftSDN" networkType
     Given I run the :get admin command with:
       | resource      | hostsubnet                                  |

--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -53,7 +53,6 @@ Feature: Egress compoment upgrade testing
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: Check egressfirewall is functional post upgrade
-    Given the cluster is not migration from sdn plugin
     Given I switch to cluster admin pseudo user
     And I save egress type to the clipboard
     When I run the :get admin command with:
@@ -264,7 +263,6 @@ Feature: Egress compoment upgrade testing
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: Check sdn egressip is functional post upgrade
-    Given the cluster is not migration from sdn plugin		
     Given the env is using "OpenShiftSDN" networkType
     Given I run the :get admin command with:
       | resource      | hostsubnet                                  |

--- a/features/upgrade/sdn/multicast-upgrade.feature
+++ b/features/upgrade/sdn/multicast-upgrade.feature
@@ -104,7 +104,6 @@
   @proxy @noproxy @disconnected @connected
   @hypershift-hosted
   Scenario: Check the multicast works well after upgrade
-    Given the cluster is not migration from sdn plugin
     Given I switch to cluster admin pseudo user
     When I use the "multicast-upgrade" project
     Given 3 pods become ready with labels:

--- a/features/upgrade/sdn/multicast-upgrade.feature
+++ b/features/upgrade/sdn/multicast-upgrade.feature
@@ -104,6 +104,7 @@
   @proxy @noproxy @disconnected @connected
   @hypershift-hosted
   Scenario: Check the multicast works well after upgrade
+    Given the cluster is not migration from sdn plugin
     Given I switch to cluster admin pseudo user
     When I use the "multicast-upgrade" project
     Given 3 pods become ready with labels:


### PR DESCRIPTION
Remove "Given the cluster is not migration from sdn plugin" for test cases multicase, egressfirewall and SDN-egressIP which are supported after sdn to ovn migration in 4.12.

@openshift/team-sdn-qe PTAL


