### PR TITLE
fix OCPQE-14529: remote worker issue

### DIFF
--- a/features/upgrade/routing/upgrade.feature
+++ b/features/upgrade/routing/upgrade.feature
@@ -98,7 +98,7 @@ Feature: Routing and DNS related scenarios
   @admin
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @baremetal-ipi
-  @vsphere-upi @openstack-upi @baremetal-upi
+  @vsphere-upi @openstack-upi
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
@@ -129,7 +129,7 @@ Feature: Routing and DNS related scenarios
   @admin
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @baremetal-ipi
-  @vsphere-upi @openstack-upi @baremetal-upi
+  @vsphere-upi @openstack-upi
   @proxy @noproxy @disconnected @connected
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn


### PR DESCRIPTION
To address https://issues.redhat.com/browse/OCPQE-14529 
We don't have good way to just skip profile with remote worker in cucushift, so remove tag "baremetal-upi" for now.
 
In future we can re-implement this case with Ginkgo framework and add logic for remote worker. 