### PR TITLE
Update dashboard URL for OCP 4.16

### DIFF
--- a/lib/rules/web/admin_console/4.16/goto.xyaml
+++ b/lib/rules/web/admin_console/4.16/goto.xyaml
@@ -255,7 +255,7 @@ goto_alertmanagerconfig_page:
   url: monitoring/alertmanagerconfig
   action: wait_box_loaded
 goto_monitoring_db_k8s_resource_pod:
-  url: monitoring/dashboards/grafana-dashboard-k8s-resources-pod
+  url: monitoring/dashboards/dashboard-k8s-resources-pod
 goto_monitoring_db_elasticsearch:
   url: monitoring/dashboards/grafana-dashboard-elasticsearch
 goto_monitoring_db_cluster_logging:


### PR DESCRIPTION
While running [openshift/cucushift](https://github.com/openshift/cucushift) tests from `features/tierN`.  Following test case fails due to incorrect URL.
```
features/tierN/web/monitoring/query-browser.feature:587 # Scenario: OCP-21263:ClusterObservability Show correct and same CPU/Memory/Filesystem usage both in prometheus and Grafana UI 
```

Updating the monitoring dashboard's `k8s-resources-pod` URL for OCP 4.16.0 release.

cc: @aleskandro