### PR TITLE
OCPQE-16894: Fix OCP-34144

### DIFF
--- a/features/step_definitions/deployment.rb
+++ b/features/step_definitions/deployment.rb
@@ -74,7 +74,7 @@ Given /^#{QUOTED} deployment becomes ready in the#{OPT_QUOTED} project$/ do | d_
     ready = deployment(d_name).ready_replicas(cached: false)
     ready == desired
   }
-  unless !@result[:success]
+  unless @result[:success]
     logger.error(user.cli_exec(:logs, resource_name: "deployment/#{d_name}"))
     raise "Deployment did not become ready"
   end


### PR DESCRIPTION
## [OCPQE-16894](https://issues.redhat.com//browse/OCPQE-16894): Fix OCP-34144
**Failed records**
- https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/1177/437394/48406037/48406523/log?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED 

 - https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/1177/437752/48451088/48451306/log?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED 

 - https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/1177/437326/48399199?item1Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED

**Root cause**

- After https://github.com/openshift/verification-tests/pull/3435 merged the check deployment ready util has the incorrect check condition. `unless` condition should without `!`
```console
Message: failed Check CSI Driver Operator installation (outline example : | OCP-34144:Storage | ebs.csi.aws.com | gp2-csi | aws-ebs-csi-driver-operator | aws-ebs-csi-driver-controller | aws-ebs-csi-driver-node |)
Type: failed

Text:

    Scenario Outline: Check CSI Driver Operator installation

Example row: | OCP-34144:Storage | ebs.csi.aws.com | gp2-csi | aws-ebs-csi-driver-operator | aws-ebs-csi-driver-controller | aws-ebs-csi-driver-node |

Message:

    Deployment did not become ready (RuntimeError)
./features/step_definitions/deployment.rb:79:in `/^"(.+?)" deployment becomes ready in the(?: "(.+?)")? project$/'
features/storage/csi.feature:410:395:in `"aws-ebs-csi-driver-operator" deployment becomes ready in the "openshift-cluster-csi-drivers" project'
  
```

**Fix solution**
- Remove the `!` in additional info print condition.

**Test record on AWS local zones cluster**
`ocp-common/job/Runner/860607`
```console
09-18 15:21:10.961        [07:21:10] INFO> === End After Scenario: Check CSI Driver Operator installation ===
09-18 15:21:10.961  
09-18 15:21:10.961  1 scenario (1 passed)
09-18 15:21:10.961  12 steps (12 passed)
09-18 15:21:10.961  0m23.535s
```


