### PR TITLE
And the appropriate pod security labels for multus cases

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -20,6 +20,7 @@ Feature: Multus-CNI related scenarios
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |
@@ -89,6 +90,7 @@ Feature: Multus-CNI related scenarios
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-private.yaml"
     When I run oc create as admin over "macvlan-private.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                     |
@@ -156,6 +158,7 @@ Feature: Multus-CNI related scenarios
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-vepa.yaml"
     When I run oc create as admin over "macvlan-vepa.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                  |
@@ -237,6 +240,7 @@ Feature: Multus-CNI related scenarios
 
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/host-device.yaml"
     When I run oc create as admin over "host-device.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                              |
@@ -302,6 +306,7 @@ Feature: Multus-CNI related scenarios
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |
@@ -356,6 +361,7 @@ Feature: Multus-CNI related scenarios
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |
@@ -431,6 +437,7 @@ Feature: Multus-CNI related scenarios
 
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/host-device.yaml"
     When I run oc create as admin over "host-device.yaml" replacing paths:
       | ["metadata"]["name"]      | host-device                                                                      |
@@ -505,6 +512,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-novlan.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-novlan.yaml |
@@ -562,6 +570,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-vlan-200.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-vlan-200.yaml |
@@ -612,6 +621,7 @@ Feature: Multus-CNI related scenarios
     Given the default interface on nodes is stored in the :default_interface clipboard
     #Patching simplemacvlan config in network operator config CRD
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"additionalNetworks":[{"name":"test-macvlan-case3","namespace":"<%= project.name %>","simpleMacvlanConfig":{"ipamConfig":{"staticIPAMConfig":{"addresses": [{"address":"10.128.2.100/23","gateway":"10.128.2.1"}]},"type":"static"},"master":"<%= cb.default_interface %>","mode":"bridge"},"type":"SimpleMacvlan"}]}} |
     #Cleanup for bringing CRD to original
@@ -652,6 +662,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin and simulating syntax errors
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
 
     Given I switch to cluster admin pseudo user
@@ -680,6 +691,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml"" replacing paths:
       | ["metadata"]["name"] | macvlan-bridge-21456 |
@@ -708,6 +720,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     And evaluation of `project.name` is stored in the :project1 clipboard
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
@@ -847,6 +860,7 @@ Feature: Multus-CNI related scenarios
     And I store all worker nodes to the :nodes clipboard
     # Create the net-attach-def with vlan 100 via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-vlan.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-vlan.yaml |
@@ -955,6 +969,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     # Create the net-attach-def without master pmtr via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-conf-without-master.yaml"
     When I run the :create admin command with:
       | f | macvlan-conf-without-master.yaml |
@@ -990,6 +1005,7 @@ Feature: Multus-CNI related scenarios
 
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-ipandmac.yaml"
     When I run the :create admin command with:
       | f | runtimeconfig-def-ipandmac.yaml |
@@ -1060,6 +1076,7 @@ Feature: Multus-CNI related scenarios
     """
     #Creating ipam type net-attach-def
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/ipam-dhcp.yaml"
     When I run oc create as admin over "ipam-dhcp.yaml" replacing paths:
       | ["metadata"]["name"]      | bridge-dhcp                                                                                                                                               |
@@ -1138,6 +1155,7 @@ Feature: Multus-CNI related scenarios
     a DHCP service is deconfigured on the "<%= cb.master[0].name %>" node
     """
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     #Patching simplemacvlan config in network operator config CRD
     And as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec": {"additionalNetworks": [{"name": "testmacvlan","namespace": "<%= project.name %>","simpleMacvlanConfig": {"ipamConfig": {"type": "dhcp"},"master": "mvlanp0"},"type": "SimpleMacvlan"}]}} |
@@ -1177,6 +1195,7 @@ Feature: Multus-CNI related scenarios
 
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-ip.yaml"
     When I run the :create admin command with:
       | f | runtimeconfig-def-ip.yaml |
