### PR TITLE
fix-13502

### DIFF
--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -78,10 +78,10 @@ Feature: Egress-ingress related networking scenarios
 
     # Check curl from pod
     When I execute on the pod:
-      | curl | --head | yahoo.com |
+      | curl | --head |  --connect-timeout | 5 | yahoo.com |
     Then the step should succeed
     When I execute on the pod:
-      | curl | --head | <%= cb.yahoo_ip %> |
+      | curl | --head | --connect-timeout | 5 | <%= cb.yahoo_ip %> |
     Then the step should succeed
 
     Given I create a new project
@@ -98,12 +98,15 @@ Feature: Egress-ingress related networking scenarios
     Then the step should succeed
 
     # Check curl from pod
+    Given I wait up to 20 seconds for the steps to pass:
+    """
     When I execute on the pod:
-      | curl | --head | yahoo.com |
+      | curl | --head | --connect-timeout | 5 | yahoo.com |
     Then the step should fail
     When I execute on the pod:
-      | curl | --head | <%= cb.yahoo_ip %> |
+      | curl | --head |  --connect-timeout | 5 | <%= cb.yahoo_ip %> |
     Then the step should fail
+    """
 
     # Check egress policy can be deleted in project1
     When I run the :delete admin command with:
@@ -113,12 +116,15 @@ Feature: Egress-ingress related networking scenarios
     Then the step should succeed
 
     # Check curl from pod after egress policy deleted
+    Given I wait up to 20 seconds for the steps to pass:
+    """
     When I execute on the pod:
-      | curl | --head | yahoo.com |
+      | curl | --head |  --connect-timeout | 5 | yahoo.com |
     Then the step should fail
     When I execute on the pod:
-      | curl | --head | <%= cb.yahoo_ip %> |
+      | curl | --head | --connect-timeout | 5 | <%= cb.yahoo_ip %> |
     Then the step should fail
+    """
 
   # @author weliang@redhat.com
   # @case_id OCP-13507


### PR DESCRIPTION
1. Add connect-timeout to reduce the curl time
2. Add waiting time to let the egressnetworkpolicy adding/deleting take effect

```
  oc exec hello-pod  --kubeconfig=/home/jenkins/ws/workspace/Runner-v3-smoke/workdir/ocp4_testuser-3.kubeconfig -n vwmah  -i -- curl --head yahoo.com
      
      STDERR:
      E0703 09:58:32.246935   50172 v2.go:105] read /dev/stdin: resource temporarily unavailable
        % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                       Dload  Upload   Total   Spent    Left  Speed
      
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
.........
  0     0    0     0    0     0      0      0 --:--:--  0:04:58 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:04:58 --:--:--     0      --> more than 4 minustes 
      curl: (28) Failed to connect to yahoo.com port 80 after 298667 ms: Operation timed out
      command terminated with exit code 28
      [10:03:31] INFO> Exit Status: 28
    Then the step should fail      
```

Test log:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/6323/console


@openshift/team-sdn-qe  PTAL, thanks!