### PR TITLE
enhance step to allow for interpreted variable to specify the number …

### DIFF
--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -30,7 +30,7 @@ end
 # @param [Table] Array of the strings we are searching for
 # @note Checks whether the output contains/(does not contain) any of the
 # strings or regular expressions listed in the given table
-Then /^(the|all)? outputs?( by order)? should( not)? (contain|match)(?: (\d+) times)?:$/ do |all, in_order, negative, match_type, times, table|
+Then /^(the|all)? outputs?( by order)? should( not)? (contain|match)(?: #{NUMBER} times)?:$/ do |all, in_order, negative, match_type, times, table|
   raise "incompatible options 'times' and 'by order'" if times && in_order
   if all == "all"
     case


### PR DESCRIPTION
…of times.  this enhancement is for a use case in which @kasturinarra wants to specify the number of matches with a dynamic variable.  Tested with https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/6690/console in which the scenario use a fix integer as well as dynamic clipboard variable. 

@kasturinarra @liangxia PTAL