### PR TITLE
added step to check all clusters operators are ready

### DIFF
--- a/features/test/operators.feature
+++ b/features/test/operators.feature
@@ -5,3 +5,6 @@ Feature: operators related
     Given I switch to cluster admin pseudo user
     Given all clusteroperators reached version "<%= ENV['UPGRADE_TARGET_VERSION'] %>" successfully
 
+  @admin
+  Scenario: test checking all clusteroperators
+    Given I wait for all clusteroperators to be ready

--- a/lib/openshift/cluster_operator.rb
+++ b/lib/openshift/cluster_operator.rb
@@ -18,5 +18,24 @@ module BushSlicer
       return rr.dig('status', 'relatedObjects')
     end
 
+    def wait_till_ready(user, seconds)
+      res = nil
+      start_time = monotonic_seconds
+
+      success = wait_for(seconds) {
+        res = ready?(user: user, quiet: true)
+        break if res
+      }
+      return res
+    end
+
+    def ready?(user: nil, cached: false, quiet: false)
+      self.condition(type: 'Available', cached: false)['status'] == 'True'
+    end
+
+    def status_match?(status_check: nil, user: nil, cached: false, quiet: false)
+      self.condition(type: status_check, cached: false)['status'] == 'True'
+    end
+
   end
 end


### PR DESCRIPTION
This check will exit upon the first clusteroperator failure instead of checking more since the timeout is 30 minutes for each.
@weliang1 PTAL, this should address your needs.