### PR TITLE
add specific version of active support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ gem 'oga' # replacemen for nokogiri when we thought we can workaround it
 # gem 'terminal-table'
 gem 'parallel_tests', '~>3.8.1'
 gem 'slack-ruby-client'
+gem 'activesupport', '= 7.0.8'


### PR DESCRIPTION
with latest version of active support  observing the below error in runner jobs.

/cc @pruan-rht @liangxia @JianLi-RH @jhou1 @mffiedler 

https://redhat-internal.slack.com/archives/CH76YSYSC/p1696593330277919 

/usr/share/gems/gems/activesupport-7.1.0/lib/active_support/core_ext/time/conversions.rb:62:in `<class:Time>': undefined method `deprecator' for ActiveSupport:Module (NoMethodError)
Did you mean?  deprecate_constant