### PR TITLE
removing ocp-27594 from 4.12+ branches

### DIFF
--- a/features/routing/operator.feature
+++ b/features/routing/operator.feature
@@ -3,7 +3,7 @@ Feature: Testing Ingress Operator related scenarios
   # @author hongli@redhat.com
   # @case_id OCP-27594
   @admin
-  @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity


### PR DESCRIPTION
OCP-27594 is shifted to ginkgo framework(https://github.com/openshift/openshift-tests-private/pull/15812 ), removed executing this case from 4.12+

@lihongan @ShudiLi  please help review the update, thanks.