### PR TITLE
fix33056

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -386,6 +386,7 @@ Feature: Machine features testing
     When evaluation of `machine_machine_openshift_io(cb.machine).gcp_region` is stored in the :default_region clipboard
     And evaluation of `machine_machine_openshift_io(cb.machine).gcp_zone` is stored in the :default_zone clipboard
     And evaluation of `machine_machine_openshift_io(cb.machine).gcp_service_account` is stored in the :default_service_account clipboard
+    And evaluation of `machine_machine_openshift_io(cb.machine).gcp_network_interface` is stored in the :default_network_interface clipboard
     Then admin ensures "default-valued-33056" machine_set_machine_openshift_io is deleted after scenario
 
     Given I obtain test data file "cloud/ms-gcp/ms_default_values.yaml"
@@ -396,6 +397,8 @@ Feature: Machine features testing
       | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-cluster"]    | <%= infrastructure("cluster").infra_name %>          |
       | ["spec"]["template"]["spec"]["providerSpec"]["value"]["region"]                           | <%= cb.default_region %>                             |
       | ["spec"]["template"]["spec"]["providerSpec"]["value"]["serviceAccounts"][0]["email"]      | <%=  cb.default_service_account[0].fetch("email") %> |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["networkInterfaces"][0]["network"]      | <%=  cb.default_network_interface[0].fetch("network") %> |
+      | ["spec"]["template"]["spec"]["providerSpec"]["value"]["networkInterfaces"][0]["subnetwork"]      | <%=  cb.default_network_interface[0].fetch("subnetwork") %> |
       | ["spec"]["template"]["spec"]["providerSpec"]["value"]["zone"]                             | <%= cb.default_zone %>                               |
       | ["spec"]["template"]["metadata"]["labels"]["machine.openshift.io/cluster-api-machineset"] | default-valued-33056                                 |
     Then the step should succeed

--- a/lib/openshift/machine_machine_openshift_io.rb
+++ b/lib/openshift/machine_machine_openshift_io.rb
@@ -78,6 +78,11 @@ module BushSlicer
          dig('spec', 'providerSpec', 'value', 'serviceAccounts')
     end
 
+    def gcp_network_interface(user: nil, cached: true, quiet: false)
+      raw_resource(user: user, cached: cached ,quiet: quiet).
+        dig('spec', 'providerSpec', 'value', 'networkInterfaces')
+    end
+
     def aws_ami_id(user: nil, cached: true, quiet: false)
        raw_resource(user: user, cached: cached ,quiet: quiet).
          dig('spec', 'providerSpec', 'value', 'ami','id')

--- a/testdata/cloud/ms-gcp/ms_default_values.yaml
+++ b/testdata/cloud/ms-gcp/ms_default_values.yaml
@@ -27,6 +27,9 @@ spec:
         value:
           region:
           zone:
+          networkInterfaces:
+          - network:
+            subnetwork:
           serviceAccounts:
           - email:
             scopes:


### PR DESCRIPTION
Similar as https://github.com/openshift/verification-tests/pull/3360, this one is for GCP
Some resource name in clustomer vpc clusters don't have random string, this causing case failed. This pr will fix this issue.
```
  errorMessage: 'error launching instance: googleapi: Error 400: Invalid value for
    field ''resource.networkInterfaces[0].network'': ''projects/openshift-qe/global/networks/huliu-gcp21a-5xrx2-network''.
    The referenced network resource cannot be found., invalid'
  errorReason: InvalidConfiguration
```
Before: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/833362/console
After: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/833434/console
@sunzhaohua2 @miyadav @jhou1 @dtobolik PTAL, thanks!
