### PR TITLE
 To handle failures in profile with(IPI) but no workers

### DIFF
--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -13,6 +13,13 @@ Given(/^I have an IPI deployment$/) do
       logger.warn "We will skip this scenario"
       skip_this_scenario
     end
+
+  machine_sets = BushSlicer::MachineSetMachineOpenshiftIo.list(user: admin, project: project("openshift-machine-api"))
+    if machine_sets.length == 0
+      logger.warn "machineset does not exist, tests running by copying existing machinesets will fail."
+      logger.warn "We will skip this scenario, even though it is IPI deployment"
+      skip_this_scenario
+    end   
   end
 end
 


### PR DESCRIPTION
@sunzhaohua2 @jhou1 @huali9 PTAL 

skipped when no worker machineset present in IPI cluster - https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/759563/console

Executed successfully when machineset is present - https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/759562/console

this is to mitigate failures due to profile where machineset is removed completely .