### PR TITLE
Fix 415 UI cases due to changes

### DIFF
--- a/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
@@ -140,6 +140,7 @@ click_actions_button:
     selector:
       xpath: //button[@class='pf-c-dropdown__toggle']
     op: click
+    timeout: 60
 
 expire_alert_from_detail:
   action: click_first_action_icon
@@ -187,13 +188,7 @@ input_matcher_name_silence:
 
 expire_alert_from_actions:
   action: click_actions_button
-  action: wait_exipre_silence_loaded
   action: click_expire_alert_button
-wait_exipre_silence_loaded:
-  element:
-    selector:
-      xpath: //button[text()='Expire silence']
-    timeout: 60
 click_duration_dropdown_button:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
@@ -187,7 +187,13 @@ input_matcher_name_silence:
 
 expire_alert_from_actions:
   action: click_actions_button
+  action: wait_exipre_silence_loaded
   action: click_expire_alert_button
+wait_exipre_silence_loaded:
+  element:
+    selector:
+      xpath: //button[text()='Expire silence']
+    timeout: 10
 click_duration_dropdown_button:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
@@ -351,7 +351,7 @@ hide_show_alert_graph_button:
 Disable_all_filters:
   element:
     selector:
-      xpath: (//button[text()='Clear all filters'])[2]
+      xpath: //button[text()='Clear all filters']
     op: click
     timeout: 60
 clear_specifc_filter:

--- a/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
@@ -193,7 +193,7 @@ wait_exipre_silence_loaded:
   element:
     selector:
       xpath: //button[text()='Expire silence']
-    timeout: 10
+    timeout: 60
 click_duration_dropdown_button:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
@@ -36,7 +36,7 @@ set_span_class:
     selector:
       xpath: //span[contains(@class, '<class_text>')]//input[@data-test-id='item-filter']
     op: send_keys <input_value>
-    type: span
+    type: input
 open_alert_detail:
   action: Disable_all_filters
   action: filter_alert

--- a/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
@@ -29,8 +29,14 @@ filter_alert:
     input_value: <alert_name>
     content: <alert_name>
   action: clear_name_filter_if_exists
-  action: set_input_class
+  action: set_span_class
   action: check_page_contains
+set_span_class:
+  element:
+    selector:
+      xpath: //span[contains(@class, '<class_text>')]//input[@data-test-id='item-filter']
+    op: send_keys <input_value>
+    type: span
 open_alert_detail:
   action: Disable_all_filters
   action: filter_alert

--- a/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
@@ -188,7 +188,13 @@ input_matcher_name_silence:
 
 expire_alert_from_actions:
   action: click_actions_button
+  action: wait_exipre_silence_loaded
   action: click_expire_alert_button
+wait_exipre_silence_loaded:
+  elements:
+  - selector:
+      xpath: //button[text()='Expire silence']
+    timeout: 60
 click_duration_dropdown_button:
   element:
     selector:


### PR DESCRIPTION
see from https://issues.redhat.com/browse/OCPQE-18274
1. update 4.15 xpath for "Clear all filters"
2. add set_span_class action, since set_input_class action is defined in https://github.com/openshift/verification-tests/blob/master/lib/rules/web/admin_console/4.15/common_ui_elements.xyaml#L266, don't want to change it.
3. add timeout: 60 for click_actions_button action
4. add wait_exipre_silence_loaded action to wait for "Expire silence" button shows, and use the action in expire_alert_from_actions action