### PR TITLE
update xpath for check_chart_using_victory

### DIFF
--- a/lib/rules/web/admin_console/4.15/style.xyaml
+++ b/lib/rules/web/admin_console/4.15/style.xyaml
@@ -1,7 +1,7 @@
 check_chart_using_victory:
   elements:
   - selector:
-      xpath: //div[contains(@class, 'pf-c-chart')]
+      xpath: //div[contains(@class, 'pf-v5-c-chart')]
 check_cluster_utilization_charts_style:
   elements:
   - selector:

--- a/lib/rules/web/admin_console/4.16/style.xyaml
+++ b/lib/rules/web/admin_console/4.16/style.xyaml
@@ -1,7 +1,7 @@
 check_chart_using_victory:
   elements:
   - selector:
-      xpath: //div[contains(@class, 'pf-c-chart')]
+      xpath: //div[contains(@class, 'pf-v5-c-chart')]
 check_cluster_utilization_charts_style:
   elements:
   - selector:


### PR DESCRIPTION
see from https://issues.redhat.com/browse/OCPQE-18476
xpath for check_chart_using_victory is changed since 4.15, this PR updates the xpath for 4.15

runner job passed:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/891522/console
also update it for 4.16, the master branch is 4.16 now