### PR TITLE
tests removed covered by ginkgo merged PRs

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -366,62 +366,6 @@ Feature: Machine features testing
     And the output should match "node-role.kubernetes.io/infra="
 
   # @author miyadav@redhat.com
-  @admin
-  @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  Scenario Outline: Implement defaulting machineset values for AWS
-    Given I have an IPI deployment
-    And I switch to cluster admin pseudo user
-    And I use the "openshift-machine-api" project
-    Then admin ensures machine number is restored after scenario
-
-    Given I pick a earliest created machineset and store in :machineset clipboard
-    When evaluation of `machine_set_machine_openshift_io(cb.machineset).aws_machineset_ami_id` is stored in the :default_ami_id clipboard
-    And evaluation of `machine_set_machine_openshift_io(cb.machineset).aws_machineset_availability_zone` is stored in the :default_availability_zone clipboard
-    And evaluation of `machine_set_machine_openshift_io(cb.machineset).aws_machineset_iamInstanceProfile` is stored in the :default_iamInstanceProfile clipboard
-    And evaluation of `machine_set_machine_openshift_io(cb.machineset).aws_machineset_subnet` is stored in the :default_subnet clipboard
-    And evaluation of `machine_set_machine_openshift_io(cb.machineset).aws_machineset_secgrp` is stored in the :default_secgrp clipboard
-    Then admin ensures "<name>" machine_set_machine_openshift_io is deleted after scenario
-
-    Given I obtain test data file "cloud/ms-aws/<file_name>"
-    When I run oc create over "<file_name>" replacing paths:
-      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]                    | <%= infrastructure("cluster").infra_name %>                    |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["iamInstanceProfile"]["id"]                  | <%= cb.default_iamInstanceProfile %>                           |
-      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]                 | <name>                                                         |
-      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]             | <%= infrastructure("cluster").infra_name %>                    |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["ami"]["id"]                                 | <%= cb.default_ami_id %>                                       |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["securityGroups"][0]["filters"][0]["values"] | <%= cb.default_secgrp[0].values[0].to_s.split(",")[1][11..-1]%>|
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["placement"]["availabilityZone"]             | <%= cb.default_availability_zone %>                            |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["subnet"]["filters"][0]["values"]            | <%= cb.default_subnet[0].values[1] %>                          |
-      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"]          | <name>                                                         |
-      | ["metadata"]["name"]                                                                               | <name>                                                         |
-    Then the step should succeed
-
-    Then I store the last provisioned machine in the :machine_latest clipboard
-    And I wait up to 300 seconds for the steps to pass:
-    """
-    Then the expression should be true> machine_machine_openshift_io(cb.machine_latest).phase(cached: false) == "Running"
-    """
-
-    When I run the :describe admin command with:
-      | resource | machines.machine.openshift.io |
-      | name     | <%= cb.machine_latest %>      |
-    Then the step should succeed
-    And the output should contain:
-      | <Validation> |
-
-    @aws-ipi
-    @noproxy @disconnected @connected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
-    
-    Examples:
-      | case_id                         | name                    | file_name                 | Validation                    |
-      | OCP-32269:ClusterInfrastructure | default-valued-32269    | ms_default_values.yaml    | Placement                     | # @case_id OCP-32269
-      | OCP-37132:ClusterInfrastructure | tenancy-dedicated-37132 | ms_tenancy_dedicated.yaml | Tenancy:            dedicated | # @case_id OCP-37132
-      | OCP-42346:ClusterInfrastructure | default-valued-42346    | ms_default_values.yaml    | Instance Type:  m5.large      | # @case_id OCP-42346
-
-  # @author miyadav@redhat.com
   # @case_id OCP-33056
   @admin
   @destructive
@@ -507,7 +451,6 @@ Feature: Machine features testing
     Examples:
       | case_id                         | name                  | file_name               | Validation                |
       | OCP-33058:ClusterInfrastructure | default-valued-33058  | ms_default_values.yaml  | Public IP                 | # @case_id OCP-33058
-      | OCP-39639:ClusterInfrastructure | encrypt-at-rest-39639 | ms_encrypt_at_rest.yaml | Encryption At Host:  true | # @case_id OCP-39639
 
   # @author miyadav@redhat.com
   # @case_id OCP-33455
