### PR TITLE
update xpath for check_chart_using_victory due to 4.15 change

### DIFF
--- a/lib/rules/web/admin_console/4.15/style.xyaml
+++ b/lib/rules/web/admin_console/4.15/style.xyaml
@@ -2,6 +2,7 @@ check_chart_using_victory:
   elements:
   - selector:
       xpath: //div[contains(@class, 'pf-v5-c-chart')]
+    timeout: 30
 check_cluster_utilization_charts_style:
   elements:
   - selector:

--- a/lib/rules/web/admin_console/4.15/style.xyaml
+++ b/lib/rules/web/admin_console/4.15/style.xyaml
@@ -2,7 +2,6 @@ check_chart_using_victory:
   elements:
   - selector:
       xpath: //div[contains(@class, 'pf-v5-c-chart')]
-    timeout: 30
 check_cluster_utilization_charts_style:
   elements:
   - selector:
@@ -18,6 +17,7 @@ check_node_detail_page_charts_style:
   elements:
   - selector:
       xpath: //*[contains(@class, 'card__title') and contains(text(), 'Utilization')]
+    timeout: 30
   action: check_chart_using_victory
 check_quota_detail_page_charts_style:
   elements:

--- a/lib/rules/web/admin_console/4.15/style.xyaml
+++ b/lib/rules/web/admin_console/4.15/style.xyaml
@@ -1,7 +1,7 @@
 check_chart_using_victory:
   elements:
   - selector:
-      xpath: //div[contains(@class, 'pf-c-chart')]
+      xpath: //div[contains(@class, 'pf-v5-c-chart')]
 check_cluster_utilization_charts_style:
   elements:
   - selector:


### PR DESCRIPTION
see from [OCPQE-18476](https://issues.redhat.com//browse/OCPQE-18476)
 xpath for check_chart_using_victory is changed for 4.15, 
```
check_chart_using_victory:
  elements:
  - selector:
      xpath: //div[contains(@class, 'pf-c-chart')] 
```
update xpath to
```
      xpath: //div[contains(@class, 'pf-v5-c-chart')] 
```
check_chart_using_victory is used for OCP-27841,OCP-24307
tested PR with the 2 cases,  https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/890428/console
failed for 
`found 0 element elements with selector: {:xpath=>"//*[contains(@class, 'card__title') and contains(text(), 'Utilization')]"}`
also add time out for check_chart_using_victory

runner job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/890448/console