### PR TITLE
Add storage tag

### DIFF
--- a/features/storage/NoDiskConflict.feature
+++ b/features/storage/NoDiskConflict.feature
@@ -10,6 +10,7 @@ Feature: NoDiskConflict
   @aws-ipi
   @aws-upi
   @hypershift-hosted
+  @storage
   Scenario: OCP-9929:Storage Only one pod with the same persistent volume can be scheduled when NoDiskConflicts policy is enabled
     Given a 5 characters random string of type :dns is stored into the :proj_name clipboard
     When I run the :oadm_new_project admin command with:

--- a/features/storage/cinder.feature
+++ b/features/storage/cinder.feature
@@ -10,6 +10,7 @@ Feature: Cinder Persistent Volume
   @openstack-ipi
   @openstack-upi
   @hypershift-hosted
+  @storage
   Scenario: OCP-9643:Storage Persistent Volume with cinder volume plugin
     Given I have a project
     And I have a 1 GB volume and save volume id in the :vid clipboard

--- a/features/storage/cloud_provider.feature
+++ b/features/storage/cloud_provider.feature
@@ -8,6 +8,7 @@ Feature: kubelet restart and node restart
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: kubelet restart should not affect attached/mounted volumes
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"

--- a/features/storage/csi.feature
+++ b/features/storage/csi.feature
@@ -5,6 +5,7 @@ Feature: CSI testing related feature
   @admin
   @stage-only
   @proxy @noproxy @connected
+  @storage
   Scenario: OCP-30787:Storage CSI images checking in stage and prod env
     Given the master version >= "4.4"
     Given I switch to cluster admin pseudo user
@@ -20,6 +21,7 @@ Feature: CSI testing related feature
   @admin
   @stage-only
   @proxy @noproxy @connected
+  @storage
   Scenario: OCP-31345:Storage CSI images checking in stage env in OCP4.3
     Given the master version == "4.3"
     Given I switch to cluster admin pseudo user
@@ -32,6 +34,7 @@ Feature: CSI testing related feature
   @admin
   @stage-only
   @proxy @noproxy @connected
+  @storage
   Scenario: OCP-31346:Storage CSI images checking in stage env in OCP4.2
     Given the master version == "4.2"
     Given I switch to cluster admin pseudo user
@@ -47,6 +50,7 @@ Feature: CSI testing related feature
   @network-ovnkubernetes @network-openshiftsdn
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: Configure 'Retain' reclaim policy
     Given I have a project
     And admin clones storage class "sc-<%= project.name %>" from "<sc_name>" with:
@@ -102,6 +106,7 @@ Feature: CSI testing related feature
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @storage
   Scenario Outline: CSI dynamic provisioning with default fstype
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -189,6 +194,7 @@ Feature: CSI testing related feature
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @storage
   Scenario Outline: CSI dynamic provisioning with fstype
     Given I have a project
     When admin clones storage class "sc-<%= project.name %>" from "<sc_name>" with:
@@ -246,6 +252,7 @@ Feature: CSI testing related feature
   @network-ovnkubernetes @network-openshiftsdn
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @storage
   Scenario Outline: CSI dynamic provisioning with block
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -300,6 +307,7 @@ Feature: CSI testing related feature
   @network-ovnkubernetes @network-openshiftsdn
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: CSI dynamic provisioning with different type
     Given I have a project
     And admin clones storage class "sc-<%= project.name %>" from "<sc_name>" with:
@@ -355,6 +363,7 @@ Feature: CSI testing related feature
   @network-ovnkubernetes @network-openshiftsdn
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: Check CSI Driver Operator installation
     When I run the :get admin command with:
       | resource | clusteroperator/storage                                                            |

--- a/features/storage/csi_clone.feature
+++ b/features/storage/csi_clone.feature
@@ -19,6 +19,7 @@ Feature: CSI clone testing related feature
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @storage
   Scenario: OCP-27615:Storage Clone a PVC and verify data consistency
     # Step 1
     Given the master version >= "4.7"
@@ -67,6 +68,7 @@ Feature: CSI clone testing related feature
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @storage
   Scenario: OCP-27689:Storage Cinder CSI Clone Clone a pvc with capacity greater than original pvc
     Given I have a project
     # Create mypvc-ori with 1Gi size
