### PR TITLE
Fix: use gp2 type create aws in-tree storageclass

### DIFF
--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -261,6 +261,11 @@ When /^admin creates new in-tree storageclass with:$/ do |table|
       eval "sc_hash#{path} = YAML.load value" unless path == ''
   end
 
+  # After CSI Migration the default volumeType change to 'gp3', but most aws local zones nodes don't support gp3 type volume
+  if platform == "aws"  
+    sc_hash["parameters"]["type"] = "gp2"
+  end
+
   # if no volumeBindingMode exists in tc, we need to pass vSphere=Immediate, others=WaitForFirstConsumer
   if !sc_hash.dig("volumeBindingMode")
     if platform == "vsphere"  


### PR DESCRIPTION
## Fix: use gp2 type create aws in-tree storageclass

#### Root cause
- After CSI Migration the default volumeType change to 'gp3', but most aws local zones nodes/outposts clusters don't support gp3 type volume, many cases use the `creates new in-tree storageclass` step maybe failed .

#### Fix solution
- Use gp2 type create aws in-tree storageclass

#### Test Record on the aws local zones cluster
`Runner-v3-smoke/6619/console`
```console
      [06:44:04] INFO> === End After Scenario: OCP-17563:Storage Using multiple block volumes ===
# @author jhou@redhat.com
# @author lxia@redhat.com
# @case_id OCP-20728

1 scenario (1 passed)
14 steps (14 passed)
```