### PR TITLE
remove fail step

### DIFF
--- a/features/upgrade/sdn/policy-upgrade.feature
+++ b/features/upgrade/sdn/policy-upgrade.feature
@@ -710,7 +710,6 @@ Feature: SDN compoment upgrade testing
     When I execute on the "<%= cb.p2pod2name %>" pod:
       | curl | -I | <%= cb.p1pod1ip %>:8080 | --connect-timeout | 20 |
     Then the output should not contain "200 OK"
-    Then the step should fail
     And I wait up to 20 seconds for the steps to pass:
     """
     Given I use the "<%= cb.proj0 %>" project


### PR DESCRIPTION
from the logs the result will not show 200 OK, however the step exit Status is 0,  so here remove this step.

```
07-03 12:36:51.795        [04:36:43] INFO> Shell Commands: oc exec hello-idle-lrk9l  --kubeconfig=/home/jenkins/ws/workspace/ocp-upgrade/upgrade-producer/workdir/ocp4_admin.kubeconfig -n policy-acl-upgrade2  -i -- curl -I 10.128.0.123:8080 --connect-timeout 20
07-03 12:36:51.795        
07-03 12:36:51.795        STDERR:
07-03 12:36:51.795        E0703 04:36:43.551126   25105 v2.go:105] read /dev/stdin: resource temporarily unavailable
07-03 12:36:51.795          % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
07-03 12:36:51.795                                         Dload  Upload   Total   Spent    Left  Speed
07-03 12:36:51.795        
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:06 --:--:--     0
07-03 12:36:51.796        [04:36:50] INFO> Exit Status: 0
07-03 12:36:51.796      Then the output should not contain "200 OK"                                                                # features/step_definitions/common.rb:113
07-03 12:37:13.661      And I wait up to 20 seconds for the steps to pass:   
```
@asood-rh 
cc @openshift/team-sdn-qe ^^
