### PR TITLE
OCPQE-17366: Fix iSCSI cases failed on defaultNodeSelector enabled cluster

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -505,6 +505,10 @@ Given /^I have a iSCSI setup in the environment$/ do
   if !_project.exists?(user:admin, quiet: true)
     @result = admin.cli_exec(:create_namespace, name: 'iscsi-target')
     raise 'failed to create "iscsi-target" project' unless @result[:success]
+    @result = admin.cli_exec(:annotate, resource: 'namespace', resourcename: 'iscsi-target', keyval: 'openshift.io/node-selector=', overwrite: 'true')
+    if !@result[:success]
+      logger.warn("failed to annotate iscsi-target namespace with openshift.io/node-selector=")
+    end
     step %Q/the appropriate pod security labels are applied to the "iscsi-target" namespace/
   end
 


### PR DESCRIPTION
### Fix iSCSI cases failed on defaultNodeSelector enabled cluster

Flake record on `profilename:78_IPI on OSP & Set default node selector on manila nic` (testrun:20231016-1323)
```console
#<RuntimeError: iSCSI pod did not become ready>
[features/step_definitions/helper_services.rb:534](https://github.com/openshift/verification-tests/blob/9ac66de42237607da56a48350d2ed1757f3cdcb9/features/step_definitions/helper_services.rb#L534):in `/^I have a iSCSI setup in the environment$/'
[features/tierN/storage/iscsi.feature:92](https://github.com/openshift/cucushift/blob/9ac66de42237607da56a48350d2ed1757f3cdcb9/features/tierN/storage/iscsi.feature#L92):in `I have a iSCSI setup in the environment'

apiVersion: v1
kind: Pod
metadata:
  annotations:
    openshift.io/description: iscsi target
    openshift.io/scc: node-exporter
  creationTimestamp: "2023-10-16T14:35:11Z"
  labels:
    storage: iscsi-target
  name: iscsi-target
  namespace: iscsi-target
  resourceVersion: "129430"
  uid: 8014ea91-dbac-4f10-baa4-6f51aa1e4914
spec:
  containers:
  - image: quay.io/openshifttest/iscsi@sha256:6a1be064e9374cbd6b075f396343307b10a108c72eea34206942355343385141
    imagePullPolicy: IfNotPresent
    name: iscsi-target
    readinessProbe:
      exec:
        command:
        - targetcli
        - ls
        - /iscsi/iqn.2016-04.test.com:storage.target00/tpg1
      failureThreshold: 3
      initialDelaySeconds: 30
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 1
    resources: {}
    securityContext:
      privileged: true
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /lib/modules
      name: kernel
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-xppfp
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  imagePullSecrets:
  - name: default-dockercfg-tn6bv
  nodeSelector:
    node-role.kubernetes.io/master: ""
    node-role.kubernetes.io/worker: ""
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoSchedule
    key: node-role.kubernetes.io/master
    operator: Exists
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - hostPath:
      path: /lib/modules
      type: ""
    name: kernel
  - name: kube-api-access-xppfp
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
      - configMap:
          items:
          - key: service-ca.crt
            path: service-ca.crt
          name: openshift-service-ca.crt
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2023-10-16T14:35:12Z"
    message: '0/6 nodes are available: 6 node(s) didn''t match Pod''s node affinity/selector.
      preemption: 0/6 nodes are available: 6 Preemption is not helpful for scheduling.'
    reason: Unschedulable
    status: "False"
    type: PodScheduled
  phase: Pending
  qosClass: BestEffort
```

**Root cause**
- The Set default node selector added the extra the nodeSelector conflict with the `node-role.kubernetes.io/master: ""` cause the iSCSI server couldn't be scheduled(None nodes have both master and worker role)
```console
nodeSelector:
    node-role.kubernetes.io/master: ""
    node-role.kubernetes.io/worker: ""
```
**Fix solution**
- Add `openshift.io/node-selector=` annotation to iSCSI server namespace dimiss the default node selector, it also works for non set default node selector test clusters

**Test record**
- IPI on OSP & Set default node selector on manila nic
`ocp-common/job/Runner/877352/console`
```console
11-08 19:16:56.969  2 scenarios (2 passed)
11-08 19:16:56.969  31 steps (31 passed)
11-08 19:16:56.969  2m3.864s
```

- AWS IPI
`ocp-common/job/Runner/877368/console`
```console
11-08 19:56:24.217  2 scenarios (2 passed)
11-08 19:56:24.217  31 steps (31 passed)
11-08 19:56:24.217  3m1.439s
```