@@ -123,6 +125,7 @@ Feature: CSI clone testing related feature
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @storage
   Scenario: OCP-27690:Storage Cinder CSI Clone Clone a pvc with capacity less than original pvc will fail
     Given I have a project
     # Create mypvc-ori with 2Gi size
@@ -179,6 +182,7 @@ Feature: CSI clone testing related feature
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @storage
   Scenario: OCP-30315:Storage Cinder CSI clone Clone a pvc with block VolumeMode successfully
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -239,6 +243,7 @@ Feature: CSI clone testing related feature
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @storage
   Scenario: OCP-27617:Storage Cinder CSI Clone Clone a pvc with default storageclass
     Given default storage class is patched to non-default
     And admin clones storage class "my-csi-default" from "standard-csi" with:
@@ -299,6 +304,7 @@ Feature: CSI clone testing related feature
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
   @inactive
+  @storage
   Scenario: OCP-27686:Storage Cinder CSI Clone Clone a pvc with different storage class is failed
     # Create mypvc-ori with sc1
     Given I have a project

--- a/features/storage/csi_resize.feature
+++ b/features/storage/csi_resize.feature
@@ -8,6 +8,7 @@ Feature: CSI Resizing related feature
   @network-ovnkubernetes @network-openshiftsdn
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: Resize online volume from 1Gi to 2Gi
     Given I have a project
 
@@ -70,6 +71,7 @@ Feature: CSI Resizing related feature
   @network-ovnkubernetes @network-openshiftsdn
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: Resize negative test
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -105,6 +107,7 @@ Feature: CSI Resizing related feature
 
   # @author ropatil@redhat.com
   @admin
+  @storage
   Scenario Outline: CSI Resize offline volume expansion from 1Gi to 2Gi
     Given I have a project
 

--- a/features/storage/csi_snapshot.feature
+++ b/features/storage/csi_snapshot.feature
@@ -9,6 +9,7 @@ Feature: Volume snapshot test
   @network-ovnkubernetes @network-openshiftsdn
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @storage
   Scenario Outline: Volume snapshot create and restore test
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -87,6 +88,7 @@ Feature: Volume snapshot test
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @storage
   Scenario Outline: Volume snapshot create and restore test with block
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"

--- a/features/storage/dynamic_provisioning.feature
+++ b/features/storage/dynamic_provisioning.feature
@@ -8,6 +8,7 @@ Feature: Dynamic provisioning
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: dynamic provisioning
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"

--- a/features/storage/fsType.feature
+++ b/features/storage/fsType.feature
@@ -8,6 +8,7 @@ Feature: testing for parameter fsType
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: persistent volume formated with fsType
     Given I have a project
     And admin creates new in-tree storageclass with:

--- a/features/storage/hostpath.feature
+++ b/features/storage/hostpath.feature
@@ -8,6 +8,7 @@ Feature: Storage of Hostpath plugin testing
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: Create hostpath pv with access mode and reclaim policy
     Given I have a project with proper privilege
     Given I obtain test data file "storage/hostpath/local.yaml"

--- a/features/storage/local-storage-operator.feature
+++ b/features/storage/local-storage-operator.feature
@@ -4,6 +4,7 @@ Feature: local-storage-operator related features
   # @case_id OCP-24493
   @admin
   @inactive
+  @storage
   Scenario: OCP-24493:Storage Operator local-storage exist in OperatorHub
     Given I switch to cluster admin pseudo user
     And admin uses the "openshift-marketplace" project

--- a/features/storage/negative.feature
+++ b/features/storage/negative.feature
@@ -7,6 +7,7 @@ Feature: negative testing
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: PV with invalid volume id should be prevented from creating
     Given admin ensures "mypv" pv is deleted after scenario
     Given I obtain test data file "storage/<dir>/<file>"

--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -13,6 +13,7 @@ Feature: NFS Persistent Volume
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @storage
   Scenario: OCP-9572:Storage Share NFS with multiple pods with ReadWriteMany mode
     Given I have a project with proper privilege
     And I have a NFS service in the project
@@ -68,6 +69,7 @@ Feature: NFS Persistent Volume
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @storage
   Scenario: OCP-10281:Storage Permission denied when nfs pv annotaion is not right
     Given I have a project with proper privilege
     And I have a NFS service in the project

