### PR TITLE
fix failure when getting storage class

### DIFF
--- a/features/logging/elasticsearch.feature
+++ b/features/logging/elasticsearch.feature
@@ -15,7 +15,7 @@ Feature: Elasticsearch related tests
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-22050:Logging Elasticsearch using dynamic volumes
-    Given default storageclass is stored in the :default_sc clipboard
+    Given I get storageclass from cluster and store it in the :default_sc clipboard
     Given I obtain test data file "logging/clusterlogging/clusterlogging-storage-template.yaml"
     Given I create clusterlogging instance with:
       | remove_logging_pods | true                                 |

--- a/features/logging/logging_acceptance.feature
+++ b/features/logging/logging_acceptance.feature
@@ -40,7 +40,7 @@ Feature: Logging smoke test case
       | f | clf-forward-with-different-tags.yaml |
     Then the step should succeed
     And I wait for the "instance" cluster_log_forwarder to appear
-    And default storageclass is stored in the :default_sc clipboard
+    And I get storageclass from cluster and store it in the :default_sc clipboard
 
     Given I obtain test data file "logging/clusterlogging/cl-storage-with-im-template.yaml"
     When I create clusterlogging instance with:

--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -1392,19 +1392,22 @@ end
 
 Given /^I get storageclass from cluster and store it in the#{OPT_SYM} clipboard$/ do | sc |
   sc = 'sc' unless sc
-
-  def get_storage_class()
-    storage_classes = BushSlicer::StorageClass.list(user: user)
-    raise "Unable to get storage class " unless storage_classes.count > 0
-    storage_classes.each do | storage_class |
-      if storage_class.default?
-        return storage_class
-      end
+  has_default_sc = false
+  _sc = ''
+  storage_classes = BushSlicer::StorageClass.list(user: user)
+  raise "Unable to get storage class " unless storage_classes.count > 0
+  storage_classes.each do | storage_class |
+    if storage_class.default?
+      has_default_sc = true
+      _sc = storage_class
+      break
     end
-    return storage_classes.first
   end
 
-  _sc = get_storage_class()
+  if !has_default_sc
+    _sc = storage_classes.first
+  end
+
   cb[sc] = _sc
   cache_resources _sc
 end

--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -1284,7 +1284,7 @@ Given /^I have clusterlogging with(?: (\d+))? persistent storage ES$/ do |es_num
       if(es_num==1)
         redundancy_policy="ZeroRedundancy"
       end
