### PR TITLE
add proxy check for egressfirewall

### DIFF
--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -14,6 +14,7 @@ Feature: Egress-ingress related networking scenarios
   @hypershift-hosted
   @critical
   Scenario: OCP-11639:SDN EgressNetworkPolicy will not take effect after delete it
+    Given the cluster is not proxy cluster
     Given I have a project
     Given I have a pod-for-ping in the project
     Given I save egress data file directory to the clipboard
@@ -61,6 +62,7 @@ Feature: Egress-ingress related networking scenarios
   @hypershift-hosted
   @critical
   Scenario: OCP-13502:SDN Apply different egress network policy in different projects
+    Given the cluster is not proxy cluster
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -139,6 +141,7 @@ Feature: Egress-ingress related networking scenarios
   @hypershift-hosted
   @critical
   Scenario: OCP-13507:SDN The rules of egress network policy are added in openflow
+    Given the cluster is not proxy cluster
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     And evaluation of `project.name` is stored in the :proj1 clipboard
@@ -187,6 +190,7 @@ Feature: Egress-ingress related networking scenarios
   @hypershift-hosted
   @critical
   Scenario: OCP-13509:SDN Egress network policy use dnsname with multiple ipv4 addresses
+    Given the cluster is not proxy cluster
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -225,6 +229,7 @@ Feature: Egress-ingress related networking scenarios
   @hypershift-hosted
   @critical
   Scenario: OCP-15005:SDN Service with a DNS name can not by pass Egressnetworkpolicy with that DNS name
+    Given the cluster is not proxy cluster
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -289,6 +294,7 @@ Feature: Egress-ingress related networking scenarios
   @hypershift-hosted
   @critical
   Scenario: OCP-15017:SDN Add nodes local IP address to OVS rules for egressnetworkpolicy
+    Given the cluster is not proxy cluster
     Given the env is using multitenant or networkpolicy network
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -344,6 +350,7 @@ Feature: Egress-ingress related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-13506:SDN Update different dnsname in same egress network policy
+    Given the cluster is not proxy cluster
     Given I have a project
     Given I have a pod-for-ping in the project
 
@@ -385,6 +392,7 @@ Feature: Egress-ingress related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-19615:SDN Iptables should be updated with correct endpoints when egress DNS policy was used
+    Given the cluster is not proxy cluster
     Given the env is using "OpenShiftSDN" networkType	
     Given I have a project
     And the appropriate pod security labels are applied to the namespace
@@ -443,6 +451,7 @@ Feature: Egress-ingress related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-33530:SDN EgressFirewall allows traffic to destination ports
+    Given the cluster is not proxy cluster
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -487,6 +496,7 @@ Feature: Egress-ingress related networking scenarios
   @hypershift-hosted
   @critical
   Scenario: OCP-33531:SDN EgressFirewall rules take effect in order
+    Given the cluster is not proxy cluster
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -514,6 +524,7 @@ Feature: Egress-ingress related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-33539:SDN EgressFirewall policy should not take effect for traffic between pods and pods to service
+    Given the cluster is not proxy cluster
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
     # Create EgressFirewall policy to deny all outbound traffic
@@ -555,6 +566,7 @@ Feature: Egress-ingress related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-33565:SDN EgressFirewall policy take effect for multiple port
+    Given the cluster is not proxy cluster
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -619,6 +631,7 @@ Feature: Egress-ingress related networking scenarios
   @hypershift-hosted
   @critical
   Scenario: OCP-37491:SDN EgressFirewall allows traffic to destination dnsName
+    Given the cluster is not proxy cluster
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -658,6 +671,7 @@ Feature: Egress-ingress related networking scenarios
   @hypershift-hosted
   @critical
   Scenario: OCP-37495:SDN EgressFirewall denys traffic to destination dnsName
+    Given the cluster is not proxy cluster
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
 
@@ -696,6 +710,7 @@ Feature: Egress-ingress related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-37496:SDN Edit EgressFirewall should take effect
+    Given the cluster is not proxy cluster
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project
@@ -737,6 +752,7 @@ Feature: Egress-ingress related networking scenarios
   @hypershift-hosted
   @critical
   Scenario: OCP-41179:SDN bug1947917 Egress Firewall should reliably apply firewall rules
+    Given the cluster is not proxy cluster
     Given the env is using "OVNKubernetes" networkType
     Given I have a project
     Given I have a pod-for-ping in the project

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1642,3 +1642,19 @@ Given /^the cluster is not migration from ovn plugin$/ do
   end
 end
 
+
+Given /^the cluster is not proxy cluster$/ do
+  ensure_admin_tagged
+  @result = admin.cli_exec(:get, resource: "proxy",resource_name: "cluster", output: "jsonpath={.status.httpProxy}")
+  unless @result[:stdout].empty?
+    logger.warn "the cluster has http proxy, will skip this scenario"
+    skip_this_scenario
+  end
+
+  @result = admin.cli_exec(:get, resource: "proxy",resource_name: "cluster", output: "jsonpath={.status.httpsProxy}")
+  unless @result[:stdout].empty?
+    logger.warn "the cluster has https proxy, will skip this scenario"
+    skip_this_scenario
+  end
+end
+

--- a/features/upgrade/sdn/egress-upgrade.feature
+++ b/features/upgrade/sdn/egress-upgrade.feature
@@ -12,6 +12,7 @@ Feature: Egress compoment upgrade testing
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: Check egressfirewall is functional post upgrade - prepare
+    Given the cluster is not proxy cluster 
     Given I switch to cluster admin pseudo user
     And I run the :new_project client command with:
       | project_name | egressfw-upgrade1 |
@@ -53,6 +54,7 @@ Feature: Egress compoment upgrade testing
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: Check egressfirewall is functional post upgrade
+    Given the cluster is not proxy cluster 
     Given I switch to cluster admin pseudo user
     And I save egress type to the clipboard
     When I run the :get admin command with:


### PR DESCRIPTION
Egressfirewall/Egressnetworkpolicy cases cannot run on proxy cluster, but was always selected into proxy cluster in CI. I used to update some CI profiles for correct tags but it seems like still having many without correct filters.   In order to let the egressfirewall cases were not affected by that, added a proxy check in our cases to skip the proxy cluster. 

Test log:
proxy cluster: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/6393/console
no proxy cluster:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/6395/console

@zhaozhanqi @anuragthehatter  PTAL, thanks!
