### PR TITLE
Fix "Selenium::WebDriver::Error::SessionNotCreatedError"

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -18,14 +18,15 @@ RUN set -x && \
     yum -y update && \
     INSTALL_PKGS="bsdtar git openssh-clients httpd-tools rsync" && \
     yum install -y $INSTALL_PKGS && \
-    yum install -y --setopt=tsflags=nodocs https://dl.google.com/linux/direct/google-chrome-stable_current_$(uname -m).rpm && \
-    CHROMEDRIVER_URL="https://chromedriver.storage.googleapis.com" && \
-    CHROMEDRIVER_VERSION=$(curl -sSL "$CHROMEDRIVER_URL/LATEST_RELEASE") && \
-    curl -sSL "$CHROMEDRIVER_URL/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" | bsdtar --no-same-owner --no-same-permissions -xvf - -C /usr/local/bin && \
+    curl --silent --location https://rpm.nodesource.com/setup_18.x | bash - && \
+    dnf -y install nodejs && \
+    CHROME_VERSION='116.0.5845.96' && \
+    npx @puppeteer/browsers install chrome@${CHROME_VERSION} && \
+    npx @puppeteer/browsers install chromedriver@${CHROME_VERSION} && \
     GECKODRIVER_SPEC="https://api.github.com/repos/mozilla/geckodriver/releases/latest" && \
     GECKODRIVER_RE='^.*"browser_download_url": ?"(http[^"]*linux64.tar.gz)".*$' && \
     curl -sSL $GITHUB_API_CURL_OPTS "$GECKODRIVER_SPEC" | sed -En "s#$GECKODRIVER_RE#\1#p" | xargs -d '\n' curl -sSL | bsdtar -xvf - -C /usr/local/bin && \
-    chmod +x /usr/local/bin/chromedriver /usr/local/bin/geckodriver && \
+    chmod +x /usr/local/bin/geckodriver && \
     JQ_SPEC="https://api.github.com/repos/stedolan/jq/releases/latest" && \
     JQ_RE='^.*"browser_download_url": ?"(http[^"]*jq-linux64)".*$' && \
     curl -sSL $GITHUB_API_CURL_OPTS "$JQ_SPEC" | sed -En "s#$JQ_RE#\1#p" | xargs -d '\n' curl -sSL -o /usr/local/bin/jq && \


### PR DESCRIPTION
```
And I open admin console in a browser
Message:
session not created: This version of ChromeDriver only supports Chrome version 114
Current browser version is 116.0.5845.110 with binary path /usr/bin/google-chrome (Selenium::WebDriver::Error::SessionNotCreatedError)
```

```
+ CHROME_VERSION=116.0.5845.96
+ npx @puppeteer/browsers install chrome@116.0.5845.96
npm WARN exec The following package was not found and will be installed: @puppeteer/browsers@1.7.0
chrome@116.0.5845.96 /chrome/linux-116.0.5845.96/chrome-linux64/chrome
npm notice
npm notice New minor version of npm available! 9.6.7 -> 9.8.1
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.8.1>
npm notice Run `npm install -g npm@9.8.1` to update!
npm notice
+ npx @puppeteer/browsers install chromedriver@116.0.5845.96
chromedriver@116.0.5845.96 /chromedriver/linux-116.0.5845.96/chromedriver-linux64/chromedriver
```