### PR TITLE
Update OCP-40569

### DIFF
--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -222,6 +222,16 @@ Feature: OVNKubernetes IPsec related networking scenarios
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":{}}}}} |
 
+    Given I wait up to 60 seconds for the steps to pass:
+    """
+    Given the status of condition "Progressing" for network operator is :True
+    """
+    Given I wait up to 900 seconds for the steps to pass:
+    """
+    Given the status of condition "Progressing" for network operator is :False
+    And OVN is functional on the cluster
+    """
+
     Given I have a project with proper privilege
     And evaluation of `project.name` is stored in the :hello_pod_project clipboard
     Given I obtain test data file "networking/pod-for-ping.json"
@@ -263,21 +273,19 @@ Feature: OVNKubernetes IPsec related networking scenarios
     And the output should contain "ESP"
     """
 
-    #Need to restart ovnkube-master "north" leader after enabling ipsec to make sure use correct "north" leader
-    Given I store the ovnkube-master "north" leader pod in the clipboard
-    Given admin ensures "<%= cb.north_leader.name %>" pod is deleted from the "openshift-ovn-kubernetes" project    
-    Given I store the ovnkube-master "north" leader pod in the clipboard
-    #Check "north" leader return ipsec enabled/ture information
-    Given I wait up to 90 seconds for the steps to pass:
-    """
-    And admin executes on the pod "northd" container:
-      | bash | -c | ovn-nbctl --no-leader-only get nb_global . ipsec \| grep true |
-    And the output should contain "true"
-    """
-    
     # Disable ipsec through CNO
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":null}}}} |
+
+    Given I wait up to 60 seconds for the steps to pass:
+    """
+    Given the status of condition "Progressing" for network operator is :True
+    """
+    Given I wait up to 900 seconds for the steps to pass:
+    """
+    Given the status of condition "Progressing" for network operator is :False
+    And OVN is functional on the cluster
+    """
 
     Given I switch to the first user
     And I use the "<%= cb.hello_pod_project %>" project
@@ -288,17 +296,5 @@ Feature: OVNKubernetes IPsec related networking scenarios
       | bash | -c | timeout  --preserve-status 2 tcpdump -v -i <%= cb.default_interface %> esp |
     Then the step should succeed
     And the output should not contain "ESP"
-    """
-    
-    #Need to restart ovnkube-master "north" leader after enabling ipsec to make sure use correct "north" leader
-    Given I store the ovnkube-master "north" leader pod in the clipboard
-    Given admin ensures "<%= cb.north_leader.name %>" pod is deleted from the "openshift-ovn-kubernetes" project    
-    Given I store the ovnkube-master "north" leader pod in the clipboard
-    #Check "north" leader return ipsec disabled/false information
-    Given I wait up to 90 seconds for the steps to pass:
-    """
-    And admin executes on the pod "northd" container:
-      | bash | -c | ovn-nbctl --no-leader-only get nb_global . ipsec \| grep false |
-    And the output should contain "false"
     """
    


### PR DESCRIPTION
This case failed more ofern than before due to network operator take more time to recovery after enable/disable IPsec during running time.

Add steps to make sure network operator is in good condition when checking ESP packets after enable/disable IPsec during running time.



