### PR TITLE
OCPQE-17806: Update OCP-12226 support versions

### DIFF
--- a/features/storage/storage_class.feature
+++ b/features/storage/storage_class.feature
@@ -129,7 +129,7 @@ Feature: storageClass related feature
   @singlenode
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @storage
   Scenario Outline: New creation PVC failed when multiple classes are set as default
     Given I have a project


### PR DESCRIPTION
### [OCPQE-17806](https://issues.redhat.com//browse/OCPQE-17806): Update OCP-12226 support versions
- After [STOR-1061](https://issues.redhat.com/browse/STOR-1061) complete, when cluster have multiple storage classe, it won't be broken for the non specified storage class provision, it will use the latest created one(storage class createTimestamp newest) provision the pv. So we should remove the versions 4.13-4.15 for this test case.