### PR TITLE
IPsec not supported on Hosted and inactive case

### DIFF
--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -9,7 +9,6 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: OCP-38846:SDN Should be able to send node to node ESP traffic on IPsec clusters
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -59,7 +58,6 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: OCP-38845:SDN Segfault on pluto IKE daemon should result in restarting pluto daemon and corresponding ovn-ipsec pod
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -92,7 +90,6 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: OCP-37591:SDN Make sure IPsec SA's are establishing in a transport mode
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -112,7 +109,6 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: OCP-39216:SDN Pod created on IPsec cluster should have appropriate MTU size to accomdate IPsec Header
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -137,7 +133,6 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: OCP-37590:SDN Delete all ovn-ipsec containers and check if they gets recreated
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -157,7 +152,6 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: OCP-37392:SDN pod to pod traffic on different nodes should be ESP encrypted
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -212,7 +206,6 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @singlenode
-  @hypershift-hosted
   Scenario: OCP-40569:SDN Allow enablement/disablement ipsec at runtime
     Given the env is using "OVNKubernetes" networkType
     Given I store all worker nodes to the :workers clipboard

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -526,6 +526,7 @@ Feature: Service related networking scenarios
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-openshiftsdn
+  @inactive
   @proxy @noproxy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   Scenario: OCP-24694:SDN Taint node with too small MTU value


### PR DESCRIPTION
@openshift/team-sdn-qe 

IPSec was never supported on hosted clusters so we need to remove this tag.
Also marking a case inactive where we never saw any issue since 4.2+