### PR TITLE
Update rule for OCP-26984

### DIFF
--- a/lib/rules/web/admin_console/4.6/projects.xyaml
+++ b/lib/rules/web/admin_console/4.6/projects.xyaml
@@ -2,7 +2,7 @@
 create_project:
   action: click_create_project_button
   action: set_project_name
-  action: 
+  action:
     if_param: display_name
     ref: set_project_display_name
   action:
@@ -70,11 +70,15 @@ check_memory_data_for_one_project_in_table:
   params:
     resource_name: <project_name>
     data: MiB
+    filter_text: <project_name>
+  action: filter_by_name
   action: check_resource_data_in_table
 check_cpu_data_for_one_project_in_table:
   params:
     resource_name: <project_name>
     data: cores
+    filter_text: <project_name>
+  action: filter_by_name
   action: check_resource_data_in_table
 switch_to_project:
   params:

--- a/lib/rules/web/admin_console/4.7/projects.xyaml
+++ b/lib/rules/web/admin_console/4.7/projects.xyaml
@@ -2,7 +2,7 @@
 create_project:
   action: click_create_project_button
   action: set_project_name
-  action: 
+  action:
     if_param: display_name
     ref: set_project_display_name
   action:
@@ -69,11 +69,15 @@ check_memory_data_for_one_project_in_table:
   params:
     resource_name: <project_name>
     data: MiB
+    filter_text: <project_name>
+  action: filter_by_name
   action: check_resource_data_in_table
 check_cpu_data_for_one_project_in_table:
   params:
     resource_name: <project_name>
     data: cores
+    filter_text: <project_name>
+  action: filter_by_name
   action: check_resource_data_in_table
 switch_to_project:
   params:


### PR DESCRIPTION
-   Changes are only for OCP 4.6 and 4.7
-   Update two functions check_memory_data_for_one_project_in_table & check_cpu_data_for_one_project_in_table
-   The action of filter_by_name is updated in PR#3399

The case pass in local, as PR#3399 is not merged yet, so could not provide Jenkins pass log
Ticket: https://issues.redhat.com/browse/OCPQE-16127