### PR TITLE
add another pfname

### DIFF
--- a/testdata/networking/sriov/ib/cx5/cx5-ib.yaml
+++ b/testdata/networking/sriov/ib/cx5/cx5-ib.yaml
@@ -9,6 +9,7 @@ spec:
     deviceID: "1017"
     pfNames:
       - ib0
+      - ibp94s0
     rootDevices:
       - '0000:5e:00.0'
     vendor: '15b3'


### PR DESCRIPTION
pfname are different in rhel8 (ib0) and rhel9(ibp94s0) to be compatible

@openshift/team-sdn-qe 