### PR TITLE
Fix upgrade test to use modified step definition

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -295,7 +295,9 @@ Feature: SDN compoment upgrade testing
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
-  Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade - prepare
+    Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade - prepare
+    # Get the worker nodes for scheduling the pod
+    Given I store the ready and schedulable nodes in the :nodes clipboard
     Given I switch to cluster admin pseudo user
     When I run the :new_project client command with:
       | project_name | policy-upgrade3 |
@@ -343,13 +345,14 @@ Feature: SDN compoment upgrade testing
     When I use the "policy-upgrade5" project
     Given I obtain test data file "networking/list_for_pods.json"
     When I run oc create over "list_for_pods.json" replacing paths:
-      | ["items"][0]["spec"]["replicas"]  | 1    |
+      | ["items"][0]["spec"]["replicas"]                      | 1                       |
+      | ["items"][0]["spec"]["template"]["spec"]["nodeName"]  | <%= cb.nodes[0].name %> |
     Then the step should succeed
     Given a pod becomes ready with labels:
       | name=test-pods |
     Then the step should succeed
     And evaluation of `pod(2).ip_url` is stored in the :p5pod1ip clipboard
-    Given I save multus pod on master node to the :multuspod clipboard
+    Given I save multus pod on node "<%= cb.nodes[1].name %>" to the :multuspod clipboard
     Given the DefaultDeny policy is applied to the "policy-upgrade5" namespace
     Then the step should succeed
     Given I obtain test data file "networking/networkpolicy/allow-from-hostnetwork.yaml"
@@ -389,6 +392,8 @@ Feature: SDN compoment upgrade testing
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade
+    # Get the worker nodes for scheduling the pod
+    Given I store the ready and schedulable nodes in the :nodes clipboard
     Given I switch to cluster admin pseudo user
     When I use the "policy-upgrade3" project
     Given a pod becomes ready with labels:
@@ -404,7 +409,7 @@ Feature: SDN compoment upgrade testing
     Given a pod becomes ready with labels:
       | name=test-pods |
     And evaluation of `pod(2).ip_url` is stored in the :p5pod1ip clipboard
-    Given I save multus pod on master node to the :multuspod clipboard
+    Given I save multus pod on node "<%= cb.nodes[1].name %>" to the :multuspod clipboard
     Given I switch to cluster admin pseudo user
     Given I use the "openshift-multus" project
     And I wait up to 30 seconds for the steps to pass:


### PR DESCRIPTION
@openshift/team-sdn-qe PTAL
Logs before upgrade
bundle exec cucumber features/upgrade/sdn/policy-upgrade.feature:298
<pre>
      Now using project "policy-upgrade5" on server "https://api.asood-3241.qe.devcluster.openshift.com:6443".
      [15:52:36] INFO> Exit Status: 0
waiting for operation up to 900 seconds..
waiting for operation up to 3600 seconds..
    Given a pod becomes ready with labels:                                                        # features/step_definitions/pod.rb:1
      | name=test-pods |
      [15:52:37] INFO> oc get pods --output=yaml -l name\=test-pods --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig -n policy-upgrade5
      [15:52:37] INFO> 1 iterations for 1 sec, returned 1 pods, 1 matching
    And evaluation of `pod(2).ip_url` is stored in the :p5pod1ip clipboard                        # features/step_definitions/common.rb:128
waiting for operation up to 3600 seconds..
    Given I save multus pod on node "<%= cb.nodes[1].name %>" to the :multuspod clipboard         # features/step_definitions/networking.rb:1366
...
       Now using project "openshift-multus" on server "https://api.asood-3241.qe.devcluster.openshift.com:6443".
      [13:56:16] INFO> Exit Status: 0
      [13:56:16] INFO> Shell Commands: oc exec multus-ckbn8  --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig -n openshift-multus  -i -- curl -I 10.129.0.34:8080
      HTTP/1.1 200 OK
      X-Request-Port: 8080
      Date: Fri, 24 Mar 2023 13:56:17 GMT
      Content-Length: 17
      Content-Type: text/plain; charset=utf-8
      
      
      STDERR:
      E0324 09:56:17.334113   67291 v2.go:105] read /dev/stdin: resource temporarily unavailable
        % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                       Dload  Upload   Total   Spent    Left  Speed
  0    17    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
      [13:56:17] INFO> Exit Status: 0
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [13:56:17] INFO> === After Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade - prepare ===
      [13:56:17] INFO> Shell Commands: rm -r -f -- /home/asood/workdir/asood-asoodx
      
      [13:56:18] INFO> Exit Status: 0
      [13:56:19] INFO> === End After Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade - prepare ===
