### PR TITLE
Fix OCP-29300 due to 4.14 UI change

### DIFF
--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -68,7 +68,7 @@ click_silence_alert:
 uncheck_start_from_now:
   element:
     selector:
-      xpath: //span[text()='Duration']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']
+      xpath: //h2[text()='Duration']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']
     op: click
 ensure_start_from_now_checked:
   element:

--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -73,7 +73,7 @@ uncheck_start_from_now:
 ensure_start_from_now_checked:
   element:
     selector:
-      xpath: //span[text()='Duration']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox'][@checked]
+      xpath: //h2[text()='Duration']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox'][@checked]
 check_regular_expression_link:
   element:
     selector:


### PR DESCRIPTION
see from https://issues.redhat.com/browse/OCPQE-16577, OCP-29300 failed due to 4.14 UI change.
update xpath for "uncheck_start_from_now" and "ensure_start_from_now_checked" actions , the only change is changed from `span` to `h2` in 4.14
```
uncheck_start_from_now:
  element:
    selector:
      xpath: //h2[text()='Duration']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox']
    op: click
```
and
```
ensure_start_from_now_checked:
  element:
    selector:
      xpath: //h2[text()='Duration']/ancestor::div[@class='co-m-pane__body-group']//input[@type='checkbox'][@checked]
```
runner job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/854012/console