### PR TITLE
typo fix

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -824,7 +824,7 @@ Feature: Service related networking scenarios
       | Connection refused |
     #It should work like ETP=cluster because its not external traffic, its within the node (ETP=local shouldn't be respected and its like ETP=cluster behaviour) 
     When I run commands on the host:
-      | curl --connect-timeout 5 [<%= cb.worker_ip %>]:<%= cb.port %> |
+      | curl --connect-timeout 5 [<%= cb.worker1_ip %>]:<%= cb.port %> |
     And the output should contain:
       | Hello OpenShift! |
     Given I ensure "hello-pod" service is deleted


### PR DESCRIPTION
Found a typo in worker cb variable. small fix

@openshift/team-sdn-qe 

logs: https://privatebin.corp.redhat.com/?e952e174bd7254ee#9zjQjxYcdSq9AR4p3ktw5HBmTB78gF8x6fagt9k9ZpS4