### PR TITLE
temp remove hypershift-hosted tag from dns upgrade case

### DIFF
--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -55,7 +55,6 @@ Feature: Routing and DNS related scenarios
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: ensure DNS works well before and after upgrade - prepare
     # Check service name can be resolvede
     Given I switch to cluster admin pseudo user
@@ -81,7 +80,6 @@ Feature: Routing and DNS related scenarios
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   @critical
   Scenario: ensure DNS works well before and after upgrade
     # Check service name can be resolvede


### PR DESCRIPTION
temporarily remove tag due to https://issues.redhat.com/browse/OCPBUGS-10604

@LiangquanLi930 PTAL, thanks