### PR TITLE
add time for OCP-28108

### DIFF
--- a/features/machine/autoscaler.feature
+++ b/features/machine/autoscaler.feature
@@ -47,7 +47,7 @@ Feature: Cluster Autoscaler Tests
     And admin ensures "workload" job is deleted from the "openshift-machine-api" project after scenario
 
     # Verify machineset has scaled
-    Given I wait up to 300 seconds for the steps to pass:
+    Given I wait up to 960 seconds for the steps to pass:
     """
     Then the expression should be true> machine_set_machine_openshift_io.desired_replicas(cached: false) == 3
     """
@@ -56,7 +56,7 @@ Feature: Cluster Autoscaler Tests
     # Delete workload
     Given admin ensures "workload" job is deleted from the "openshift-machine-api" project
     # Check cluster auto scales down
-    And I wait up to 300 seconds for the steps to pass:
+    And I wait up to 1200 seconds for the steps to pass:
     """
     Then the expression should be true> machine_set_machine_openshift_io.desired_replicas(cached: false) == 1
     """


### PR DESCRIPTION
This if for https://issues.redhat.com/browse/OCPQE-15975. Add time to keep consistent with golang https://github.com/openshift/openshift-tests-private/blob/master/test/extended/util/machine_helpers.go#L187
https://github.com/openshift/openshift-tests-private/blob/master/test/extended/util/machine_helpers.go#L244
 @sunzhaohua2 @miyadav @jhou1 PTAL, thanks!
without the pr, failed.
```
07-18 14:50:31.146        expression returned non-positive status: false
07-18 14:50:31.146        left_operand: 3, 
07-18 14:50:31.146        right_operand: 1
07-18 14:50:31.146         (RuntimeError)
07-18 14:50:31.146        ./features/step_definitions/common.rb:168:in `/^(?:the )?expression should be true> (.+)$/'
07-18 14:50:31.146        ./features/step_definitions/transform.rb:33:in `call'
07-18 14:50:31.146        ./features/step_definitions/transform.rb:33:in `block in singleton class'
07-18 14:50:31.146        ./features/step_definitions/meta_steps.rb:48:in `block (2 levels) in <top (required)>'
07-18 14:50:31.146        ./lib/base_helper.rb:160:in `wait_for'
07-18 14:50:31.146        ./features/step_definitions/meta_steps.rb:43:in `/^I wait(?: up to ([0-9]+|<%=.+?%>) seconds)? for the steps to pass:$/'
07-18 14:50:31.146        features/machine/autoscaler.feature:59:in `I wait up to 300 seconds for the steps to pass:'

07-18 14:50:31.146  1 scenario (1 failed)
07-18 14:50:31.146  28 steps (1 failed, 6 skipped, 21 passed)
07-18 14:50:31.146  23m47.323s
```
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/830678/console

with the pr, passed.
```
07-18 16:31:33.501  1 scenario (1 passed)
07-18 16:31:33.501  28 steps (28 passed)
07-18 16:31:33.501  33m6.300s
```
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/830758/console
