### PR TITLE
Fix the script to use correct node and its IP

### DIFF
--- a/features/upgrade/sdn/service-upgrade.feature
+++ b/features/upgrade/sdn/service-upgrade.feature
@@ -90,6 +90,10 @@ Feature: service upgrade scenarios
     Then the step should succeed
     And a pod becomes ready with labels:
       | name=hello-pod |
+    And evaluation of `pod.name` is stored in the :podname clipboard
+    And evaluation of `pod(cb.podname).node_ip(user:user)` is stored in the :hostip clipboard
+    # if IP format is v6 include square brackets
+    And evaluation of `"<%= cb.hostip %>" =~ /:/ ? "[<%= cb.hostip %>]" : "<%= cb.hostip %>"` is stored in the :hostip clipboard
     When I obtain test data file "networking/nodeport_test_service.yaml"
     When I run oc create over "nodeport_test_service.yaml" replacing paths:
       | ["spec"]["ports"][0]["nodePort"] | <%= cb.port %> |
@@ -101,7 +105,6 @@ Feature: service upgrade scenarios
     Then the step should succeed
     And a pod becomes ready with labels:
       | name=test-pods |
-    And evaluation of `pod.node_name` is stored in the :hostip clipboard
     When I execute on the pod:
       | curl | <%= cb.hostip %>:<%= cb.port %> |
     Then the step should succeed
@@ -125,8 +128,13 @@ Feature: service upgrade scenarios
     When I use the "nodeport-upgrade" project
     Given I use the "hello-pod" service
     And a pod becomes ready with labels:
+      | name=hello-pod |
+    And evaluation of `pod.name` is stored in the :podname clipboard
+    And evaluation of `pod(cb.podname).node_ip(user:user)` is stored in the :hostip clipboard
+    # if IP format is v6 include square brackets
+    And evaluation of `"<%= cb.hostip %>" =~ /:/ ? "[<%= cb.hostip %>]" : "<%= cb.hostip %>"` is stored in the :hostip clipboard
+    And a pod becomes ready with labels:
       | name=test-pods |
-    And evaluation of `pod.node_name` is stored in the :hostip clipboard
     When I execute on the pod:
       | curl | <%= cb.hostip %>:<%= service.ports[0]["nodePort"] %> |
     Then the step should succeed


### PR DESCRIPTION
@openshift/team-sdn-qe 
cc @anuragthehatter @zhaozhanqi 

Prepare
<pre>
bundle exec cucumber features/upgrade/sdn/service-upgrade.feature:80
Using the default, devel and _devel profiles...
Feature: service upgrade scenarios

  # @author zzhao@redhat.com
  # @author zzhao@redhat.com
  # @case_id OCP-44259
  # @author zzhao@redhat.com
  @admin @upgrade-prepare @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6 @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi @proxy @noproxy @disconnected @connected @upgrade @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy @heterogeneous @arm64 @amd64 @hypershift-hosted
  Scenario: Check the nodeport service works well after upgrade - prepare                                                        # features/upgrade/sdn/service-upgrade.feature:80
