### PR TITLE
OCP-40569 will not be supported after 4.15

### DIFF
--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -201,7 +201,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @admin
   @destructive
   @network-ovnkubernetes
-  @4.16 @4.15 @4.14 @4.13 @4.12 @4.11
+  @4.14 @4.13 @4.12 @4.11
   @vsphere-ipi @openstack-ipi @nutanix-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected


### PR DESCRIPTION
Due to changes in IPsec features in version 4.15 and the presence of different configurations for enabling/disabling IPsec at runtime, just remove tag @4.16 and @4.15  

New OCP-71024 is for testing enable/disable IPsec at runtime for version 4.15 and beyond

@openshift/team-sdn-qe PTAL
