### PR TITLE
Remove CCO Upgrade test for Hypershift hosted cluster

### DIFF
--- a/features/upgrade/cloudcredential/upgrade.feature
+++ b/features/upgrade/cloudcredential/upgrade.feature
@@ -11,7 +11,6 @@ Feature: CloudCredentialOperator components upgrade tests
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @ppc64le @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: Cluster operator cloud-credential should be available after upgrade - prepare
     Given I switch to cluster admin pseudo user
     #Check cloud-credential version
@@ -41,7 +40,6 @@ Feature: CloudCredentialOperator components upgrade tests
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   @critical
   Scenario: Cluster operator cloud-credential should be available after upgrade
     # Check cloud-credential operator version after upgraded


### PR DESCRIPTION
CCO doesn't exist on Hypershift hosted cluster so its upgrade tests shall be removed