waiting for operation up to 3600 seconds..
      [14:38:53] INFO> === Before Scenario: Check the nodeport service works well after upgrade - prepare ===
      [14:38:53] INFO> Shell Commands: mkdir -v -p '/home/asood/workdir/asood-asoodx'
      mkdir: created directory '/home/asood/workdir/asood-asoodx'
      [14:38:54] INFO> Exit Status: 0
      [14:38:54] INFO> === End Before Scenario: Check the nodeport service works well after upgrade - prepare ===
    Given I switch to cluster admin pseudo user                                                                                  # features/step_definitions/user.rb:13
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    When I run the :new_project client command with:                                                                             # features/step_definitions/cli.rb:13
      | project_name | nodeport-upgrade |
      [14:38:54] INFO> Shell Commands: rm  -f -- /home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig
      
      [14:38:55] INFO> Exit Status: 0
      [14:38:56] INFO> Shell Commands: oc version -o yaml --client --kubeconfig=/tmp/kubeconfig20230714-683285-6svoiw
      clientVersion:
        buildDate: "2023-04-19T04:06:40Z"
        compiler: gc
        gitCommit: 92b1a3d0e5d092430b523f6541aa0c504b2222b3
        gitTreeState: clean
        gitVersion: 4.13.0-202304190216.p0.g92b1a3d.assembly.stream-92b1a3d
        goVersion: go1.19.6
        major: ""
        minor: ""
        platform: linux/amd64
      kustomizeVersion: v4.5.7
      releaseClientVersion: 4.13.0
      [14:38:57] INFO> Exit Status: 0
      [14:38:57] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc config set-credentials admin --client-certificate=/home/asood/workdir/asood-asoodx/clcert20230714-683285-17ax9mu --client-key=/home/asood/workdir/asood-asoodx/clkey20230714-683285-zxck31 --embed-certs=true --server=https://api.asood-7142.qe.devcluster.openshift.com:6443 --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      User "admin" set.
      [14:38:58] INFO> Exit Status: 0
      [14:38:58] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc config set-cluster generated-cluster --server=https://api.asood-7142.qe.devcluster.openshift.com:6443 --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Cluster "generated-cluster" set.
      [14:38:59] INFO> Exit Status: 0
      [14:38:59] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc config set-context generated --cluster=generated-cluster --user=admin --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Context "generated" created.
      [14:39:00] INFO> Exit Status: 0
      [14:39:00] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc config use-context generated --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Switched to context "generated".
      [14:39:01] INFO> Exit Status: 0
      [14:39:01] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc new-project nodeport-upgrade --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig
      Now using project "nodeport-upgrade" on server "https://api.asood-7142.qe.devcluster.openshift.com:6443".
      
      You can add applications to this project with the 'new-app' command. For example, try:
      
          oc new-app rails-postgresql-example
      
      to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:
      
          kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname
      [14:39:02] INFO> Exit Status: 0
    Then the step should succeed                                                                                                 # features/step_definitions/common.rb:4
    And evaluation of `rand(30000..32767)` is stored in the :port clipboard                                                      # features/step_definitions/common.rb:128
waiting for operation up to 3600 seconds..
    When I use the "nodeport-upgrade" project                                                                                    # features/step_definitions/project.rb:126
      [14:39:02] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc project nodeport-upgrade --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig
      Already on project "nodeport-upgrade" on server "https://api.asood-7142.qe.devcluster.openshift.com:6443".
      [14:39:03] INFO> Exit Status: 0
cp /home/asood/github-projects/verification-tests/testdata/networking/nodeport_test_pod.yaml nodeport_test_pod.yaml
    Given I obtain test data file "networking/nodeport_test_pod.yaml"                                                            # features/step_definitions/file.rb:1
waiting for operation up to 3600 seconds..
    When I run the :create client command with:                                                                                  # features/step_definitions/cli.rb:13
      | f | nodeport_test_pod.yaml |
      [14:39:03] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc create -f nodeport_test_pod.yaml --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig
      replicationcontroller/hello-pod created
      [14:39:04] INFO> Exit Status: 0
    Then the step should succeed                                                                                                 # features/step_definitions/common.rb:4
waiting for operation up to 900 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    And a pod becomes ready with labels:                                                                                         # features/step_definitions/pod.rb:1
      | name=hello-pod |
      [14:39:09] INFO> oc get pods --output=yaml -l name\=hello-pod --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig -n nodeport-upgrade
      [14:39:09] INFO> 2 iterations for 5 sec, returned 1 pods, 1 matching
    And evaluation of `pod.name` is stored in the :podname clipboard                                                             # features/step_definitions/common.rb:128
    And evaluation of `pod(cb.podname).node_ip(user:user)` is stored in the :hostip clipboard                                    # features/step_definitions/common.rb:128
    # if IP format is v6 include square brackets
    And evaluation of `"<%= cb.hostip %>" =~ /:/ ? "[<%= cb.hostip %>]" : "<%= cb.hostip %>"` is stored in the :hostip clipboard # features/step_definitions/common.rb:128
