### PR TITLE
Automate OCP-54166

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1620,3 +1620,22 @@ Given /^I store kubernetes elected leader pod for ovnkube-master in the#{OPT_SYM
   target_pod = pods.select {|p| p.props[:node_name] == holder_id }.first
   cb[cb_leader_name ] = target_pod
 end
+
+Given /^the plugin is openshift-ovs-networkpolicy on the cluster$/ do
+  ensure_admin_tagged
+  @result = admin.cli_exec(:get, resource: "clusternetwork", output: "jsonpath={.items[*].pluginName}")
+  if @result[:response] != "redhat/openshift-ovs-networkpolicy"
+    raise "The openshift-ovs-networkpolicy plugin is not used in the cluster" 
+    skip_this_scenario
+  end
+end
+
+Given /^the OVN joint network CIDR is patched in the node$/ do 
+  ensure_admin_tagged
+  @result = admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.defaultNetwork.ovnKubernetesConfig.v4InternalSubnet}")
+  unless @result[:response].include? "100.66.0"
+    logger.warn "JointNetworkCIDR is not patched"
+    skip_this_scenario
+  end
+end
+

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1639,3 +1639,28 @@ Given /^the OVN joint network CIDR is patched in the node$/ do
   end
 end
 
+Given /^the cluster is migrated from sdn$/ do
+  ensure_admin_tagged
+  _admin = admin
+  @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration.networkType}")
+  unless @result[:stdout]["OVNKubernetes"]
+    logger.warn "the cluster is not migration from sdn plugin"
+    logger.warn "We will skip this scenario"
+    skip_this_scenario
+  end
+end
+
+Given /^the joint network CIDR is updateded in the node "([^"]*)"$/ do | node_name |
+  ensure_admin_tagged
+  @result1 = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.metadata.annotations.alpha.kubernetes.io/provided-node-ip}")
+  def_inf1 = @result1[:response]
+  logger.info "The node's default interface is #{def_inf1}"
+  @result = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.metadata.annotations.k8s\.ovn\.org/node-gateway-router-lrp-ifaddr}")
+  def_inf = @result[:response]
+  logger.info "The node's default interface is #{def_inf}"
+  raise "Failed to install load-sctp-module" unless @result[:success]
+  unless @result[:response].include? ("100.66.0")
+    logger.warn "JointNetworkCIDR is not updated on the cluster"
+    skip_this_scenario
+  end
+end

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1652,9 +1652,6 @@ end
 
 Given /^the joint network CIDR is updateded in the node "([^"]*)"$/ do | node_name |
   ensure_admin_tagged
-  @result1 = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.metadata.annotations.alpha.kubernetes.io/provided-node-ip}")
-  def_inf1 = @result1[:response]
-  logger.info "The node's default interface is #{def_inf1}"
   @result = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.metadata.annotations.k8s\.ovn\.org/node-gateway-router-lrp-ifaddr}")
   def_inf = @result[:response]
   logger.info "The node's default interface is #{def_inf}"

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1649,15 +1649,3 @@ Given /^the cluster is migrated from sdn$/ do
     skip_this_scenario
   end
 end
-
-Given /^the joint network CIDR is updateded in the node "([^"]*)"$/ do | node_name |
-  ensure_admin_tagged
-  @result = admin.cli_exec(:get, resource: "node/#{node_name}", output: "jsonpath={.metadata.annotations.k8s\.ovn\.org/node-gateway-router-lrp-ifaddr}")
-  def_inf = @result[:response]
-  logger.info "The node's default interface is #{def_inf}"
-  raise "Failed to install load-sctp-module" unless @result[:success]
-  unless @result[:response].include? ("100.66.0")
-    logger.warn "JointNetworkCIDR is not updated on the cluster"
-    skip_this_scenario
-  end
-end

--- a/features/upgrade/sdn/sdn2ovn-migration.feature
+++ b/features/upgrade/sdn/sdn2ovn-migration.feature
@@ -28,8 +28,10 @@ Feature: sdn2ovn migration testing
   @upgrade
   @proxy @noproxy @disconnected @connected
   Scenario: sdn2ovn migration support custom OVNKube joint network CIDR - check after migration
