### PR TITLE
fix OCP-33058 to support customer vpc

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -419,6 +419,9 @@ Feature: Machine features testing
 
     Given I store the last provisioned machine in the :machine clipboard
     Then evaluation of `machine_machine_openshift_io(cb.machine).azure_location` is stored in the :default_location clipboard
+    Then evaluation of `machine_machine_openshift_io(cb.machine).azure_vnet` is stored in the :default_vnet clipboard
+    Then evaluation of `machine_machine_openshift_io(cb.machine).azure_subnet` is stored in the :default_subnet clipboard
+    Then evaluation of `machine_machine_openshift_io(cb.machine).azure_network_resource_group` is stored in the :default_network_resource_group clipboard
     And admin ensures "<name>" machine_set_machine_openshift_io is deleted after scenario
 
     Given I obtain test data file "cloud/ms-azure/<file_name>"
@@ -428,6 +431,9 @@ Feature: Machine features testing
       | ["spec"]["selector"]["matchLabels"]["machine.openshift.io/cluster-api-machineset"]        | <name>                                      |
       | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %> |
       | ["spec"]["template"]["spec"]["providerSpec"]["value"]["location"]                         | <%= cb.default_location %>                  |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["vnet"]                             | <%= cb.default_vnet %>                      |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["subnet"]                           | <%= cb.default_subnet %>                    |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["networkResourceGroup"]             | <%= cb.default_network_resource_group %>      |
       | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | <name>                                      |
       | ["metadata"]["name"]                                                                      | <name>                                      |
     Then the step should succeed

--- a/lib/openshift/machine_machine_openshift_io.rb
+++ b/lib/openshift/machine_machine_openshift_io.rb
@@ -48,6 +48,21 @@ module BushSlicer
          dig('spec', 'providerSpec', 'value', 'location')
     end
 
+    def azure_vnet(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'vnet')
+    end
+
+    def azure_subnet(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'subnet')
+    end
+
+    def azure_network_resource_group(user: nil, cached: true, quiet: false)
+       raw_resource(user: user, cached: cached ,quiet: quiet).
+         dig('spec', 'providerSpec', 'value', 'networkResourceGroup')
+    end
+
     def gcp_region(user: nil, cached: true, quiet: false)
        raw_resource(user: user, cached: cached ,quiet: quiet).
          dig('spec', 'providerSpec', 'value', 'region')


### PR DESCRIPTION
Some resource name in clustomer vpc clusters don't have random string, this causing case failed. This pr will fix this issue.
```
  errorMessage: 'failed to reconcile machine "default-valued-33058-v4bkl": network.SubnetsClient#Get:
    Failure responding to request: StatusCode=404 -- Original Error: autorest/azure:
    Service returned an error. Status=404 Code="ResourceNotFound" Message="The Resource
    ''Microsoft.Network/virtualNetworks/sdli-az410-gkkk4-vnet'' under resource group
    ''sdli-az410-gkkk4-rg'' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"'
  errorReason: InvalidConfiguration
```
Before: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/817722/console
After:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/817779/console
@miyadav @huali9 @jhou1 PTAL