### PR TITLE
fix OCP-27901

### DIFF
--- a/lib/rules/web/admin_console/4.15/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.15/dashboards.xyaml
@@ -130,7 +130,7 @@ check_table_loaded:
 check_chart_loaded:
   elements:
   - selector:
-      xpath: //div[contains(@class,'pf-v5-c-chart')]
+      xpath: //div[contains(@class,'pf-c-chart')]
     timeout: 90
 send_filter_options:
   elements:

--- a/lib/rules/web/admin_console/4.16/dashboards.xyaml
+++ b/lib/rules/web/admin_console/4.16/dashboards.xyaml
@@ -130,7 +130,7 @@ check_table_loaded:
 check_chart_loaded:
   elements:
   - selector:
-      xpath: //div[contains(@class,'pf-v5-c-chart')]
+      xpath: //div[contains(@class,'pf-c-chart')]
     timeout: 90
 send_filter_options:
   elements:

--- a/lib/rules/web/admin_console/4.16/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.16/operator_hub.xyaml
@@ -182,7 +182,7 @@ set_array_field_group:
 set_advanced_configuration:
   elements:
   - selector:
-      xpath: //button[contains(@class,'pf-c-expandable-section__toggle')]
+      xpath: //button[contains(@class,'expandable-section__toggle')]
     op: click
   params:
     label_text: Advanced


### PR DESCRIPTION
according to https://issues.redhat.com/browse/OCPBUGS-25878, monitoring charts has no plan to migrate to PF5 as of now, so fix the rules