### PR TITLE
OCPQE-15438: Add subteam and case ID info to scenario name for workloads

### DIFF
--- a/features/upgrade/workloads/scheduler-upgrade.feature
+++ b/features/upgrade/workloads/scheduler-upgrade.feature
@@ -13,7 +13,7 @@ Feature: scheduler with custom policy upgrade check
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
-  Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine - prepare
+  Scenario: OCP-34164:Workloads Upgrading cluster when using a custom policy for kube-scheduler should work fine - prepare
     Given the "kube-scheduler" operator version matches the current cluster version
     Given the expression should be true> cluster_operator('kube-scheduler').condition(type: 'Progressing')['status'] == "False"
     And the expression should be true> cluster_operator('kube-scheduler').condition(type: 'Available')['status'] == "True"
@@ -63,7 +63,7 @@ Feature: scheduler with custom policy upgrade check
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  Scenario: Upgrading cluster when using a custom policy for kube-scheduler should work fine
+  Scenario: OCP-34164:Workloads Upgrading cluster when using a custom policy for kube-scheduler should work fine
     Given the "kube-scheduler" operator version matches the current cluster version
     Given the expression should be true> cluster_operator('kube-scheduler').condition(type: 'Progressing')['status'] == "False"
     And the expression should be true> cluster_operator('kube-scheduler').condition(type: 'Available')['status'] == "True"


### PR DESCRIPTION
To explicitly trigger a image build process for verification-tests, so that we can bring in code changes in cucushift.