cp /home/asood/github-projects/verification-tests/testdata/networking/nodeport_test_service.yaml nodeport_test_service.yaml
    When I obtain test data file "networking/nodeport_test_service.yaml"                                                         # features/step_definitions/file.rb:1
waiting for operation up to 3600 seconds..
    When I run oc create over "nodeport_test_service.yaml" replacing paths:                                                      # features/step_definitions/cli.rb:66
      | ["spec"]["ports"][0]["nodePort"] | <%= cb.port %> |
      [14:39:09] INFO> {"kind":"Service","apiVersion":"v1","metadata":{"name":"hello-pod","labels":{"name":"hello-pod"}},"spec":{"ports":[{"name":"http","protocol":"TCP","port":27017,"nodePort":31190,"targetPort":8080}],"type":"NodePort","selector":{"name":"hello-pod"}}}
      [14:39:09] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc create -f - --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig
      service/hello-pod created
      [14:39:10] INFO> Exit Status: 0
    Then the step should succeed                                                                                                 # features/step_definitions/common.rb:4
cp /home/asood/github-projects/verification-tests/testdata/networking/list_for_pods.json list_for_pods.json
    Given I obtain test data file "networking/list_for_pods.json"                                                                # features/step_definitions/file.rb:1
waiting for operation up to 3600 seconds..
    When I run oc create over "list_for_pods.json" replacing paths:                                                              # features/step_definitions/cli.rb:66
      | ["items"][0]["spec"]["replicas"] | 1 |
      [14:39:10] INFO> {"apiVersion":"v1","kind":"List","items":[{"apiVersion":"v1","kind":"ReplicationController","metadata":{"labels":{"name":"test-rc"},"name":"test-rc"},"spec":{"replicas":1,"template":{"metadata":{"labels":{"name":"test-pods"}},"spec":{"containers":[{"image":"quay.io/openshifttest/hello-sdn@sha256:c89445416459e7adea9a5a416b3365ed3d74f2491beb904d61dc8d1eb89a72a4","name":"test-pod","imagePullPolicy":"IfNotPresent","resources":{"limits":{"memory":"340Mi"}}}]}}}},{"apiVersion":"v1","kind":"Service","metadata":{"labels":{"name":"test-service"},"name":"test-service"},"spec":{"ports":[{"name":"http","port":27017,"protocol":"TCP","targetPort":8080}],"selector":{"name":"test-pods"}}}]}
      [14:39:10] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc create -f - --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig
      replicationcontroller/test-rc created
      service/test-service created
      [14:39:11] INFO> Exit Status: 0
    Then the step should succeed                                                                                                 # features/step_definitions/common.rb:4
waiting for operation up to 900 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    And a pod becomes ready with labels:                                                                                         # features/step_definitions/pod.rb:1
      | name=test-pods |
      [14:39:16] INFO> oc get pods --output=yaml -l name\=test-pods --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig -n nodeport-upgrade
      [14:39:16] INFO> 2 iterations for 5 sec, returned 1 pods, 1 matching
waiting for operation up to 3600 seconds..
    When I execute on the pod:                                                                                                   # features/step_definitions/pod.rb:216
      | curl | <%= cb.hostip %>:<%= cb.port %> |
      [14:39:16] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc exec test-rc-wghm5  --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig -n nodeport-upgrade  -i -- curl 192.168.221.23:31190
      Hello OpenShift!
      
      STDERR:
        % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                       Dload  Upload   Total   Spent    Left  Speed
100    17  100    17    0     0   6515      0 --:--:-- --:--:-- --:--:--  8500
      E0714 10:39:18.092779  683524 v2.go:104] read /dev/stdin: resource temporarily unavailable
      [14:39:18] INFO> Exit Status: 0
    Then the step should succeed                                                                                                 # features/step_definitions/common.rb:4
    And the output should contain:                                                                                               # features/step_definitions/common.rb:33
      | Hello OpenShift! |
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [14:39:18] INFO> === After Scenario: Check the nodeport service works well after upgrade - prepare ===
      [14:39:18] INFO> Shell Commands: rm -r -f -- /home/asood/workdir/asood-asoodx
      
      [14:39:19] INFO> Exit Status: 0
      [14:39:20] INFO> === End After Scenario: Check the nodeport service works well after upgrade - prepare ===
