### PR TITLE
update-OCP-22504

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1385,16 +1385,7 @@ Feature: Multus-CNI related scenarios
       | ["metadata"]["name"]      | macvlan-bridge-25657    |
       | ["metadata"]["namespace"] | <%= project(-1).name %> |
     Then the step should succeed
-    # Check NAD is configured under project namespace
-    And I wait up to 30 seconds for the steps to pass:
-    """
-    When I run the :get admin command with:
-      | resource | net-attach-def          |
-      | n        | <%= project(-1).name %> |
-    Then the step should succeed
-    And the output should contain:
-      | macvlan-bridge-25657 |
-    """   
+    And admin checks that the "macvlan-bridge-25657" network_attachment_definition exists in the "<%= project(-1).name %>" project  
     Given I use the "<%= project(-2).name %>" project
     # Create a pod in new project consuming net-attach-def from 1st project
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1385,6 +1385,16 @@ Feature: Multus-CNI related scenarios
       | ["metadata"]["name"]      | macvlan-bridge-25657    |
       | ["metadata"]["namespace"] | <%= project(-1).name %> |
     Then the step should succeed
+    # Check NAD is configured under project namespace
+    And I wait up to 30 seconds for the steps to pass:
+    """
+    When I run the :get admin command with:
+      | resource | net-attach-def          |
+      | n        | <%= project(-1).name %> |
+    Then the step should succeed
+    And the output should contain:
+      | macvlan-bridge-25657 |
+    """   
     Given I use the "<%= project(-2).name %>" project
     # Create a pod in new project consuming net-attach-def from 1st project
     Given I obtain test data file "networking/multus-cni/Pods/generic_multus_pod.yaml"


### PR DESCRIPTION
[OCP-22504](http://10.14.89.3:3000/prow_test_cases/OCP-22504) case has 50% pass rate in 4.12/4.13/4.14 since 2/18/2023. Dev think it's timing related issue and suggest to add step to print out the configured NAD in the script.

@openshift/team-sdn-qe PTAL

Test log: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/6027/console