@@ -1219,6 +1238,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-mac.yaml"
     When I run the :create admin command with:
       | f | runtimeconfig-def-mac.yaml |
@@ -1260,6 +1280,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/ipam-static.yaml"
     When I run oc create as admin over "ipam-static.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                      |
@@ -1311,6 +1332,7 @@ Feature: Multus-CNI related scenarios
     # Create the net-attach-def via cluster admin
     Given I switch to the first user
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     And evaluation of `project.name` is stored in the :usr_project clipboard
 
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-mac.yaml"
@@ -1408,6 +1430,7 @@ Feature: Multus-CNI related scenarios
     And evaluation of `@result[:response].match(/\h+:\h+:\h+:\h+:\h+:\h+/)[0]` is stored in the :default_interface_mac clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/ipvlan-host-local.yaml"
     When I run oc create as admin over "ipvlan-host-local.yaml" replacing paths:
       | ["metadata"]["name"]      | myipvlan76                                                                                                                                                              |
@@ -1464,6 +1487,7 @@ Feature: Multus-CNI related scenarios
     Given the default interface on nodes is stored in the :default_interface clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml"
     When I run oc create as admin over "whereabouts-macvlan.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                      |
@@ -1528,6 +1552,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/route-override.yaml"
     When I run oc create as admin over "route-override.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                 |
@@ -1576,6 +1601,7 @@ Feature: Multus-CNI related scenarios
 
     # Create a pod absorbing above net-attach-def defined in default namespace
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
       | ["metadata"]["name"]                                       | macvlan-bridge-whereabouts-pod1    |
@@ -1600,6 +1626,7 @@ Feature: Multus-CNI related scenarios
     And I store all worker nodes to the :nodes clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml"
     When I run oc create as admin over "whereabouts-macvlan.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                             |
@@ -1654,6 +1681,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-excludeIP.yaml"
     When I run oc create as admin over "whereabouts-excludeIP.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %> |
@@ -1717,6 +1745,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     # Create the net-attach-def with whereabouts-shortrange
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-overlapping.yaml"
     When I run oc create as admin over "whereabouts-overlapping.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>    |
@@ -1798,6 +1827,7 @@ Feature: Multus-CNI related scenarios
     And I store all worker nodes to the :nodes clipboard
     # Create the net-attach-def via cluster admin
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/Bug-1944678.yaml"
     When I run oc create as admin over "Bug-1944678.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %> |
@@ -1861,6 +1891,7 @@ Feature: Multus-CNI related scenarios
     Given the default interface on nodes is stored in the :default_interface clipboard
     #Patching rawCNIConfig config in network operator config CRD
     Given I have a project
+    And the appropriate pod security labels are applied to the namespace
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:    
       | {"spec": {"additionalNetworks": [{"name": "macvlan-bridge-ipam-dhcp","namespace": "<%= project.name %>","rawCNIConfig": "{ \"cniVersion\": \"0.3.1\", \"name\": \"test-network-1\", \"type\": \"bridge\", \"ipam\": { \"type\": \"static\", \"addresses\": [ { \"address\": \"191.168.1.23\" } ] } }","type":"Raw"}]}} |
 

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -19,8 +19,7 @@ Feature: Multus-CNI related scenarios
     Given the default interface on nodes is stored in the :default_interface clipboard
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |
@@ -89,8 +88,7 @@ Feature: Multus-CNI related scenarios
     Given the default interface on nodes is stored in the :default_interface clipboard
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-private.yaml"
     When I run oc create as admin over "macvlan-private.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                     |
@@ -157,8 +155,7 @@ Feature: Multus-CNI related scenarios
     Given the default interface on nodes is stored in the :default_interface clipboard
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-vepa.yaml"
     When I run oc create as admin over "macvlan-vepa.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                  |
