### PR TITLE
[hotfix] Add back chromedriver/geckodriver for prow ci

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -9,6 +9,13 @@ RUN set -x && \
     INSTALL_PKGS="bsdtar git openssh-clients httpd-tools rsync" && \
     yum install -y $INSTALL_PKGS && \
     yum install -y --setopt=tsflags=nodocs https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm && \
+    CHROMEDRIVER_URL="https://chromedriver.storage.googleapis.com" && \
+    CHROMEDRIVER_VERSION=$(curl -sSL "$CHROMEDRIVER_URL/LATEST_RELEASE") && \
+    curl -sSL "$CHROMEDRIVER_URL/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" | bsdtar --no-same-owner --no-same-permissions -xvf - -C /usr/local/bin && \
+    GECKODRIVER_SPEC="https://api.github.com/repos/mozilla/geckodriver/releases/latest" && \
+    GECKODRIVER_RE='^.*"browser_download_url": ?"(http[^"]*linux64.tar.gz)".*$' && \
+    curl -sSL $GITHUB_API_CURL_OPTS "$GECKODRIVER_SPEC" | sed -En "s#$GECKODRIVER_RE#\1#p" | xargs -d '\n' curl -sSL | bsdtar -xvf - -C /usr/local/bin && \
+    chmod +x /usr/local/bin/chromedriver /usr/local/bin/geckodriver && \
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm  && \
     yum module reset ruby && \
     yum module -y enable ruby:2.7 && \


### PR DESCRIPTION
It turns out that the change in https://github.com/openshift/verification-tests/pull/3201 does not work in Prow CI, thus for prow CI fallback to the old way.