### PR TITLE
OCPQE-17992: Fix OCP-23501

### DIFF
--- a/features/upgrade/storage/upgrade.feature
+++ b/features/upgrade/storage/upgrade.feature
@@ -4,7 +4,7 @@ Feature: Storage upgrade tests
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
-  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   @singlenode
@@ -82,7 +82,7 @@ Feature: Storage upgrade tests
   @upgrade-check
   @users=upuser1,upuser2
   @admin
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
   @singlenode
@@ -172,7 +172,7 @@ Feature: Storage upgrade tests
   @upgrade-prepare
   @users=upuser1,upuser2
   @admin
-  @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @baremetal-ipi
   @baremetal-upi
   @singlenode


### PR DESCRIPTION
### [OCPQE-17992](https://issues.redhat.com//browse/OCPQE-17992): Fix OCP-23501
- The prepare case OCP-23501 is not executed in [cucushift-upgrade-prepare step](https://gcsweb-qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-4.13-upgrade-from-stable-4.13-gcp-ipi-ovn-ipsec-f28/1728672649476837376/artifacts/gcp-ipi-ovn-ipsec-f28/cucushift-upgrade-prepare/), this is the reason why failed in [cucushift-upgrade-check step](https://gcsweb-qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-4.13-upgrade-from-stable-4.13-gcp-ipi-ovn-ipsec-f28/1728672649476837376/artifacts/gcp-ipi-ovn-ipsec-f28/cucushift-upgrade-check/), the job upgrade path is from 4.13-stable to 4.13 nightly so it is expected we need also add the 4.13 tag for prepare