### PR TITLE
Make-OCP22504-flaky

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -1366,6 +1366,7 @@ Feature: Multus-CNI related scenarios
 
   # @author anusaxen@redhat.com
   # @case_id OCP-22504
+  @flaky
   @admin
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi


### PR DESCRIPTION
Case failed in https://gcsweb-qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-nightly-baremetal-compact-agent-ipv4-static-disconnected-proxy-p1-f7/1653874772552978432/artifacts/baremetal-compact-agent-ipv4-static-disconnected-proxy-p1-f7/cucushift-e2e/build-log.txt

Case OCP-22504 is very flaky in CI testing. 
It has 50% pass/fail rate in http://10.14.89.3:3000/prow_test_cases/OCP-22504
But it always passed in manual testing.

Mark this case with label @flaky now.

@openshift/team-sdn-qe PTAL
