### PR TITLE
added CLI support to sync run from Polarion to Polarshift

### DIFF
--- a/lib/polarshift/request.rb
+++ b/lib/polarshift/request.rb
@@ -115,6 +115,18 @@ module BushSlicer
         }
       end
 
+      def sync_run(project_id, run_id, with_cases: "full")
+        params = with_cases ? {test_cases: with_cases} : {}
+        Http.request_with_retry(
+          method: :put,
+          url: "#{base_url}project/#{project_id}/run/#{run_id}/replace",
+          params: params,
+          raise_on_error: false,
+          read_timeout: 120,
+          **common_opts
+        )
+      end
+
       def get_run(project_id, run_id, with_cases: "automation")
         params = with_cases ? {test_cases: with_cases} : {}
         Http.request_with_retry(

--- a/tools/polarshift.rb
+++ b/tools/polarshift.rb
@@ -193,6 +193,22 @@ module BushSlicer
         end
       end
 
+      command :"sync-run" do |c|
+        c.syntax = "#{$0} sync-run [options]"
+        c.description = "sync a test run from Polarion into existing Polashift \n\t" \
+          'e.g. tools/polarshift.rb sync-run polarion_run_id'
+        c.action do |args, options|
+          setup_global_opts(options)
+
+          raise 'command expects exactly one parameter being the test run id' if args.size != 1
+
+          test_run_id = args.first
+          query_result = polarshift.sync_run(project, test_run_id)
+          result = query_result
+          pp(result)
+        end
+      end
+
       command :"clone-run" do |c|
         c.syntax = "#{$0} clone-run [options]"
         c.description = "clone a test run from Polarion\n\t" \


### PR DESCRIPTION
depends on https://gitlab.cee.redhat.com/aosqe/polarshift/-/merge_requests/26 which adds the API support in the backend.