### PR TITLE
fix OCP-22330

### DIFF
--- a/lib/rules/web/admin_console/base/logout.xyaml
+++ b/lib/rules/web/admin_console/base/logout.xyaml
@@ -4,5 +4,5 @@ click_logout:
       xpath: //*[@data-test='user-dropdown']
     op: click
   - selector:
-      visible_text: !ruby/regexp /Log.*out/
+      xpath: //button[contains(., 'Log out')]
     op: click


### PR DESCRIPTION
Replace ruby regex which often fail in jenkins. 
log on 4.14: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/853360/console