### PR TITLE
remove OCP-27609 on Azure

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -180,7 +180,7 @@ Feature: Machine features testing
   @admin
   @destructive
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @aws-ipi @alicloud-ipi
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64


### PR DESCRIPTION
This case failed on azure private cluster.
`Error from server (providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation with publish strategy as internal): admission webhook "validation.machineset.machine.openshift.io" denied the request: providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation with publish strategy as internal`

This is already covered in [OCP-36489](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-36489) on Azure. and OCP-36489 already automated in golang, in golang, we handle both cases (private and not private).

so remove this case on azure in cucushift.

@sunzhaohua2 @miyadav  @jhou1 PTAL, thanks!