# @author zzhao@redhat.com
# @case_id OCP-44302
# if IP format is v6 include square brackets

1 scenario (1 passed)
22 steps (22 passed)
0m27.252s
[14:39:20] INFO> === At Exit ===

</pre>
Upgrade Check phase
<pre>
bundle exec cucumber features/upgrade/sdn/service-upgrade.feature:126
Using the default, devel and _devel profiles...
Feature: service upgrade scenarios

  # @author zzhao@redhat.com
  # @author zzhao@redhat.com
  # @case_id OCP-44259
  # @author zzhao@redhat.com
  # if IP format is v6 include square brackets
  # @author zzhao@redhat.com
  # @case_id OCP-44302
  @admin @upgrade-check @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6 @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi @proxy @noproxy @disconnected @connected @upgrade @network-ovnkubernetes @network-openshiftsdn @network-networkpolicy @s390x @ppc64le @heterogeneous @arm64 @amd64 @hypershift-hosted
  Scenario: Check the nodeport service works well after upgrade                                                                  # features/upgrade/sdn/service-upgrade.feature:126
waiting for operation up to 3600 seconds..
      [14:39:47] INFO> === Before Scenario: Check the nodeport service works well after upgrade ===
      [14:39:47] INFO> Shell Commands: mkdir -v -p '/home/asood/workdir/asood-asoodx'
      mkdir: created directory '/home/asood/workdir/asood-asoodx'
      [14:39:48] INFO> Exit Status: 0
      [14:39:48] INFO> === End Before Scenario: Check the nodeport service works well after upgrade ===
    Given I switch to cluster admin pseudo user                                                                                  # features/step_definitions/user.rb:13
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    When I use the "nodeport-upgrade" project                                                                                    # features/step_definitions/project.rb:126
      [14:39:48] INFO> Shell Commands: rm  -f -- /home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig
      
      [14:39:49] INFO> Exit Status: 0
      [14:39:50] INFO> Shell Commands: oc version -o yaml --client --kubeconfig=/tmp/kubeconfig20230714-683616-1jro8x3
      clientVersion:
        buildDate: "2023-04-19T04:06:40Z"
        compiler: gc
        gitCommit: 92b1a3d0e5d092430b523f6541aa0c504b2222b3
        gitTreeState: clean
        gitVersion: 4.13.0-202304190216.p0.g92b1a3d.assembly.stream-92b1a3d
        goVersion: go1.19.6
        major: ""
        minor: ""
        platform: linux/amd64
      kustomizeVersion: v4.5.7
      releaseClientVersion: 4.13.0
      [14:39:51] INFO> Exit Status: 0
      [14:39:51] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc config set-credentials admin --client-certificate=/home/asood/workdir/asood-asoodx/clcert20230714-683616-1tnpygs --client-key=/home/asood/workdir/asood-asoodx/clkey20230714-683616-16lex2z --embed-certs=true --server=https://api.asood-7142.qe.devcluster.openshift.com:6443 --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      User "admin" set.
      [14:39:52] INFO> Exit Status: 0
      [14:39:52] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc config set-cluster generated-cluster --server=https://api.asood-7142.qe.devcluster.openshift.com:6443 --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Cluster "generated-cluster" set.
      [14:39:53] INFO> Exit Status: 0
      [14:39:53] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc config set-context generated --cluster=generated-cluster --user=admin --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Context "generated" created.
      [14:39:54] INFO> Exit Status: 0
      [14:39:54] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc config use-context generated --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig --insecure-skip-tls-verify=true
      Switched to context "generated".
      [14:39:55] INFO> Exit Status: 0
      [14:39:55] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc project nodeport-upgrade --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig
      Now using project "nodeport-upgrade" on server "https://api.asood-7142.qe.devcluster.openshift.com:6443".
      [14:39:56] INFO> Exit Status: 0
    Given I use the "hello-pod" service                                                                                          # features/step_definitions/service.rb:1
