### PR TITLE
check csidrivers

### DIFF
--- a/features/step_definitions/cluster_configuration/csi.rb
+++ b/features/step_definitions/cluster_configuration/csi.rb
@@ -143,3 +143,16 @@ Given /^I checked #{QUOTED} csi driver is running$/ do |driver|
   step %Q/the step should succeed/
   step %Q/the "#{dynamic_pvc_name}" PVC becomes :bound within 120 seconds/
 end
+
+Given /^I check the env has clustercsidrivers$/ do
+  ensure_admin_tagged
+  
+  @result = admin.cli_exec(:get, resource: "clustercsidrivers")
+  if @result[:success]
+    clustercsidriverscheck = @result[:stderr]
+    if clustercsidriverscheck.include?("No resources found")
+      logger.warn "We will skip this scenario as no clustercsidrivers installed"
+      skip_this_scenario
+    end
+  end
+end


### PR DESCRIPTION
Hi Team, 

PTAL Fix for the issue: https://issues.redhat.com/browse/OCPQE-17109 
In general: Where ever the tc does not have default sc installed, check cluster csi drivers we can skip the execution using this logic. Do not call this method when executing tc for nfs/iscsi/lso. 

Jenkins logs: 
baremetal: OCP-17734 https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/865626/console 
AWS: OCP-9845 https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/865627/console Dummy execution to run through the "I check the env has clustercsidrivers" and can be seen in logs

assign @duanwei33 @Phaow @chao007 @radeore 