### PR TITLE
update 44315

### DIFF
--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -3,7 +3,7 @@ Feature: Egress compoment upgrade testing
   # @author huirwang@redhat.com
   @admin
   @upgrade-prepare
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.9 @4.8 @4.7
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @noproxy @connected
@@ -44,7 +44,7 @@ Feature: Egress compoment upgrade testing
   # @case_id OCP-44315
   @admin
   @upgrade-check
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.9 @4.8 @4.7
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @noproxy @connected


### PR DESCRIPTION
OCP-44315 (egressfirewall/egressnetworkpolicy upgrade case) will only be for the version 4.9 and previous 

@zhaozhanqi   Can you take a look? Thanks!