### PR TITLE
Update OCP-46116 and OCP-24467

### DIFF
--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -541,12 +541,6 @@ Feature: Multus-CNI related scenarios
     Given I have a project with proper privilege
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
       | {"spec":{"additionalNetworks":[{"name":"test-macvlan-case3","namespace":"<%= project.name %>","simpleMacvlanConfig":{"ipamConfig":{"staticIPAMConfig":{"addresses": [{"address":"10.128.2.100/23","gateway":"10.128.2.1"}]},"type":"static"},"master":"<%= cb.default_interface %>","mode":"bridge"},"type":"SimpleMacvlan"}]}} |
-    #Cleanup for bringing CRD to original
-    Given I register clean-up steps:
-    """
-    Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:
-      | {"spec":{"additionalNetworks": null}} |
-    """
 
     And I wait up to 60 seconds for the steps to pass:
     """

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -548,7 +548,7 @@ Feature: Multus-CNI related scenarios
       | {"spec":{"additionalNetworks": null}} |
     """
 
-    And I wait up to 30 seconds for the steps to pass:
+    And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :get admin command with:
       | resource | net-attach-def      |
@@ -1726,7 +1726,7 @@ Feature: Multus-CNI related scenarios
     """
 
     # Check NAD is configured under project namespace
-    And I wait up to 30 seconds for the steps to pass:
+    And I wait up to 60 seconds for the steps to pass:
     """
     When I run the :get admin command with:
       | resource | net-attach-def      |


### PR DESCRIPTION

Fix Failure breakdown for polarion run '20240205-0719'

@openshift/team-sdn-qe PTAL

Test log for OCP-46116:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/7164/console

Test log for OCP-24467:https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/7166/console