### PR TITLE
Automate OCP-54552: Migrate egressIP configuration from openshift-sdn to ovn-kubernetes	

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1649,15 +1649,3 @@ Given /^the cluster is migrated from sdn$/ do
     skip_this_scenario
   end
 end
-
-Given /^the cluster is migrated from sdn$/ do
-  ensure_admin_tagged
-  _admin = admin
-  @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration.networkType}")
-  unless @result[:stdout]["OVNKubernetes"]
-    logger.warn "the cluster is not migration from sdn plugin"
-    logger.warn "We will skip this scenario"
-    skip_this_scenario
-  end
-end
-


### PR DESCRIPTION
The configuration steps for egressip are different in SDN and OVN cluster. Need to create a new egressip automation for sdn2ovn migration testing.

# upgrade - prepare
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5398/console

# post upgrade
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5400/console

@openshift/team-sdn-qe PTAL