### PR TITLE
remove some tags which moved to go

### DIFF
--- a/features/networking/egress-ip.feature
+++ b/features/networking/egress-ip.feature
@@ -3,7 +3,7 @@ Feature: Egress IP related features
   # @author bmeng@redhat.com
   # @case_id OCP-15465
   @admin
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @aws-ipi
   @vsphere-upi @aws-upi
   @upgrade-sanity
@@ -26,7 +26,7 @@ Feature: Egress IP related features
 
   # @author bmeng@redhat.com
   # @case_id OCP-15466
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @aws-ipi
   @admin
   @vsphere-upi @aws-upi
@@ -50,7 +50,7 @@ Feature: Egress IP related features
   # @author bmeng@redhat.com
   # @case_id OCP-15471
   @admin
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @upgrade-sanity
@@ -114,7 +114,7 @@ Feature: Egress IP related features
   # @author huirwang@redhat.com
   # @case_id OCP-15472
   @admin
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @aws-ipi
   @vsphere-upi @aws-upi
   @proxy @noproxy @connected
@@ -156,7 +156,7 @@ Feature: Egress IP related features
   # @bug_id  1609112
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @network-openshiftsdn @network-networkpolicy
@@ -210,7 +210,7 @@ Feature: Egress IP related features
   # @case_id OCP-15992
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -260,7 +260,7 @@ Feature: Egress IP related features
   # @case_id OCP-15473
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @aws-ipi
   @vsphere-upi @aws-upi
   @network-openshiftsdn @network-networkpolicy
@@ -313,7 +313,7 @@ Feature: Egress IP related features
   # @case_id OCP-19973
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -357,7 +357,7 @@ Feature: Egress IP related features
   # @author huirwang@redhat.com
   # @case_id OCP-15998
   @admin
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @network-openshiftsdn @network-networkpolicy
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
@@ -383,7 +383,7 @@ Feature: Egress IP related features
   # @case_id OCP-25694
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -422,7 +422,7 @@ Feature: Egress IP related features
   # @case_id OCP-25640
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -483,7 +483,7 @@ Feature: Egress IP related features
   # @case_id OCP-18316
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -521,7 +521,7 @@ Feature: Egress IP related features
   # @case_id OCP-18315
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -565,7 +565,7 @@ Feature: Egress IP related features
   # @case_id OCP-19785
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -617,7 +617,7 @@ Feature: Egress IP related features
   # @case_id OCP-15989
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -690,7 +690,7 @@ Feature: Egress IP related features
   # @case_id OCP-18586
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -737,7 +737,7 @@ Feature: Egress IP related features
   # @case_id OCP-40928
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8
+  @4.9 @4.8
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -789,7 +789,7 @@ Feature: Egress IP related features
   # @case_id OCP-40933
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8
+  @4.9 @4.8
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -842,7 +842,7 @@ Feature: Egress IP related features
   # @case_id OCP-40957
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8
+  @4.9 @4.8
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -896,7 +896,7 @@ Feature: Egress IP related features
   # @case_id OCP-40956
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8
+  @4.9 @4.8
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -957,7 +957,7 @@ Feature: Egress IP related features
   # @case_id OCP-46244
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.9 @4.8 @4.7
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -1004,7 +1004,7 @@ Feature: Egress IP related features
   # @case_id OCP-46637
   @admin
   @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.9 @4.8 @4.7
   @vsphere-ipi
   @vsphere-upi
   @qeci

--- a/features/networking/ovn-egress-ip.feature
+++ b/features/networking/ovn-egress-ip.feature
@@ -4,7 +4,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-33618
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @upgrade-sanity
@@ -77,7 +77,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-33723
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @upgrade-sanity
@@ -153,7 +153,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-33641
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @upgrade-sanity
@@ -231,7 +231,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-33699
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @network-ovnkubernetes
@@ -290,7 +290,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-33700
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @network-ovnkubernetes
@@ -356,7 +356,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-33631
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @upgrade-sanity
@@ -412,7 +412,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-33704
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @network-ovnkubernetes
@@ -479,7 +479,7 @@ Feature: OVN Egress IP related features
   @admin
   @destructive
   @network-ovnkubernetes
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @aws-ipi
   @vsphere-upi @aws-upi
   @noproxy @connected
