### PR TITLE
Fix path for chromedriver

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.rhel8
+++ b/tools/jenkins/slaves/Dockerfile.rhel8
@@ -20,7 +20,8 @@ RUN set -x && \
     #CHROMEDRIVER_URL="https://chromedriver.storage.googleapis.com" && \
     #CHROMEDRIVER_VERSION=$(curl -sSL "$CHROMEDRIVER_URL/LATEST_RELEASE") && \
     #curl -sSL "$CHROMEDRIVER_URL/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" | bsdtar --no-same-owner --no-same-permissions -xvf - -C /usr/local/bin && \
-    curl -sSL 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chromedriver-linux64.zip' | bsdtar --no-same-owner --no-same-permissions -xvf - -C /usr/local/bin && \
+    curl -sSL 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chromedriver-linux64.zip' | bsdtar --no-same-owner --no-same-permissions -xvf - -C /tmp && \
+    mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/ && \
     GECKODRIVER_SPEC="https://api.github.com/repos/mozilla/geckodriver/releases/latest" && \
     GECKODRIVER_RE='^.*"browser_download_url": ?"(http[^"]*linux64.tar.gz)".*$' && \
     curl -sSL $GITHUB_API_CURL_OPTS "$GECKODRIVER_SPEC" | sed -En "s#$GECKODRIVER_RE#\1#p" | xargs -d '\n' curl -sSL | bsdtar -xvf - -C /usr/local/bin && \


### PR DESCRIPTION
```
+ curl -sSL https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chromedriver-linux64.zip
+ bsdtar --no-same-owner --no-same-permissions -xvf - -C /usr/local/bin
x chromedriver-linux64/LICENSE.chromedriver
x chromedriver-linux64/chromedriver
......
+ chmod +x /usr/local/bin/chromedriver /usr/local/bin/geckodriver
chmod: cannot access '/usr/local/bin/chromedriver': No such file or directory
```