### PR TITLE
skip if platform is NONE

### DIFF
--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -134,6 +134,9 @@ Feature: Machine misc features testing
   Scenario: OCP-37744:ClusterInfrastructure kube-rbac-proxy should not expose tokens, have excessive verbosity
     Given I switch to cluster admin pseudo user
 
+    Then I check the cluster platform is not None
+    And the step should succeed
+
     Given I use the "openshift-machine-api" project
     Given a pod becomes ready with labels:
       | api=clusterapi | k8s-app=controller |

--- a/features/step_definitions/machine_misc.rb
+++ b/features/step_definitions/machine_misc.rb
@@ -18,3 +18,12 @@ Given(/^thin sc or thin-csi sc is present as default$/) do
   end
 end
 
+Given(/I check the cluster platform is not None$/) do
+  ensure_admin_tagged
+
+  if infrastructure("cluster").platform == "None"
+     logger.warn "When platform is None,machine-api-controllers are not present"
+     logger.warn "We will skip this scenario"
+     skip_this_scenario
+  end
+end 


### PR DESCRIPTION
if platform is none we need to skip OCP-37744 as it keeps waiting for controller pods to come up and then fails , adding condition to skip in the case platform is "None"

Validation -  https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/758858/console 

@sunzhaohua2 @jhou1 @huali9 PTAL when you get time