### PR TITLE
Removing 4.15 and 4.16 tags

### DIFF
--- a/features/upgrade/workloads/descheduler-upgrade.feature
+++ b/features/upgrade/workloads/descheduler-upgrade.feature
@@ -13,7 +13,7 @@ Feature: Descheduler major upgrade should work fine
   @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
-  @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   Scenario: upgrade - upgrade descheduler from 4.x to 4.y - prepare
     Given I switch to cluster admin pseudo user
     Given I store master major version in the clipboard
@@ -48,7 +48,7 @@ Feature: Descheduler major upgrade should work fine
   @upgrade-check
   @users=upuser1,upuser2
   @destructive
-  @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
+  @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade
@@ -79,5 +79,4 @@ Feature: Descheduler major upgrade should work fine
       | resource     | csv                                 |
       | n            | openshift-kube-descheduler-operator |
     Then the step should succeed
-    Given evaluation of `env.version_ge("4.15", user: user) ? "v5.0" : cb.master_version` is stored in the :descheduler_version clipboard
-    And the output should match "clusterkubedescheduleroperator.*<%= cb.descheduler_version %>.*Succeeded"
+    And the output should match "clusterkubedescheduleroperator.*<%= cb.master_version %>.*Succeeded"


### PR DESCRIPTION
Removing 4.15 & 4.16 tags because from 4.15 descheduler is being released via CPASS and not part of ocp corepayload so will move the upgrade testing for these versions to golang.

cc: @dis016 