### PR TITLE
Remove option depth when git clone as we need the older release branch

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -50,7 +50,7 @@ RUN set -x && \
     rm -rf /var/cache/yum /var/tmp/* /tmp/* /verification-tests/Gemfile.lock
 
 # Add ansible playbooks
-RUN git clone --depth 1 https://github.com/openshift/openshift-ansible.git /usr/share/ansible/openshift-ansible && \
+RUN git clone https://github.com/openshift/openshift-ansible.git /usr/share/ansible/openshift-ansible && \
     chmod -R 777 /usr/share/ansible/openshift-ansible
 
 # Fixing OCPQE-11756


### PR DESCRIPTION
```
$ git checkout release-4.10
error: pathspec 'release-4.10' did not match any file(s) known to git
```

/cc @gpei @shellyyang1989 @jhou1 @JianLi-RH @pruan-rht @dis016 