### PR TITLE
some rules fixes

### DIFF
--- a/lib/rules/web/admin_console/4.10/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.10/operator_hub.xyaml
@@ -731,7 +731,7 @@ open_k8sresource_dropdown:
   action:
     if_element:
       selector:
-        id: form
+        xpath: //input[@value='form']
     ref: switch_to_form_view
   element:
     selector:


### PR DESCRIPTION
on `4.10` the Form/YAML view has different definition
<img width="978" alt="Screen Shot 2023-06-27 at 10 32 00" src="https://github.com/openshift/verification-tests/assets/12692381/aa82a14a-5e27-4515-9dec-a2958cc6aafa">

OCP-32151 pass log on 4.10 Runner/817696/console