+  Given the cluster is migrated from sdn
   Given I store the masters in the :masters clipboard
   And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard
+  Given the joint network CIDR is updateded in the node "<%= cb.masters[0].name %>"
   When I run the :get admin command with:
     | resource      | node                                                                          |
     | resource_name | <%= cb.masters[0].name %>                                                     |

--- a/features/upgrade/sdn/sdn2ovn-migration.feature
+++ b/features/upgrade/sdn/sdn2ovn-migration.feature
@@ -30,7 +30,6 @@ Feature: sdn2ovn migration testing
   Scenario: sdn2ovn migration support custom OVNKube joint network CIDR - check after migration
   Given the cluster is migrated from sdn
   Given I store the masters in the :masters clipboard
-  Given the joint network CIDR is updateded in the node "<%= cb.masters[0].name %>"
   When I run the :get admin command with:
     | resource      | node                                                                          |
     | resource_name | <%= cb.masters[0].name %>                                                     |

--- a/features/upgrade/sdn/sdn2ovn-migration.feature
+++ b/features/upgrade/sdn/sdn2ovn-migration.feature
@@ -1,0 +1,38 @@
+Feature: sdn2ovn migration testing
+
+  # @author weliang@redhat.com
+  @admin
+  @upgrade-prepare
+  @4.13 @4.12
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @upgrade
+  @network-openshiftsdn
+  @proxy @noproxy @disconnected @connected
+  Scenario: sdn2ovn migration support custom OVNKube joint network CIDR - prepare before migration 
+    Given the plugin is openshift-ovs-networkpolicy on the cluster
+    Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
+      | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"v4InternalSubnet":"100.66.0.0/16" }}}} |
+    Given I store the masters in the :masters clipboard
+    And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard
+    Given the OVN joint network CIDR is patched in the node
+    
+  # @author weliang@redhat.com
+  # @case_id OCP-54166
+  @admin
+  @upgrade-check
+  @network-ovnkubernetes
+  @4.13 @4.12
+  @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
+  @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @upgrade
+  @proxy @noproxy @disconnected @connected
+  Scenario: sdn2ovn migration support custom OVNKube joint network CIDR - check after migration
+  Given I store the masters in the :masters clipboard
+  And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard
+  When I run the :get admin command with:
+    | resource      | node                                                                          |
+    | resource_name | <%= cb.masters[0].name %>                                                     |
+    | o             | jsonpath={.metadata.annotations.k8s\.ovn\.org/node-gateway-router-lrp-ifaddr} |
+  Then the step should succeed
+  Then the outputs should contain "{"ipv4":"100.66.0."

--- a/features/upgrade/sdn/sdn2ovn-migration.feature
+++ b/features/upgrade/sdn/sdn2ovn-migration.feature
@@ -13,8 +13,6 @@ Feature: sdn2ovn migration testing
     Given the plugin is openshift-ovs-networkpolicy on the cluster
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"v4InternalSubnet":"100.66.0.0/16" }}}} |
-    Given I store the masters in the :masters clipboard
-    And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard
     Given the OVN joint network CIDR is patched in the node
     
   # @author weliang@redhat.com

--- a/features/upgrade/sdn/sdn2ovn-migration.feature
+++ b/features/upgrade/sdn/sdn2ovn-migration.feature
@@ -30,7 +30,6 @@ Feature: sdn2ovn migration testing
   Scenario: sdn2ovn migration support custom OVNKube joint network CIDR - check after migration
   Given the cluster is migrated from sdn
   Given I store the masters in the :masters clipboard
-  And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master0_ip clipboard
   Given the joint network CIDR is updateded in the node "<%= cb.masters[0].name %>"
   When I run the :get admin command with:
     | resource      | node                                                                          |


### PR DESCRIPTION
Automate OCP-54166: CNO support custom OVNKube joint network CIDR

This case is created under features/upgrade/sdn subfolder where the test cases will be used for sdn2ovn migration testing too.  As scripts checked, this case can only be tested by migration testing.

Test log:
prepare before migration:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5367/console
check after migration:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5368/console

@openshift/team-sdn-qe PTAL