### PR TITLE
Limit selenium-webdriver to 4.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,12 +37,14 @@ gem 'azure_mgmt_network', '~>0.17.0'
 # gem 'timers'
 ## Logging
 gem 'term-ansicolor'
+
 ## Webauto
 gem 'watir'
 gem 'headless'
-gem 'selenium-webdriver'
+gem 'selenium-webdriver', '4.8.0'
 gem 'protobuf'
 gem 'reportportal'
+
 ## Docs
 # beware https://github.com/pry/pry/issues/1465
 #        https://bugzilla.redhat.com/show_bug.cgi?id=1257578


### PR DESCRIPTION
We've been experience breaking UI automation issue several times from selenium-webdriver due to newer version comes out. So we'd like to limit selenium-webdriver to a specific working version to avoid such issue from happening again.

The idea is that we want to limit most of the gems, but change only one gem each time, get it in and let the automation run for a week or two, move to next gem if no issue found/report.

/cc @yapei @yanpzhan @XiyunZhao 
/cc @pruan-rht @jhou1 