### PR TITLE
Add write permission for /.ansible

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -55,5 +55,5 @@ RUN mkdir -p /usr/share/ansible/ && cd /usr/share/ansible/  && \
 
 # Fixing OCPQE-11756
 RUN set -x && \
-    mkdir /.local && \
-    chmod -R 777 /.local
+    mkdir /.ansible /.local && \
+    chmod -R 777 /.ansible /.local


### PR DESCRIPTION
Supports https://github.com/openshift/release/pull/38103, to workaround issue as below, before we submit the fix to openshift-ansible repository (and get their approval).
```
TASK [openshift_node : Get cluster version] ************************************
task path: /usr/share/ansible/openshift-ansible/roles/openshift_node/tasks/version_checks.yml:4
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: 1007580000
<localhost> EXEC /bin/sh -c 'echo ~1007580000 && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /.ansible/tmp `"&& mkdir "` echo /.ansible/tmp/ansible-tmp-1681142912.4549086-776-152307679452199 `" && echo ansible-tmp-1681142912.4549086-776-152307679452199="` echo /.ansible/tmp/ansible-tmp-1681142912.4549086-776-152307679452199 `" ) && sleep 0'
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: 1007580000
<localhost> EXEC /bin/sh -c 'echo ~1007580000 && sleep 0'
fatal: [10.0.32.5 -> localhost]: UNREACHABLE! => {
    "changed": false,
    "msg": "Failed to create temporary directory. In some cases, you may have been able to authenticate and did not have permissions on the target directory. Consider changing the remote tmp path in ansible.cfg to a path rooted in \"/tmp\", for more error information use -vvv. Failed command was: ( umask 77 && mkdir -p \"` echo /.ansible/tmp `\"&& mkdir \"` echo /.ansible/tmp/ansible-tmp-1681142912.4549086-776-152307679452199 `\" && echo ansible-tmp-1681142912.4549086-776-152307679452199=\"` echo /.ansible/tmp/ansible-tmp-1681142912.4549086-776-152307679452199 `\" ), exited with result 1",
    "unreachable": true
}
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /.ansible/tmp `"&& mkdir "` echo /.ansible/tmp/ansible-tmp-1681142912.5367908-777-196543933656744 `" && echo ansible-tmp-1681142912.5367908-777-196543933656744="` echo /.ansible/tmp/ansible-tmp-1681142912.5367908-777-196543933656744 `" ) && sleep 0'
fatal: [10.0.32.6 -> localhost]: UNREACHABLE! => {
    "changed": false,
    "msg": "Failed to create temporary directory. In some cases, you may have been able to authenticate and did not have permissions on the target directory. Consider changing the remote tmp path in ansible.cfg to a path rooted in \"/tmp\", for more error information use -vvv. Failed command was: ( umask 77 && mkdir -p \"` echo /.ansible/tmp `\"&& mkdir \"` echo /.ansible/tmp/ansible-tmp-1681142912.5367908-777-196543933656744 `\" && echo ansible-tmp-1681142912.5367908-777-196543933656744=\"` echo /.ansible/tmp/ansible-tmp-1681142912.5367908-777-196543933656744 `\" ), exited with result 1",
    "unreachable": true
}
```

/cc @pruan-rht @shellyyang1989 @jhou1 @JianLi-RH @dis016 