### PR TITLE
skip testing on cluster with rhel nodes

### DIFF
--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -19,7 +19,14 @@ Given(/^I have an IPI deployment$/) do
       logger.warn "machineset does not exist, tests running by copying existing machinesets will fail."
       logger.warn "We will skip this scenario, even though it is IPI deployment"
       skip_this_scenario
-    end   
+    end
+    
+  rhel_nodes = BushSlicer::Node.get_labeled("node.openshift.io/os_id=rhel", user: admin)
+    if rhel_nodes.length > 0
+      logger.warn "There are rhel nodes and rhel nodes may created by machineset, tests running by copying existing machinesets will fail."
+      logger.warn "We will skip this scenario, even though it is IPI deployment"
+      skip_this_scenario
+    end 
   end
 end
 


### PR DESCRIPTION
In prow, for aws cluster with rhel nodes, the [rhel nodes are created by machineset](https://github.com/openshift/release/blob/master/ci-operator/step-registry/workers-rhel/aws-provision/workers-rhel-aws-provision-commands.sh) although these nodes are created by machineset, but we can't scaling up directly as some additional steps are required, so I want to skip the test for the clusters with rhel nodes. Now almost all destructive cases failed in [aws-ipi-proxy-sdn-workers-rhel8](https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/613/362063/34785011?item1Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED)
@jhou1 @miyadav @huali9 PTAL