### PR TITLE
OCPQE-13355: Fix undefined method 'gsub' for firefox

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -119,13 +119,12 @@ require_relative 'chrome_extension'
         raise "auth proxy not implemented for Firefox" if proxy_pass
         browser_opts = {
           browser_name: 'firefox',
-          accept_insecure_certs: true,
-          "moz:webdriverClick": true
+          accept_insecure_certs: true
         }
-        browser_opts["moz:firefoxOptions"] = {}
-        if Integer === @scroll_strategy
-          browser_opts["moz:firefoxOptions"][:element_scroll_behavior] = @scroll_strategy
-        end
+        #browser_opts["moz:firefoxOptions"] ||= {}
+        #if Integer === @scroll_strategy
+          #browser_opts["moz:firefoxOptions"][:element_scroll_behavior] = @scroll_strategy
+        #end
         # This is actually a shortcut for trace logging
         # this also needs debug webdriver logging enabled above to work
         # options.log_level = 'trace'


### PR DESCRIPTION
Fix issue
```
INFO> Launching Firefox Marionette/Geckodriver
#<NoMethodError: undefined method `gsub' for #<Selenium::WebDriver::Remote::Capabilities:0x00005630081279b8>>
```

/cc @yapei @xingxingxia @jhou1 @chengzhang1016 