### PR TITLE
fix OCPQE-7318

### DIFF
--- a/features/logging/collector.feature
+++ b/features/logging/collector.feature
@@ -231,14 +231,14 @@ Feature: collector related tests
       | op           | GET   |
     Then the step should succeed
     Given evaluation of `@result[:parsed]['aggregations']['exists_field_kubernetes']['distinct_node_ip']['buckets'].map {|furn| furn["key"]}` is stored in the :kuber_ips clipboard
-    And the expression should be true> Set.new(cb.node_ips) == Set.new(cb.kuber_ips)
+    And the expression should be true> (cb.node_ips-cb.kuber_ips).empty?
 
     And I perform the HTTP request on the ES pod with labels "es-node-master=true":
       | relative_url | _search?pretty&size=0' -d'{"aggs" : {"exists_field_systemd" : {"filter": {"exists": {"field":"systemd"}},"aggs" : {"distinct_node_ip" : {"terms" : {"field" : "pipeline_metadata.collector.ipaddr4"}}}}}} |
       | op           | GET  |
     Then the step should succeed
     Given evaluation of `@result[:parsed]['aggregations']['exists_field_systemd']['distinct_node_ip']['buckets'].map {|furn| furn["key"]}` is stored in the :journal_ips clipboard
-    And the expression should be true> Set.new(cb.node_ips) == Set.new(cb.journal_ips)
+    And the expression should be true> (cb.node_ips-cb.journal_ips).empty?
     """
 
     Given evaluation of `cluster_logging('instance').collection_type` is stored in the :collection_type clipboard

--- a/lib/openshift/cluster_logging.rb
+++ b/lib/openshift/cluster_logging.rb
@@ -141,7 +141,7 @@ module BushSlicer
     end
 
     def collection_type(user: nil, quiet: false, cached: true)
-      return collection_spec(user: user, cached: cached, quiet: quiet).dig('logs', 'type')
+      return collection_spec(user: user, cached: cached, quiet: quiet).dig('logs', 'type') || collection_spec(user: user, cached: cached, quiet: quiet).dig('type')
     end
 
     def management_state(user: nil, quiet: false, cached: false)


### PR DESCRIPTION
To fix failure:
```
#<RuntimeError: expression returned non-positive status: false left_operand: #<Set:

{"10.143.1.169", "10.143.1.87", "10.143.1.60", "10.143.1.89", "10.143.1.208", "10.143.1.215"}
>, right_operand: #<Set:

{"10.143.1.87", "10.143.1.169", "10.143.1.208", "10.143.1.60", "10.143.1.89", "10.143.1.215", "10.143.1.43"}
> >
features/step_definitions/common.rb:168:in `/^(?:the )?expression should be true> (.+)$/'
```
Some nodes have been scaled up and some nodes have been scaled down before this case, collector pods are running during that period and logs in these nodes are all collected. When executing this case, the nodes in the cluster are not the same as the nodes in ES data, here change to check if the node IPs in ES data contain all the nodes' IP in the cluster. 

Log: http://pastebin.test.redhat.com/1086663 