### PR TITLE
Assign proper permission for folder openshift-ansible

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -51,7 +51,7 @@ RUN set -x && \
 
 # Add ansible playbooks
 RUN git clone https://github.com/openshift/openshift-ansible.git /usr/share/ansible/openshift-ansible && \
-    chmod -R 777 /usr/share/ansible/openshift-ansible
+    chmod -R g=rwx /usr/share/ansible/openshift-ansible
 
 # Fixing OCPQE-11756
 RUN set -x && \


### PR DESCRIPTION
Permission 777 is too open, 
```
[WARNING]: Ansible is being run in a world writable directory
(/usr/share/ansible/openshift-ansible), ignoring it as an ansible.cfg source.
```

/cc @dis016 @pruan-rht @jhou1 @JianLi-RH 