### PR TITLE
indent correction

### DIFF
--- a/testdata/storage/azure-file/azf-rolebind.yaml
+++ b/testdata/storage/azure-file/azf-rolebind.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: persistent-volume-binder
-namespace: kube-system
+  namespace: kube-system


### PR DESCRIPTION
The ServiceAccount/persistent-volume-binder is under ns/kube-system.

@liangxia Could you help take a looks?

cc @ropatil010 