### PR TITLE
Update 40569

### DIFF
--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -207,7 +207,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @singlenode
-    Scenario: OCP-40569:SDN Allow enablement/disablement ipsec at runtime
+  Scenario: OCP-40569:SDN Allow enablement/disablement ipsec at runtime
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is disabled on the cluster
     Given I store all worker nodes to the :workers clipboard

--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -1705,3 +1705,15 @@ Given /^the corresponding version ovn masterDB components ds is deleted$/ do
     })
   end
 end 
+
+Given /^the IPsec is disabled on the cluster$/ do
+  ensure_admin_tagged
+  _admin = admin
+  network_operator = BushSlicer::NetworkOperator.new(name: "cluster", env: env)
+  config = network_operator.ovn_kubernetes_config(user: admin)
+  if config && config["ipsecConfig"]
+    logger.warn "env does have IPSec enabled"
+    logger.warn "We will skip this scenario in the IPsec cluster"
+    skip_this_scenario
+  end
+end


### PR DESCRIPTION
Update 40569 to:
1. Check cluster operators' state after patching enabling/disabling IPsec 
2. Skip case if the cluster is IPsec enabled cluster.

Test logs:
4.13
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/7404/console

4.14
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/7405/console

IPsec enabled cluster:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/7406/console

@openshift/team-sdn-qe PTAL
@anuragthehatter @huiran0826 