--- a/features/storage/node_operations.feature
+++ b/features/storage/node_operations.feature
@@ -7,6 +7,7 @@ Feature: Node operations test scenarios
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: Drain a node that has cloud vendor volumes
     Given environment has at least 2 schedulable nodes
     And I have a project

--- a/features/storage/persistent_volume.feature
+++ b/features/storage/persistent_volume.feature
@@ -9,6 +9,7 @@ Feature: Persistent Volume Claim binding policies
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: PVC with one accessMode can bind PV with all accessMode
     Given I have a project
 
@@ -52,6 +53,7 @@ Feature: Persistent Volume Claim binding policies
   # @author yinzhou@redhat.com
   # @case_id OCP-11933
   @inactive
+  @storage
   Scenario: OCP-11933:Workloads deployment hook volume inheritance -- with persistentvolumeclaim Volume
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -83,6 +85,7 @@ Feature: Persistent Volume Claim binding policies
   @network-ovnkubernetes @network-openshiftsdn
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: PV can not bind PVC which request more storage
     Given I have a project
     # PV is 100Mi and PVC is 1Gi
@@ -121,6 +124,7 @@ Feature: Persistent Volume Claim binding policies
   @network-ovnkubernetes @network-openshiftsdn
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: PV can not bind PVC with mismatched accessMode
     Given I have a project
     Given I obtain test data file "storage/nfs/auto/pv-template.json"

--- a/features/storage/pre-bind.feature
+++ b/features/storage/pre-bind.feature
@@ -10,6 +10,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
+  @storage
   Scenario: OCP-10107:Storage Prebound pv is availabe due to requested pvc status is bound
     Given I create a project with non-leading digit name
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -40,6 +41,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
+  @storage
   Scenario: OCP-10109:Storage Prebound pv is availabe due to mismatched accessmode with requested pvc
     Given I create a project with non-leading digit name
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
@@ -69,6 +71,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
+  @storage
   Scenario: OCP-10111:Storage Prebound pvc is pending due to requested pv status is bound
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -98,6 +101,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
+  @storage
   Scenario: OCP-10113:Storage Prebound PVC is pending due to mismatched accessmode with requested PV
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -126,6 +130,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
+  @storage
   Scenario: OCP-10114:Storage Prebound PVC is pending due to mismatched volume size with requested PV
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -154,6 +159,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
+  @storage
   Scenario: OCP-9941:Storage PV and PVC bound successfully when pvc created prebound to pv
     Given I have a project
     Given I obtain test data file "storage/nfs/nfs.json"
@@ -185,6 +191,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
+  @storage
   Scenario: OCP-9940:Storage PV and PVC bound successfully when pv created prebound to pvc
     Given I create a project with non-leading digit name
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"
@@ -211,6 +218,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: Prebound pv/pvc is availabe/pending due to requested pvc/pv prebound to other pv/pvc
     Given I create a project with non-leading digit name
     Given I obtain test data file "storage/nfs/preboundpv-rwo.yaml"

--- a/features/storage/quota.feature
+++ b/features/storage/quota.feature
@@ -12,6 +12,7 @@ Feature: ResourceQuata for storage
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @storage
   Scenario: OCP-14173:Storage Requested storage can not exceed the namespace's storage quota
     Given I have a project with proper privilege
     And I switch to cluster admin pseudo user
@@ -91,6 +92,7 @@ Feature: ResourceQuata for storage
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @storage
   Scenario: OCP-14382:Storage Setting quota for a StorageClass
     Given I have a project
     Given admin clones storage class "sc-<%= project.name %>" from ":default" with:

--- a/features/storage/reclaim_policy.feature
+++ b/features/storage/reclaim_policy.feature
@@ -6,6 +6,7 @@ Feature: Persistent Volume reclaim policy tests
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: Persistent volume with RWO access mode and Delete policy
     Given I have a project
     And I have a 1 GB volume and save volume id in the :vid clipboard

--- a/features/storage/regression.feature
+++ b/features/storage/regression.feature
@@ -12,6 +12,7 @@ Feature: Regression testing cases
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @storage
   Scenario: OCP-16485:Storage RWO volumes are exclusively mounted on different nodes
     Given I have a project
     Given I store the schedulable workers in the :workers clipboard

