### PR TITLE
Fix some cases on multi-arch compute nodes clusters

### DIFF
--- a/features/cli/deploy.feature
+++ b/features/cli/deploy.feature
@@ -501,11 +501,11 @@ Feature: deployment related features
   @critical
   Scenario: OCP-9566:Workloads Blue-Green Deployment
     Given I have a project
-    When I run the :new_app client command with:
+    When I run the :new_app client command with importmode if supported with:
       | docker_image | quay.io/openshifttest/deployment-example:v1-1.2.0 |
       | name         | bluegreen-example-old                       |
     Then the step should succeed
-    When I run the :new_app client command with:
+    When I run the :new_app client command with importmode if supported with:
       | docker_image | quay.io/openshifttest/deployment-example:v2-1.2.0 |
       | name         | bluegreen-example-new                       |
     Then the step should succeed
@@ -1020,7 +1020,7 @@ Feature: deployment related features
   Scenario: OCP-31200:Workloads A/B Deployment for OCP 4.5 or greater
     Given the master version >= "4.5"
     Given I have a project
-    When I run the :new_app client command with:
+    When I run the :new_app client command with importmode if supported with:
       | app_repo             | quay.io/openshifttest/deployment-example:v1-1.2.0 |
       | name                 | ab-example-a                                          |
       | as_deployment_config | true                                                  |