@@ -239,8 +236,7 @@ Feature: Multus-CNI related scenarios
     """
 
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/host-device.yaml"
     When I run oc create as admin over "host-device.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                              |
@@ -305,8 +301,7 @@ Feature: Multus-CNI related scenarios
     Given the default interface on nodes is stored in the :default_interface clipboard
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |
@@ -360,8 +355,7 @@ Feature: Multus-CNI related scenarios
     Given the default interface on nodes is stored in the :default_interface clipboard
     And evaluation of `node.name` is stored in the :target_node clipboard
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                                    |
@@ -436,8 +430,7 @@ Feature: Multus-CNI related scenarios
     And an 4 character random string of type :hex is stored into the :nic_name2 clipboard
 
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/host-device.yaml"
     When I run oc create as admin over "host-device.yaml" replacing paths:
       | ["metadata"]["name"]      | host-device                                                                      |
@@ -511,8 +504,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-novlan.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-novlan.yaml |
@@ -569,8 +561,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-vlan-200.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-vlan-200.yaml |
@@ -620,8 +611,7 @@ Feature: Multus-CNI related scenarios
     And I store all worker nodes to the :nodes clipboard
     Given the default interface on nodes is stored in the :default_interface clipboard
     #Patching simplemacvlan config in network operator config CRD
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"additionalNetworks":[{"name":"test-macvlan-case3","namespace":"<%= project.name %>","simpleMacvlanConfig":{"ipamConfig":{"staticIPAMConfig":{"addresses": [{"address":"10.128.2.100/23","gateway":"10.128.2.1"}]},"type":"static"},"master":"<%= cb.default_interface %>","mode":"bridge"},"type":"SimpleMacvlan"}]}} |
     #Cleanup for bringing CRD to original
@@ -661,8 +651,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin and simulating syntax errors
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
 
     Given I switch to cluster admin pseudo user
@@ -690,8 +679,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml"" replacing paths:
       | ["metadata"]["name"] | macvlan-bridge-21456 |
@@ -719,8 +707,7 @@ Feature: Multus-CNI related scenarios
   Scenario: OCP-21793:SDN User cannot consume the net-attach-def created in other project which is namespace isolated
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     And evaluation of `project.name` is stored in the :project1 clipboard
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-bridge.yaml"
     When I run oc create as admin over "macvlan-bridge.yaml" replacing paths:
@@ -764,8 +751,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-vlan.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-vlan.yaml |
@@ -859,8 +845,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
     # Create the net-attach-def with vlan 100 via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/bridge-host-local-vlan.yaml"
     When I run the :create admin command with:
       | f | bridge-host-local-vlan.yaml |
@@ -968,8 +953,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def without master pmtr via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/macvlan-conf-without-master.yaml"
     When I run the :create admin command with:
       | f | macvlan-conf-without-master.yaml |
@@ -1004,8 +988,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
 
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-ipandmac.yaml"
     When I run the :create admin command with:
       | f | runtimeconfig-def-ipandmac.yaml |
@@ -1075,8 +1058,7 @@ Feature: Multus-CNI related scenarios
     a DHCP service is deconfigured on the "<%= cb.nodes[0].name %>" node
     """
     #Creating ipam type net-attach-def
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/ipam-dhcp.yaml"
     When I run oc create as admin over "ipam-dhcp.yaml" replacing paths:
       | ["metadata"]["name"]      | bridge-dhcp                                                                                                                                               |
@@ -1154,8 +1136,7 @@ Feature: Multus-CNI related scenarios
     """
     a DHCP service is deconfigured on the "<%= cb.master[0].name %>" node
     """
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     #Patching simplemacvlan config in network operator config CRD
     And as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec": {"additionalNetworks": [{"name": "testmacvlan","namespace": "<%= project.name %>","simpleMacvlanConfig": {"ipamConfig": {"type": "dhcp"},"master": "mvlanp0"},"type": "SimpleMacvlan"}]}} |
@@ -1194,8 +1175,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
 
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-ip.yaml"
     When I run the :create admin command with:
       | f | runtimeconfig-def-ip.yaml |
