### PR TITLE
skip default valued machineset scenario in ingress-controller-profile…

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -414,6 +414,7 @@ Feature: Machine features testing
   Scenario Outline: Implement defaulting machineset values for azure
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
+    And The cluster does not have ingress controller machineset
     And I use the "openshift-machine-api" project
     Then admin ensures machine number is restored after scenario
 

--- a/features/step_definitions/machine_set.rb
+++ b/features/step_definitions/machine_set.rb
@@ -5,6 +5,15 @@ Given(/^I pick a random( windows)? machineset to scale$/) do | windows |
   cache_resources *machine_sets.shuffle
 end
 
+Given(/^The cluster does not have ingress controller machineset$/) do
+  ensure_admin_tagged
+  machine_sets = BushSlicer::MachineSetMachineOpenshiftIo.list(user: admin, project: project("openshift-machine-api"))
+  if machine_sets.to_s.include? "ingress"
+    logger.warn "We will skip the scenario"
+      skip_this_scenario
+  end    
+end
+
 Given(/^I pick a earliest created machineset and store in#{OPT_SYM} clipboard$/) do | cb_name | 
   ensure_admin_tagged
   machine_sets = BushSlicer::MachineSetMachineOpenshiftIo.list(user: admin, project: project("openshift-machine-api"))


### PR DESCRIPTION
… on azure cluster

[Issue](https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/all/373784/36525736?item1Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.issueType%3Dti001%252Cti_1hrghcxlbgshc%252Cti_s4scyws6guht%252Cti_sok676b1k8j5%252Cti_r1ifkmkw19o1%252Cab001%26page.page%3D1) -  On cluster profile ingress-custom-controller , we install cluster with infra machinesets , there is config which is done in the workflow itself , so the resource groups  and other names seems to be slightly different(example resourceId url) , which we fetch for default machineset causes the case to fail. 

Mitigation - We are skipping the case if we identify it as ingress-custom cluster .

Seems it is ok to skip , instead of trying to fix cluster-install for this case. As this case runs on all profile anyways. 
Failed [run](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/797985/console)
Skipped [run](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/798055/console) with this PR