### PR TITLE
resolve unable to locate element error

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -689,6 +689,10 @@ require_relative 'chrome_extension'
           logger.info("Looks like we caught stale element, let's try again")
           # https://github.com/watir/watir/issues/571
           res = []
+        rescue Watir::Exception::LocatorException
+          logger.warn("hard wait 15 seconds and try again")
+          sleep(15)
+          res = []
         end
       else
         # some element types/methods return a single element


### PR DESCRIPTION
tries to resolve https://issues.redhat.com/browse/OCPQE-13174, we have seen following error occurring in CI logs quite often 
```
02-27 16:06:46.926        [08:06:41] INFO> embedding "2023-02-27T08:06:41+00:00-screenshot.png"
02-27 16:06:46.926        [08:06:41] INFO> elements..
02-27 16:06:46.926        [08:06:41] INFO> found 1 element elements with selector: {:xpath=>"//button[@data-test-id='perspective-switcher-toggle']"}
02-27 16:06:46.926        Unable to locate element collection from {:xpath=>"//li//h2[contains(., 'Administrator')]"} due to changing page (Watir::Exception::LocatorException)
02-27 16:06:46.926        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:685:in `get_elements'
02-27 16:06:46.926        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:702:in `get_visible_elements'
02-27 16:06:46.926        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:799:in `block in wait_for_elements'
02-27 16:06:46.926        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:792:in `all?'
02-27 16:06:46.926        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:792:in `wait_for_elements'
02-27 16:06:46.926        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:537:in `handle_element'
02-27 16:06:46.926        /home/jenkins/ws/workspace/ocp-common/Runner/lib/webauto/web4cucumber.rb:244:in `block (2 levels) in run_action' 
```

However it is very hard to reproduce this error in Jenkins or Locally, so I can just confirm no regression with my changes
Runner/753912/console 