### PR TITLE
removed hypershift-hosted labels from few cases

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -170,7 +170,6 @@ Feature: Pod related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: OCP-23890:SDN A pod with or without hostnetwork cannot access the MCS port 22623 or 22624 on the master
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard
@@ -234,7 +233,6 @@ Feature: Pod related networking scenarios
   @network-openshiftsdn
   @proxy @noproxy
   @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: OCP-23893:SDN A pod in a namespace with an egress IP cannot access the MCS
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard

--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -461,7 +461,6 @@ Feature: SDN compoment upgrade testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: Conntrack rule for UDP traffic should be removed when the pod for NodePort service deleted post upgrade
     Given I switch to cluster admin pseudo user
     And I use the "conntrack-upgrade" project
@@ -543,7 +542,6 @@ Feature: SDN compoment upgrade testing
   @network-ovnkubernetes @network-networkpolicy
   @upgrade
   @proxy @noproxy @disconnected @connected
-  @hypershift-hosted
   Scenario: Check network policy ACL logging works post upgrade -prepare
     Given I switch to cluster admin pseudo user
     Given the env is using "OVNKubernetes" networkType


### PR DESCRIPTION
These tests are have masters dependency and shouldn't be run on hosted clusters

@openshift/team-sdn-qe 