### PR TITLE
Fix OCP-24306 and OCP-19653 rules

### DIFF
--- a/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
@@ -612,7 +612,7 @@ check_page_contains:
 check_page_match:
   element:
     selector: &page_content
-      visible_text: !ruby/regexp /<content>/i
+      xpath: //*[contains(translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), translate('<content>','ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'))]
     timeout: 15
 check_page_not_match:
   element:

--- a/lib/rules/web/admin_console/4.6/goto.xyaml
+++ b/lib/rules/web/admin_console/4.6/goto.xyaml
@@ -16,7 +16,7 @@ goto_project_topology_page:
   url: topology/ns/<project_name>?view=list
   action: wait_box_loaded
 # Dashboard renamed to Overview in 4.4, url is same "k8s/cluster/projects/<project_name>"
-goto_one_project_page: 
+goto_one_project_page:
   url: k8s/cluster/projects/<project_name>
   action: wait_box_loaded
 goto_one_project_dashboard_page:
@@ -32,6 +32,8 @@ goto_api_explore_page:
   url: api-explorer
 goto_one_api_explore_page:
   url: api-resource/ns/<project_name>/<api_explore_name>
+goto_cluster_buildconfig_api_explore_page:
+  url: /api-resource/cluster/config.openshift.io~v1~Build
 
 # builds
 goto_buildconfigs_page:
@@ -58,7 +60,7 @@ goto_tasks_list_page:
 goto_cluster_tasks_list_page:
   url: tasks/ns/<project_name>/cluster-tasks
   action: wait_box_loaded
-  
+
 # command line tools page
 goto_cli_tools_page:
   url: command-line-tools
@@ -80,7 +82,7 @@ goto_jobs_page:
   url: k8s/ns/<project_name>/jobs
 goto_one_job_page:
   url: k8s/ns/<project_name>/jobs/<job_name>
-          
+
 # events
 goto_project_events:
   url: k8s/ns/<project_name>/events
@@ -148,7 +150,7 @@ goto_daemonsets_page:
   action: wait_box_loaded
 goto_one_statefulset_page:
   url: /k8s/ns/<project_name>/statefulsets/<statefulset_name>
-  
+
 #pod
 goto_all_projects_pods_list:
   url: k8s/all-namespaces/pods
@@ -375,9 +377,9 @@ goto_rolebinding_creation_page:
   url: k8s/cluster/rolebindings/~new
   action: wait_form_loaded
 
-goto_all_machines_page: 
+goto_all_machines_page:
   url: k8s/all-namespaces/machine.openshift.io~v1beta1~Machine
-goto_all_machine_sets_page: 
+goto_all_machine_sets_page:
   url: k8s/all-namespaces/machine.openshift.io~v1beta1~MachineSet
 
 #ImageManifestVuln
@@ -402,7 +404,7 @@ goto_co_relatedobjects_page:
   action: wait_box_loaded
 goto_global_configuration_page:
   url: settings/cluster/globalconfig
-  action: wait_box_loaded 
+  action: wait_box_loaded
 goto_cluster_settings_details_page:
   url: settings/cluster
   action: wait_box_loaded
@@ -413,4 +415,4 @@ goto_command_line_tools:
     selector:
       xpath: //div[contains(text(), "Command Line Tools")]
     timeout: 15
-    
+

--- a/lib/rules/web/admin_console/4.7/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.7/common_ui_elements.xyaml
@@ -619,7 +619,7 @@ check_page_contains:
 check_page_match:
   element:
     selector: &page_content
-      visible_text: !ruby/regexp /<content>/i
+      xpath: //*[contains(translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), translate('<content>','ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'))]
     timeout: 15
 check_page_not_match:
   element:

--- a/lib/rules/web/admin_console/4.7/goto.xyaml
+++ b/lib/rules/web/admin_console/4.7/goto.xyaml
@@ -21,7 +21,7 @@ goto_project_topology_page:
   url: topology/ns/<project_name>?view=list
   action: wait_box_loaded
 # Dashboard renamed to Overview in 4.4, url is same "k8s/cluster/projects/<project_name>"
-goto_one_project_page: 
+goto_one_project_page:
   url: k8s/cluster/projects/<project_name>
   action: wait_box_loaded
 goto_one_project_dashboard_page:
@@ -37,6 +37,8 @@ goto_api_explore_page:
   url: api-explorer
 goto_one_api_explore_page:
   url: api-resource/ns/<project_name>/<api_explore_name>
+goto_cluster_buildconfig_api_explore_page:
+  url: /api-resource/cluster/config.openshift.io~v1~Build
 
 # builds
 goto_buildconfigs_page:
@@ -64,7 +66,7 @@ goto_tasks_list_page:
 goto_cluster_tasks_list_page:
   url: tasks/ns/<project_name>/cluster-tasks
   action: wait_box_loaded
-  
+
 # command line tools page
 goto_cli_tools_page:
   url: command-line-tools
@@ -89,7 +91,7 @@ goto_jobs_page:
 goto_one_job_page:
   url: k8s/ns/<project_name>/jobs/<job_name>
   action: wait_box_loaded
-          
+
 # events
 goto_project_events:
   url: k8s/ns/<project_name>/events
@@ -387,9 +389,9 @@ goto_rolebinding_creation_page:
   url: k8s/cluster/rolebindings/~new
   action: wait_form_loaded
 
-goto_all_machines_page: 
+goto_all_machines_page:
   url: k8s/all-namespaces/machine.openshift.io~v1beta1~Machine
-goto_all_machine_sets_page: 
+goto_all_machine_sets_page:
   url: k8s/all-namespaces/machine.openshift.io~v1beta1~MachineSet
 
 #ImageManifestVuln
@@ -414,7 +416,7 @@ goto_co_relatedobjects_page:
   action: wait_box_loaded
 goto_global_configuration_page:
   url: settings/cluster/globalconfig
-  action: wait_box_loaded 
+  action: wait_box_loaded
 goto_cluster_settings_details_page:
   url: settings/cluster
   action: wait_box_loaded
@@ -425,4 +427,4 @@ goto_command_line_tools:
     selector:
       xpath: //div[contains(text(), "Command Line Tools")]
     timeout: 15
-    
+

--- a/lib/rules/web/admin_console/4.8/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.8/common_ui_elements.xyaml
@@ -675,7 +675,7 @@ check_page_contains:
 check_page_match:
   element:
     selector: &page_content
-      visible_text: !ruby/regexp /<content>/i
+      xpath: //*[contains(translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), translate('<content>','ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'))]
     timeout: 15
 check_page_not_match:
   element:


### PR DESCRIPTION
- Fix only for OCP 4.6, 4.7, 4.8
- For OCP-19653, update rules check_page_match
- For OCP-24306, update rules check_page_match and add goto_cluster_buildconfig_api_explore_page

Pass log for 4.7: Runner/845577/, Runner/846131/
Fix Ticket: https://issues.redhat.com/browse/OCPQE-16111
                   https://issues.redhat.com/browse/OCPQE-16119
                   https://issues.redhat.com/browse/OCPQE-16125