### PR TITLE
Backport change of PR3292

### DIFF
--- a/lib/rules/web/admin_console/4.12/catalog.xyaml
+++ b/lib/rules/web/admin_console/4.12/catalog.xyaml
@@ -38,9 +38,6 @@ choose_k8s_type:
     resource_id: select-option-resources-kubernetes
   action: choose_resource_type
 choose_resource_type:
-  params:
-    button_text: Resource type
-  action: click_button
   elements:
   - selector:
       xpath: //button[@id='form-select-input-resources-field']

--- a/lib/rules/web/admin_console/4.13/catalog.xyaml
+++ b/lib/rules/web/admin_console/4.13/catalog.xyaml
@@ -38,9 +38,6 @@ choose_k8s_type:
     resource_id: select-option-resources-kubernetes
   action: choose_resource_type
 choose_resource_type:
-  params:
-    button_text: Resource type
-  action: click_button
   elements:
   - selector:
       xpath: //button[@id='form-select-input-resources-field']


### PR DESCRIPTION
Remove the logic of "click on Resource type button" in OCP4.13 and 4.12, based on the changes on PR 3292 
Since there is no "resource type" related function on the subsequent version page, only the rule of 4.12&4.13 is updated
Pass log
4.12: Runner/793940
4.13: Runner/793941