### PR TITLE
Update descheduler rb file to have project name

### DIFF
--- a/features/step_definitions/descheduler.rb
+++ b/features/step_definitions/descheduler.rb
@@ -12,16 +12,16 @@ Given(/^the "([^"]*)" descheduler CR is restored from the "([^"]*)" after scenar
   patch_json = org_descheduler.to_json
   _admin = admin
   teardown_add {
-    @result = admin.cli_exec(:get, resource: 'kubedescheduler', resource_name: name, o: 'yaml')
+    @result = admin.cli_exec(:get, resource: 'kubedescheduler', resource_name: name, o: 'yaml', n: project_name)
     if @result[:success] and @result[:parsed]['spec']['profileCustomizations']
       patch_pc_json = [{"op": "remove","path": "/spec/profileCustomizations"}].to_json
       opts_pc = {resource: 'kubedescheduler', resource_name: name, p: patch_pc_json, type: 'json' }
-      @result_pc = _admin.cli_exec(:patch, **opts_pc)
+      @result_pc = _admin.cli_exec(:patch, **opts_pc, n: project_name)
       rasie "Cannot restore profileCustomizations" unless @result_pc[:success]
       opts = {resource: 'kubedescheduler', resource_name: name, p: patch_json, type: 'merge' }
     end
     opts = {resource: 'kubedescheduler', resource_name: name, p: patch_json, type: 'merge' }
-    @result = _admin.cli_exec(:patch, **opts)
+    @result = _admin.cli_exec(:patch, **opts, n: project_name)
     raise "Cannot restore descheduler: #{name}" unless @result[:success]
 }
 end


### PR DESCRIPTION
with out the fix here i see that test is failing because it is unable to find kubedescheduler cluster object as it is switching over to openshift-monitoring project with the recent updated code. 