### PR TITLE
fix none platform

### DIFF
--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -248,7 +248,8 @@ When /^admin creates new in-tree storageclass with:$/ do |table|
   when 'openstack'
     provisioner = 'cinder'
   else
-    raise "Unsupported platform `#{platform}`"
+    logger.error "Unsupported platform `#{platform}`"
+    skip_this_scenario
   end
 
   # load file 

--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -248,7 +248,7 @@ When /^admin creates new in-tree storageclass with:$/ do |table|
   when 'openstack'
     provisioner = 'cinder'
   else
-    logger.error "Unsupported platform `#{platform}`"
+    logger.warn "Unsupported platform `#{platform}`"
     skip_this_scenario
   end
 


### PR DESCRIPTION
Hi Team, 
PTAL. 

Fix for: https://issues.redhat.com/browse/OCPQE-17051 

Failure log:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/864376/console
10-02 13:06:49.454        Unsupported platform `none` (RuntimeError)
10-02 13:06:49.454        /home/jenkins/ws/workspace/ocp-common/Runner/features/step_definitions/storage_class.rb:251:in `/^admin creates new in-tree storageclass with:$/'
10-02 13:06:49.454        features/tierN/storage/dynamic_provisioning.feature:192:in `admin creates new in-tree 
10-02 13:07:01.608  1 scenario (1 failed)
10-02 13:07:01.608  14 steps (1 failed, 12 skipped, 1 passed)

Jenkins logs to skip for None platform:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/864377/console
10-02 13:09:26.533        [07:39:26] ERROR> Unsupported platform `none`
10-02 13:09:38.686        [07:39:37] INFO> === End After Scenario: OCP-17563:Storage Using multiple block volumes ===
10-02 13:09:38.686  1 scenario (1 skipped)
10-02 13:09:38.686  14 steps (13 skipped, 1 passed)
10-02 13:09:38.686  0m27.886s

/assign @duanwei33 @Phaow @chao007 @radeore 