### PR TITLE
OCPQE-18716: Install nodejs from Red Hat

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.rhel8
+++ b/tools/jenkins/slaves/Dockerfile.rhel8
@@ -15,8 +15,9 @@ RUN set -x && \
     yum -y update --exclude java-1.8.0-openjdk-headless && \
     INSTALL_PKGS="bsdtar mesa-libgbm" && \
     dnf -y install --allowerasing --setopt=skip_missing_names_on_install=False,tsflags=nodocs $INSTALL_PKGS && \
-    dnf -y install https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
-    dnf -y install nodejs --setopt=nodesource-nodejs.module_hotfixes=1 && \
+    yum -y module reset nodejs && \
+    yum -y module enable nodejs:18 && \
+    yum -y module install nodejs:18/common && \
     CFT_VERSION='117.0.5938.88' && \
     npx @puppeteer/browsers install chrome@${CFT_VERSION} && \
     find /chrome -type f -name chrome -exec ln -s {} /usr/local/bin/chrome \; && \
@@ -28,7 +29,7 @@ RUN set -x && \
     chmod +x /usr/local/bin/chromedriver /usr/local/bin/geckodriver && \
     dnf -y install --setopt=tsflags=nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf -y install --setopt=tsflags=nodocs https://cbs.centos.org/kojifiles/packages/git-crypt/0.6.0/2.el8/x86_64/git-crypt-0.6.0-2.el8.x86_64.rpm && \
-    yum module reset ruby && \
+    yum -y module reset ruby && \
     yum -y module enable ruby:2.7 && \
     yum -y module install ruby:2.7 && \
     yum -y clean all && \

--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -18,8 +18,9 @@ RUN set -x && \
     yum -y update && \
     INSTALL_PKGS="diffutils bsdtar git openssh-clients httpd-tools mesa-libgbm rsync" && \
     yum install -y $INSTALL_PKGS && \
-    yum -y install https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
-    yum -y install nodejs --setopt=nodesource-nodejs.module_hotfixes=1 && \
+    yum -y module reset nodejs && \
+    yum -y module enable nodejs:18 && \
+    yum -y module install nodejs:18/common && \
     CFT_VERSION='117.0.5938.88' && \
     npx @puppeteer/browsers install chrome@${CFT_VERSION} && \
     find /chrome -type f -name chrome -exec ln -s {} /usr/local/bin/chrome \; && \
@@ -46,10 +47,10 @@ RUN set -x && \
       pip install --upgrade pip setuptools && \
       pip install 'ansible-core < 2.14' && \
     deactivate && \
-    yum module reset ruby && \
-    yum module -y enable ruby:2.7 && \
-    yum module -y install ruby:2.7 && \
-    yum clean all -y && \
+    yum -y module reset ruby && \
+    yum -y module enable ruby:2.7 && \
+    yum -y module install ruby:2.7 && \
+    yum -y clean all && \
     rm -rf /var/cache/yum /var/tmp/* /tmp/*
 
 ADD . /verification-tests/


### PR DESCRIPTION
The old way to install nodejs got error,
```
+ yum -y install nodejs --setopt=nodesource-nodejs.module_hotfixes=1
Nsolid Packages for Linux RPM based distros - x 564 kB/s | 146 kB     00:00    
Node.js Packages for Linux RPM based distros -  2.0 MB/s | 700 kB     00:00    
Dependencies resolved.
======================================================================================== 
Package               Arch    Version                          Repository          Size
========================================================================================
Installing:
nodejs                x86_64  2:18.19.0-1nodesource            nodesource-nodejs   34 M
Installing dependencies:
platform-python-pip   noarch  9.0.3-23.el8                     baseos             1.7 M 
python3-pip           noarch  9.0.3-23.el8                     appstream           20 k 
python3-setuptools    noarch  39.2.0-7.el8                     baseos             163 k 
python36              x86_64  3.6.8-39.module_el8+762+77bd8591 appstream           19 k
Enabling module streams:
python36                      3.6                                                      

Transaction Summary
========================================================================================
Install  5 Packages

Total download size: 36 M
Installed size: 107 M
Downloading Packages:
(1/5): python36-3.6.8-39.module_el8+762+77bd859  86 kB/s |  19 kB     00:00    
(2/5): python3-pip-9.0.3-23.el8.noarch.rpm       89 kB/s |  20 kB     00:00    
(3/5): python3-setuptools-39.2.0-7.el8.noarch.r 880 kB/s | 163 kB     00:00    
(4/5): platform-python-pip-9.0.3-23.el8.noarch. 4.7 MB/s | 1.7 MB     00:00    
(5/5): nodejs-18.19.0-1nodesource.x86_64.rpm     42 MB/s |  34 MB     00:00    
--------------------------------------------------------------------------------
Total                                            30 MB/s |  36 MB     00:01     
Node.js Packages for Linux RPM based distros -  1.6 MB/s | 1.7 kB     00:00    
Importing GPG key 0x9B1BE0B4:
Userid     : "NSolid <nsolid-gpg@nodesource.com>"
Fingerprint: 6F71 F525 2828 41EE DAF8 51B4 2F59 B5F9 9B1B E0B4
From       : /etc/pki/rpm-gpg/NODESOURCE-NSOLID-GPG-SIGNING-KEY-EL
Key imported successfully
Import of key(s) didn't help, wrong key(s)?
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'yum clean packages'.
Public key for nodejs-18.19.0-1nodesource.x86_64.rpm is not installed. Failing package is: nodejs-2:18.19.0-1nodesource.x86_64
GPG Keys are configured as: file:///etc/pki/rpm-gpg/NODESOURCE-NSOLID-GPG-SIGNING-KEY-EL
Error: GPG check FAILED 
```