### PR TITLE
add get events for pod not present

### DIFF
--- a/features/step_definitions/pod.rb
+++ b/features/step_definitions/pod.rb
@@ -49,6 +49,7 @@ Given /^the pod(?: named "(.+)")? becomes present$/ do |name|
 
   unless @result[:success]
     logger.error(@result[:response])
+    step %Q{I get project events}
     raise "#{pod.name} pod was never present"
   end
 end


### PR DESCRIPTION
to debug the failure https://issues.redhat.com/browse/OCPQE-3204. 
@kasturinarra Please help review ,  no idea why the build pod not present, so add check the project events .
