### PR TITLE
update rules for deploy from image

### DIFF
--- a/lib/rules/web/admin_console/4.14/catalog.xyaml
+++ b/lib/rules/web/admin_console/4.14/catalog.xyaml
@@ -38,9 +38,6 @@ choose_k8s_type:
     resource_id: select-option-resources-kubernetes
   action: choose_resource_type
 choose_resource_type:
-  params:
-    button_text: Resource type
-  action: click_button
   elements:
   - selector:
       xpath: //button[@id='form-select-input-resources-field']


### PR DESCRIPTION
in OCP 4.14, `Resource type` was shown on the deploy page by default, hence removed the logic to click on `Resource type` button
![Screenshot 2023-04-10 at 10 05 16 AM](https://user-images.githubusercontent.com/12692381/230811778-5dbefa5d-e009-4519-9c52-11b6aec39c87.png)
