### PR TITLE
Fix OCP19817 miss rule issue in 4.6 4.7

### DIFF
--- a/lib/rules/web/admin_console/4.6/goto.xyaml
+++ b/lib/rules/web/admin_console/4.6/goto.xyaml
@@ -16,7 +16,7 @@ goto_project_topology_page:
   url: topology/ns/<project_name>?view=list
   action: wait_box_loaded
 # Dashboard renamed to Overview in 4.4, url is same "k8s/cluster/projects/<project_name>"
-goto_one_project_page: 
+goto_one_project_page:
   url: k8s/cluster/projects/<project_name>
   action: wait_box_loaded
 goto_one_project_dashboard_page:
@@ -58,7 +58,7 @@ goto_tasks_list_page:
 goto_cluster_tasks_list_page:
   url: tasks/ns/<project_name>/cluster-tasks
   action: wait_box_loaded
-  
+
 # command line tools page
 goto_cli_tools_page:
   url: command-line-tools
@@ -80,7 +80,7 @@ goto_jobs_page:
   url: k8s/ns/<project_name>/jobs
 goto_one_job_page:
   url: k8s/ns/<project_name>/jobs/<job_name>
-          
+
 # events
 goto_project_events:
   url: k8s/ns/<project_name>/events
@@ -146,9 +146,12 @@ goto_rc_list_page:
 goto_daemonsets_page:
   url: k8s/ns/<project_name>/daemonsets
   action: wait_box_loaded
+goto_one_daemonsets_page:
+  url: k8s/ns/<project_name>/daemonsets/<daemonsets_name>
+  action: wait_box_loaded
 goto_one_statefulset_page:
   url: /k8s/ns/<project_name>/statefulsets/<statefulset_name>
-  
+
 #pod
 goto_all_projects_pods_list:
   url: k8s/all-namespaces/pods
@@ -375,9 +378,9 @@ goto_rolebinding_creation_page:
   url: k8s/cluster/rolebindings/~new
   action: wait_form_loaded
 
-goto_all_machines_page: 
+goto_all_machines_page:
   url: k8s/all-namespaces/machine.openshift.io~v1beta1~Machine
-goto_all_machine_sets_page: 
+goto_all_machine_sets_page:
   url: k8s/all-namespaces/machine.openshift.io~v1beta1~MachineSet
 
 #ImageManifestVuln
@@ -402,7 +405,7 @@ goto_co_relatedobjects_page:
   action: wait_box_loaded
 goto_global_configuration_page:
   url: settings/cluster/globalconfig
-  action: wait_box_loaded 
+  action: wait_box_loaded
 goto_cluster_settings_details_page:
   url: settings/cluster
   action: wait_box_loaded
@@ -413,4 +416,4 @@ goto_command_line_tools:
     selector:
       xpath: //div[contains(text(), "Command Line Tools")]
     timeout: 15
-    
+

--- a/lib/rules/web/admin_console/4.7/goto.xyaml
+++ b/lib/rules/web/admin_console/4.7/goto.xyaml
@@ -21,7 +21,7 @@ goto_project_topology_page:
   url: topology/ns/<project_name>?view=list
   action: wait_box_loaded
 # Dashboard renamed to Overview in 4.4, url is same "k8s/cluster/projects/<project_name>"
-goto_one_project_page: 
+goto_one_project_page:
   url: k8s/cluster/projects/<project_name>
   action: wait_box_loaded
 goto_one_project_dashboard_page:
@@ -64,7 +64,7 @@ goto_tasks_list_page:
 goto_cluster_tasks_list_page:
   url: tasks/ns/<project_name>/cluster-tasks
   action: wait_box_loaded
-  
+
 # command line tools page
 goto_cli_tools_page:
   url: command-line-tools
@@ -89,7 +89,7 @@ goto_jobs_page:
 goto_one_job_page:
   url: k8s/ns/<project_name>/jobs/<job_name>
   action: wait_box_loaded
-          
+
 # events
 goto_project_events:
   url: k8s/ns/<project_name>/events
@@ -154,6 +154,9 @@ goto_rc_list_page:
 
 goto_daemonsets_page:
   url: k8s/ns/<project_name>/daemonsets
+  action: wait_box_loaded
+goto_one_daemonsets_page:
+  url: k8s/ns/<project_name>/daemonsets/<daemonsets_name>
   action: wait_box_loaded
 goto_one_statefulset_page:
   url: /k8s/ns/<project_name>/statefulsets/<statefulset_name>
@@ -387,9 +390,9 @@ goto_rolebinding_creation_page:
   url: k8s/cluster/rolebindings/~new
   action: wait_form_loaded
 
-goto_all_machines_page: 
+goto_all_machines_page:
   url: k8s/all-namespaces/machine.openshift.io~v1beta1~Machine
-goto_all_machine_sets_page: 
+goto_all_machine_sets_page:
   url: k8s/all-namespaces/machine.openshift.io~v1beta1~MachineSet
 
 #ImageManifestVuln
@@ -414,7 +417,7 @@ goto_co_relatedobjects_page:
   action: wait_box_loaded
 goto_global_configuration_page:
   url: settings/cluster/globalconfig
-  action: wait_box_loaded 
+  action: wait_box_loaded
 goto_cluster_settings_details_page:
   url: settings/cluster
   action: wait_box_loaded
@@ -425,4 +428,4 @@ goto_command_line_tools:
     selector:
       xpath: //div[contains(text(), "Command Line Tools")]
     timeout: 15
-    
+


### PR DESCRIPTION
-   Add the miss rule goto_one_daemonsets_page

Pass log for 4.7: Runner/845591/
Resolved Ticket: https://issues.redhat.com/browse/OCPQE-16115