--- a/features/storage/security.feature
+++ b/features/storage/security.feature
@@ -9,6 +9,7 @@ Feature: storage security check
   @network-ovnkubernetes @network-openshiftsdn
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: volume security testing
     Given I have a project with proper privilege
     Given I obtain test data file "storage/misc/pvc.json"
@@ -143,6 +144,7 @@ Feature: storage security check
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @storage
   Scenario: OCP-9709:Storage secret volume security check
     Given I have a project with proper privilege
     Given I obtain test data file "storage/secret/secret.yaml"

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -6,6 +6,7 @@ Feature: storageClass related feature
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: PVC modification after creating storage class
     Given I have a project
     Given I obtain test data file "storage/misc/pvc-without-annotations.json"
@@ -63,6 +64,7 @@ Feature: storageClass related feature
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: storage class provisioner
     Given I have a project
     And admin clones storage class "sc-<%= project.name %>" from ":default" with:
@@ -123,6 +125,7 @@ Feature: storageClass related feature
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: New creation PVC failed when multiple classes are set as default
     Given I have a project
     Given I obtain test data file "storage/misc/storageClass.yaml"
@@ -192,6 +195,7 @@ Feature: storageClass related feature
 
   # @author lxia@redhat.com
   @inactive
+  @storage
   Scenario Outline: New created PVC without specifying storage class use default class when only one class is marked as default
     Given I have a project
     Given I obtain test data file "storage/misc/pvc-without-annotations.json"
@@ -214,6 +218,7 @@ Feature: storageClass related feature
   @proxy @noproxy @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: PVC with storage class will provision pv with io1 type and 100/20000 iops ebs volume
     Given I have a project
     Given I obtain test data file "storage/ebs/dynamic-provisioning/storageclass-io1.yaml"
@@ -265,6 +270,7 @@ Feature: storageClass related feature
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: PVC with storage class will not provision pv with st1/sc1 type ebs volume if request size is wrong
     Given I have a project
     Given I obtain test data file "storage/ebs/dynamic-provisioning/storageclass.yaml"
@@ -309,6 +315,7 @@ Feature: storageClass related feature
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @storage
   Scenario: OCP-10159:Storage PVC with storage class won't provisioned pv if no storage class or wrong storage class object
     Given I have a project
     # No sc exists
@@ -340,6 +347,7 @@ Feature: storageClass related feature
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @storage
   Scenario: OCP-10228:Storage AWS ebs volume is dynamic provisioned with default storageclass
     Given I have a project
     Given I obtain test data file "storage/ebs/pvc-retain.json"

--- a/features/storage/storage_object_in_use_protection.feature
+++ b/features/storage/storage_object_in_use_protection.feature
@@ -2,6 +2,7 @@ Feature: Storage object in use protection
 
   # @author lxia@redhat.com
   # @case_id OCP-17253
+  @storage
   Scenario: OCP-17253:Storage Delete pvc which is not in active use by pod should be deleted immediately
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -13,6 +14,7 @@ Feature: Storage object in use protection
 
   # @author lxia@redhat.com
   # @case_id OCP-17254
+  @storage
   Scenario: OCP-17254:Storage Delete pvc which is in active use by pod should postpone deletion
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -51,6 +53,7 @@ Feature: Storage object in use protection
   # @author lxia@redhat.com
   # @case_id OCP-18796
   @admin
+  @storage
   Scenario: OCP-18796:Storage Delete pv which is bind with pvc should postpone deletion
     Given I have a project
     Given I obtain test data file "storage/nfs/auto/pv-template.json"

--- a/features/storage/vsphere.feature
+++ b/features/storage/vsphere.feature
@@ -8,6 +8,7 @@ Feature: vSphere test scenarios
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @storage
   Scenario Outline: Dynamically provision a vSphere volume with different disk formats
     Given I have a project
     Given I obtain test data file "storage/vsphere/storageclass.yml"
@@ -81,6 +82,7 @@ Feature: vSphere test scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @storage
   Scenario: OCP-13389:Storage Dynamically provision a vSphere volume with invalid disk format
     Given I have a project
     Given I obtain test data file "storage/vsphere/storageclass.yml"


### PR DESCRIPTION
Currently, cucushift has no label to unselect storage cases in baselinecaps-none profiles in CI, which make all cucushift storage cases failed.
This PR is to add storage tag.
See https://issues.redhat.com/browse/OCPQE-15009