### PR TITLE
Fix OCP-29724 in 4.15&4.16

### DIFF
--- a/lib/rules/web/admin_console/4.15/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.15/common_ui_elements.xyaml
@@ -551,12 +551,12 @@ check_column_header:
   action: wait_box_loaded
   elements:
   - selector:
-      xpath: //th[contains(@data-label,"<column_name>")]
+      xpath: //th[@data-label="<column_name>"]
     timeout: 15
 check_column_header_missing:
   element:
     selector:
-      xpath: //th[contains(@data-label,"<column_name>")]
+      xpath: //th[@data-label="<column_name>"]
     missing: true
 check_name_column_header:
   params:

--- a/lib/rules/web/admin_console/4.16/common_ui_elements.xyaml
+++ b/lib/rules/web/admin_console/4.16/common_ui_elements.xyaml
@@ -551,12 +551,12 @@ check_column_header:
   action: wait_box_loaded
   elements:
   - selector:
-      xpath: //th[contains(@data-label,"<column_name>")]
+      xpath: //th[@data-label="<column_name>"]
     timeout: 15
 check_column_header_missing:
   element:
     selector:
-      xpath: //th[contains(@data-label,"<column_name>")]
+      xpath: //th[@data-label="<column_name>"]
     missing: true
 check_name_column_header:
   params:


### PR DESCRIPTION
-   update rule of check_column_header/missing
-   update xpath, changing from relative checking to absolute checking

When checking whether the 'Namespaces column' is included in Installed operator page for a specific namespace. the relative checking will bring error as below:
`[07:39:32] INFO> running web action check_column_header_missing ... 
 [07:39:32] INFO> element..
 [07:39:32] INFO> found 1 element elements with selector: {:xpath=>"//th[contains(@data-label,\"Namespace\")]"}
 [07:39:33] INFO> found 1 element elements with selector: {:xpath=>"//th[contains(@data-label,\"Namespace\")]"}
`
![image](https://github.com/openshift/verification-tests/assets/78589509/90425d1f-4d52-48fb-9a5c-62e22362b222)

Pass log: job/Runner/894907/
