### PR TITLE
Optimization OCP-27601 for CI failure

### DIFF
--- a/lib/rules/web/admin_console/4.10/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.10/dashboards.xyaml
@@ -132,17 +132,26 @@ check_chart_loaded:
   - selector:
       xpath: //div[contains(@class,'pf-c-chart')]
     timeout: 90
+send_filter_options:
+  elements:
+  - selector:
+      xpath: //input[@type='search']
+    op: send_keys <options_text>
 change_namespace:
   params:
     label_text: namespace
     button_text: <namespace>
+    options_text: <namespace>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 change_workload:
   params:
     label_text: workload
     button_text: <workload>
+    options_text: <workload>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 check_dashboard_dropdown_items:
   action: click_dashboard_dropdown

--- a/lib/rules/web/admin_console/4.11/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.11/dashboards.xyaml
@@ -128,17 +128,26 @@ check_chart_loaded:
   - selector:
       xpath: //div[contains(@class,'pf-c-chart')]
     timeout: 90
+send_filter_options:
+  elements:
+  - selector:
+      xpath: //input[@type='search']
+    op: send_keys <options_text>
 change_namespace:
   params:
     label_text: namespace
     button_text: <namespace>
+    options_text: <namespace>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 change_workload:
   params:
     label_text: workload
     button_text: <workload>
+    options_text: <workload>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 check_dashboard_dropdown_items:
   action: click_dashboard_dropdown
@@ -597,7 +606,7 @@ choose_node_type:
 click_operator_status:
   elements:
   - selector:
-      xpath: //div[@class='co-status-card__health-item']//button[contains(.,'Operators')] 
+      xpath: //div[@class='co-status-card__health-item']//button[contains(.,'Operators')]
     op: click
     timeout: 60
 check_operator_status:

--- a/lib/rules/web/admin_console/4.12/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.12/dashboards.xyaml
@@ -128,17 +128,26 @@ check_chart_loaded:
   - selector:
       xpath: //div[contains(@class,'pf-c-chart')]
     timeout: 90
+send_filter_options:
+  elements:
+  - selector:
+      xpath: //input[@type='search']
+    op: send_keys <options_text>
 change_namespace:
   params:
     label_text: namespace
     button_text: <namespace>
+    options_text: <namespace>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 change_workload:
   params:
     label_text: workload
     button_text: <workload>
+    options_text: <workload>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 check_dashboard_dropdown_items:
   action: click_dashboard_dropdown
@@ -597,7 +606,7 @@ choose_node_type:
 click_operator_status:
   elements:
   - selector:
-      xpath: //div[@class='co-status-card__health-item']//button[contains(.,'Operators')] 
+      xpath: //div[@class='co-status-card__health-item']//button[contains(.,'Operators')]
     op: click
     timeout: 60
 check_operator_status:

--- a/lib/rules/web/admin_console/4.13/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.13/dashboards.xyaml
@@ -132,17 +132,26 @@ check_chart_loaded:
   - selector:
       xpath: //div[contains(@class,'pf-c-chart')]
     timeout: 90
+send_filter_options:
+  elements:
+  - selector:
+      xpath: //input[@type='search']
+    op: send_keys <options_text>
 change_namespace:
   params:
     label_text: namespace
     button_text: <namespace>
+    options_text: <namespace>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 change_workload:
   params:
     label_text: workload
     button_text: <workload>
+    options_text: <workload>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 check_dashboard_dropdown_items:
   action: click_dashboard_dropdown

--- a/lib/rules/web/admin_console/4.14/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.14/dashboards.xyaml
@@ -132,17 +132,26 @@ check_chart_loaded:
   - selector:
       xpath: //div[contains(@class,'pf-c-chart')]
     timeout: 90
+send_filter_options:
+  elements:
+  - selector:
+      xpath: //input[@type='search']
+    op: send_keys <options_text>
 change_namespace:
   params:
     label_text: namespace
     button_text: <namespace>
+    options_text: <namespace>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 change_workload:
   params:
     label_text: workload
     button_text: <workload>
+    options_text: <workload>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 check_dashboard_dropdown_items:
   action: click_dashboard_dropdown

--- a/lib/rules/web/admin_console/4.9/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.9/dashboards.xyaml
@@ -132,17 +132,26 @@ check_chart_loaded:
   - selector:
       xpath: //div[contains(@class,'pf-c-chart')]
     timeout: 40
+send_filter_options:
+  elements:
+  - selector:
+      xpath: //input[@type='search']
+    op: send_keys <options_text>
 change_namespace:
   params:
     label_text: namespace
     button_text: <namespace>
+    options_text: <namespace>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 change_workload:
   params:
     label_text: workload
     button_text: <workload>
+    options_text: <workload>
   action: click_label_filter_dropdown_button
+  action: send_filter_options
   action: click_button_text
 check_dashboard_dropdown_items:
   action: click_dashboard_dropdown
@@ -551,7 +560,7 @@ check_metrics_query_filesystem_filter_by_node_type:
   scripts:
   - command:
       return /sum.*node_filesystem_size_bytes.*kube_node_role.*<node_type>/.test(decodeURI(document.querySelectorAll('div.co-utilization-card__item-chart>div>a')[2].href).replaceAll('\n',''))
-    expect_result: true   
+    expect_result: true
 check_metrics_query_network_filter_by_node_type:
   scripts:
   - command:


### PR DESCRIPTION
Add function of send filter option before clicking the button, to make sure the option is listed in the dropdown list
This issue is found in CI failed log, somehow the option of 'download' is not listed in the Workload dropdown list in Observe -> Dashboards page, as below shown:
![filter](https://github.com/openshift/verification-tests/assets/78589509/160fb768-d03f-4b00-b96c-b1c1eda88db1)

Pass log:
4.14: /Runner/821829/
4.13: /Runner/821834/
4.12: /Runner/821832/
4.11: /Runner/821833/
4.10: /Runner/821831/
4.9: /Runner/821830/