### PR TITLE
OCPQE-19162: Exclude vSphere CSI unsupported scenarios for 4.13 above

### DIFF
--- a/features/storage/vsphere.feature
+++ b/features/storage/vsphere.feature
@@ -7,7 +7,7 @@ Feature: vSphere test scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @storage
   Scenario Outline: Dynamically provision a vSphere volume with different disk formats
     Given I have a project
@@ -73,7 +73,7 @@ Feature: vSphere test scenarios
   # @author jhou@redhat.com
   # @case_id OCP-13389
   @admin
-  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi
   @vsphere-upi
   @upgrade-sanity


### PR DESCRIPTION
### [OCPQE-19162](https://issues.redhat.com//browse/OCPQE-19162): Exclude vSphere CSI unsupported scenarios for 4.13 above
**Root Cause**
From 4.13 all fresh installed vsphere ocp clusters enabled CSIMigration, the diskformat parameter will be not supported.
https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/release-2.4/docs/book/features/vsphere_csi_migration.md#things-to-consider-before-turning-on-migration-
Falke recore -> `testrun:20240126-1132`

**Fix solution**
Exclude vSphere CSI unsupported scenarios for 4.13 above

Reminder to @Phaow update the polarion as well after it merged.