### PR TITLE
OCPQE-13355: Fix undefined method 'gsub'

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -141,9 +141,8 @@ require_relative 'chrome_extension'
         end
       elsif @browser_type == :chrome
         logger.info "Launching Chrome"
-
-	      #https://bugs.chromium.org/p/chromium/issues/detail?id=1056073
-	      chrome_caps[:acceptInsecureCerts] = true
+        #https://bugs.chromium.org/p/chromium/issues/detail?id=1056073
+        chrome_caps[:acceptInsecureCerts] = true
         if Integer === @scroll_strategy
           chrome_caps[:element_scroll_behavior] = @scroll_strategy
         end
@@ -154,8 +153,8 @@ require_relative 'chrome_extension'
           browser_name: 'chrome',
           accept_insecure_certs: true
         }
-        options["goog:chromeOptions"] = {}
-        options["goog:chromeOptions"][:element_scroll_behavior] = @scroll_strategy if Integer === @scroll_strategy
+        #options["goog:chromeOptions"] = {}
+        #options["goog:chromeOptions"][:element_scroll_behavior] = @scroll_strategy if Integer === @scroll_strategy
         # options = Selenium::WebDriver::Chrome::Options.new
         # options.add_extension proxy_chrome_ext_file if proxy_chrome_ext_file
         options[:extensions] = [proxy_chrome_ext_file] if proxy_chrome_ext_file


### PR DESCRIPTION
Fix the issue,
```
01-03 02:05:52.565        [18:05:52] INFO> Launching Chrome
01-03 02:05:52.565        undefined method `gsub' for #<Selenium::WebDriver::Remote::Capabilities:0x0000558616a8e778> (NoMethodError)
01-03 02:05:52.565        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:166:in `new'
01-03 02:05:52.565        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:166:in `browser'
01-03 02:05:52.565        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:505:in `goto_url'
01-03 02:05:52.565        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:255:in `block in run_action'
01-03 02:05:52.565        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:251:in `each'
01-03 02:05:52.565        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:251:in `run_action'
01-03 02:05:52.565        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/admin_console.rb:25:in `/^I open admin console in a browser$/'
01-03 02:05:52.565        features/tierN/web/admin-console/configmaps.feature:94:in `I open admin console in a browser'
```
Original failure [log](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/717104/consoleFull), and the pass [log](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/717636/consoleFull) with the fixes.

/cc @yapei @yanpzhan @jhou1 @chengzhang1016 