### PR TITLE
reduced cpu requirement

### DIFF
--- a/testdata/cloud/autoscaler-auto-tmpl.yml
+++ b/testdata/cloud/autoscaler-auto-tmpl.yml
@@ -13,7 +13,9 @@ spec:
         resources:
           requests:
             memory: 500Mi
-            cpu: 1100m
+            cpu: 500m
+          limits:
+            cpu: 1500m      
       restartPolicy: Never
       tolerations:
       - key: mapi


### PR DESCRIPTION
@jhou1 @huali9 @sunzhaohua2 @dtobolik , PTAL ..

The test is failing with below error ( not scaling and pods remains in pending)
` Normal   NotTriggerScaleUp  2m59s (x3 over 3m24s)  cluster-autoscaler  pod didn't trigger scale-up (it wouldn't fit if a new node is added)`

latest [failure](https://s3.upshift.redhat.com/cucushift-html-logs/logs/2023/07/20/08%3A22%3A29/OCP-28108_ClusterInfrastructure_Cluster_should_automatically_scale_up_and_scale_down_with_0369923378?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20230721%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20230721T034754Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=e4f44a3cb479e5d922753cfecb00e68e9b22cdd06ae36809ed57a2449a49d7ed)

Hence reduced cpu requirement for workload 

It passes now - 
```
`        resourceVersion: ""
      [03:47:13] INFO> Exit Status: 0
      [03:47:13] INFO> Shell Commands: oc delete machines.machine.openshift.io machineset-clone-28108-mnnwv --wait=false --kubeconfig=/home/miyadav/workdir/miyadav-miyadavx/ocp4_admin.kubeconfig --namespace=openshift-machine-api
      machine.machine.openshift.io "machineset-clone-28108-mnnwv" deleted
      [03:47:16] INFO> Exit Status: 0
      [03:47:16] INFO> Shell Commands: oc delete machines.machine.openshift.io machineset-clone-28108-mnnwv --wait=false --kubeconfig=/home/miyadav/workdir/miyadav-miyadavx/ocp4_admin.kubeconfig --namespace=openshift-machine-api
      machine.machine.openshift.io "machineset-clone-28108-mnnwv" deleted
      [03:47:21] INFO> Exit Status: 0
      [03:47:24] INFO> oc get machines.machine.openshift.io machineset-clone-28108-mnnwv --output=yaml --kubeconfig=/home/miyadav/workdir/miyadav-miyadavx/ocp4_admin.kubeconfig --namespace=openshift-machine-api
      [03:48:08] INFO> After 12 iterations and 47 seconds:
      
      STDERR:
      Error from server (NotFound): machines.machine.openshift.io "machineset-clone-28108-mnnwv" not found
      [03:48:08] INFO> Shell Commands: oc get machines.machine.openshift.io machineset-clone-28108-mnnwv --output=yaml --kubeconfig=/home/miyadav/workdir/miyadav-miyadavx/ocp4_admin.kubeconfig --namespace=openshift-machine-api
      
      STDERR:
      Error from server (NotFound): machines.machine.openshift.io "machineset-clone-28108-mnnwv" not found
      [03:48:11] INFO> Exit Status: 1
      [03:48:11] INFO> Shell Commands: rm -r -f -- /home/miyadav/workdir/miyadav-miyadavx
      
      [03:48:12] INFO> Exit Status: 0
      [03:48:13] INFO> === End After Scenario: OCP-28108:ClusterInfrastructure Cluster should automatically scale up and 

scale down with clusterautoscaler deployed ===
# @author zhsun@redhat.com
# @case_id OCP-21516
# @author zhsun@redhat.com
# @case_id OCP-21517
# @author zhsun@redhat.com
# @case_id OCP-22102
# @author zhsun@redhat.com
# @case_id OCP-23745

1 scenario (1 passed)
28 steps (28 passed)
13m8.297s
[03:48:13] INFO> === At Exit ===

```