### PR TITLE
Skip empty lines when parse scenario name/id

### DIFF
--- a/lib/gherkin_parse.rb
+++ b/lib/gherkin_parse.rb
@@ -79,7 +79,7 @@ module BushSlicer
           if id_found
             # valid scenario or examples table should be located at first
             #   non-comment/tag line
-            if line =~ COMMENT_OR_TAG
+            if line =~ COMMENT_OR_TAG || line =~ /^\s*$/
               # skip this line as it is a comment or cucumber scenario tags
               next
             elsif line =~ /^\s*(Scenario|Examples:)/


### PR DESCRIPTION
When there are empty lines exist before `Scenario` as introduced in https://github.com/openshift/verification-tests/pull/3150, got error,
```
01-11 13:18:23.364  /home/jenkins/ws/workspace/ocp-tools/sync-tc-tags-to-polarion/lib/gherkin_parse.rb:91:in `block (2 levels) in locations_for': invalid line following OCP-28108 comment:    (RuntimeError)
```

The empty lines are removed in https://github.com/openshift/verification-tests/pull/3186, but we should tolerate the empty lines, too.