### PR TITLE
shifting a step later in conntrack case check

### DIFF
--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -418,9 +418,6 @@ Feature: Pod related networking scenarios
 
     #Deleting the udp listener pod which will trigger a new udp listener pod with new IP
     Given I ensure "<%= cb.host_pod1.name %>" pod is deleted
-    And a pod becomes ready with labels:
-      | name=udp-pods |
-    And evaluation of `pod` is stored in the :host_pod2 clipboard
 
     # The 3 seconds mechanism via for loop will create an Assured conntrack entry which will give us enough time to validate upcoming steps
     When I run the :exec background client command with:
@@ -430,6 +427,13 @@ Feature: Pod related networking scenarios
       | exec_command_arg | -c                                                                                       |
       | exec_command_arg | for n in {1..3}; do echo $n; sleep 1; done>/dev/udp/<%= cb.node_ip %>/<%= cb.nodeport %> |
     Then the step should succeed
+
+    #Storing new udp listener pod IP which was created as a result of deletion of old udp listener pod above
+    Given I use the "<%= project.name %>" project
+    And a pod is present with labels:
+      | name=udp-pods |
+    And evaluation of `pod` is stored in the :host_pod2 clipboard
+
     #Making sure that the conntrack table should not contain old deleted udp listener pod IP entries but new pod one's
     Given I wait up to 20 seconds for the steps to pass:
     """


### PR DESCRIPTION
This is one of the case failing frequently in CI, why? Probably due to race
I was able to repro it once in every 3 runs
```
 Given I ensure "<%= cb.host_pod1.name %>" pod is deleted
 And a pod becomes ready with labels:
```
The above steps means a pod has been deleted successfully and a new pod readiness is expected as that earlier pod was backed by an rc.

But due to some reason when a pod gets deleted and terminated successfully, the next step is storing old pod name. However if i add a 5 second delay after ensure, its not. So clearly a race among oc get and what api is responding at a certain time. Anyways I don't want to re-invent what ensure step is doing and things after that as such step is being leveraged by other teams in misc scenarios. So simple logic is moving that step later in the flow to give its sometime as I am against hard code wait poll of 5/10 seconds.

Tested 10 times locally with
```
seq 10 | xargs -Iz bundle exec cucumber features/networking/pod.feature:360
```