### PR TITLE
update xpath for click_pod_chart_link for OCP-21263

### DIFF
--- a/lib/rules/web/admin_console/4.15/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.15/monitoring_metrics.xyaml
@@ -295,7 +295,7 @@ click_pod_chart_link:
   action: click_link_with_text
   element:
     selector:
-      xpath: //div[contains(text(),'<chart_name>')]/../..//a
+      xpath: //div[contains(text(),'<chart_name>')]/../../../..//a
     op: click
 check_data_diplayed_db:
   element:


### PR DESCRIPTION
see from https://issues.redhat.com/browse/OCPQE-18472
update xpath for click_pod_chart_link, and click_pod_chart_link action is only used in OCP-21263, so it won't affect other cases
runner job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/890212/console