### PR TITLE
Add testdata for descheduler 4.12 & modify for 4.11

### DIFF
--- a/testdata/descheduler/kubedescheduler-4.12.yaml
+++ b/testdata/descheduler/kubedescheduler-4.12.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster
   namespace: openshift-kube-descheduler-operator
 spec:
-  image: registry.redhat.io/openshift4/ose-descheduler:v4.11
+  image: registry.redhat.io/openshift4/ose-descheduler:v4.12
   logLevel: Normal
   mode: Automatic
   operatorLogLevel: Normal


### PR DESCRIPTION
I see that descheduler upgrade prepare test is failing due to missing testdata file for 4.12, so adding the same. Also some data needs to be updated in 4.11 yaml file so adding the same.