### PR TITLE
Fix the change for OCP-33744

### DIFF
--- a/lib/rules/web/admin_console/4.10/check_links.xyaml
+++ b/lib/rules/web/admin_console/4.10/check_links.xyaml
@@ -371,11 +371,15 @@ check_items_on_downloads_route_page:
   - selector:
       xpath: //li/a[@href="amd64/mac/oc" and contains(text(), "amd64 mac")]
   - selector:
-      xpath: //li/a[@href="amd64/mac/oc.zip" and contains(text(), "zip")]
-  - selector:
       xpath: //li/a[@href="amd64/windows/oc.exe" and contains(text(), "amd64 windows")]
   - selector:
-      xpath: //li/a[@href="amd64/windows/oc.exe.tar" and contains(text(), "tar")]
+      xpath: //li/a[@href="arm64/linux/oc" and contains(text(), "arm64 linux")]
+  - selector:
+      xpath: //li/a[@href="arm64/mac/oc" and contains(text(), "arm64 mac")]
+  - selector:
+      xpath: //li/a[@href="ppc64le/linux/oc" and contains(text(), "ppc64le linux")]
+  - selector:
+      xpath: //li/a[@href="s390x/linux/oc" and contains(text(), "s390x linux")]
 check_refresh_notification:
   elements:
   - selector:

--- a/lib/rules/web/admin_console/4.11/check_links.xyaml
+++ b/lib/rules/web/admin_console/4.11/check_links.xyaml
@@ -371,11 +371,15 @@ check_items_on_downloads_route_page:
   - selector:
       xpath: //li/a[@href="amd64/mac/oc" and contains(text(), "amd64 mac")]
   - selector:
-      xpath: //li/a[@href="amd64/mac/oc.zip" and contains(text(), "zip")]
-  - selector:
       xpath: //li/a[@href="amd64/windows/oc.exe" and contains(text(), "amd64 windows")]
   - selector:
-      xpath: //li/a[@href="amd64/windows/oc.exe.tar" and contains(text(), "tar")]
+      xpath: //li/a[@href="arm64/linux/oc" and contains(text(), "arm64 linux")]
+  - selector:
+      xpath: //li/a[@href="arm64/mac/oc" and contains(text(), "arm64 mac")]
+  - selector:
+      xpath: //li/a[@href="ppc64le/linux/oc" and contains(text(), "ppc64le linux")]
+  - selector:
+      xpath: //li/a[@href="s390x/linux/oc" and contains(text(), "s390x linux")]
 check_refresh_notification:
   elements:
   - selector:

--- a/lib/rules/web/admin_console/4.12/check_links.xyaml
+++ b/lib/rules/web/admin_console/4.12/check_links.xyaml
@@ -371,11 +371,15 @@ check_items_on_downloads_route_page:
   - selector:
       xpath: //li/a[@href="amd64/mac/oc" and contains(text(), "amd64 mac")]
   - selector:
-      xpath: //li/a[@href="amd64/mac/oc.zip" and contains(text(), "zip")]
-  - selector:
       xpath: //li/a[@href="amd64/windows/oc.exe" and contains(text(), "amd64 windows")]
   - selector:
-      xpath: //li/a[@href="amd64/windows/oc.exe.tar" and contains(text(), "tar")]
+      xpath: //li/a[@href="arm64/linux/oc" and contains(text(), "arm64 linux")]
+  - selector:
+      xpath: //li/a[@href="arm64/mac/oc" and contains(text(), "arm64 mac")]
+  - selector:
+      xpath: //li/a[@href="ppc64le/linux/oc" and contains(text(), "ppc64le linux")]
+  - selector:
+      xpath: //li/a[@href="s390x/linux/oc" and contains(text(), "s390x linux")]
 check_refresh_notification:
   elements:
   - selector:

--- a/lib/rules/web/admin_console/4.13/check_links.xyaml
+++ b/lib/rules/web/admin_console/4.13/check_links.xyaml
@@ -371,11 +371,15 @@ check_items_on_downloads_route_page:
   - selector:
       xpath: //li/a[@href="amd64/mac/oc" and contains(text(), "amd64 mac")]
   - selector:
-      xpath: //li/a[@href="amd64/mac/oc.zip" and contains(text(), "zip")]
-  - selector:
       xpath: //li/a[@href="amd64/windows/oc.exe" and contains(text(), "amd64 windows")]
   - selector:
-      xpath: //li/a[@href="amd64/windows/oc.exe.tar" and contains(text(), "tar")]
+      xpath: //li/a[@href="arm64/linux/oc" and contains(text(), "arm64 linux")]
+  - selector:
+      xpath: //li/a[@href="arm64/mac/oc" and contains(text(), "arm64 mac")]
+  - selector:
+      xpath: //li/a[@href="ppc64le/linux/oc" and contains(text(), "ppc64le linux")]
+  - selector:
+      xpath: //li/a[@href="s390x/linux/oc" and contains(text(), "s390x linux")]
 check_refresh_notification:
   elements:
   - selector:


### PR DESCRIPTION
The changes are for the update for the download page
![image](https://user-images.githubusercontent.com/78589509/221450469-ae212fdc-d468-4cfd-849a-43cde0eae677.png)

Pass log 
4.13: /Runner/751788/console
4.12: /Runner/751790/console
4.10: /Runner/751791/console