### PR TITLE
fix multicast failure in IPv6 single stack cluster

### DIFF
--- a/features/upgrade/sdn/multicast-upgrade.feature
+++ b/features/upgrade/sdn/multicast-upgrade.feature
@@ -77,7 +77,7 @@
       | netstat | -ng |
     Then the step should succeed
     And the output should match:
-      | eth0\s+1\s+232.43.211.234 |
+      | eth0\s+1\s+(232.43.211.234\|ff3e::4321:1234) |
     """
     And I wait up to 20 seconds for the steps to pass:
     """
@@ -85,8 +85,8 @@
       | cat | /tmp/p3.log |
     Then the step should succeed
     And the output should match:
-      | <%= cb.pod1ip %>.*joined \(S,G\) = \(\*, 232.43.211.234\), pinging |
-      | <%= cb.pod2ip %>.*joined \(S,G\) = \(\*, 232.43.211.234\), pinging |
+      | <%= cb.pod1ip %>.*joined \(S,G\) = \(\*, (232.43.211.234\|ff3e::4321:1234)\), pinging |
+      | <%= cb.pod2ip %>.*joined \(S,G\) = \(\*, (232.43.211.234\|ff3e::4321:1234)\), pinging |
     And the output should not match:
       | <%= cb.pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
       | <%= cb.pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
@@ -159,7 +159,7 @@
       | netstat | -ng |
     Then the step should succeed
     And the output should match:
-      | eth0\s+1\s+232.43.211.234 |
+      | eth0\s+1\s+(232.43.211.234\|ff3e::4321:1234) |
     """
     And I wait up to 20 seconds for the steps to pass:
     """
@@ -167,8 +167,8 @@
       | cat | /tmp/p3.log |
     Then the step should succeed
     And the output should match:
-      | <%= cb.pod1ip %>.*joined \(S,G\) = \(\*, 232.43.211.234\), pinging |
-      | <%= cb.pod2ip %>.*joined \(S,G\) = \(\*, 232.43.211.234\), pinging |
+      | <%= cb.pod1ip %>.*joined \(S,G\) = \(\*, (232.43.211.234\|ff3e::4321:1234)\), pinging |
+      | <%= cb.pod2ip %>.*joined \(S,G\) = \(\*, (232.43.211.234\|ff3e::4321:1234)\), pinging |
     And the output should not match:
       | <%= cb.pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
       | <%= cb.pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |


### PR DESCRIPTION
Fix multicast cases failure in single IPv6 cluster. 

Tested in IPv6 single cluster:
pre-upgrade:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5525/console
post-upgrade:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5526/console
Other multicast cases:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5527/console

Tested on ipv4 cluster locally, passed as well.

@openshift/team-sdn-qe  PTAL, thanks!