### PR TITLE
this is converted to ginkgo from 4.14 onwards

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -414,7 +414,7 @@ Feature: Machine features testing
   # @author miyadav@redhat.com
   @admin
   @destructive
-  @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   Scenario Outline: Implement defaulting machineset values for azure
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user


### PR DESCRIPTION
@sunzhaohua2 @huali9 @shellyyang1989 @liangxia , @jhou1 PTAL when time permits 

from 4.14 it is in [ginkgo](https://github.com/openshift/openshift-tests-private/blob/release-4.14/test/extended/clusterinfrastructure/machines.go) 