### PR TITLE
Fix for hosted hypershift

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1363,15 +1363,13 @@ Given /^the node's active nmcli connection is stored in the#{OPT_SYM} clipboard$
   logger.info "Node's active nmcli connection uuid is stored in the #{cb_name} clipboard as #{cb[cb_name]}"
 end
 
-Given /^I save multus pod on master node to the#{OPT_SYM} clipboard$/ do | cb_name |
+Given /^I save multus pod on node "([^"]*)" to the#{OPT_SYM} clipboard$/ do | node_name,cb_name |
   ensure_admin_tagged
   cb_name ||= :multuspod
-  master_nodes = env.nodes.select { |n| n.schedulable? && n.is_master? }
-  master_node_names = master_nodes.collect { |n| n.name }
   cb[cb_name] = BushSlicer::Pod.get_labeled("app=multus", project: project("openshift-multus", switch: false), user: admin) { |pod, hash|
-     master_node_names.include?(pod.node_name)
+    node_name.include?(pod.node_name)
   }.first.name
-  logger.info "The multus pod is stored to the #{cb[cb_name]} clipboard."
+  logger.info "The multus pod on node #{node_name} is stored to the #{cb[cb_name]} clipboard."
 end
 
 Given /^I disable multicast for the "(.+?)" namespace$/ do | project_name |


### PR DESCRIPTION
@openshift/team-sdn-qe PTAL

The hypershift hosted clusters do not have master nodes, therefore changing the step definition to use multus pod running on specific node.
The step definition change to use multus pod on  worker node other than the one running the back end pod of the service. 

Tested on cluster created with profile private-templates/functionality-testing/aos-4_13/ipi-on-aws/versioned-installer-ovn-hypershift-ci
Test logs can be found here 
http://file.rdu.redhat.com/asood/OCP-41944-hh.log
http://file.rdu.redhat.com/asood/OCP-40908-hh.log
http://file.rdu.redhat.com/asood/OCP-41083-hh.log