### PR TITLE
OCPQE-16557: [ProwCI] Add chromedriver into PATH

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -23,10 +23,11 @@ RUN set -x && \
     CHROME_VERSION='116.0.5845.96' && \
     npx @puppeteer/browsers install chrome@${CHROME_VERSION} && \
     npx @puppeteer/browsers install chromedriver@${CHROME_VERSION} && \
+    find /chromedriver -type f -name chromedriver -exec ln {} /usr/local/bin/chromedriver \; && \
     GECKODRIVER_SPEC="https://api.github.com/repos/mozilla/geckodriver/releases/latest" && \
     GECKODRIVER_RE='^.*"browser_download_url": ?"(http[^"]*linux64.tar.gz)".*$' && \
     curl -sSL $GITHUB_API_CURL_OPTS "$GECKODRIVER_SPEC" | sed -En "s#$GECKODRIVER_RE#\1#p" | xargs -d '\n' curl -sSL | bsdtar -xvf - -C /usr/local/bin && \
-    chmod +x /usr/local/bin/geckodriver && \
+    chmod +x /usr/local/bin/chromedriver /usr/local/bin/geckodriver && \
     JQ_SPEC="https://api.github.com/repos/stedolan/jq/releases/latest" && \
     JQ_RE='^.*"browser_download_url": ?"(http[^"]*jq-linux64)".*$' && \
     curl -sSL $GITHUB_API_CURL_OPTS "$JQ_SPEC" | sed -En "s#$JQ_RE#\1#p" | xargs -d '\n' curl -sSL -o /usr/local/bin/jq && \


### PR DESCRIPTION
```
    Scenario: OCP-25816:UserInterface Expose console_url metrics in console-operator metric

And I open admin console in a browser

Message:

    Unable to find chromedriver. Please download the server from
https://chromedriver.storage.googleapis.com/index.html and place it somewhere on your PATH.
More info at https://www.selenium.dev/documentation/webdriver/getting_started/install_drivers/?language=ruby.
 (Selenium::WebDriver::Error::WebDriverError)
./lib/webauto/web4cucumber.rb:151:in `new'
./lib/webauto/web4cucumber.rb:151:in `browser'
./lib/webauto/web4cucumber.rb:490:in `goto_url'
./lib/webauto/web4cucumber.rb:240:in `block in run_action'
./lib/webauto/web4cucumber.rb:236:in `each'
./lib/webauto/web4cucumber.rb:236:in `run_action'
./features/step_definitions/admin_console.rb:25:in `/^I open admin console in a browser$/'
features/tierN/web/admin-console/admin-console-api.feature:22:in `I open admin console in a browser'
```