### PR TITLE
fix kebab action rule

### DIFF
--- a/lib/rules/web/admin_console/4.10/actions.xyaml
+++ b/lib/rules/web/admin_console/4.10/actions.xyaml
@@ -105,7 +105,7 @@ choose_item_from_list:
 click_resource_action_icon:
   elements:
   - selector:
-      xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr//td/div[contains(@class,'dropdown')]
+      xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr[@data-test-rows='resource-row']//button[@data-test-id='kebab-button']
     op: click
 # a combined action can be directly used for Edit Labels
 add_label_for_resource:

--- a/lib/rules/web/admin_console/4.11/actions.xyaml
+++ b/lib/rules/web/admin_console/4.11/actions.xyaml
@@ -105,7 +105,7 @@ choose_item_from_list:
 click_resource_action_icon:
   elements:
   - selector:
-      xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr//td/div[contains(@class,'dropdown')]
+      xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr[@data-test-rows='resource-row']//button[@data-test-id='kebab-button']
     op: click
 # a combined action can be directly used for Edit Labels
 add_label_for_resource:

--- a/lib/rules/web/admin_console/4.12/actions.xyaml
+++ b/lib/rules/web/admin_console/4.12/actions.xyaml
@@ -105,7 +105,7 @@ choose_item_from_list:
 click_resource_action_icon:
   elements:
   - selector:
-      xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr//td/div[contains(@class,'dropdown')]
+      xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr[@data-test-rows='resource-row']//button[@data-test-id='kebab-button']
     op: click
 # a combined action can be directly used for Edit Labels
 add_label_for_resource:

--- a/lib/rules/web/admin_console/4.13/actions.xyaml
+++ b/lib/rules/web/admin_console/4.13/actions.xyaml
@@ -105,7 +105,7 @@ choose_item_from_list:
 click_resource_action_icon:
   elements:
   - selector:
-      xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr//td/div[contains(@class,'dropdown')]
+      xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr[@data-test-rows='resource-row']//button[@data-test-id='kebab-button']
     op: click
 # a combined action can be directly used for Edit Labels
 add_label_for_resource:

--- a/lib/rules/web/admin_console/4.14/actions.xyaml
+++ b/lib/rules/web/admin_console/4.14/actions.xyaml
@@ -105,7 +105,7 @@ choose_item_from_list:
 click_resource_action_icon:
   elements:
   - selector:
-      xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr//td/div[contains(@class,'dropdown')]
+      xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr[@data-test-rows='resource-row']//button[@data-test-id='kebab-button']
     op: click
 # a combined action can be directly used for Edit Labels
 add_label_for_resource:


### PR DESCRIPTION
In CI logs, sometimes we can see the element `xpath: //h1[contains(.,'<resource_name>')]/ancestor::tr//td/div[contains(@class,'dropdown')]` can be found but clicking doesn't open the kebab button as we expect

Changed the element definition to `button`  