### PR TITLE
change from cluster_version to prometheus_build_info to fit for hypershift guest cluster

### DIFF
--- a/features/upgrade/monitoring/monitoring-upgrade.feature
+++ b/features/upgrade/monitoring/monitoring-upgrade.feature
@@ -48,7 +48,7 @@ Feature: cluster monitoring related upgrade check
     Given I find a bearer token of the prometheus-k8s service account
     When evaluation of `service_account('prometheus-k8s').cached_tokens.first` is stored in the :sa_token clipboard
 
-    # curl -k -H "Authorization: Bearer $token" 'https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query?query=cluster_installer'
+    # curl -k -H "Authorization: Bearer $token" 'https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query?query=prometheus_build_info'
     When I run the :exec admin command with:
       | n                | openshift-monitoring |
       | pod              | prometheus-k8s-0     |
@@ -56,10 +56,10 @@ Feature: cluster monitoring related upgrade check
       | oc_opts_end      |                      |
       | exec_command     | sh                   |
       | exec_command_arg | -c                   |
-      | exec_command_arg | curl -k -H "Authorization: Bearer <%= cb.sa_token %>" https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query?query=cluster_installer |
+      | exec_command_arg | curl -k -H "Authorization: Bearer <%= cb.sa_token %>" https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query?query=prometheus_build_info |
     Then the step should succeed
     And the output should contain:
-      | "__name__":"cluster_installer" |
+      | "__name__":"prometheus_build_info" |
 
     # curl -k -H "Authorization: Bearer $token" 'https://alertmanager-main.openshift-monitoring.svc:9094/api/v1/alerts'
     When I run the :exec admin command with:
@@ -78,7 +78,7 @@ Feature: cluster monitoring related upgrade check
     Then the output should contain:
       | CPU(cores) |
 
-    # curl -k -H "Authorization: Bearer $token" 'https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query?query=cluster_installer'
+    # curl -k -H "Authorization: Bearer $token" 'https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query?query=prometheus_build_info'
     When I run the :exec admin command with:
       | n                | openshift-monitoring |
       | pod              | prometheus-k8s-0     |
@@ -86,7 +86,7 @@ Feature: cluster monitoring related upgrade check
       | oc_opts_end      |                      |
       | exec_command     | sh                   |
       | exec_command_arg | -c                   |
-      | exec_command_arg | curl -k -H "Authorization: Bearer <%= cb.sa_token %>" https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query?query=cluster_installer |
+      | exec_command_arg | curl -k -H "Authorization: Bearer <%= cb.sa_token %>" https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query?query=prometheus_build_info |
     Then the step should succeed
     And the output should contain:
-      | "__name__":"cluster_installer" |
+      | "__name__":"prometheus_build_info" |


### PR DESCRIPTION
upgrade post check failed on hypershift guest cluster, see logs:
https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/all/378068/37336746/37336759/log?item1Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED

reason is there is not pod under openshift-cluster-version namespace in hypershift guest cluster, there will not have result for cluster_version metrics(the metrics is exposed by cluster-version-operator pod of openshift-cluster-version namespace), the upgrade post check case would be failed
```
    When I run the :exec admin command with:
      | n                | openshift-monitoring |
      | pod              | prometheus-k8s-0     |
      | c                | prometheus           |
      | oc_opts_end      |                      |
      | exec_command     | sh                   |
      | exec_command_arg | -c                   |
      | exec_command_arg | curl -k -H "Authorization: Bearer <%= cb.sa_token %>" https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query?query=cluster_installer |
    Then the step should succeed
    And the output should contain:
      | "__name__":"cluster_installer" |
```
hypershift guest cluster
```
$ oc -n openshift-cluster-version get deploy,pod
No resources found in openshift-cluster-version namespace.

$ token=`oc create token prometheus-k8s -n openshift-monitoring`
$ oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- curl -k -H "Authorization: Bearer $token" 'https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query?query=cluster_version' | jq
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": []
  }
}
```
change to prometheus_build_info metrics, then the case can pass on normal OCP cluster or hypershift guest/management cluster
1. hypershift guest cluster
prepare job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/801838/console

post check job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/801840/console


2. normal OCP cluster
prepare job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/801842/console

post check job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/801843/console