### PR TITLE
fix OCP-33743

### DIFF
--- a/lib/rules/web/admin_console/4.10/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.10/operator_hub.xyaml
@@ -730,23 +730,19 @@ check_k8sresource_dropdown_items:
       xpath: //li//span[contains(@class,'co-resource-item__resource-name') and contains(text(),'<item>')]
 check_required_badge_on_operator_installation_page:
   elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
-check_required_badge_during_installation:
-  elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
+  - selector: &required_badge
+      xpath: //span[@data-test='status-text' and contains(text(),'Required')]
 check_create_operand_button_and_requied_badge_when_ready:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-clusterserviceversion-install__heading') and contains(.,'Installed operator') and contains(.,'operand required')]
+      <<: *required_badge
     timeout: 30
   - selector: &create_operand_button
       xpath: //button[contains(.,'Create Ditto') and not(disabled)]
 check_create_operand_button_and_requied_badge_on_csv_details:
   elements:
   - selector:
-      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'required')]
+      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'Ditto required')]
   action: check_operand_button_link
 check_operand_button_link:
   element:

--- a/lib/rules/web/admin_console/4.11/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.11/operator_hub.xyaml
@@ -730,23 +730,19 @@ check_k8sresource_dropdown_items:
       xpath: //li//span[contains(@class,'co-resource-item__resource-name') and contains(text(),'<item>')]
 check_required_badge_on_operator_installation_page:
   elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
-check_required_badge_during_installation:
-  elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
+  - selector: &required_badge
+      xpath: //span[@data-test='status-text' and contains(text(),'Required')]
 check_create_operand_button_and_requied_badge_when_ready:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-clusterserviceversion-install__heading') and contains(.,'Installed operator') and contains(.,'operand required')]
+      <<: *required_badge
     timeout: 30
   - selector: &create_operand_button
       xpath: //button[contains(.,'Create Ditto') and not(disabled)]
 check_create_operand_button_and_requied_badge_on_csv_details:
   elements:
   - selector:
-      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'required')]
+      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'Ditto required')]
   action: check_operand_button_link
 check_operand_button_link:
   element:

--- a/lib/rules/web/admin_console/4.12/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.12/operator_hub.xyaml
@@ -729,23 +729,19 @@ check_k8sresource_dropdown_items:
       xpath: //li//span[contains(@class,'co-resource-item__resource-name') and contains(text(),'<item>')]
 check_required_badge_on_operator_installation_page:
   elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
-check_required_badge_during_installation:
-  elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
+  - selector: &required_badge
+      xpath: //span[@data-test='status-text' and contains(text(),'Required')]
 check_create_operand_button_and_requied_badge_when_ready:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-clusterserviceversion-install__heading') and contains(.,'Installed operator') and contains(.,'operand required')]
+      <<: *required_badge
     timeout: 30
   - selector: &create_operand_button
       xpath: //button[contains(.,'Create Ditto') and not(disabled)]
 check_create_operand_button_and_requied_badge_on_csv_details:
   elements:
   - selector:
-      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'required')]
+      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'Ditto required')]
   action: check_operand_button_link
 check_operand_button_link:
   element:

--- a/lib/rules/web/admin_console/4.13/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.13/operator_hub.xyaml
@@ -729,23 +729,19 @@ check_k8sresource_dropdown_items:
       xpath: //li//span[contains(@class,'co-resource-item__resource-name') and contains(text(),'<item>')]
 check_required_badge_on_operator_installation_page:
   elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
-check_required_badge_during_installation:
-  elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
+  - selector: &required_badge
+      xpath: //span[@data-test='status-text' and contains(text(),'Required')]
 check_create_operand_button_and_requied_badge_when_ready:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-clusterserviceversion-install__heading') and contains(.,'Installed operator') and contains(.,'operand required')]
