### PR TITLE
storage-identifyplatform fix

### DIFF
--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -235,19 +235,20 @@ When /^admin creates new in-tree storageclass with:$/ do |table|
   ensure_admin_tagged
   project_name = project.name
 
-  iaas_type = env.iaas[:type].downcase rescue nil 
-  if iaas_type == "aws"   
+  platform = infrastructure('cluster').platform.downcase 
+  case platform
+  when 'aws'
     provisioner = 'aws-ebs'
-  elsif iaas_type == "gcp"
+  when 'gcp' 
     provisioner = 'gce-pd'
-  elsif iaas_type == "azure"
+  when 'azure'
     provisioner = 'azure-disk'
-  elsif iaas_type == "vsphere"
+  when 'vsphere'
     provisioner = 'vsphere-volume'
-  elsif iaas_type == "openstack"
+  when 'openstack'
     provisioner = 'cinder'
   else
-    raise "Unsupported iass_type `#{iaas_type}`"
+    raise "Unsupported platform `#{platform}`"
   end
 
   # load file 


### PR DESCRIPTION
Hi Team, 

As known issue from framework side wrt iaas_type, fixing only from storage point of view. 

Profile: versioned-installer-customer_vpc-disconnected_private_cluster-arm-ci
Image: installer_payload_image: registry.ci.openshift.org/ocp-arm64/release-arm64:4.11.0-0.nightly-arm64-2022-12-09-094448

Issue description and fix written here: https://issues.redhat.com/browse/OCPQE-13208
Execution log: 
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/702783/console
12-20 11:28:24.103  8 scenarios (8 passed)

/assign @chao007 @duanwei33 @Phaow 
