### PR TITLE
Fix OCP-19722 rule miss issue

### DIFF
--- a/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.6/common_ui_elements.xyaml
@@ -705,6 +705,11 @@ click_link_with_text_only:
     selector:
       xpath: //a[contains(text(),'<text>')]
     op: click
+click_link_text:
+  element:
+    selector:
+      xpath: //a[text()='<text>']
+    op: click
 click_primary_menu:
   action:
     if_element:

--- a/lib/rules/web/admin_console/4.6/filters.xyaml
+++ b/lib/rules/web/admin_console/4.6/filters.xyaml
@@ -36,6 +36,10 @@ set_strings_in_filter_box:
   - selector:
       <<: *filter_string
     op: send_keys <filter_text>
+filter_by_name:
+  params:
+    test_id_value: item-filter
+  action: set_strings_in_filter_box
 set_filter_strings_on_explore_page:
   elements:
   - selector: &filter_text_for_explore
@@ -118,7 +122,7 @@ check_results_contain_correct_catagory:
           contain = catagory.className.includes('<catagory>'.toLowerCase()) || contain
         })
         return contain
-      expect_result: true 
+      expect_result: true
 check_item_in_table:
   elements:
   - selector:

--- a/lib/rules/web/admin_console/4.7/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.7/common_ui_elements.xyaml
@@ -712,6 +712,11 @@ click_link_with_text_only:
     selector:
       xpath: //a[contains(text(),'<text>')]
     op: click
+click_link_text:
+  element:
+    selector:
+      xpath: //a[text()='<text>']
+    op: click
 click_primary_menu:
   action:
     if_element:

--- a/lib/rules/web/admin_console/4.7/filters.xyaml
+++ b/lib/rules/web/admin_console/4.7/filters.xyaml
@@ -36,6 +36,10 @@ set_strings_in_filter_box:
   - selector:
       <<: *filter_string
     op: send_keys <filter_text>
+filter_by_name:
+  params:
+    test_id_value: item-filter
+  action: set_strings_in_filter_box
 set_filter_strings_on_explore_page:
   elements:
   - selector: &filter_text_for_explore
@@ -118,7 +122,7 @@ check_results_contain_correct_catagory:
           contain = catagory.className.includes('<catagory>'.toLowerCase()) || contain
         })
         return contain
-      expect_result: true 
+      expect_result: true
 check_item_in_table:
   elements:
   - selector:

--- a/lib/rules/web/admin_console/4.8/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.8/common_ui_elements.xyaml
@@ -768,6 +768,11 @@ click_link_with_text_only:
     selector:
       xpath: //a[contains(text(),'<text>')]
     op: click
+click_link_text:
+  element:
+    selector:
+      xpath: //a[text()='<text>']
+    op: click
 click_primary_menu:
   action:
     if_element:


### PR DESCRIPTION
-  The changes is for OCP4.8 4.7 4.6
-  Add missing rules filter_by_name and click_link_text

Pass log for 4.7:
Ticket: https://issues.redhat.com/browse/OCPQE-16114