+      <<: *required_badge
     timeout: 30
   - selector: &create_operand_button
       xpath: //button[contains(.,'Create Ditto') and not(disabled)]
 check_create_operand_button_and_requied_badge_on_csv_details:
   elements:
   - selector:
-      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'required')]
+      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'Ditto required')]
   action: check_operand_button_link
 check_operand_button_link:
   element:

--- a/lib/rules/web/admin_console/4.7/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.7/operator_hub.xyaml
@@ -686,23 +686,19 @@ check_k8sresource_dropdown_items:
       xpath: //li//span[contains(@class,'co-resource-item__resource-name') and contains(text(),'<item>')]
 check_required_badge_on_operator_installation_page:
   elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
-check_required_badge_during_installation:
-  elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
+  - selector: &required_badge
+      xpath: //span[@data-test='status-text' and contains(text(),'Required')]
 check_create_operand_button_and_requied_badge_when_ready:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-clusterserviceversion-install__heading') and contains(.,'Installed operator') and contains(.,'operand required')]
+      <<: *required_badge
     timeout: 30
   - selector: &create_operand_button
       xpath: //button[contains(.,'Create Ditto') and not(disabled)]
 check_create_operand_button_and_requied_badge_on_csv_details:
   elements:
   - selector:
-      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'required')]
+      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'Ditto required')]
   action: check_operand_button_link
 check_operand_button_link:
   element:

--- a/lib/rules/web/admin_console/4.8/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.8/operator_hub.xyaml
@@ -685,23 +685,19 @@ check_k8sresource_dropdown_items:
       xpath: //li//span[contains(@class,'co-resource-item__resource-name') and contains(text(),'<item>')]
 check_required_badge_on_operator_installation_page:
   elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
-check_required_badge_during_installation:
-  elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
+  - selector: &required_badge
+      xpath: //span[@data-test='status-text' and contains(text(),'Required')]
 check_create_operand_button_and_requied_badge_when_ready:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-clusterserviceversion-install__heading') and contains(.,'Installed operator') and contains(.,'operand required')]
+      <<: *required_badge
     timeout: 30
   - selector: &create_operand_button
       xpath: //button[contains(.,'Create Ditto') and not(disabled)]
 check_create_operand_button_and_requied_badge_on_csv_details:
   elements:
   - selector:
-      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'required')]
+      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'Ditto required')]
   action: check_operand_button_link
 check_operand_button_link:
   element:

--- a/lib/rules/web/admin_console/4.9/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.9/operator_hub.xyaml
@@ -717,23 +717,19 @@ check_k8sresource_dropdown_items:
       xpath: //li//span[contains(@class,'co-resource-item__resource-name') and contains(text(),'<item>')]
 check_required_badge_on_operator_installation_page:
   elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
-check_required_badge_during_installation:
-  elements:
-  - selector:
-      xpath: //span[contains(@class,'co-resource-item')]//span[contains(text(),'Ditto')]/following::span[contains(text(),'Required')]
+  - selector: &required_badge
+      xpath: //span[@data-test='status-text' and contains(text(),'Required')]
 check_create_operand_button_and_requied_badge_when_ready:
   elements:
   - selector:
-      xpath: //h2[contains(@class,'co-clusterserviceversion-install__heading') and contains(.,'Installed operator') and contains(.,'operand required')]
+      <<: *required_badge
     timeout: 30
   - selector: &create_operand_button
       xpath: //button[contains(.,'Create Ditto') and not(disabled)]
 check_create_operand_button_and_requied_badge_on_csv_details:
   elements:
   - selector:
-      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'required')]
+      xpath: //h4[contains(@class,'pf-c-alert__title') and contains(.,'Ditto required')]
   action: check_operand_button_link
 check_operand_button_link:
   element:


### PR DESCRIPTION
- remove `check_required_badge_during_installation` rule since it is not used in any feature
[yapei@yapei-mac cucushift (fix)]$ grep -nr 'check_required_badge_during_installation' web/admin-console
- updated rules checking `Required` badge to be simpler and more stable