### PR TITLE
fix OCP-13016

### DIFF
--- a/features/upgrade/node/hpa/upgrade.feature
+++ b/features/upgrade/node/hpa/upgrade.feature
@@ -3,7 +3,6 @@ Feature: basic verification for upgrade testing
   # @author weinliu@redhat.com
   @upgrade-prepare
   @admin
-  @4.12 @4.11
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
   @singlenode
@@ -11,9 +10,9 @@ Feature: basic verification for upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  @4.14 @4.12 @4.11
+  @4.15 @4.14 @4.13 @4.12 @4.11
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  Scenario: Upgrade - Make sure multiple resources work well after upgrade - prepare
+  Scenario: OCP-13016:Upgrade - Make sure multiple resources work well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     Given I ensure "node-upgrade" project is deleted
     When I run the :new_project client command with:
@@ -65,7 +64,7 @@ Feature: basic verification for upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  Scenario: Upgrade - Make sure multiple resources work well after upgrade
+  Scenario: OCP-13016: Upgrade - Make sure multiple resources work well after upgrade
     Given I switch to cluster admin pseudo user
     When I use the "node-upgrade" project
     And admin ensures "node-upgrade" namespace is deleted after scenario


### PR DESCRIPTION
add tag 4.13,4.15 to support upgrade path 4.13 and 4.15 for OCP-13016. 
(the job [https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/all/473748](url) failed due to the case OCP-13016 is not executed in ccushift-prepare step [https://gcsweb-qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-4.13-upgrade-from-stable-4.13-gcp-ipi-ovn-ipsec-f28/1728672649476837376/artifacts/gcp-ipi-ovn-ipsec-f28/cucushift-upgrade-prepare/build-log.txt](url))