### PR TITLE
assertion modified

### DIFF
--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -239,6 +239,6 @@ Feature: Machine misc features testing
       | resource_name | <%= pod.name %>    |
       | c             | machine-controller |
     Then the output should contain:
-      | Detaching disks before vm destroy  |
+      | Checking attached disks before vm destroy |
 
 


### PR DESCRIPTION
based on history of changes - https://github.com/openshift/machine-api-operator/commit/928b044c0476e821baf0c35ed683bb54f57fea44 

This happened due to - https://issues.redhat.com/browse/OCPBUGS-6063 

the text has changed , causing the test to fail . 
Failed - https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/811460/console
Passed - https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/811470/console