### PR TITLE
Kubernetes elected OVN leader fix to prevent few CI failures

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1585,9 +1585,9 @@ Given /^I store kubernetes elected leader pod for ovnkube-master in the#{OPT_SYM
     @result = admin.cli_exec(:get, resource: 'lease', o: "jsonpath={.items[*].spec.holderIdentity}")
     holder_id = @result[:response]
   end
-    pods = project.pods(by:user)
-    target_pod = pods.select {|p| p.props[:node_name] == holder_id }.first
-    cb[cb_leader_name ] = target_pod
+  pods = project.pods(by:user)
+  target_pod = pods.select {|p| p.props[:node_name] == holder_id }.first
+  cb[cb_leader_name ] = target_pod
 end
 
 Given /^the plugin is openshift-ovs-networkpolicy on the cluster$/ do


### PR DESCRIPTION
This was a long pending fix as per discussion https://redhat-internal.slack.com/archives/GLDDW02SJ/p1668593109540909
@openshift/team-sdn-qe 

Small change, < 4.13 we have `ovn-kubernetes-master` config map which is helpful is providing kubernetes elected OVN leader but for 4.13+ there is no config map so get lease is only option apparently.

Thanks