waiting for operation up to 900 seconds..
waiting for operation up to 3600 seconds..
    And a pod becomes ready with labels:                                                                                         # features/step_definitions/pod.rb:1
      | name=hello-pod |
      [14:39:57] INFO> oc get pods --output=yaml -l name\=hello-pod --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig -n nodeport-upgrade
      [14:39:57] INFO> 1 iterations for 1 sec, returned 1 pods, 1 matching
    And evaluation of `pod.name` is stored in the :podname clipboard                                                             # features/step_definitions/common.rb:128
    And evaluation of `pod(cb.podname).node_ip(user:user)` is stored in the :hostip clipboard                                    # features/step_definitions/common.rb:128
    # if IP format is v6 include square brackets
    And evaluation of `"<%= cb.hostip %>" =~ /:/ ? "[<%= cb.hostip %>]" : "<%= cb.hostip %>"` is stored in the :hostip clipboard # features/step_definitions/common.rb:128
waiting for operation up to 900 seconds..
waiting for operation up to 3600 seconds..
    And a pod becomes ready with labels:                                                                                         # features/step_definitions/pod.rb:1
      | name=test-pods |
      [14:39:58] INFO> oc get pods --output=yaml -l name\=test-pods --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig -n nodeport-upgrade
      [14:39:58] INFO> 1 iterations for 1 sec, returned 1 pods, 1 matching
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
    When I execute on the pod:                                                                                                   # features/step_definitions/pod.rb:216
      | curl | <%= cb.hostip %>:<%= service.ports[0]["nodePort"] %> |
      [14:39:58] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc get services hello-pod --output=yaml --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig --namespace=nodeport-upgrade
      apiVersion: v1
      kind: Service
      metadata:
        creationTimestamp: "2023-07-14T14:39:10Z"
        labels:
          name: hello-pod
        name: hello-pod
        namespace: nodeport-upgrade
        resourceVersion: "66087"
        uid: 322b6b31-c6f4-425e-b848-faadfad7770e
      spec:
        clusterIP: 172.30.55.155
        clusterIPs:
        - 172.30.55.155
        externalTrafficPolicy: Cluster
        internalTrafficPolicy: Cluster
        ipFamilies:
        - IPv4
        ipFamilyPolicy: SingleStack
        ports:
        - name: http
          nodePort: 31190
          port: 27017
          protocol: TCP
          targetPort: 8080
        selector:
          name: hello-pod
        sessionAffinity: None
        type: NodePort
      status:
        loadBalancer: {}
      [14:39:59] INFO> Exit Status: 0
      [14:39:59] INFO> Shell Commands: http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@10.0.76.163:3128
      oc exec test-rc-wghm5  --kubeconfig=/home/asood/workdir/asood-asoodx/ocp4_admin.kubeconfig -n nodeport-upgrade  -i -- curl 192.168.221.23:31190
      Hello OpenShift!
      
      STDERR:
      E0714 10:40:00.186490  683769 v2.go:104] read /dev/stdin: resource temporarily unavailable
        % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                       Dload  Upload   Total   Spent    Left  Speed
100    17  100    17    0     0  14049      0 --:--:-- --:--:-- --:--:-- 17000
      [14:40:00] INFO> Exit Status: 0
    Then the step should succeed                                                                                                 # features/step_definitions/common.rb:4
    And the output should contain:                                                                                               # features/step_definitions/common.rb:33
      | Hello OpenShift! |
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [14:40:00] INFO> === After Scenario: Check the nodeport service works well after upgrade ===
      [14:40:00] INFO> Shell Commands: rm -r -f -- /home/asood/workdir/asood-asoodx
      
      [14:40:01] INFO> Exit Status: 0
      [14:40:02] INFO> === End After Scenario: Check the nodeport service works well after upgrade ===

1 scenario (1 passed)
11 steps (11 passed)
0m15.211s
[14:40:02] INFO> === At Exit ===

</pre>