### PR TITLE
fix OCP-19722 rules

### DIFF
--- a/lib/rules/web/admin_console/4.10/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.10/common_ui_elements.xyaml
@@ -778,6 +778,11 @@ click_link_with_text_only:
     selector:
       xpath: //a[contains(text(),'<text>')]
     op: click
+click_link_text:
+  element:
+    selector:
+      xpath: //a[text()='<text>']
+    op: click
 click_primary_menu:
   action:
     if_element:

--- a/lib/rules/web/admin_console/4.11/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.11/common_ui_elements.xyaml
@@ -778,6 +778,11 @@ click_link_with_text_only:
     selector:
       xpath: //a[contains(text(),'<text>')]
     op: click
+click_link_text:
+  element:
+    selector:
+      xpath: //a[text()='<text>']
+    op: click
 click_primary_menu:
   action:
     if_element:

--- a/lib/rules/web/admin_console/4.12/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.12/common_ui_elements.xyaml
@@ -778,6 +778,11 @@ click_link_with_text_only:
     selector:
       xpath: //a[contains(text(),'<text>')]
     op: click
+click_link_text:
+  element:
+    selector:
+      xpath: //a[text()='<text>']
+    op: click
 click_primary_menu:
   action:
     if_element:

--- a/lib/rules/web/admin_console/4.13/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.13/common_ui_elements.xyaml
@@ -778,6 +778,11 @@ click_link_with_text_only:
     selector:
       xpath: //a[contains(text(),'<text>')]
     op: click
+click_link_text:
+  element:
+    selector:
+      xpath: //a[text()='<text>']
+    op: click
 click_primary_menu:
   action:
     if_element:

--- a/lib/rules/web/admin_console/4.14/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.14/common_ui_elements.xyaml
@@ -778,6 +778,11 @@ click_link_with_text_only:
     selector:
       xpath: //a[contains(text(),'<text>')]
     op: click
+click_link_text:
+  element:
+    selector:
+      xpath: //a[text()='<text>']
+    op: click
 click_primary_menu:
   action:
     if_element:

--- a/lib/rules/web/admin_console/4.9/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.9/common_ui_elements.xyaml
@@ -777,6 +777,11 @@ click_link_with_text_only:
     selector:
       xpath: //a[contains(text(),'<text>')]
     op: click
+click_link_text:
+  element:
+    selector:
+      xpath: //a[text()='<text>']
+    op: click
 click_primary_menu:
   action:
     if_element:


### PR DESCRIPTION
added a new rule `click_link_text` which enables user to click on exact text