### PR TITLE
OCPQE-16695: Fix OCP-9699

### DIFF
--- a/features/storage/security.feature
+++ b/features/storage/security.feature
@@ -12,13 +12,17 @@ Feature: storage security check
   @storage
   Scenario Outline: volume security testing
     Given I have a project with proper privilege
+    And admin creates new in-tree storageclass with:
+      | ["metadata"]["name"] | sc-<%= project.name %> |
     Given I obtain test data file "storage/misc/pvc.json"
     When I run oc create over "pvc.json" replacing paths:
-      | ["metadata"]["name"] | mypvc1 |
+      | ["metadata"]["name"]         | mypvc1                 |
+      | ["spec"]["storageClassName"] | sc-<%= project.name %> |
     Then the step should succeed
     Given I obtain test data file "storage/misc/pvc.json"
     When I run oc create over "pvc.json" replacing paths:
-      | ["metadata"]["name"] | mypvc2 |
+      | ["metadata"]["name"]         | mypvc2                 |
+      | ["spec"]["storageClassName"] | sc-<%= project.name %> |
     Then the step should succeed
 
     Given I switch to cluster admin pseudo user


### PR DESCRIPTION
## Fix OCP-9699

#### Root cause
- For several storage new added CI profiles we changed the default storageClass to the fileshare one, then some cases which use the default storageClass still want to provision a block volume/ volume securify check will be failed.

#### Flake records
- https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/all/430754

#### Fix solution
- Create a new block storageclass used by pvcs do the tests

#### Test Record on the flake config cluster
`Runner-v3-smoke/6589/console`
```console
1 scenario (1 passed)
57 steps (57 passed)
2m8.348s

```
