### PR TITLE
fix network plugin checking failure

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -51,37 +51,9 @@ Given /^the env is using one of the listed network plugins:$/ do |table|
       skip_this_scenario
     end
   else
-    _host = node.host rescue nil
-    unless _host
-      step "I store the schedulable nodes in the clipboard"
-      _host = node.host
-    end
-
-    step %Q/I run the ovs commands on the host:/, table([[
-      "ovs-ofctl dump-flows br0 -O openflow13 | grep table=253"
-    ]])
-    unless @result[:success]
-      raise "failed to get table 253 from the open flows."
-    end
-
-    plugin_type = @result[:response][-17]
-    case plugin_type
-    when "0"
-      plugin_name = "subnet"
-    when "1"
-      plugin_name = "multitenant"
-    when "2"
-      plugin_name = "networkpolicy"
-    else
-      raise "unknown network plugins."
-    end
-    logger.info("environment network plugin name: #{plugin_name}")
-
-    unless plugin_list.include? plugin_name
-      logger.warn "the env network plugin is #{plugin_name} but expecting #{plugin_list}."
-      logger.warn "We will skip this scenario"
-      skip_this_scenario
-    end
+    logger.warn "the env network is not SDN cluster."
+    logger.warn "We will skip this scenario"
+    skip_this_scenario
   end
 end
 


### PR DESCRIPTION
According to slack conversation https://redhat-internal.slack.com/archives/GLDDW02SJ/p1676400962812149, update this step step to skip 'not sdn' cluster. 

SDN:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5564/console
OVN: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/5563/console

@openshift/team-sdn-qe  PTAL, thanks!