### PR TITLE
Revert "update securityContext for some test pods"

### DIFF
--- a/testdata/routing/test-client-pod.yaml
+++ b/testdata/routing/test-client-pod.yaml
@@ -11,6 +11,3 @@ spec:
     ports:
     - containerPort: 8080
     - containerPort: 8443
-  securityContext:
-    seccompProfile:
-      type: RuntimeDefault

--- a/testdata/routing/web-server-1.yaml
+++ b/testdata/routing/web-server-1.yaml
@@ -11,6 +11,3 @@ spec:
     ports:
     - containerPort: 8080
     - containerPort: 8443
-  securityContext:
-    seccompProfile:
-      type: RuntimeDefault

--- a/testdata/routing/web-server-rc.yaml
+++ b/testdata/routing/web-server-rc.yaml
@@ -17,9 +17,6 @@ items:
         containers:
         - image: quay.io/openshifttest/nginx-alpine@sha256:04f316442d48ba60e3ea0b5a67eb89b0b667abf1c198a3d0056ca748736336a0
           name: nginx
-        securityContext:
-          seccompProfile:
-            type: RuntimeDefault
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
Reverts openshift/verification-tests#3256

I see some errors in 4.9 and the pod cannot be created, so revert the change for now.
```
Error from server (Forbidden): error when creating "web-server-1.yaml": pods "web-server-1" is forbidden: unable to validate against any security context constraint
```

@melvinjoseph86 @ShudiLi PTAL. thanks