### PR TITLE
ignore normal messages when checking logs in ES pod

### DIFF
--- a/features/step_definitions/logging.rb
+++ b/features/step_definitions/logging.rb
@@ -1386,6 +1386,8 @@ Given /^I (check|record) all pods logs in the#{OPT_QUOTED} project(?: in last (\
           log = check_log(@result[:response], error_strings, ["the object has been modified"])
         when "kibana"
           log = check_log(@result[:response], error_strings, ["java.lang.UnsupportedOperationException"])
+        when "elasticsearch"
+          log = check_log(@result[:response], error_strings, ["INFO", "WARN"])
         when "collector"
           log = check_log(@result[:response], error_strings, ["Timeout flush: kubernetes.var.log"])
         when "elasticsearch-operator"


### PR DESCRIPTION
To fix failure: https://redhat-internal.slack.com/archives/CH76YSYSC/p1682476488689379 