### PR TITLE
fix OCPQE-14200 and OCPQE-11093

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -1204,6 +1204,9 @@ Given /^I have(?: "(\w+)")? log pod in project #{QUOTED}$/ do | log_type, projec
       step %Q/I run the :new_app client command with:/,table(%{
         | file | #{template_file} |
       })
+      step %Q/a pod becomes ready with labels:/, table(%{
+        | run=centos-logtest|
+      })
     end
 end
 

--- a/features/upgrade/logging/upgrade.feature
+++ b/features/upgrade/logging/upgrade.feature
@@ -25,8 +25,10 @@ Feature: Logging upgrading related features
       | group_name | project-group-share                |
       | user_name  | <%= user(1, switch: false).name %> |
     Given logging operators are installed successfully
-    Given I have clusterlogging with persistent storage ES
-    Then I wait for the project "logging-upg-prep-1" logs to appear in the ES pod
+    And I have clusterlogging with persistent storage ES
+    Given I wait for the "infra" index to appear in the ES pod with labels "es-node-master=true"
+    And I wait for the "app" index to appear in the ES pod with labels "es-node-master=true"
+    And I wait for the project "logging-upg-prep-1" logs to appear in the ES pod
     When I check the cronjob status
     Then the step should succeed
 


### PR DESCRIPTION
Many tests failed at:
```
       oc exec elasticsearch-cdm-4ht50v5g-3-7ccfc9c895-b9nkb  --kubeconfig=/home/jenkins/ws/workspace/ocp-upgrade/upgrade-producer/workdir/ocp4_admin.kubeconfig -n openshift-logging  --container=elasticsearch -i -- bash -c es_util\ \'--query\=\*/_count\?format\=JSON\'\ -d\ \'\{\"query\":\ \{\"match\":\ \{\"kubernetes.namespace_name\":\ \"logging-upg-prep-1\"\}\}\}\'\ -X\ GET
       {"count":0,"_shards":{"total":11,"successful":11,"skipped":0,"failed":0}}
       STDERR:
       E0301 22:25:20.977300   33592 v2.go:105] read /dev/stdin: resource temporarily unavailable
       [22:25:21] INFO> Exit Status: 0
       Can't find logs from project 'logging-upg-prep-1' in 600 seconds (RuntimeError)
```
I'm not able to reproduce the failure, here add a step to check pod's status in project 'logging-upg-prep-1' and add steps to check app and infra indices before checking data in ES.