@@ -628,58 +571,4 @@ Feature: Machine features testing
   Scenario: OCP-47989:ClusterInfrastructure Baremetal clusteroperator should be enabled in vsphere and osp
     Given evaluation of `cluster_operator('baremetal').condition(type: 'Disabled')` is stored in the :co_disabled clipboard
     Then the expression should be true> cb.co_disabled["status"]=="False"
-
-  # @author miyadav@redhat.com
-  @admin
-  @destructive
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  Scenario Outline: Implement defaulting machineset values for AWS proxy clusters
-    Given I have an IPI deployment
-    And I switch to cluster admin pseudo user
-    And I use the "openshift-machine-api" project
-    Then admin ensures machine number is restored after scenario
-
-    Given I pick a earliest created machineset and store in :machineset clipboard
-    When evaluation of `machine_set_machine_openshift_io(cb.machineset).aws_machineset_ami_id` is stored in the :default_ami_id clipboard
-    And evaluation of `machine_set_machine_openshift_io(cb.machineset).aws_machineset_availability_zone` is stored in the :default_availability_zone clipboard
-    And evaluation of `machine_set_machine_openshift_io(cb.machineset).aws_machineset_iamInstanceProfile` is stored in the :default_iamInstanceProfile clipboard
-    And evaluation of `machine_set_machine_openshift_io(cb.machineset).aws_machineset_subnet_proxy` is stored in the :default_subnet clipboard
-    Then admin ensures "<name>" machine_set_machine_openshift_io is deleted after scenario
-
-    Given I obtain test data file "cloud/ms-aws/proxy-clusters/<file_name>"
-    When I run oc create over "<file_name>" replacing paths:
-      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-cluster"]           | <%= infrastructure("cluster").infra_name %> |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["iamInstanceProfile"]["id"]         | <%= cb.default_iamInstanceProfile %>        |
-      | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | <name>                                      |
-      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %> |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["ami"]["id"]                        | <%= cb.default_ami_id %>                    |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["placement"]["availabilityZone"]    | <%= cb.default_availability_zone %>         |
-      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["subnet"]["id"]                     | <%= cb.default_subnet %>                    |
-      | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | <name>                                      |
-      | ["metadata"]["name"]                                                                      | <name>                                      |
-    Then the step should succeed
-
-    Then I store the last provisioned machine in the :machine_latest clipboard
-    And I wait up to 540 seconds for the steps to pass:
-    """
-    Then the expression should be true> machine_machine_openshift_io(cb.machine_latest).phase(cached: false) == "Running"
-    """
-
-    When I run the :describe admin command with:
-      | resource | machines.machine.openshift.io |
-      | name     | <%= cb.machine_latest %>      |
-    Then the step should succeed
-    And the output should contain:
-      | <Validation> |
-
-    @aws-ipi
-    @proxy @disconnected
-    @network-ovnkubernetes @network-openshiftsdn
-    @heterogeneous @arm64 @amd64
-    
-    Examples:
-      | case_id                         | name                    | file_name                 | Validation                    |
-      | OCP-48463:ClusterInfrastructure | default-valued-48463    | ms_default_values.yaml    | Placement                     | # @case_id OCP-48463
-      | OCP-48464:ClusterInfrastructure | tenancy-dedicated-48464 | ms_tenancy_dedicated.yaml | Tenancy:            dedicated | # @case_id OCP-48464
-      | OCP-48462:ClusterInfrastructure | default-valued-48462    | ms_default_values.yaml    | Instance Type:  m5.large      | # @case_id OCP-48462
 


### PR DESCRIPTION
32269,42346,39639,48464,48463,37132
PR https://github.com/openshift/openshift-tests-private/pull/8114

PR-https://github.com/openshift/openshift-tests-private/pull/8062

PR-https://github.com/openshift/openshift-tests-private/pull/8054/


@sunzhaohua2 @huali9 @jhou1 PTAL , when time permits , there might be few issue we need to handle during cherry-pick to old < 4.10 versions.
multiple tests are covered in one PR to let us remove them from cucushift.