### PR TITLE
added support for monitoring openstack usage

### DIFF
--- a/tools/cloud_watch.rb
+++ b/tools/cloud_watch.rb
@@ -20,8 +20,6 @@ require 'google/apis/compute_v1'
 require 'googleauth'
 require 'launchers/openstack'
 
-# require 'pry-byebug'
-
 # user libs
 require 'resource_monitor'
 
@@ -54,6 +52,17 @@ module BushSlicer
         c.description = 'display resource summary for AWS'
         c.action do |args, options|
           ps = AwsResources.new
+          options.config = conf
+          say 'Getting summary...'
+          ps.summarize_resources
+        end
+      end
+
+      command :openstack do |c|
+        c.syntax = "#{File.basename __FILE__}"
+        c.description = 'display resource summary for Openstack'
+        c.action do |args, options|
+          ps = OpenstackResources.new
           options.config = conf
           say 'Getting summary...'
           ps.summarize_resources


### PR DESCRIPTION
adding watch for Openstack usage and post warnings to a new dedicated channel #ocpqe_cloud_usage.  Currently it only prints out a warning message when it's over 95% and there's no auto removal of staled volume PTAL.  @liangxia @jiajliu @duanwei33 