### PR TITLE
Add testdata file for kubedescheduler 4.13

### DIFF
--- a/testdata/descheduler/kubedescheduler-4.13.yaml
+++ b/testdata/descheduler/kubedescheduler-4.13.yaml
@@ -1,0 +1,22 @@
+apiVersion: operator.openshift.io/v1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  image: registry.redhat.io/openshift4/ose-descheduler:v4.13
+  logLevel: Normal
+  mode: Automatic
+  operatorLogLevel: Normal
+  profileCustomizations:
+    devLowNodeUtilizationThresholds: Medium
+    podLifetime: 12h
+  deschedulingIntervalSeconds: 3600
+  profiles:
+    - AffinityAndTaints
+    - TopologyAndDuplicates
+    - LifecycleAndUtilization
+    - EvictPodsWithLocalStorage
+    - EvictPodsWithPVC
+  managementState: Managed
+


### PR DESCRIPTION
Currently testdata file for kubedescheduler 4.13 is missing, so adding the same.