# @author asood@redhat.com
# @case_id OCP-40620
# Get the worker nodes for scheduling the pod
# @author anusaxen@redhat.com
#Using node port to expose the service on port 8080 on the node IP address
# @author anusaxen@redhat.com
# @case_id OCP-44901
#Getting service name and nodeport value
# Creating a simple client pod to generate traffic from it towards the exposed node IP address
# The 3 seconds mechanism via for loop will create an Assured conntrack entry which will give us enough time to validate upcoming steps
#Creating network test pod to levearage conntrack tool
#Deleting the udp listener pod which will trigger a new udp listener pod with new IP
# The 3 seconds mechanism via for loop will create an Assured conntrack entry which will give us enough time to validate upcoming steps
#Making sure that the conntrack table should not contain old deleted udp listener pod IP entries but new pod one's
# @author asood@redhat.com
# @author asood@redhat.com
# @case_id OCP-44978

1 scenario (1 passed)
46 steps (46 passed)
0m56.152s
[13:56:19] INFO> === At Exit ===

</pre>

Post Upgrade
bundle exec cucumber features/upgrade/sdn/policy-upgrade.feature:394
<pre>

Using the default, devel and _devel profiles...
Feature: SDN compoment upgrade testing

....
....
      [15:52:38] INFO> Exit Status: 0
      [15:52:38] INFO> The multus pod on node ip-10-0-150-108.us-east-2.compute.internal is stored to the multus-vcfbb clipboard.
    Given I switch to cluster admin pseudo user                                                   # features/step_definitions/user.rb:13
waiting for operation up to 3600 seconds..
    Given I use the "openshift-multus" project                                                    # features/step_definitions/project.rb:126
      [15:52:38] INFO> Shell Commands: oc project openshift-multus --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig
      Now using project "openshift-multus" on server "https://api.asood-3241.qe.devcluster.openshift.com:6443".
      [15:52:39] INFO> Exit Status: 0
waiting for operation up to 3600 seconds..
    And I wait up to 30 seconds for the steps to pass:                                            # features/step_definitions/meta_steps.rb:33
      """
      When I execute on the "<%= cb.multuspod %>" pod:
        | curl | -I | <%= cb.p5pod1ip %>:8080 |
      Then the step should succeed
      """
      [15:52:39] INFO> Shell Commands: oc exec multus-vcfbb  --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig -n openshift-multus  -i -- curl -I 10.129.0.7:8080
      HTTP/1.1 200 OK
      X-Request-Port: 8080
      Date: Fri, 24 Mar 2023 15:52:39 GMT
      Content-Length: 17
      Content-Type: text/plain; charset=utf-8
      
      
      STDERR:
      E0324 11:52:39.722940   77232 v2.go:105] read /dev/stdin: resource temporarily unavailable
        % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                       Dload  Upload   Total   Spent    Left  Speed
  0    17    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
      [15:52:40] INFO> Exit Status: 0
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [15:52:40] INFO> === After Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade ===
      [15:52:40] INFO> Shell Commands: rm -r -f -- /home/asood/workdir/asood-asoodx
      
      [15:52:41] INFO> Exit Status: 0
      [15:52:42] INFO> === End After Scenario: Check allow from router and allow from hostnetwork policy are functional post upgrade ===
# @author anusaxen@redhat.com
#Using node port to expose the service on port 8080 on the node IP address
# @author anusaxen@redhat.com
# @case_id OCP-44901
#Getting service name and nodeport value
# Creating a simple client pod to generate traffic from it towards the exposed node IP address
# The 3 seconds mechanism via for loop will create an Assured conntrack entry which will give us enough time to validate upcoming steps
#Creating network test pod to levearage conntrack tool
#Deleting the udp listener pod which will trigger a new udp listener pod with new IP
# The 3 seconds mechanism via for loop will create an Assured conntrack entry which will give us enough time to validate upcoming steps
#Making sure that the conntrack table should not contain old deleted udp listener pod IP entries but new pod one's
# @author asood@redhat.com
# @author asood@redhat.com
# @case_id OCP-44978

1 scenario (1 passed)
15 steps (15 passed)
0m28.621s
[15:52:42] INFO> === At Exit ===