### PR TITLE
GCP defaulting machineset creation to skip for clusters when no publicZone exists

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -377,6 +377,8 @@ Feature: Machine features testing
   Scenario: OCP-33056:ClusterInfrastructure Implement defaulting machineset values for GCP
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
+    Then admin check that cluster does not have empty public zone 
+
     And I use the "openshift-machine-api" project
     Then admin ensures machine number is restored after scenario
 

--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -84,6 +84,15 @@ Given(/^I wait for the node of machine_machine_openshift_io(?: named "(.+)")? to
   cb["new_node"] = node_name
 end
 
+Then(/admin check that cluster does not have empty public zone$/) do
+  ensure_admin_tagged
+
+  if dns("cluster").public_zone == nil
+     logger.warn "The scenario will be skipped because publicZone is empty, default values won't work"
+     skip_this_scenario
+   end
+end
+
 Then(/^admin ensures machine number is restored after scenario$/) do
   ensure_admin_tagged
   machine_names_orig = BushSlicer::MachineMachineOpenshiftIo.list(user: admin, project: project("openshift-machine-api")).map(&:name)

--- a/lib/openshift/dns.rb
+++ b/lib/openshift/dns.rb
@@ -1,0 +1,13 @@
+module BushSlicer
+  class Dns < ClusterResource
+    RESOURCE = "dns"
+
+    # Avoid API name in class name for dis particular class
+    @kind = "DNS"
+
+    def public_zone(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached, quiet: quiet).
+        dig('spec', 'publicZone', 'id')
+    end
+  end
+end  


### PR DESCRIPTION
@jhou1 @sunzhaohua2 @huali9  PTAL , this is to fix - one of the case mentioned [here](https://issues.redhat.com/browse/OCPQE-10145?focusedId=22075597&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22075597) 

Validation (For failing cases to make it skip ) - https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/784464/console

Regular cases - https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/784463/console

Jenkins flake might cause job to stuck , here is the cluster which confirms creation - 

```
[miyadav@miyadav ~]$ oc get machines
NAME                                  PHASE     TYPE            REGION        ZONE            AGE
default-valued-33056-h2pxx            Running   n1-standard-4   us-central1   us-central1-a   7m16s
miyadav-1304v1-4wdsq-master-0         Running   n2-standard-4   us-central1   us-central1-a   66m
miyadav-1304v1-4wdsq-master-1         Running   n2-standard-4   us-central1   us-central1-b   66m
miyadav-1304v1-4wdsq-master-2         Running   n2-standard-4   us-central1   us-central1-c   66m
miyadav-1304v1-4wdsq-worker-a-r68lj   Running   n2-standard-4   us-central1   us-central1-a   59m
miyadav-1304v1-4wdsq-worker-b-fspft   Running   n2-standard-4   us-central1   us-central1-b   59m
miyadav-1304v1-4wdsq-worker-c-7bjtz   Running   n2-standard-4   us-central1   us-central1-c   59m

```