### PR TITLE
Add @cloud tag for upgrade case running in Prow

### DIFF
--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -131,6 +131,7 @@ Feature: Machine-api components upgrade tests
   @upgrade-check
   @admin
   @destructive
+  @cloud
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @proxy @noproxy @disconnected @connected


### PR DESCRIPTION
@jhou1 @liangxia @miyadav @huali9 PTAl, this is for https://github.com/openshift/release/pull/37261 run machineset scale up/down in prow upgrade jobs.
```
$ bundle exec cucumber --tags '@upgrade-check and @4.12 and @aws-ipi and not @fips and not @customer and not @flaky and not @inactive and not @prod-only and not @qeci and not @security and not @stage-only and @cloud' --dry-run
1 scenario (1 skipped)
```