@@ -515,7 +515,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-33706
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @network-ovnkubernetes
@@ -571,7 +571,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-33718
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @network-ovnkubernetes
@@ -639,7 +639,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-33710
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @baremetal-ipi
   @vsphere-upi @baremetal-upi
   @network-ovnkubernetes
@@ -675,7 +675,7 @@ Feature: OVN Egress IP related features
   # @author huirwang@redhat.com
   # @case_id OCP-33617
   @admin
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @aws-ipi
   @aws-upi
   @network-ovnkubernetes
@@ -701,7 +701,7 @@ Feature: OVN Egress IP related features
   @admin
   @destructive
   @network-ovnkubernetes
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @aws-ipi
   @aws-upi
   @noproxy @connected
@@ -752,7 +752,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-44250
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.9 @4.8 @4.7
   @vsphere-ipi
   @vsphere-upi
   @network-ovnkubernetes
@@ -867,7 +867,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-44251
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.9 @4.8 @4.7
   @vsphere-ipi
   @vsphere-upi
   @network-ovnkubernetes
@@ -963,7 +963,7 @@ Feature: OVN Egress IP related features
   # @case_id OCP-42925
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9
+  @4.9
   @network-ovnkubernetes
   @vsphere-ipi
   @vsphere-upi

--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -4,7 +4,7 @@ Feature: SCTP related scenarios
   # @case_id OCP-28757
   @admin
   @destructive
-  @4.10 @4.9
+  @4.9
   Scenario: OCP-28757:SDN Establish pod to pod SCTP connections
     Given I store the ready and schedulable workers in the :workers clipboard
     And I install machineconfigs load-sctp-module
@@ -57,7 +57,7 @@ Feature: SCTP related scenarios
   # @case_id OCP-28758
   @admin
   @destructive
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode

--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -76,7 +76,7 @@ Feature: Egress compoment upgrade testing
   @admin
   @upgrade-prepare
   @network-ovnkubernetes
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.9 @4.8 @4.7
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -136,7 +136,7 @@ Feature: Egress compoment upgrade testing
   @admin
   @upgrade-check
   @network-ovnkubernetes
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.9 @4.8 @4.7
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -180,7 +180,7 @@ Feature: Egress compoment upgrade testing
   @admin
   @flaky
   @upgrade-prepare
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.9 @4.8 @4.7
   @vsphere-ipi
   @vsphere-upi
   @qeci
@@ -254,7 +254,7 @@ Feature: Egress compoment upgrade testing
   @admin
   @flaky
   @upgrade-check
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.9 @4.8 @4.7
   @vsphere-ipi
   @vsphere-upi
   @qeci

--- a/features/upgrade/sdn/sctp-upgrade.feature
+++ b/features/upgrade/sdn/sctp-upgrade.feature
@@ -3,7 +3,7 @@ Feature: SDN sctp compoment upgrade testing
   # @author weliang@redhat.com
   @admin
   @upgrade-prepare
-  @4.13 @4.12 @4.11 @4.10 @4.9
+  @4.9
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @upgrade
@@ -73,7 +73,7 @@ Feature: SDN sctp compoment upgrade testing
   # @case_id OCP-44765
   @admin
   @upgrade-check
-  @4.13 @4.12 @4.11 @4.10 @4.9
+  @4.9
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @upgrade


### PR DESCRIPTION
As below cases were covered in go framework from 4.10, remove the tags 4.10+ from below cases to avoid duplicate.

@openshift/team-sdn-qe  PTAL, thanks!