### PR TITLE
skip for no machineset on UPI

### DIFF
--- a/features/machine/upi_gcp.feature
+++ b/features/machine/upi_gcp.feature
@@ -2,7 +2,6 @@ Feature: UPI GCP Tests
 
   # @author zhsun@redhat.com
   # @case_id OCP-34697
-  @flaky
   @admin
   @destructive
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
@@ -15,7 +14,6 @@ Feature: UPI GCP Tests
 
   # @author zhsun@redhat.com
   # @case_id OCP-25034
-  @flaky
   @admin
   @destructive
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7

--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -20,12 +20,16 @@ Given(/^I have an UPI deployment and machinesets are enabled$/) do
   # In an UPI deployment, if enabled machinesets, machines should be linked to nodes
   machines = BushSlicer::MachineMachineOpenshiftIo.list(user: admin, project: project("openshift-machine-api"))
   if machines.length == 0
-    raise "Machinesets are not enabled, there are no machines"
+    logger.warn "Machinesets are not enabled, there are no machines"
+    logger.warn "We will skip this scenario"
+    skip_this_scenario
   end
 
   machines.each do | machine |
     if machine.node_name.nil?
-      raise "machine #{machine.name} does not have nodeRef."
+      logger.warn "machine #{machine.name} has no node ref."
+      logger.warn "We will skip this scenario"
+      skip_this_scenario
     end
   end
 end


### PR DESCRIPTION
OCP-34697 and OCP-25034 failed on GCP UPI cluster which has no machineset, 
`Machinesets are not enabled, there are no machines (RuntimeError)`
but for such case, we should skip the test, not reporting error. so update to skip the test cases for such case.
@sunzhaohua2 @miyadav @jhou1 PTAL, thanks!

test cases passed on GCP UPI cluster which has machineset:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/763586/console
test cases skipped on GCP UPI cluster which has no machineset:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/763597/console