@@ -1237,8 +1217,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-mac.yaml"
     When I run the :create admin command with:
       | f | runtimeconfig-def-mac.yaml |
@@ -1279,8 +1258,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/ipam-static.yaml"
     When I run oc create as admin over "ipam-static.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                      |
@@ -1331,8 +1309,7 @@ Feature: Multus-CNI related scenarios
 
     # Create the net-attach-def via cluster admin
     Given I switch to the first user
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     And evaluation of `project.name` is stored in the :usr_project clipboard
 
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/runtimeconfig-def-mac.yaml"
@@ -1429,8 +1406,7 @@ Feature: Multus-CNI related scenarios
     Then the step should succeed
     And evaluation of `@result[:response].match(/\h+:\h+:\h+:\h+:\h+:\h+/)[0]` is stored in the :default_interface_mac clipboard
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/ipvlan-host-local.yaml"
     When I run oc create as admin over "ipvlan-host-local.yaml" replacing paths:
       | ["metadata"]["name"]      | myipvlan76                                                                                                                                                              |
@@ -1486,8 +1462,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     Given the default interface on nodes is stored in the :default_interface clipboard
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml"
     When I run oc create as admin over "whereabouts-macvlan.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                      |
@@ -1551,8 +1526,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/route-override.yaml"
     When I run oc create as admin over "route-override.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                                                                                                                                                                 |
@@ -1600,8 +1574,7 @@ Feature: Multus-CNI related scenarios
     And admin ensures "macvlan-bridge-whereabouts" network_attachment_definition is deleted from the "default" project after scenario
 
     # Create a pod absorbing above net-attach-def defined in default namespace
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"
     When I run oc create over "generic_multus_pod.yaml" replacing paths:
       | ["metadata"]["name"]                                       | macvlan-bridge-whereabouts-pod1    |
@@ -1625,8 +1598,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-macvlan.yaml"
     When I run oc create as admin over "whereabouts-macvlan.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>                                                                                                             |
@@ -1680,8 +1652,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-excludeIP.yaml"
     When I run oc create as admin over "whereabouts-excludeIP.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %> |
@@ -1744,8 +1715,7 @@ Feature: Multus-CNI related scenarios
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster
     # Create the net-attach-def with whereabouts-shortrange
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/whereabouts-overlapping.yaml"
     When I run oc create as admin over "whereabouts-overlapping.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %>    |
@@ -1826,8 +1796,7 @@ Feature: Multus-CNI related scenarios
     Given the multus is enabled on the cluster
     And I store all worker nodes to the :nodes clipboard
     # Create the net-attach-def via cluster admin
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given I obtain test data file "networking/multus-cni/NetworkAttachmentDefinitions/Bug-1944678.yaml"
     When I run oc create as admin over "Bug-1944678.yaml" replacing paths:
       | ["metadata"]["namespace"] | <%= project.name %> |
@@ -1890,8 +1859,7 @@ Feature: Multus-CNI related scenarios
     And I store all worker nodes to the :nodes clipboard
     Given the default interface on nodes is stored in the :default_interface clipboard
     #Patching rawCNIConfig config in network operator config CRD
-    Given I have a project
-    And the appropriate pod security labels are applied to the namespace
+    Given I have a project with proper privilege
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:    
       | {"spec": {"additionalNetworks": [{"name": "macvlan-bridge-ipam-dhcp","namespace": "<%= project.name %>","rawCNIConfig": "{ \"cniVersion\": \"0.3.1\", \"name\": \"test-network-1\", \"type\": \"bridge\", \"ipam\": { \"type\": \"static\", \"addresses\": [ { \"address\": \"191.168.1.23\" } ] } }","type":"Raw"}]}} |
 


### PR DESCRIPTION
After debugging https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/all/276500/22372643?item1Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED, then found out most multus cases need `And the appropriate pod security labels are applied to the namespace`

@openshift/team-sdn-qe PTAL