### PR TITLE
fix sctp failure in ipv6 single cluster

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -203,10 +203,14 @@ Feature: Service related networking scenarios
     And the pod named "externalip-pod" becomes ready
  
     # Curl externalIP:portnumber should pass
+    And evaluation of `cb.hostip.include?(":") ? "[#{cb.hostip}]" : cb.hostip` is stored in the :hostip_url clipboard
+    And I wait up to 60 seconds for the steps to pass:
+    """
     When I execute on the pod:
-      | /usr/bin/curl | --connect-timeout | 10 | <%= cb.hostip %>:27017 |
+      | /usr/bin/curl | --connect-timeout | 10 | <%= cb.hostip_url %>:27017 |
     Then the output should contain:
       | Hello OpenShift! |
+    """
 
   # @author weliang@redhat.com
   # @case_id OCP-24692
@@ -393,10 +397,14 @@ Feature: Service related networking scenarios
     And the pod named "externalip-pod" becomes ready
 
     # Curl externalIP:portnumber from pod
+    And evaluation of `cb.host1ip.include?(":") ? "[#{cb.host1ip}]" : cb.host1ip` is stored in the :host1ip_url clipboard
+    And I wait up to 60 seconds for the steps to pass:
+    """
     When I execute on the pod:
-      | /usr/bin/curl | --connect-timeout | 10 | <%= cb.host1ip %>:27017 |
+      | /usr/bin/curl | --connect-timeout | 10 | <%= cb.host1ip_url %>:27017 |
     Then the output should contain:
       | Hello OpenShift! |
+    """
 
     # Delete created pod and svc
     When I run the :delete client command with:
@@ -421,10 +429,14 @@ Feature: Service related networking scenarios
     And the pod named "externalip-pod" becomes ready
 
     # Curl externalIP:portnumber on new pod
+    And evaluation of `cb.host2ip.include?(":") ? "[#{cb.host2ip}]" : cb.host2ip` is stored in the :host2ip_url clipboard
+    And I wait up to 60 seconds for the steps to pass:
+    """
     When I execute on the pod:
-      | /usr/bin/curl | --connect-timeout | 10 | <%= cb.host2ip %>:27017 |
+      | /usr/bin/curl | --connect-timeout | 10 | <%= cb.host2ip_url %>:27017 |
     Then the output should contain:
       | Hello OpenShift! |
+    """
 
   # @author anusaxen@redhat.com
   # @case_id OCP-26035

--- a/features/upgrade/sdn/externalIP-upgrade.feature
+++ b/features/upgrade/sdn/externalIP-upgrade.feature
@@ -44,10 +44,14 @@ Feature: SDN externalIP compoment upgrade testing
     And evaluation of `pod.name` is stored in the :pod1name clipboard
 
     # Curl externalIP:portnumber should pass
+    And evaluation of `cb.hostip.include?(":") ? "[#{cb.hostip}]" : cb.hostip` is stored in the :hostip_url clipboard
+    And I wait up to 60 seconds for the steps to pass:
+    """
     When I execute on the "<%= cb.pod1name %>" pod:
-      | /usr/bin/curl | --connect-timeout | 10 | <%= cb.hostip %>:27017 |
+      | /usr/bin/curl | --connect-timeout | 10 | <%= cb.hostip_url %>:27017 |
     Then the output should contain:
       | Hello OpenShift! |
+    """
 
   # @author weliang@redhat.com
   # @case_id OCP-44790
@@ -70,8 +74,9 @@ Feature: SDN externalIP compoment upgrade testing
     And evaluation of `pod.name` is stored in the :pod1name clipboard
 
     # Curl externalIP:portnumber should pass
+    And evaluation of `cb.hostip.include?(":") ? "[#{cb.hostip}]" : cb.hostip` is stored in the :hostip_url clipboard
     When I execute on the "<%= cb.pod1name %>" pod:
-      | /usr/bin/curl | --connect-timeout | 10 | <%= cb.hostip %>:27017 |
+      | /usr/bin/curl | --connect-timeout | 10 | <%= cb.hostip_url %>:27017 |
     Then the output should contain:
       | Hello OpenShift! |
 


### PR DESCRIPTION
Resolve externalIP failure in IPv6 single cluster,ticket https://issues.redhat.com/browse/OCPQE-13697.  Moreover, add  timeout to make the case more stable. 


Tested in single IPv6 cluster:
pre-upgrade: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5518/console
post-upgrade:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5519/console

Another updated two cases test logs:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5520/console
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5521/console

Tested in IPv4 cluster locally as well, all passed.

@openshift/team-sdn-qe  PTAL, thanks!
