### PR TITLE
updated for OCPQE-18363(remove hypershift-hosted tag)  for verification-tests

### DIFF
--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -12,7 +12,6 @@ Feature: Testing haproxy router
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-11903:NetworkEdge haproxy cookies based sticky session for unsecure routes
     #create route and service which has two endpoints
@@ -78,7 +77,6 @@ Feature: Testing haproxy router
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-11130:NetworkEdge haproxy cookies based sticky session for edge termination routes
     #create route and service which has two endpoints
@@ -149,7 +147,6 @@ Feature: Testing haproxy router
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-11619:NetworkEdge Limit the number of TCP connection per IP in specified time period
     Given I have a project
@@ -358,7 +355,6 @@ Feature: Testing haproxy router
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-11679:NetworkEdge Disable haproxy hash based sticky session for unsecure routes
     Given I have a project

--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -521,7 +521,7 @@ Feature: Testing route
       | http://<%= route("reen", service("service-secure")).dns(by: user) %>/ |
       | -k |
     Then the step should succeed
-   And the output should contain:
+    And the output should contain:
       | Hello-OpenShift |
       | HTTP/1.1 302 Found |
       | ocation: https:// |

--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -138,7 +138,6 @@ Feature: Testing route
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-12562:NetworkEdge The path specified in route can work well for edge terminated
     Given I have a project
@@ -224,7 +223,6 @@ Feature: Testing route
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-12564:NetworkEdge The path specified in route can work well for reencrypt terminated
     Given I have a project
@@ -275,7 +273,6 @@ Feature: Testing route
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-9651:NetworkEdge Config insecureEdgeTerminationPolicy to Redirect for route
     Given I have a project
@@ -428,7 +425,6 @@ Feature: Testing route
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-11036:NetworkEdge Set insecureEdgeTerminationPolicy to Redirect for passthrough route
     Given I have a project
@@ -487,7 +483,6 @@ Feature: Testing route
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-13839:NetworkEdge Set insecureEdgeTerminationPolicy to Redirect and Allow for reencrypt route
     Given I have a project
@@ -526,7 +521,7 @@ Feature: Testing route
       | http://<%= route("reen", service("service-secure")).dns(by: user) %>/ |
       | -k |
     Then the step should succeed
-    And the output should contain:
+   And the output should contain:
       | Hello-OpenShift |
       | HTTP/1.1 302 Found |
       | ocation: https:// |
@@ -606,7 +601,6 @@ Feature: Testing route
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-13753:NetworkEdge Check the cookie if using secure mode when insecureEdgeTerminationPolicy to Redirect for edge/reencrypt route
     Given I have a project

--- a/features/routing/timeout.feature
+++ b/features/routing/timeout.feature
@@ -11,7 +11,6 @@ Feature: Testing timeout route
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
-  @hypershift-hosted
   @critical
   Scenario: OCP-11635:NetworkEdge Set timeout server for passthough route
     Given I have a project

--- a/features/routing/websocket.feature
+++ b/features/routing/websocket.feature
@@ -10,7 +10,6 @@ Feature: Testing websocket features
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   @critical
   Scenario: OCP-17145:NetworkEdge haproxy router support websocket via unsecure route
     Given I have a project


### PR DESCRIPTION
remove hypershift-hosted tag from cucushift cases which using client pod inside the cluster


@lihongan @melvinjoseph86 please help review the changes, thanks.