### PR TITLE
Set browser to chrome in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,7 @@ export OPENSHIFT_ENV_OCP4_USER_MANAGER_USERS=user1:redhat,user2:redhat
 export OPENSHIFT_ENV_OCP4_ADMIN_CREDS_SPEC=file:///home/path-to/kubeconfig
 export BUSHSLICER_CONFIG='
 global:
-  browser: firefox
+  browser: chrome
 environments:
   ocp4:
     version: "4.9.0"


### PR DESCRIPTION
Chrome is the suggested browser from UI team, so update the README to use chrome instead of firefox, to avoid external teams to met unexpected issues when first adapt to cucushift tests.

/cc @yapei @yanpzhan @jhou1 @pruan-rht 