### PR TITLE
fix ipsec checking function

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1368,9 +1368,8 @@ end
 Given /^the IPsec is enabled on the cluster$/ do
   ensure_admin_tagged
   _admin = admin
-  network_operator = BushSlicer::NetworkOperator.new(name: "cluster", env: env)
-  config = network_operator.ovn_kubernetes_config(user: admin)
-  unless config && config["ipsecConfig"]
+  @result = admin.cli_exec(:get, resource: "network.operator", output: "jsonpath={.items[*].spec.defaultNetwork.ovnKubernetesConfig.ipsecConfig}")
+  unless (@result[:response] != nil) && (@result[:response].include?("Full") || @result[:response].include?("{}"))
     logger.warn "env doesn't have IPSec enabled"
     logger.warn "We will skip this scenario"
     skip_this_scenario


### PR DESCRIPTION
As see http://ocpqe-webapp-aosqe.apps.ocp-c1.prod.psi.redhat.com/prow_test_cases/OCP-37591,  step `the IPsec is enabled on the cluster` failed in 4.15+ non-ipsec clusters. Fixed it.

4.15+
ipsec enable cluster,passed: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/915369/console
 non-ipsec cluster,skipped: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/915350/console

before  4.15
ipsec enabled cluster, passed: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/915360/console
non-ipsec enabled cluster,skipped: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/915373/console


@openshift/team-sdn-qe @anuragthehatter   PTAL, thanks!   
