### PR TITLE
fix check_use_regular xpath for 4.12/4.13/4.14

### DIFF
--- a/lib/rules/web/admin_console/4.12/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.12/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox' and text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.12/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.12/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox' and text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.12/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.12/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[text()='RegEx']/input[@type='checkbox']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.12/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.12/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']//label[text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.12/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.12/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']//label[text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox' and text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox' and text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[text()='RegEx']/input[@type='checkbox']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']//label[text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']//label[text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox' and text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox' and text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[text()='RegEx']/input[@type='checkbox']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']//label[text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:

--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -265,7 +265,7 @@ silence_alert_from_create_button:
 check_use_regular:
   element:
     selector:
-      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[@type='checkbox' and text()='RegEx']
+      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']//label[text()='RegEx']
     op: click
 check_info_of_silence_detail_reg:
   params:


### PR DESCRIPTION
see from https://issues.redhat.com/browse/OCPQE-14398
since 4.12, UI added "Negative matcher" checkbox on "Create silence" page, the element is after "RegEx" checkbox.
the check_use_regular action is used OCP-21363,OCP-21166,OCP-21192 cases and defines as
```
check_use_regular:
  element:
    selector:
      xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']
    op: click
```
since there are 2 checkbox on page now, the action would select the second checkbox  "Negative matcher", not the "RegEx" which we wanted to check.

This PR updates the xpath to strictly select the  "RegEx" checkbox
```
xpath: //span[text()='Alert labels']/ancestor::div[@class='co-m-pane__body-group']//label[text()='RegEx']/input[@type='checkbox']
```
4.12 runner job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/768397/consoleFull

4.13 runner job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/768396/consoleFull

4.14 runner job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/768399/consoleFull
