### PR TITLE
Prepare ovn2sdn automation

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1500,13 +1500,11 @@ end
 Given /^the cluster is not migration from sdn plugin$/ do
   ensure_admin_tagged
   _admin = admin
-  if env.version_le("4.11", user: user)
-    @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration.networkType}")
-    if @result[:stdout]["OVNKubernetes"]
-      logger.warn "the cluster is migration from sdn plugin"
-      logger.warn "We will skip this scenario"
-      skip_this_scenario
-    end
+  @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration.networkType}")
+  if @result[:stdout]["OVNKubernetes"]
+    logger.warn "the cluster is migration from sdn plugin"
+    logger.warn "We will skip this scenario"
+    skip_this_scenario
   end
 end
 
@@ -1637,13 +1635,11 @@ end
 Given /^the cluster is not migration from ovn plugin$/ do
   ensure_admin_tagged
   _admin = admin
-  if env.version_le("4.12", user: user)
-    @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration.networkType}")
-    if @result[:stdout]["OpenShiftSDN"]
-      logger.warn "the cluster is migration from sdn plugin"
-      logger.warn "We will skip this scenario"
-      skip_this_scenario
-    end
+  @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration.networkType}")
+  if @result[:stdout]["OpenShiftSDN"]
+    logger.warn "the cluster is migration from sdn plugin"
+    logger.warn "We will skip this scenario"
+    skip_this_scenario
   end
 end
 

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1637,7 +1637,7 @@ end
 Given /^the cluster is not migration from ovn plugin$/ do
   ensure_admin_tagged
   _admin = admin
-  if env.version_le("4.21", user: user)
+  if env.version_le("4.12", user: user)
     @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration.networkType}")
     if @result[:stdout]["OpenShiftSDN"]
       logger.warn "the cluster is migration from sdn plugin"

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1501,8 +1501,8 @@ Given /^the cluster is not migration from sdn plugin$/ do
   ensure_admin_tagged
   _admin = admin
   if env.version_le("4.11", user: user)
-    @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration}")
-    if @result[:stdout]["networkType"]
+    @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration.networkType}")
+    if @result[:stdout]["OVNKubernetes"]
       logger.warn "the cluster is migration from sdn plugin"
       logger.warn "We will skip this scenario"
       skip_this_scenario
@@ -1633,3 +1633,17 @@ Given /^make sure no coredump on the master hosts$/ do
     end
   end
 end
+
+Given /^the cluster is not migration from ovn plugin$/ do
+  ensure_admin_tagged
+  _admin = admin
+  if env.version_le("4.21", user: user)
+    @result = _admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.migration.networkType}")
+    if @result[:stdout]["OpenShiftSDN"]
+      logger.warn "the cluster is migration from sdn plugin"
+      logger.warn "We will skip this scenario"
+      skip_this_scenario
+    end
+  end
+end
+

--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -54,7 +54,6 @@ Feature: Egress compoment upgrade testing
   @hypershift-hosted
   Scenario: Check egressfirewall is functional post upgrade
     Given I switch to cluster admin pseudo user
-    Given the cluster is not migration from sdn plugin
     And I save egress type to the clipboard
     When I run the :get admin command with:
       | resource | <%= cb.cb_egress_type %>  |
@@ -147,6 +146,7 @@ Feature: Egress compoment upgrade testing
   Scenario: Check ovn egressip is functional post upgrade
     Given I save ipecho url to the clipboard
     Given I switch to cluster admin pseudo user
+    Given the cluster is not migration from sdn plugin
     When I use the "egressip-upgrade1" project
     Given status becomes :running of 1 pod labeled:
       | name=test-pods |
@@ -265,7 +265,7 @@ Feature: Egress compoment upgrade testing
   @hypershift-hosted
   Scenario: Check sdn egressip is functional post upgrade
     Given I switch to cluster admin pseudo user
-    Given the cluster is not migration from sdn plugin
+    Given the cluster is not migration from ovn plugin
     Given the env is using "OpenShiftSDN" networkType
     Given I run the :get admin command with:
       | resource      | hostsubnet                                  |


### PR DESCRIPTION
Update existing steps to prepare ovn2sdn automation

@openshift/team-sdn-qe PTAL

OVN migrate to SDN
oc get network.operator cluster  -o jsonpath={.spec.migration.networkType}
return: OpenShiftSDN

SDN migrate to OVN
oc get network.operator cluster  -o jsonpath={.spec.migration.networkType}
return: OVNKubernetes