### PR TITLE
remove some version tags for OCP-29645

### DIFF
--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -191,7 +191,7 @@ Feature: SCTP related scenarios
   # @case_id OCP-29645
   @admin
   @destructive
-  @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode


### PR DESCRIPTION
As we moved  OCP-29645 to go in https://github.com/openshift/openshift-tests-private/blob/master/test/extended/networking/sctp-dualstack.go#L504, remove tags from cucushift.

@zhaozhanqi @anuragthehatter PTAL, thanks!