### PR TITLE
update for ocp-41964

### DIFF
--- a/lib/rules/web/admin_console/4.10/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.10/operator_hub.xyaml
@@ -926,7 +926,7 @@ enable_plugin_from_install_page:
     op: click
 uninstall_operator_and_check_pluginremoval_msg:
   params:
-    check_msg: console plugins provided by this operator will be disabled and removed
+    check_msg: disabled and removed
   action: uninstall_operator_with_msg_check
 uninstall_operator_and_check_operandremoval_msg:
   params:
@@ -943,7 +943,7 @@ uninstall_operator_with_msg_check:
 check_no_plugin_message_on_uninstall_modal:
   params:
     item: Remove Subscription
-    content: console plugins provided by this operator will be disabled and removed
+    content: disabled and removed
   action: click_one_dropdown_action
   action: check_page_not_match
 toggle_plugin_status:

--- a/lib/rules/web/admin_console/4.11/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.11/operator_hub.xyaml
@@ -926,7 +926,7 @@ enable_plugin_from_install_page:
     op: click
 uninstall_operator_and_check_pluginremoval_msg:
   params:
-    check_msg: console plugins provided by this operator will be disabled and removed
+    check_msg: disabled and removed
   action: uninstall_operator_with_msg_check
 uninstall_operator_and_check_operandremoval_msg:
   params:
@@ -943,7 +943,7 @@ uninstall_operator_with_msg_check:
 check_no_plugin_message_on_uninstall_modal:
   params:
     item: Remove Subscription
-    content: console plugins provided by this operator will be disabled and removed
+    content: disabled and removed
   action: click_one_dropdown_action
   action: check_page_not_match
 toggle_plugin_status:

--- a/lib/rules/web/admin_console/4.12/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.12/operator_hub.xyaml
@@ -925,7 +925,7 @@ enable_plugin_from_install_page:
     op: click
 uninstall_operator_and_check_pluginremoval_msg:
   params:
-    check_msg: console plugins provided by this operator will be disabled and removed
+    check_msg: disabled and removed
   action: uninstall_operator_with_msg_check
 uninstall_operator_and_check_operandremoval_msg:
   params:
@@ -942,7 +942,7 @@ uninstall_operator_with_msg_check:
 check_no_plugin_message_on_uninstall_modal:
   params:
     item: Remove Subscription
-    content: console plugins provided by this operator will be disabled and removed
+    content: disabled and removed
   action: click_one_dropdown_action
   action: check_page_not_match
 toggle_plugin_status:

--- a/lib/rules/web/admin_console/4.13/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.13/operator_hub.xyaml
@@ -925,7 +925,7 @@ enable_plugin_from_install_page:
     op: click
 uninstall_operator_and_check_pluginremoval_msg:
   params:
-    check_msg: console plugins provided by this operator will be disabled and removed
+    check_msg: disabled and removed
   action: uninstall_operator_with_msg_check
 uninstall_operator_and_check_operandremoval_msg:
   params:
@@ -942,7 +942,7 @@ uninstall_operator_with_msg_check:
 check_no_plugin_message_on_uninstall_modal:
   params:
     item: Remove Subscription
-    content: console plugins provided by this operator will be disabled and removed
+    content: disabled and removed
   action: click_one_dropdown_action
   action: check_page_not_match
 toggle_plugin_status:

--- a/lib/rules/web/admin_console/4.9/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.9/operator_hub.xyaml
@@ -913,7 +913,7 @@ enable_plugin_from_install_page:
     op: click
 uninstall_operator_and_check_pluginremoval_msg:
   params:
-    check_msg: console plugins provided by this operator will be disabled and removed
+    check_msg: disabled and removed
   action: uninstall_operator_with_msg_check
 uninstall_operator_and_check_operandremoval_msg:
   params:
@@ -930,7 +930,7 @@ uninstall_operator_with_msg_check:
 check_no_plugin_message_on_uninstall_modal:
   params:
     item: Remove Subscription
-    content: console plugins provided by this operator will be disabled and removed
+    content: disabled and removed
   action: click_one_dropdown_action
   action: check_page_not_match
 toggle_plugin_status:


### PR DESCRIPTION
on 4.13 text "console plugins" becomes "console plugin", remove it form text check. Pass log on 4.13: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/746523/console