### PR TITLE
Add query for critical test cases to support hypershift tests

### DIFF
--- a/doc/prow/query_critical.json
+++ b/doc/prow/query_critical.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:critical"
+}


### PR DESCRIPTION
Hypershift wants to run only critical cucushift tests, so add the query to tag test cases with critical.

/cc @jhou1 @JianLi-RH @dis016 @pruan-rht 