### PR TITLE
replace raise error with skip cases

### DIFF
--- a/features/step_definitions/networking.rb
+++ b/features/step_definitions/networking.rb
@@ -858,7 +858,11 @@ Given /^the cluster has "([^"]*)" endpoint publishing strategy$/ do |ep_pub_stra
   ensure_admin_tagged
   _admin = admin
   @result = admin.cli_exec(:get, n: "openshift-ingress-operator", resource: "ingresscontrollers", resource_name: "default", o: "jsonpath={.status.endpointPublishingStrategy.type}")
-  raise "the endpoint strategy is not #{ep_pub_strategy}" unless @result[:response] == ep_pub_strategy
+  unless @result[:response] == ep_pub_strategy
+    logger.warn "the endpoint strategy is not #{ep_pub_strategy}"
+    logger.warn "We will skip this scenario"
+    skip_this_scenario
+  end
 end
 
 Given /^the env is using windows nodes$/ do


### PR DESCRIPTION
as this cases `Allow_from_router_network_policy_allows_traffic_from_router` always be chosen by the test run on cloud provider even though the tag for cloud platform is not exit.   here replace the raise the error using skip cases scenarios 

https://s3.upshift.redhat.com/cucushift-html-logs/logs/2024/04/12/01%3A48%3A33/Allow_from_router_network_policy_allows_traffic_from_router-OCP-40898_SDN_router-ingress?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=OFB641O8HD3MWZW5AUE3%2F20240415%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20240415T064928Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=a76ebd07cc3ac25725126ebfcaf72844734fe68e867abdea444b744ccee3b454

@asood-rh @openshift/team-sdn-qe ^^