### PR TITLE
even if replicas is zero , we copy machineset

### DIFF
--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -1,7 +1,7 @@
 Given(/^I pick a random( windows)? machineset to scale$/) do | windows |
   ensure_admin_tagged
   machine_sets = BushSlicer::MachineSetMachineOpenshiftIo.list(user: admin, project: project("openshift-machine-api")).
-    select { |ms| ms.available_replicas >= 1 && (windows ? ms.is_windows_machinesets? : !ms.is_windows_machinesets?) }
+    select { |ms| ms.available_replicas >= 0 && (windows ? ms.is_windows_machinesets? : !ms.is_windows_machinesets?) }
   cache_resources *machine_sets.shuffle
 end
 


### PR DESCRIPTION
@huali9 @jhou1 @sunzhaohua2  PTAL , as reported if we have cluster like below - 

> [miyadav@miyadav 1_march]$ oc get machineset
> NAME                         DESIRED   CURRENT   READY   AVAILABLE   AGE
> huliu-gcp1a-82jdt-worker-a   0         0                             3h54m
> huliu-gcp1a-82jdt-worker-b   0         0                             3h54m
> huliu-gcp1a-82jdt-worker-c   0         0                             3h54m
> huliu-gcp1a-82jdt-worker-f   0         0                             3h54m


We were getting `what MachineSetMachineOpenshiftIo are you talking about? (RuntimeError)` error , to mitigate that , made this change.
Don't think it would cause any regression .

Validation : https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/755462/console , below was the cluster 

> [miyadav@miyadav aws]$ oc get machineset --kubeconfig kk
> NAME                                   DESIRED   CURRENT   READY   AVAILABLE   AGE
> miyadav-0103-vst96-worker-us-east-2a   0         0                             4h56m
> miyadav-0103-vst96-worker-us-east-2b   0         0                             4h56m
> miyadav-0103-vst96-worker-us-east-2c   0         0                             4h56m
> [miyadav@miyadav aws]$ 
