### PR TITLE
add check_limited_access action for OCP-44501 to fit for 4.15 and previous versions

### DIFF
--- a/lib/rules/web/admin_console/4.10/monitoring.xyaml
+++ b/lib/rules/web/admin_console/4.10/monitoring.xyaml
@@ -143,3 +143,7 @@ check_non_exist_reportquery_conditions_table:
       xpath: //div[contains(@class,'co-conditions__message') and contains(.,'ReportQuery (namespace-memory-request-testtest) does not exist')]
   - selector:
       xpath: //div[contains(.,'error getting reportQuery')]
+check_limited_access:
+  params:
+    content: Restricted Access
+  action: check_page_contains

--- a/lib/rules/web/admin_console/4.11/monitoring.xyaml
+++ b/lib/rules/web/admin_console/4.11/monitoring.xyaml
@@ -143,3 +143,7 @@ check_non_exist_reportquery_conditions_table:
       xpath: //div[contains(@class,'co-conditions__message') and contains(.,'ReportQuery (namespace-memory-request-testtest) does not exist')]
   - selector:
       xpath: //div[contains(.,'error getting reportQuery')]
+check_limited_access:
+  params:
+    content: Restricted Access
+  action: check_page_contains

--- a/lib/rules/web/admin_console/4.12/monitoring.xyaml
+++ b/lib/rules/web/admin_console/4.12/monitoring.xyaml
@@ -143,3 +143,7 @@ check_non_exist_reportquery_conditions_table:
       xpath: //div[contains(@class,'co-conditions__message') and contains(.,'ReportQuery (namespace-memory-request-testtest) does not exist')]
   - selector:
       xpath: //div[contains(.,'error getting reportQuery')]
+check_limited_access:
+  params:
+    content: Restricted Access
+  action: check_page_contains

--- a/lib/rules/web/admin_console/4.13/monitoring.xyaml
+++ b/lib/rules/web/admin_console/4.13/monitoring.xyaml
@@ -143,3 +143,7 @@ check_non_exist_reportquery_conditions_table:
       xpath: //div[contains(@class,'co-conditions__message') and contains(.,'ReportQuery (namespace-memory-request-testtest) does not exist')]
   - selector:
       xpath: //div[contains(.,'error getting reportQuery')]
+check_limited_access:
+  params:
+    content: Restricted Access
+  action: check_page_contains

--- a/lib/rules/web/admin_console/4.14/monitoring.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring.xyaml
@@ -138,3 +138,7 @@ check_non_exist_reportquery_conditions_table:
       xpath: //div[contains(@class,'co-conditions__message') and contains(.,'ReportQuery (namespace-memory-request-testtest) does not exist')]
   - selector:
       xpath: //div[contains(.,'error getting reportQuery')]
+check_limited_access:
+  params:
+    content: Restricted Access
+  action: check_page_contains

--- a/lib/rules/web/admin_console/4.15/monitoring.xyaml
+++ b/lib/rules/web/admin_console/4.15/monitoring.xyaml
@@ -138,3 +138,7 @@ check_non_exist_reportquery_conditions_table:
       xpath: //div[contains(@class,'co-conditions__message') and contains(.,'ReportQuery (namespace-memory-request-testtest) does not exist')]
   - selector:
       xpath: //div[contains(.,'error getting reportQuery')]
+check_limited_access:
+  params:
+    content: No Pods found
+  action: check_page_contains

--- a/lib/rules/web/admin_console/4.16/monitoring.xyaml
+++ b/lib/rules/web/admin_console/4.16/monitoring.xyaml
@@ -138,3 +138,7 @@ check_non_exist_reportquery_conditions_table:
       xpath: //div[contains(@class,'co-conditions__message') and contains(.,'ReportQuery (namespace-memory-request-testtest) does not exist')]
   - selector:
       xpath: //div[contains(.,'error getting reportQuery')]
+check_limited_access:
+  params:
+    content: No Pods found
+  action: check_page_contains

--- a/lib/rules/web/admin_console/4.9/monitoring.xyaml
+++ b/lib/rules/web/admin_console/4.9/monitoring.xyaml
@@ -129,3 +129,7 @@ check_non_exist_reportquery_conditions_table:
       xpath: //div[contains(@class,'co-conditions__message') and contains(.,'ReportQuery (namespace-memory-request-testtest) does not exist')]
   - selector:
       xpath: //div[contains(.,'error getting reportQuery')]
+check_limited_access:
+  params:
+    content: Restricted Access
+  action: check_page_contains


### PR DESCRIPTION
see from https://issues.redhat.com/browse/OCPQE-18943
4.14 and before versions, need to check the page contains "Restricted Access"
from 4.15, need to check the page contains "No Pods found"

this PR add check_limited_access action for OCP-44501 from 4.9 to 4.16 to fit for 4.15 and previous versions
test along with https://github.com/openshift/cucushift/pull/9694
4.12 runner job pass
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/903626/console

4.13 runner job pass
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/903628/console


4.14 runner job pass
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/903629/console

4.15 runner job pass
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/903630/console

4.16 runner job pass
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/903631/console