### PR TITLE
Fix check silence detail xpath for 4.14 due to UI change

### DIFF
--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -88,7 +88,7 @@ perform_silence:
 check_silence_detail:
   element:
     selector:
-      xpath: //h2[@class='co-section-heading' and text()='Silence details']
+      xpath: //h2[text()='Silence details']
 
 silence_alert_from_detail_if:     
   action:

--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -88,7 +88,7 @@ perform_silence:
 check_silence_detail:
   element:
     selector:
-      xpath: //span[text()='Silence details']
+      xpath: //div[@class='co-section-heading' and text()='Silence details']
 
 silence_alert_from_detail_if:     
   action:

--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -88,7 +88,7 @@ perform_silence:
 check_silence_detail:
   element:
     selector:
-      xpath: //div[@class='co-section-heading' and text()='Silence details']
+      xpath: //h2[@class='co-section-heading' and text()='Silence details']
 
 silence_alert_from_detail_if:     
   action:


### PR DESCRIPTION
see from https://issues.redhat.com/browse/OCPQE-16575
due to 4.14 UI changes, the 4 cases failed at "silence_alert_from_detail_if" action, root cause is in check_silence_detail action
```
check_silence_detail:
  element:
    selector:
      xpath: //span[text()='Silence details']
```
4.13 xpath
```
<h2 class="co-section-heading" data-test-section-heading="Silence details"><span class="">Silence details</span></h2>
```

4.14 changed to
```
<h2 class="co-section-heading" data-test-section-heading="Silence details">Silence details</h2>
```
update xpath for 4.14 only to
```
check_silence_detail:
  element:
    selector:
      xpath: //h2[@class='co-section-heading' and text()='Silence details']
```
runner job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/853266/console