### PR TITLE
fix failed to wait for extension background page to load

### DIFF
--- a/lib/webauto/web4cucumber.rb
+++ b/lib/webauto/web4cucumber.rb
@@ -137,7 +137,7 @@ require_relative 'chrome_extension'
       elsif @browser_type == :chrome
         logger.info "Launching Chrome"
         if self.class.container?
-          chrome_switches.concat %w[--no-sandbox --headless --disable-setuid-sandbox --disable-gpu --disable-infobars --disable-dev-shm-usage --disable-extensions]
+          chrome_switches.concat %w[--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-infobars --disable-dev-shm-usage]
         end
         options = {
           browser_name: 'chrome',


### PR DESCRIPTION
In our last fix for chrome crash issue, we added two additional flags `--headless` `--disable-extensions` (they are not the root cause of chrome crash though)

remove them to fix the error on proxy env
```
unknown error: failed to wait for extension background page to load: chrome-extension://aclcanenaacekdmjiifonplhjidphjin/_generated_background_page.html

from unknown error: page could not be found: chrome-extension://aclcanenaacekdmjiifonplhjidphjin/_generated_background_page.html (Selenium::WebDriver::Error::UnknownError)
```
pass log on proxy env: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/771517/console 
pass log on normal env: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/771528/console 