### PR TITLE
Introduced bug by adding 'succeed' validation

### DIFF
--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -135,7 +135,6 @@ Feature: Machine misc features testing
     Given I switch to cluster admin pseudo user
 
     Then I check the cluster platform is not None
-    And the step should succeed
 
     Given I use the "openshift-machine-api" project
     Given a pod becomes ready with labels:


### PR DESCRIPTION
This was not needed as , it is not returning any cli output which was causing the test case to fail , it was due to earlier [commit](https://github.com/openshift/verification-tests/pull/3244) .

Failures noticed from - http://10.14.89.3:3000/failed_tests , filter using OCP-37744

Here are the failure details due to it - 
```
`      undefined method `[]' for nil:NilClass (NoMethodError)
      ./features/step_definitions/common.rb:5:in `/^the step should( not)? (succeed|fail)$/'
      features/machine/machine_misc.feature:138:in `the step should succeed'`


```
Validation - 
```
`waiting for operation up to 3600 seconds..
    When I run the :logs admin command with:                                                                                                                     # features/step_definitions/cli.rb:31
      | resource_name | <%= pod.name %> |
      | c             | kube-rbac-proxy |
      [05:20:32] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.168.250.243:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.168.250.243:3128
      oc logs machine-approver-6d44f5cdd9-fztst -c kube-rbac-proxy --kubeconfig=/home/miyadav/workdir/miyadav-miyadavx/ocp4_admin.kubeconfig
      I0315 04:34:55.595203       1 main.go:151] Reading config file: /etc/kube-rbac-proxy/config-file.yaml
      I0315 04:34:55.596635       1 main.go:181] Valid token audiences: 
      I0315 04:34:55.596770       1 main.go:305] Reading certificate files
      I0315 04:34:55.596952       1 main.go:339] Starting TCP socket on 0.0.0.0:9192
      I0315 04:34:55.597442       1 main.go:346] Listening securely on 0.0.0.0:9192
      [05:20:34] INFO> Exit Status: 0
    Then the output should not contain:                                                                                                                          # features/step_definitions/common.rb:33
      | Response Headers |
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [05:20:34] INFO> === After Scenario: OCP-37744:ClusterInfrastructure kube-rbac-proxy should not expose tokens, have excessive verbosity ===
      [05:20:34] INFO> Shell Commands: rm -r -f -- /home/miyadav/workdir/miyadav-miyadavx
      
      [05:20:35] INFO> Exit Status: 0
      [05:20:36] INFO> === End After Scenario: OCP-37744:ClusterInfrastructure kube-rbac-proxy should not expose tokens, have excessive verbosity ===
# @author miyadav@redhat.com
# @case_id OCP-37180
# @author miyadav@redhat.com
# @case_id OCP-40665

1 scenario (1 passed)
13 steps (13 passed)
0m41.270s
[05:20:36] INFO> === At Exit ===
`
```

@sunzhaohua2 @huali9 @jhou1 PTAL.