### PR TITLE
update securityContext for some test pods

### DIFF
--- a/testdata/routing/test-client-pod.yaml
+++ b/testdata/routing/test-client-pod.yaml
@@ -11,3 +11,6 @@ spec:
     ports:
     - containerPort: 8080
     - containerPort: 8443
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/testdata/routing/web-server-1.yaml
+++ b/testdata/routing/web-server-1.yaml
@@ -11,3 +11,6 @@ spec:
     ports:
     - containerPort: 8080
     - containerPort: 8443
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/testdata/routing/web-server-rc.yaml
+++ b/testdata/routing/web-server-rc.yaml
@@ -17,6 +17,9 @@ items:
         containers:
         - image: quay.io/openshifttest/nginx-alpine@sha256:04f316442d48ba60e3ea0b5a67eb89b0b667abf1c198a3d0056ca748736336a0
           name: nginx
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
adding `securityContext.seccompProfile` for some test pods to avoid error message 
```
violates PodSecurity "restricted:latest"
```
when creating the pod resources with admin user in non-default namespace.

@melvinjoseph86 @ShudiLi Please help take a look. Thanks