### PR TITLE
add ability to reset the run-status of a Polarshift run using CLI

### DIFF
--- a/tools/polarshift.rb
+++ b/tools/polarshift.rb
@@ -192,6 +192,27 @@ module BushSlicer
           end
         end
       end
+      command :"reset-run" do |c|
+        c.syntax = "#{$0} reset-run [options]"
+        c.description = "reset a test run from Polarion run status\n\t" \
+          'e.g. tools/polarshift.rb reset-run <POLARION_RUN_ID> <OPTIONS>'
+        c.option('-s', "--status CASE_STATUS", "testcase status to be set, Passed/Failed/Waiting, default to Waiting")
+        c.option('-f', "--testcase_file CASE_STATUS_MAP", "yaml of testcase status to be set, Passed/Failed/Waiting, default to Waiting")
+        c.action do |args, options|
+          setup_global_opts(options)
+
+          raise 'command expects exactly one parameter being the test run id' if args.size != 1
+          test_run_id = args.first
+
+          if options.testcase_file
+            new_status = YAML.load_file(File.expand_path(options.testcase_file))
+          else
+            new_status = options.status
+            new_status ||= 'Waiting'
+          end
+          query_result = polarshift.reset_run(project, test_run_id, new_status: new_status)
+        end
+      end
 
       command :"sync-run" do |c|
         c.syntax = "#{$0} sync-run [options]"
@@ -213,7 +234,7 @@ module BushSlicer
         c.syntax = "#{$0} clone-run [options]"
         c.description = "clone a test run from Polarion\n\t" \
           "e.g. tools/polarshift.rb clone-run my_run_id"
-        c.option('-s', "--status CASE_STAUTS", "testcase status to be cloned, passed, failed, default to all")
+        c.option('-s', "--status CASE_STATUS", "testcase status to be cloned, passed, failed, default to all")
         c.option('-t', "--title RUN_TITLE", "Title of the clone run you wish to be")
         c.option('-e', "--subteam SUBTEAM_NAME", "the subteam to filter on")
         c.action do |args, options|


### PR DESCRIPTION
@awolffredhat this PR should address your need to reset a polarshift run using CLI.  PTAL.  
```
pruan@fedora ~/workspace/bushslicer (master●)$ ./tools/polarshift.rb reset-run OS-20220526-1835
waiting for operation up to 360 seconds..
[18:23:38] INFO> HTTP GET user@http://localhost:3000/project/OSE/run/OS-20220526-1835
[18:23:38] INFO> HTTP GET took 0.013 sec: 200 OK | application/json 3105 bytes
[18:23:38] INFO> HTTP POST user@http://localhost:3000/project/OSE/run/OS-20220526-1835/records
[18:23:38] INFO> HTTP POST took 0.010 sec: 200 OK | text/plain 1 bytes
[18:23:38] INFO> Run OS-20220526-1835 has been updated to 'Waiting'
pruan@fedora ~/workspace/bushslicer (master●)$ ./tools/polarshift.rb reset-run OS-20220526-1835 --status=Failed
waiting for operation up to 360 seconds..
[18:23:49] INFO> HTTP GET user@http://localhost:3000/project/OSE/run/OS-20220526-1835
[18:23:49] INFO> HTTP GET took 0.010 sec: 200 OK | application/json 3108 bytes
[18:23:49] INFO> HTTP POST user@http://localhost:3000/project/OSE/run/OS-20220526-1835/records
[18:23:49] INFO> HTTP POST took 0.008 sec: 200 OK | text/plain 1 bytes
[18:23:49] INFO> Run OS-20220526-1835 has been updated to 'Failed'
pruan@fedora ~/workspace/bushslicer (master●)$ ./tools/polarshift.rb reset-run OS-20220526-1835 --testcase_file=~/tmp/new_case_status.yaml
waiting for operation up to 360 seconds..
[18:23:56] INFO> HTTP GET user@http://localhost:3000/project/OSE/run/OS-20220526-1835
[18:23:56] INFO> HTTP GET took 0.010 sec: 200 OK | application/json 3105 bytes
[18:23:56] INFO> HTTP POST user@http://localhost:3000/project/OSE/run/OS-20220526-1835/records
[18:23:56] INFO> HTTP POST took 0.009 sec: 200 OK | text/plain 1 bytes
[18:23:56] INFO> Run OS-20220526-1835 has been updated to '{"OCP-11247"=>"Passed", "OCP-10033"=>"Failed", "OCP-22065"=>"Waiting"}'
pruan@fedora ~/workspace/bushslicer (set_status_via_polarshift_cli)$ cat ~/tmp/new_case_status.yaml
---
OCP-11247: Passed
OCP-10033: Failed
OCP-22065: Waiting

```
