### PR TITLE
OCPQE-16557: Fix chrome and chromedriver

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.rhel8
+++ b/tools/jenkins/slaves/Dockerfile.rhel8
@@ -13,12 +13,11 @@ RUN set -x && \
     dnf config-manager --save --setopt=\*.skip_if_unavailable=1 $NEW_REPOS && \
     yum repolist enabled && \
     yum -y update && \
+    dnf -y install --allowerasing --setopt=skip_missing_names_on_install=False,tsflags=nodocs https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm && \
+    dnf config-manager --save --setopt=google-chrome.skip_if_unavailable=true && \
     curl --silent --location https://rpm.nodesource.com/setup_18.x | bash - && \
     dnf -y install nodejs && \
-    CHROME_VERSION='116.0.5845.96' && \
-    npx @puppeteer/browsers install chrome@${CHROME_VERSION} && \
-    find /chrome -type d -name chrome-linux64 -exec ln -s {} /chrome/chrome-linux64 \; && \
-    npx @puppeteer/browsers install chromedriver@${CHROME_VERSION} && \
+    npx @puppeteer/browsers install chromedriver@stable && \
     find /chromedriver -type f -name chromedriver -exec ln {} /usr/local/bin/chromedriver \; && \
     INSTALL_PKGS="bsdtar" && \
     dnf -y install --allowerasing --setopt=skip_missing_names_on_install=False,tsflags=nodocs $INSTALL_PKGS && \
@@ -34,8 +33,6 @@ RUN set -x && \
     yum -y clean all && \
     rm -rf /var/cache/yum /var/tmp/* /tmp/* && \
     mkdir -p --mode=g+rw $HOME/bin
-
-ENV PATH="${PATH}:/chrome/chrome-linux64"
 
 # make sure context dir is at the repo root
 ADD . $HOME/verification-tests


### PR DESCRIPTION
```
08-28 05:24:50.296        [05:24:49] INFO> Launching Chrome
08-28 05:24:50.296        unknown error: Chrome failed to start: exited abnormally.
08-28 05:24:50.296          (unknown error: DevToolsActivePort file doesn't exist)
08-28 05:24:50.296          (The process started from chrome location /chrome/chrome-linux64/chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.) (Selenium::WebDriver::Error::UnknownError)
```
The `chrome` installed via `npx` does not work well with `selenium-webdriver (4.8.0)`. And we can not bump up selenium-webdriver due to the requirement of ruby 3.0+ since 4.9.1
So revert the old way to install `chrome`, and using the new way to install `chromedriver`.
The image build passed (with chrome 116.0.5845.110-1 and chromedriver 116.0.5845.96), but not sure if the tests will works or not.