-      step %Q/default storageclass is stored in the :default_sc clipboard/
+      step %Q/I get storageclass from cluster and store it in the :default_sc clipboard/
       step %Q|I obtain test data file "logging/clusterlogging/clusterlogging-storage-template.yaml"|
       step %Q/I create clusterlogging instance with:/, table(%{
         | crd_yaml          | clusterlogging-storage-template.yaml |
@@ -1373,10 +1373,10 @@ Given /^I (check|record) all pods logs in the#{OPT_QUOTED} project(?: in last (\
       end
       if action == "check"
         # read logs line by line
-        # ignore errors in https://issues.redhat.com/browse/LOG-2674 and https://issues.redhat.com/browse/LOG-2702
+        # ignore errors in https://issues.redhat.com/browse/LOG-2702
         case container.name
-        when "logfilesmetricexporter"
-          log = check_log(@result[:response], error_strings, ["can't remove non-existent inotify watch for"])
+        when "cluster-logging-operator"
+          log = check_log(@result[:response], error_strings, ["the object has been modified"])
         when "kibana"
           log = check_log(@result[:response], error_strings, ["java.lang.UnsupportedOperationException"])
         when "collector"
@@ -1388,4 +1388,23 @@ Given /^I (check|record) all pods logs in the#{OPT_QUOTED} project(?: in last (\
       end
     end
   end
+end
+
+Given /^I get storageclass from cluster and store it in the#{OPT_SYM} clipboard$/ do | sc |
+  sc = 'sc' unless sc
+
+  def get_storage_class()
+    storage_classes = BushSlicer::StorageClass.list(user: user)
+    raise "Unable to get storage class " unless storage_classes.count > 0
+    storage_classes.each do | storage_class |
+      if storage_class.default?
+        return storage_class
+      end
+    end
+    return storage_classes.first
+  end
+
+  _sc = get_storage_class()
+  cb[sc] = _sc
+  cache_resources _sc
 end


### PR DESCRIPTION
Fix failure:
```
And default storageclass is stored in the :default_sc clipboard ==>@  [features/step_definitions/storage_class.rb:225](https://github.com/openshift/verification-tests/blob/dc75f2d8dd581f79b7b5aa3b1b6504722092042c/features/step_definitions/storage_class.rb#L225)
11:30:22 INFO> Shell Commands: oc get storageclasses --output=yaml --kubeconfig=/home/jenkins/agent/workspace/ocp-cucushift-Runner/workdir/ocp4_demouser13.kubeconfig
apiVersion: v1
items:
- apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    creationTimestamp: "2023-01-11T11:10:21Z"
    labels:
      local.storage.openshift.io/owner-name: local-block
      local.storage.openshift.io/owner-namespace: openshift-local-storage
    name: localblock
    resourceVersion: "97378"
    uid: 9037e643-6372-48dc-bd20-4c2560760e03
  provisioner: kubernetes.io/no-provisioner
  reclaimPolicy: Delete
  volumeBindingMode: WaitForFirstConsumer
- allowVolumeExpansion: true
  apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    annotations:
      description: Provides RWO Filesystem volumes, and RWO and RWX Block volumes
    creationTimestamp: "2023-01-11T11:15:00Z"
    name: ocs-storagecluster-ceph-rbd
    resourceVersion: "101193"
    uid: 735358ab-d878-43c0-bc52-56eb7788f82c
  parameters:
    clusterID: openshift-storage
    csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
    csi.storage.k8s.io/controller-expand-secret-namespace: openshift-storage
    csi.storage.k8s.io/fstype: ext4
    csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
    csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
    csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
    csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
    imageFeatures: layering,deep-flatten,exclusive-lock,object-map,fast-diff
    imageFormat: "2"
    pool: ocs-storagecluster-cephblockpool
  provisioner: openshift-storage.rbd.csi.ceph.com
  reclaimPolicy: Delete
  volumeBindingMode: Immediate
- apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    annotations:
      description: Provides Object Bucket Claims (OBCs)
    creationTimestamp: "2023-01-11T11:12:27Z"
    name: ocs-storagecluster-ceph-rgw
    resourceVersion: "98619"
    uid: 79a214af-f334-428c-b5b9-08f9ff17ca3a
  parameters:
    objectStoreName: ocs-storagecluster-cephobjectstore
    objectStoreNamespace: openshift-storage
    region: us-east-1
  provisioner: openshift-storage.ceph.rook.io/bucket
  reclaimPolicy: Delete
  volumeBindingMode: Immediate
- allowVolumeExpansion: true
  apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    annotations:
      description: Provides RWO and RWX Filesystem volumes
    creationTimestamp: "2023-01-11T11:15:00Z"
    name: ocs-storagecluster-cephfs
    resourceVersion: "101191"
    uid: d9b1125a-74da-4c4d-9e3a-82642fdffd41
  parameters:
    clusterID: openshift-storage
    csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
    csi.storage.k8s.io/controller-expand-secret-namespace: openshift-storage
    csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
    csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
    csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
    csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
    fsName: ocs-storagecluster-cephfilesystem
  provisioner: openshift-storage.cephfs.csi.ceph.com
  reclaimPolicy: Delete
  volumeBindingMode: Immediate
- apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    annotations:
      description: Provides Object Bucket Claims (OBCs)
    creationTimestamp: "2023-01-11T11:16:20Z"
    name: openshift-storage.noobaa.io
    resourceVersion: "102101"
    uid: e0bbdaee-11b6-4114-a2c7-afb7096ebdbb
  parameters:
    bucketclass: noobaa-default-bucket-class
  provisioner: openshift-storage.noobaa.io/obc
  reclaimPolicy: Delete
  volumeBindingMode: Immediate
kind: List
metadata:
  resourceVersion: ""
11:30:23 INFO> Exit Status: 0
#<RuntimeError: Unable to get default storage class >
[features/step_definitions/storage_class.rb:229](https://github.com/openshift/verification-tests/blob/dc75f2d8dd581f79b7b5aa3b1b6504722092042c/features/step_definitions/storage_class.rb#L229):in `/^default storageclass is stored in the(?: :(\S+))? clipboard$/'
[features/logging/logging_acceptance.feature:43](https://github.com/openshift/verification-tests/blob/dc75f2d8dd581f79b7b5aa3b1b6504722092042c/features/logging/logging_acceptance.feature#L43):in `default storageclass is stored in the :default_sc clipboard'
```

Some clusters have storage classes but don't have default storage class, previously, the logging cases always fail in these cluster, here change to get a storage class if there doesn't have a default storage class in the cluster.

Also fix [OCPQE-5845 ](https://issues.redhat.com/browse/OCPQE-5845)