### PR TITLE
Revert "Use fixed chromedriver/chrome 117.0.5938.88 (#3440)"

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.rhel8
+++ b/tools/jenkins/slaves/Dockerfile.rhel8
@@ -13,12 +13,11 @@ RUN set -x && \
     dnf config-manager --save --setopt=\*.skip_if_unavailable=1 $NEW_REPOS && \
     yum repolist enabled && \
     yum -y update && \
+    dnf -y install --allowerasing --setopt=skip_missing_names_on_install=False,tsflags=nodocs https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm && \
+    dnf config-manager --save --setopt=google-chrome.skip_if_unavailable=true && \
     curl --silent --location https://rpm.nodesource.com/setup_18.x | bash - && \
     dnf -y install nodejs && \
-    CFT_VERSION='117.0.5938.88' && \
-    npx @puppeteer/browsers install chrome@${CFT_VERSION} && \
-    npx @puppeteer/browsers install chromedriver@${CFT_VERSION} && \
-    find /chrome -type f -name chrome -exec ln {} /usr/local/bin/chrome \; && \
+    npx @puppeteer/browsers install chromedriver@stable && \
     find /chromedriver -type f -name chromedriver -exec ln {} /usr/local/bin/chromedriver \; && \
     INSTALL_PKGS="bsdtar" && \
     dnf -y install --allowerasing --setopt=skip_missing_names_on_install=False,tsflags=nodocs $INSTALL_PKGS && \

--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -18,12 +18,10 @@ RUN set -x && \
     yum -y update && \
     INSTALL_PKGS="bsdtar git openssh-clients httpd-tools rsync" && \
     yum install -y $INSTALL_PKGS && \
+    yum install -y --setopt=tsflags=nodocs https://dl.google.com/linux/direct/google-chrome-stable_current_$(uname -m).rpm && \
     curl --silent --location https://rpm.nodesource.com/setup_18.x | bash - && \
     yum -y install nodejs && \
-    CFT_VERSION='117.0.5938.88' && \
-    npx @puppeteer/browsers install chrome@${CFT_VERSION} && \
-    npx @puppeteer/browsers install chromedriver@${CFT_VERSION} && \
-    find /chrome -type f -name chrome -exec ln {} /usr/local/bin/chrome \; && \
+    npx @puppeteer/browsers install chromedriver@stable && \
     find /chromedriver -type f -name chromedriver -exec ln {} /usr/local/bin/chromedriver \; && \
     GECKODRIVER_SPEC="https://api.github.com/repos/mozilla/geckodriver/releases/latest" && \
     GECKODRIVER_RE='^.*"browser_download_url": ?"(http[^"]*linux64.tar.gz)".*$' && \


### PR DESCRIPTION
This reverts commit 90708dff0e3e351610ce09eb447ded7a99e818c0.

Still not working as expected,
```
session not created: Chrome failed to start: exited normally.
  (session not created: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /usr/local/bin/chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.) (Selenium::WebDriver::Error::SessionNotCreatedError)
```