### PR TITLE
Fix permission for folder openshift-ansible

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -50,8 +50,8 @@ RUN set -x && \
     rm -rf /var/cache/yum /var/tmp/* /tmp/* /verification-tests/Gemfile.lock
 
 # Add ansible playbooks
-RUN mkdir -p /usr/share/ansible/ && cd /usr/share/ansible/  && \
-    git clone https://github.com/openshift/openshift-ansible.git  
+RUN git clone --depth 1 https://github.com/openshift/openshift-ansible.git /usr/share/ansible/openshift-ansible && \
+    chmod -R 777 /usr/share/ansible/openshift-ansible
 
 # Fixing OCPQE-11756
 RUN set -x && \


### PR DESCRIPTION
Support https://github.com/openshift/release/pull/38103 to fix error `fatal: Unable to create '/usr/share/ansible/openshift-ansible/.git/index.lock': Permission denied`

/cc @shellyyang1989 @pruan-rht @jhou1 @JianLi-RH @dis016 