### PR TITLE
Adding rosa/osd/aro tag

### DIFF
--- a/features/storage/NoDiskConflict.feature
+++ b/features/storage/NoDiskConflict.feature
@@ -7,6 +7,7 @@ Feature: NoDiskConflict
   @singlenode
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @rosa @osd_ccs @aro
   @aws-ipi
   @aws-upi
   @hypershift-hosted

--- a/features/storage/cloud_provider.feature
+++ b/features/storage/cloud_provider.feature
@@ -44,6 +44,7 @@ Feature: kubelet restart and node restart
     Then the step should succeed
     """
 
+    @rosa @osd_ccs @aro
     @azure-ipi
     @azure-upi
     Examples:
@@ -56,6 +57,7 @@ Feature: kubelet restart and node restart
       | case_id           | platform |
       | OCP-11317:Storage | cinder   | # @case_id OCP-11317
 
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:

--- a/features/storage/csi.feature
+++ b/features/storage/csi.feature
@@ -82,6 +82,7 @@ Feature: CSI testing related feature
     Then the PV becomes :released
     And admin ensures "<%= pvc.volume_name %>" pv is deleted
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:
@@ -342,6 +343,7 @@ Feature: CSI testing related feature
     Then the step should succeed
     And the output should contain "Hello OpenShift Storage"
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:
@@ -400,6 +402,7 @@ Feature: CSI testing related feature
       | case_id           | provisioner              | sc_name      | deployment_operator                  | deployment_controller                  | daemonset_node                   |
       | OCP-37557:Storage | cinder.csi.openstack.org | standard-csi | openstack-cinder-csi-driver-operator | openstack-cinder-csi-driver-controller | openstack-cinder-csi-driver-node | # @case_id OCP-37557
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:

--- a/features/storage/csi_resize.feature
+++ b/features/storage/csi_resize.feature
@@ -45,12 +45,14 @@ Feature: CSI Resizing related feature
     And the output should not contain:
       | No space left on device |
 
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:
       | case_id           | sc_name      |
       | OCP-37479:Storage | standard-csi | # @case_id OCP-37479
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:
@@ -98,6 +100,7 @@ Feature: CSI Resizing related feature
     And the output should match:
       | Forbidden.*field can not be less than previous value |
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     @hypershift-hosted

--- a/features/storage/csi_snapshot.feature
+++ b/features/storage/csi_snapshot.feature
@@ -60,12 +60,14 @@ Feature: Volume snapshot test
     Then the step should succeed
     And the output should contain "snapshot test"
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:
       | case_id           | csi-sc  | csi-vsc     |
       | OCP-27727:Storage | gp2-csi | csi-aws-vsc | # @case_id OCP-27727
 
+    @rosa @osd_ccs @aro
     @azure-ipi
     @azure-upi
     Examples:

--- a/features/storage/dynamic_provisioning.feature
+++ b/features/storage/dynamic_provisioning.feature
@@ -62,18 +62,21 @@ Feature: Dynamic provisioning
       | <%= cb.volumeID %>     |
     # And I verify that the IAAS volume with id "<%= cb.volumeID %>" was deleted
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:
       | case_id          | cloud_provider |
       | OCP-9685:Storage | ebs            | # @case_id OCP-9685
 
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:
       | case_id           | cloud_provider |
       | OCP-12665:Storage | gce            | # @case_id OCP-12665
 
+    @rosa @osd_ccs @aro
     @azure-ipi
     @azure-upi
     Examples:

--- a/features/storage/fsType.feature
+++ b/features/storage/fsType.feature
@@ -38,6 +38,7 @@ Feature: testing for parameter fsType
       | ls | /mnt/testfile |
     Then the step should succeed
 
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:
@@ -46,6 +47,7 @@ Feature: testing for parameter fsType
       | OCP-10094:Storage | ext4   | gce  | # @case_id OCP-10094
       | OCP-10096:Storage | xfs    | gce  | # @case_id OCP-10096
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:

--- a/features/storage/hostpath.feature
+++ b/features/storage/hostpath.feature
@@ -52,6 +52,7 @@ Feature: Storage of Hostpath plugin testing
       | ls /etc/origin/hostpath/<%= project.name %>/test |
     Then the step should <step_status>
 
+    @rosa @osd_ccs @aro
     @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
     @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
     @hypershift-hosted

--- a/features/storage/negative.feature
+++ b/features/storage/negative.feature
@@ -17,6 +17,7 @@ Feature: negative testing
     And the output should contain:
       | <error> |
 
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:

--- a/features/storage/nfs.feature
+++ b/features/storage/nfs.feature
@@ -5,6 +5,7 @@ Feature: NFS Persistent Volume
   # @case_id OCP-9572
   @admin
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity

--- a/features/storage/node_operations.feature
+++ b/features/storage/node_operations.feature
@@ -39,12 +39,14 @@ Feature: Node operations test scenarios
     And a pod becomes ready with labels:
       | name=jenkins |
 
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:
       | case_id           | cloud_provider |
       | OCP-15287:Storage | gcp            | # @case_id OCP-15287
 
+    @rosa @osd_ccs @aro
     @azure-ipi
     @azure-upi
     Examples:

--- a/features/storage/persistent_volume.feature
+++ b/features/storage/persistent_volume.feature
@@ -40,6 +40,7 @@ Feature: Persistent Volume Claim binding policies
     And the "mypvc" PVC becomes bound to the "pv1-<%= project.name %>" PV
     And the "pv2-<%= project.name %>" PV status is :available
 
+    @rosa @osd_ccs @aro
     @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
     @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
     @hypershift-hosted
@@ -105,6 +106,7 @@ Feature: Persistent Volume Claim binding policies
     And the "pv-<%= project.name %>" PV status is :available
     And the "mypvc" PVC becomes :pending
 
+    @rosa @osd_ccs @aro
     @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
     @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
     @hypershift-hosted
@@ -149,6 +151,7 @@ Feature: Persistent Volume Claim binding policies
     And the "mypvc1" PVC becomes :pending
     And the "mypvc2" PVC becomes :pending
 
+    @rosa @osd_ccs @aro
     @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
     @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
     @hypershift-hosted

--- a/features/storage/pre-bind.feature
+++ b/features/storage/pre-bind.feature
@@ -7,6 +7,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
@@ -38,6 +39,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
@@ -68,6 +70,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
@@ -98,6 +101,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
@@ -127,6 +131,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
@@ -156,6 +161,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
@@ -188,6 +194,7 @@ Feature: Testing for pv and pvc pre-bind feature
   @singlenode
   @proxy @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
@@ -237,6 +244,7 @@ Feature: Testing for pv and pvc pre-bind feature
     And the "mypvc" PVC becomes :pending
     And the "pv-<%= project.name %>" PV status is :available
 
+    @rosa @osd_ccs @aro
     @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
     @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
     @hypershift-hosted

--- a/features/storage/quota.feature
+++ b/features/storage/quota.feature
@@ -4,6 +4,7 @@ Feature: ResourceQuata for storage
   # @case_id OCP-14173
   @admin
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   @upgrade-sanity
@@ -84,6 +85,7 @@ Feature: ResourceQuata for storage
   # @case_id OCP-14382
   @admin
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   @upgrade-sanity

--- a/features/storage/reclaim_policy.feature
+++ b/features/storage/reclaim_policy.feature
@@ -44,12 +44,14 @@ Feature: Persistent Volume reclaim policy tests
     Given I switch to cluster admin pseudo user
     And I wait for the resource "pv" named "<%= pv.name %>" to disappear within 1200 seconds
 
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:
       | case_id          | storage_type      | volume_name | path | file                |
       | OCP-9949:Storage | gcePersistentDisk | pdName      | gce  | pv-default-rwo.json | # @case_id OCP-9949
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:

--- a/features/storage/regression.feature
+++ b/features/storage/regression.feature
@@ -4,6 +4,7 @@ Feature: Regression testing cases
   # @case_id OCP-16485
   @admin
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   @upgrade-sanity

--- a/features/storage/security.feature
+++ b/features/storage/security.feature
@@ -112,12 +112,14 @@ Feature: storage security check
     And the output should contain "Hello OpenShift Storage"
 
     # keep the parameters for 3.11 cases can be run.
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:
       | case_id          | storage_type      | volume_name | type |
       | OCP-9700:Storage | gcePersistentDisk | pdName      | gce  | # @case_id OCP-9700
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:
@@ -136,6 +138,7 @@ Feature: storage security check
   @admin
   @smoke
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @rosa @osd_ccs @aro
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity

--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -30,12 +30,14 @@ Feature: storageClass related feature
       | p             | {"metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"<storage-class-name>"}}} |
     Then the expression should be true> @result[:success] == env.version_le("3.5", user: user)
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:
       | case_id           | storage-class-name |
       | OCP-12269:Storage | gp2                | # @case_id OCP-12269
 
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:
@@ -48,6 +50,7 @@ Feature: storageClass related feature
       | case_id           | storage-class-name |
       | OCP-12272:Storage | standard           | # @case_id OCP-12272
 
+    @rosa @osd_ccs @aro
     @azure-ipi
     @azure-upi
     @hypershift-hosted
@@ -100,6 +103,7 @@ Feature: storageClass related feature
     Given I switch to cluster admin pseudo user
     And I wait for the resource "pv" named "<%= pvc.volume_name %>" to disappear
 
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:
@@ -107,6 +111,7 @@ Feature: storageClass related feature
       | OCP-11359:Storage | gce-pd      | pd-ssd      | us-central1-a | false      | 1Gi  | # @case_id OCP-11359
       | OCP-11640:Storage | gce-pd      | pd-standard | us-central1-a | false      | 2Gi  | # @case_id OCP-11640
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     @hypershift-hosted
@@ -161,12 +166,14 @@ Feature: storageClass related feature
     And the "mypvc1" PVC becomes :bound within 120 seconds
     And the "mypvc2" PVC becomes :bound within 120 seconds
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     Examples:
       | case_id           | provisioner |
       | OCP-12226:Storage | aws-ebs     | # @case_id OCP-12226
 
+    @rosa @osd_ccs @aro
     @azure-ipi
     @azure-upi
     Examples:
@@ -179,6 +186,7 @@ Feature: storageClass related feature
       | case_id           | provisioner |
       | OCP-12227:Storage | cinder      | # @case_id OCP-12227
 
+    @rosa @osd_ccs @aro
     @gcp-ipi
     @gcp-upi
     Examples:
@@ -256,6 +264,7 @@ Feature: storageClass related feature
     Given I switch to cluster admin pseudo user
     And I wait for the resource "pv" named "<%= pvc.volume_name %>" to disappear within 300 seconds
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     @hypershift-hosted
@@ -297,6 +306,7 @@ Feature: storageClass related feature
       | <errorMessage>        |
     """
 
+    @rosa @osd_ccs @aro
     @aws-ipi
     @aws-upi
     @hypershift-hosted
@@ -309,6 +319,7 @@ Feature: storageClass related feature
   # @case_id OCP-10159
   @admin
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @rosa @osd_ccs @aro
   @aws-ipi
   @aws-upi
   @singlenode
@@ -339,6 +350,7 @@ Feature: storageClass related feature
   # @case_id OCP-10228
   @smoke
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @rosa @osd_ccs @aro
   @aws-ipi
   @aws-upi
   @upgrade-sanity


### PR DESCRIPTION
Adding "rosa/osd/aro" for service clusters, in our ci we will filter the case with platform, so it is safe to add this "@rosa @osd_ccs @aro".