### PR TITLE
Fix OCPQE-13180

### DIFF
--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -53,8 +53,8 @@ Feature: Egress compoment upgrade testing
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: Check egressfirewall is functional post upgrade
-    Given the cluster is not migration from sdn plugin
     Given I switch to cluster admin pseudo user
+    Given the cluster is not migration from sdn plugin
     And I save egress type to the clipboard
     When I run the :get admin command with:
       | resource | <%= cb.cb_egress_type %>  |
@@ -264,6 +264,7 @@ Feature: Egress compoment upgrade testing
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: Check sdn egressip is functional post upgrade
+    Given I switch to cluster admin pseudo user
     Given the cluster is not migration from sdn plugin
     Given the env is using "OpenShiftSDN" networkType
     Given I run the :get admin command with:

--- a/features/upgrade/sdn/multicast-upgrade.feature
+++ b/features/upgrade/sdn/multicast-upgrade.feature
@@ -104,8 +104,8 @@
   @proxy @noproxy @disconnected @connected
   @hypershift-hosted
   Scenario: Check the multicast works well after upgrade
-    Given the cluster is not migration from sdn plugin
     Given I switch to cluster admin pseudo user
+    Given the cluster is not migration from sdn plugin
     When I use the "multicast-upgrade" project
     Given 3 pods become ready with labels:
       | name=mcast-pods |


### PR DESCRIPTION
Fix `no specification for user index 0 in a scenario @users tag (RuntimeError)` in [OCPQE-13180](https://issues.redhat.com/browse/OCPQE-13180)

@openshift/team-sdn-qe PTAL
