### PR TITLE
redundant step

### DIFF
--- a/features/networking/ovn.feature
+++ b/features/networking/ovn.feature
@@ -13,7 +13,6 @@ Feature: OVN related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-29954:SDN Creating a resource in Kube API should be synced to OVN NB db correctly even post NB db crash too
-    Given the env is using "OVNKubernetes" networkType
     Given I have a project
     And I obtain test data file "networking/list_for_pods.json"
     Given I obtain test data file "networking/list_for_pods.json"
@@ -61,7 +60,6 @@ Feature: OVN related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-30055:SDN OVN DB should be updated correctly if a resource only exist in Kube API but not in OVN NB db
-    Given the env is using "OVNKubernetes" networkType
     Given I register clean-up steps:
     """
     And I run the :scale admin command with:
@@ -117,7 +115,6 @@ Feature: OVN related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-30057:SDN OVN DB should be updated correctly if a resource only exist in NB db but not in Kube API
-    Given the env is using "OVNKubernetes" networkType
     Given I have a project
     And evaluation of `project.name` is stored in the :hello_pod_project clipboard
     And I have a pod-for-ping in the project
@@ -181,7 +178,6 @@ Feature: OVN related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-32205:SDN Thrashing ovnkube master IPAM allocator by creating and deleting various pods on a specific node
-    Given the env is using "OVNKubernetes" networkType
     Given I store the ready and schedulable workers in the :nodes clipboard
     And I have a project
     Given I obtain test data file "networking/generic_test_pod_with_replica.yaml"
@@ -244,7 +240,6 @@ Feature: OVN related networking scenarios
   @hypershift-hosted
   Scenario: OCP-28936:SDN Create/delete pods while forcing OVN leader election
   #Test for bug https://bugzilla.redhat.com/show_bug.cgi?id=1781297
-    Given the env is using "OVNKubernetes" networkType
     Given I have a project
     And evaluation of `project.name` is stored in the :usr_project clipboard
 
@@ -274,7 +269,6 @@ Feature: OVN related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-26092:SDN Pods and Services should keep running when a new raft leader gets be elected
-    Given the env is using "OVNKubernetes" networkType
     Given I store the ovnkube-master "south" leader pod in the clipboard
     Given I have a project
     And evaluation of `project.name` is stored in the :usr_project clipboard
@@ -321,7 +315,6 @@ Feature: OVN related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-26139:SDN Traffic flow shouldn't be interrupted when master switches the leader positions
-    Given the env is using "OVNKubernetes" networkType
     Given I switch to cluster admin pseudo user
     Given admin creates a project
     And evaluation of `project.name` is stored in the :iperf_project clipboard
@@ -392,7 +385,6 @@ Feature: OVN related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-26089:SDN New raft leader should be elected if existing leader gets deleted or crashed in hybrid/non-hybrid clusters
-    Given the env is using "OVNKubernetes" networkType
     Given admin uses the "openshift-ovn-kubernetes" project
     When I store the ovnkube-master "north" leader pod in the clipboard
     Then the step should succeed
@@ -413,8 +405,8 @@ Feature: OVN related networking scenarios
   @destructive
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @network-ovnkubernetes
-    @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
-    @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   Scenario Outline: New corresponding raft leader should be elected if SB db or NB db on existing master is crashed
     Given the env is using "OVNKubernetes" networkType
@@ -528,7 +520,6 @@ Feature: OVN related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-26140:SDN Delete all OVN master pods and makes sure leader/follower election converges smoothly
-    Given the env is using "OVNKubernetes" networkType
     Given admin uses the "openshift-ovn-kubernetes" project
     When I store the ovnkube-master "north" leader pod in the clipboard
     Then the step should succeed
@@ -557,7 +548,6 @@ Feature: OVN related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-37031:SDN OVN handles projects that start with a digit
-    Given the env is using "OVNKubernetes" networkType
     Given I create a project with leading digit name
     And I obtain test data file "networking/list_for_pods.json"
     When I run the :create client command with:
@@ -643,9 +633,8 @@ Feature: OVN related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-46285:SDN Logical Router Policies and Annotations for a given node should be current
-    Given the env is using "OVNKubernetes" networkType
     #Find apiVIP address of the cluster
-    When I run the :get admin command with:
+    Given I run the :get admin command with:
       | resource | infrastructure                                                         |
       | o        | jsonpath={.items[*].status.platformStatus.*.apiServerInternalIP} |
     Then the step should succeed


### PR DESCRIPTION
For cases tagged with @hypershift-hosed, `Given the env is using "OVNKubernetes" networkType` don;t make sense as hosted cluster has no network operator and since cases are tagged as @network-ovnkubernetes already, that makes the step redundant @openshift/team-sdn-qe PTAL