@@ -1039,7 +1039,7 @@ Feature: deployment related features
     Then I wait for a web server to become available via the "ab-example" route
     And the output should contain "shardA"
     """
-    When I run the :new_app client command with:
+    When I run the :new_app client command with importmode if supported with:
       | app_repo             | quay.io/openshifttest/deployment-example:v1-1.2.0 |
       | name                 | ab-example-b                                          |
       | as_deployment_config | true                                                  |

--- a/features/cli/oc_import_image.feature
+++ b/features/cli/oc_import_image.feature
@@ -82,13 +82,13 @@ Feature: oc import-image related feature
   @hypershift-hosted
   Scenario: OCP-12765:ImageRegistry Allow imagestream request deployment config triggers by different mode('TagreferencePolicy':source/local)
     Given I have a project
-    When I run the :tag client command with:
+    When I run the :tag client command with importmode if supported with:
       | source_type | docker                                                |
       | source      | quay.io/openshifttest/deployment-example:v1-1.2.0 |
       | dest        | deployment-example:latest                             |
     Then the step should succeed
     And the "deployment-example" image stream becomes ready
-    When I run the :new_app_as_dc client command with:
+    When I run the :new_app_as_dc client command with importmode if supported with:
       | image_stream | deployment-example:latest   |
     Then the output should match:
       | .*[Ss]uccess.*|
@@ -116,14 +116,14 @@ Feature: oc import-image related feature
       | object_type | svc |
       | all         |     |
     Then the step should succeed
-    When I run the :tag client command with:
+    When I run the :tag client command with importmode if supported with:
       | source_type      | docker                                                |
       | source           | quay.io/openshifttest/deployment-example:v1-1.2.0 |
       | dest             | deployment-example:latest                             |
       | reference_policy | local                                                 |
     Then the step should succeed
     And the "deployment-example" image stream becomes ready
-    When I run the :new_app_as_dc client command with:
+    When I run the :new_app_as_dc client command with importmode if supported with:
       | image_stream | deployment-example:latest   |
     Then the output should match:
       | .*[Ss]uccess.* |

--- a/features/cli/oc_volume.feature
+++ b/features/cli/oc_volume.feature
@@ -24,7 +24,7 @@ Feature: oc_volume.feature
       | secret_name | test-secret |
       | sa_name     | default     |
     Then the step should succeed
-    When I run the :new_app_as_dc client command with:
+    When I run the :new_app_as_dc client command with importmode if supported with:
       | docker_image | quay.io/openshifttest/hello-openshift@sha256:56c354e7885051b6bb4263f9faa58b2c292d44790599b7dde0e49e7c466cf339 |
       | name         | mydc                                                                                                  |
     Then the step should succeed
@@ -66,7 +66,7 @@ Feature: oc_volume.feature
   @critical
   Scenario: OCP-11906:Storage Add secret volume to dc and rc
     Given I have a project
-    When I run the :new_app_as_dc client command with:
+    When I run the :new_app_as_dc client command with importmode if supported with:
       | docker_image | quay.io/openshifttest/hello-openshift@sha256:56c354e7885051b6bb4263f9faa58b2c292d44790599b7dde0e49e7c466cf339 |
       | name         | mydc                                                                                                  |
     Then the step should succeed

--- a/features/cli/route.feature
+++ b/features/cli/route.feature
@@ -15,7 +15,7 @@ Feature: route related features via cli
   @critical
   Scenario: OCP-10629:Workloads Expose routes from services
     Given I have a project
-    When I run the :new_app client command with:
+    When I run the :new_app client command with importmode if supported with:
       | image | quay.io/openshifttest/hello-openshift@sha256:4200f438cf2e9446f6bcff9d67ceea1f69ed07a2f83363b7fb52529f7ddd8a83 |
     Then the step should succeed
     Given number of replicas of "hello-openshift" deployment becomes:

--- a/features/cli/serviceaccount.feature
+++ b/features/cli/serviceaccount.feature
@@ -54,7 +54,7 @@ Feature: ServiceAccount and Policy Managerment
   @critical
   Scenario: OCP-11494:Authentication Could grant admin permission for the service account group to access to its own project
     Given I have a project
-    When I run the :new_app client command with:
+    When I run the :new_app client command with importmode if supported with:
       | app_repo | quay.io/openshifttest/hello-openshift:1.2.0 |
     Then the step should succeed
     When I run the :policy_add_role_to_group client command with:
@@ -68,7 +68,7 @@ Feature: ServiceAccount and Policy Managerment
     Then the output should contain:
       | hello-openshift |
     # Verify the permission of various operations
-    When I run the :new_app client command with:
+    When I run the :new_app client command with importmode if supported with:
       | app_repo | quay.io/openshifttest/hello-openshift:1.2.0 |
       | name     | app2                                            |
     Then the step should succeed

--- a/features/step_definitions/cli.rb
+++ b/features/step_definitions/cli.rb
@@ -23,6 +23,12 @@ When /^I run the :([a-z_]*?)( background)? client command with:$/ do |yaml_key, 
   end
 end
 
+When /^I run the :([a-z_]*?)( background)? client command with importmode if supported with:$/ do |yaml_key, background, table|
+  opts_array = env.version_ge("4.14", user: user) ? table.raw << [ "import_mode" , "PreserveOriginal" ] : table.raw
+  step "I run the :#{yaml_key}#{background} client command with:",
+    table(opts_array)
+end
+
 When /^I run the :([a-z_]*?)( background)? admin command$/ do |yaml_key, background|
   step "I run the :#{yaml_key}#{background} admin command with:",
     table([["dummy"]])

--- a/lib/rules/cli/4.14.yaml
+++ b/lib/rules/cli/4.14.yaml
@@ -595,6 +595,7 @@
     :group: --group=<value>
     :image: --image=<value>
     :image_stream: --image-stream=<value>
+    :import_mode: --import-mode=<value>
     :insecure_registry: --insecure-registry=<value>
     :l: -l <value>
     :labels: --labels=<value>
@@ -617,6 +618,7 @@
     :docker_image: --docker-image=<value>
     :env: --env=<value>
     :image_stream: --image-stream=<value>
+    :import_mode: --import-mode=<value>
     :labels: --labels=<value>
     :name: --name=<value>
     :source_secret: --source-secret=<value>
@@ -641,6 +643,7 @@
     :env_file: --env-file=<value>
     :image: --image=<value>
     :image_stream: --image-stream=<value>
+    :import_mode: --import-mode=<value>
     :l: -l <value>
     :name: --name=<value>
     :no-output: --no-output=<value>
@@ -1144,6 +1147,7 @@
     :alias: --alias=<value>
     :d: --delete=<value>
     :dest: <value>
+    :import_mode: --import-mode=<value>
     :insecure: --insecure=<value>
     :reference: --reference=<value>
     :reference_policy: --reference-policy=<value>


### PR DESCRIPTION
as of 4.13, The OCP internal registry supports importing images with local reference policy and import mode preserveOriginal, we need to enable it for multi-arch compute nodes clusters.

test job: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/827036/console