### PR TITLE
Resync tags from Polarion

### DIFF
--- a/doc/prow/query_alicloud-ipi.json
+++ b/doc/prow/query_alicloud-ipi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ alicloud)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ alicloud)"
 }

--- a/doc/prow/query_alicloud-upi.json
+++ b/doc/prow/query_alicloud-upi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ alicloud)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ alicloud)"
 }

--- a/doc/prow/query_amd64.json
+++ b/doc/prow/query_amd64.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND arch.KEY:x8664"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND arch.KEY:x8664"
 }

--- a/doc/prow/query_arm64.json
+++ b/doc/prow/query_arm64.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND arch.KEY:arm"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND arch.KEY:arm"
 }

--- a/doc/prow/query_aws-ipi.json
+++ b/doc/prow/query_aws-ipi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ aws)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ aws)"
 }

--- a/doc/prow/query_aws-upi.json
+++ b/doc/prow/query_aws-upi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ aws)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ aws)"
 }

--- a/doc/prow/query_azure-ipi.json
+++ b/doc/prow/query_azure-ipi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ azure)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ azure)"
 }

--- a/doc/prow/query_azure-upi.json
+++ b/doc/prow/query_azure-upi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ azure)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ azure)"
 }

--- a/doc/prow/query_baremetal-ipi.json
+++ b/doc/prow/query_baremetal-ipi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ baremetal)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ baremetal)"
 }

--- a/doc/prow/query_baremetal-upi.json
+++ b/doc/prow/query_baremetal-upi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ baremetal)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ baremetal)"
 }

--- a/doc/prow/query_connected.json
+++ b/doc/prow/query_connected.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND env_disconnected.KEY:(__all__ no)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND env_disconnected.KEY:(__all__ no)"
 }

--- a/doc/prow/query_critical.json
+++ b/doc/prow/query_critical.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:critical"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND caseimportance.KEY:critical"
 }

--- a/doc/prow/query_disconnected.json
+++ b/doc/prow/query_disconnected.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND env_disconnected.KEY:(__all__ yes)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND env_disconnected.KEY:(__all__ yes)"
 }

--- a/doc/prow/query_gcp-ipi.json
+++ b/doc/prow/query_gcp-ipi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ gce)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ gce)"
 }

--- a/doc/prow/query_gcp-upi.json
+++ b/doc/prow/query_gcp-upi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ gce)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ gce)"
 }

--- a/doc/prow/query_heterogeneous.json
+++ b/doc/prow/query_heterogeneous.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND arch.KEY:heterogeneous"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND arch.KEY:heterogeneous"
 }

--- a/doc/prow/query_hypershift-hosted.json
+++ b/doc/prow/query_hypershift-hosted.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:hypershift AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only)"
+  "case_query": "products.KEY:hypershift AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only)"
 }

--- a/doc/prow/query_ibmcloud-ipi.json
+++ b/doc/prow/query_ibmcloud-ipi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ ibmpubliccloud)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ ibmpubliccloud)"
 }

--- a/doc/prow/query_ibmcloud-upi.json
+++ b/doc/prow/query_ibmcloud-upi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ ibmpubliccloud)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ ibmpubliccloud)"
 }

--- a/doc/prow/query_level0.json
+++ b/doc/prow/query_level0.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND tags:LEVEL0"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND tags:LEVEL0"
 }

--- a/doc/prow/query_network-multitenant.json
+++ b/doc/prow/query_network-multitenant.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_network_plugin.KEY:multitenant"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_network_plugin.KEY:multitenant"
 }

--- a/doc/prow/query_network-networkpolicy.json
+++ b/doc/prow/query_network-networkpolicy.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_network_plugin.KEY:networkpolicy"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_network_plugin.KEY:networkpolicy"
 }

--- a/doc/prow/query_network-openshiftsdn.json
+++ b/doc/prow/query_network-openshiftsdn.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_network_backend.KEY:(__all__ openshift-sdn)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_network_backend.KEY:(__all__ openshift-sdn)"
 }

--- a/doc/prow/query_network-ovnkubernetes.json
+++ b/doc/prow/query_network-ovnkubernetes.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_network_backend.KEY:(__all__ ovn)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_network_backend.KEY:(__all__ ovn)"
 }

--- a/doc/prow/query_noproxy.json
+++ b/doc/prow/query_noproxy.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND env_behind_proxy.KEY:(__all__ no)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND env_behind_proxy.KEY:(__all__ no)"
 }

--- a/doc/prow/query_nutanix-ipi.json
+++ b/doc/prow/query_nutanix-ipi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ nutanixaos)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ nutanixaos)"
 }

--- a/doc/prow/query_nutanix-upi.json
+++ b/doc/prow/query_nutanix-upi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ nutanixaos)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ nutanixaos)"
 }

--- a/doc/prow/query_openstack-ipi.json
+++ b/doc/prow/query_openstack-ipi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ openstack16)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ openstack16)"
 }

--- a/doc/prow/query_openstack-upi.json
+++ b/doc/prow/query_openstack-upi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ openstack16)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ openstack16)"
 }

--- a/doc/prow/query_ppc64le.json
+++ b/doc/prow/query_ppc64le.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND arch.KEY:ppc64"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND arch.KEY:ppc64"
 }

--- a/doc/prow/query_proxy.json
+++ b/doc/prow/query_proxy.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND env_behind_proxy.KEY:(__all__ http_proxy https_proxy)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND env_behind_proxy.KEY:(__all__ http_proxy https_proxy)"
 }

--- a/doc/prow/query_s390x.json
+++ b/doc/prow/query_s390x.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND arch.KEY:s390x"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND arch.KEY:s390x"
 }

--- a/doc/prow/query_singlenode.json
+++ b/doc/prow/query_singlenode.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND env_single_node.KEY:(__all__ yes)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND env_single_node.KEY:(__all__ yes)"
 }

--- a/doc/prow/query_stage-only.json
+++ b/doc/prow/query_stage-only.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND tags:stage_only"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND tags:stage_only"
 }

--- a/doc/prow/query_upgrade.json
+++ b/doc/prow/query_upgrade.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND subcomponent.KEY:upgrade"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND subcomponent.KEY:upgrade"
 }

--- a/doc/prow/query_vsphere-ipi.json
+++ b/doc/prow/query_vsphere-ipi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ vsphere vsphere67 vsphere70)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ ipi) AND env_iaas_cloud_provider.KEY:(__all__ vsphere vsphere67 vsphere70)"
 }

--- a/doc/prow/query_vsphere-upi.json
+++ b/doc/prow/query_vsphere-upi.json
@@ -1,3 +1,3 @@
 {
-  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT upstream.KEY:yes AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ vsphere vsphere67 vsphere70)"
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND env_install_method.KEY:(__all__ upi) AND env_iaas_cloud_provider.KEY:(__all__ vsphere vsphere67 vsphere70)"
 }

--- a/doc/prow/query_wrs.json
+++ b/doc/prow/query_wrs.json
@@ -1,0 +1,3 @@
+{
+  "case_query": "products.KEY:ocp AND type:testcase AND caseautomation.KEY:automated AND automation_script:cucushift AND NOT status:inactive AND NOT tags:(stage_only prod_only) AND tags:WRS"
+}

--- a/features/admin/pod.feature
+++ b/features/admin/pod.feature
@@ -3,14 +3,15 @@ Feature: pod related features
   # @author xiuli@redhat.com
   # @case_id OCP-15808
   @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
   @singlenode
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @critical
+  @hypershift-hosted
   Scenario: OCP-15808:Node Endpoints should update in time and no delay
     Given I have a project
     Given I obtain test data file "networking/list_for_pods.json"
@@ -143,13 +144,14 @@ Feature: pod related features
   @admin
   @destructive
   @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @critical
+  @hypershift-hosted
   Scenario: OCP-11925:Node Pods will still be created by DaemonSet when nodes are SchedulingDisabled
     Given I have a project
     Given I store the schedulable workers in the :nodes clipboard
@@ -180,13 +182,14 @@ Feature: pod related features
   # @case_id OCP-12047
   @admin
   @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @critical
+  @hypershift-hosted
   Scenario: OCP-12047:Node When node labels change, DaemonSet will add pods to newly matching nodes and delete pods from not-matching nodes
     Given I have a project
     Given I run the :patch admin command with:

--- a/features/admin/quota.feature
+++ b/features/admin/quota.feature
@@ -52,14 +52,15 @@ Feature: Quota related scenarios
   # @case_id OCP-12292
   @admin
   @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @critical
+  @hypershift-hosted
   Scenario: OCP-12292:Node The quota usage should NOT be incremented if Requests and Limits aren't specified
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
@@ -774,14 +775,15 @@ Feature: Quota related scenarios
   # @case_id OCP-11927
   @admin
   @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @critical
+  @hypershift-hosted
   Scenario: OCP-11927:Node The quota usage should be incremented if Requests = Limits and in the range of hard quota but exceed the real node available resources
     Given I have a project
     Given I obtain test data file "quota/myquota.yaml"
@@ -931,14 +933,15 @@ Feature: Quota related scenarios
   # @case_id OCP-12086
   @admin
   @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
   @singlenode
   @proxy @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @critical
+  @hypershift-hosted
   Scenario: OCP-12086:Node Quota with Terminating and NotTerminating scope
     Given I have a project
     When I run the :create_quota admin command with:

--- a/features/build/buildconfig.feature
+++ b/features/build/buildconfig.feature
@@ -25,6 +25,11 @@ Feature: buildconfig.feature
   # @author haowang@redhat.com
   # @case_id OCP-10667
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-10667:BuildAPI Rebuild image when the underlying image changed for Docker build
     Given I have a project
     When I run the :new_build client command with:
@@ -44,6 +49,11 @@ Feature: buildconfig.feature
   # @author dyan@redhat.com
   # @case_id OCP-12020
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-12020:BuildAPI Trigger chain builds from a image update
     Given I have a project
     When I run the :new_build client command with:

--- a/features/build/buildlogic.feature
+++ b/features/build/buildlogic.feature
@@ -25,6 +25,11 @@ Feature: buildlogic.feature
   # @author xiazhao@redhat.com
   # @case_id OCP-11170
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-11170:BuildAPI Result image will be tried to push after multi-build
     Given I have a project
     Given I obtain test data file "image/language-image-templates/php-55-rhel7-stibuild.json"
@@ -51,6 +56,12 @@ Feature: buildlogic.feature
   # @author gpei@redhat.com
   # @case_id OCP-11767
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-11767:BuildAPI Create build without output
     Given I have a project
     When I run the :new_build client command with:
@@ -333,6 +344,12 @@ Feature: buildlogic.feature
   # @author xiuwang@redhat.com
   # @case_id OCP-13914
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @critical
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-13914:BuildAPI Prune old builds automaticly
     #Should prune completed builds based on the successfulBuildsHistoryLimit setting
     Given I have a project
@@ -361,6 +378,11 @@ Feature: buildlogic.feature
   # @author xiuwang@redhat.com
   # @case_id OCP-24154
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-24154:BuildAPI Should prune canceled builds based on the failedBuildsHistoryLimit setting
     Given I have a project
     When I run the :new_app client command with:
@@ -395,6 +417,12 @@ Feature: buildlogic.feature
   # @author xiuwang@redhat.com
   # @case_id OCP-24155
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-24155:BuildAPI Should prune failed builds based on the failedBuildsHistoryLimit setting
     Given I have a project
     When I run the :new_app client command with:
@@ -421,6 +449,11 @@ Feature: buildlogic.feature
   # @author xiuwang@redhat.com
   # @case_id OCP-24156
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-24156:BuildAPI Should prune errored builds based on the failedBuildsHistoryLimit setting
     Given I have a project
     When I run the :create client command with:
@@ -444,6 +477,11 @@ Feature: buildlogic.feature
   # @author xiuwang@redhat.com
   # @case_id OCP-24158
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-24158:BuildAPI Should prune builds after a buildConfig change
     Given I have a project
     When I run the :new_app client command with:
@@ -490,6 +528,12 @@ Feature: buildlogic.feature
   # @author xiuwang@redhat.com
   # @case_id OCP-24159
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @critical
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-24159:BuildAPI Buildconfigs should have a default history limit set when created via the group api
     Given I have a project
     When I run the :new_build client command with:

--- a/features/build/dockerbuild.feature
+++ b/features/build/dockerbuild.feature
@@ -83,6 +83,12 @@ Feature: dockerbuild.feature
   # @author dyan@redhat.com
   # @case_id OCP-13083
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @proxy @noproxy @disconnected
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-13083:BuildAPI Docker build using Dockerfile with 'FROM scratch'
     Given I have a project
     When I run the :new_build client command with:

--- a/features/cli/build.feature
+++ b/features/cli/build.feature
@@ -62,6 +62,11 @@ Feature: build 'apps' with CLI
       | ruby-sample-build |
 
     @inactive
+    @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+    @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+    @s390x @ppc64le @heterogeneous @arm64 @amd64
+    @network-ovnkubernetes @network-openshiftsdn
+    @proxy @noproxy
     Examples:
       | case_id            | number   | build_status |
       | OCP-11224:BuildAPI | ocp11224 | :complete    | # @case_id OCP-11224
@@ -418,6 +423,12 @@ Feature: build 'apps' with CLI
     Given the "<build_name>" build becomes :complete
 
     @inactive
+    @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+    @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+    @s390x @ppc64le @heterogeneous @arm64 @amd64
+    @proxy @noproxy @connected
+    @critical
+    @network-ovnkubernetes @network-openshiftsdn
     Examples:
       | case_id            | bc_name              | build_name             | file_name        |
       | OCP-11580:BuildAPI | ruby-sample-build-ns | ruby-sample-build-ns-1 | Nonesrc-sti.json | # @case_id OCP-11580

--- a/features/cli/deployment.feature
+++ b/features/cli/deployment.feature
@@ -2,6 +2,12 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11421
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @critical
+  @hypershift-hosted
   Scenario: OCP-11421:Workloads Add perma-failed - Deplyment succeed after change pod template by edit deployment
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-1.yaml"
@@ -76,6 +82,13 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11046
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-11046:Workloads Add perma-failed - Deployment failed after pausing and resuming
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-1.yaml"
@@ -169,6 +182,12 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11681
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @critical
+  @hypershift-hosted
   Scenario: OCP-11681:Workloads Add perma-failed - Failing deployment can be rolled back successful
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-3.yaml"
@@ -268,6 +287,12 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-12110
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @critical
+  @hypershift-hosted
   Scenario: OCP-12110:Workloads Add perma-failed - Rolling back to a failing deployment revision
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-3.yaml"
@@ -375,6 +400,12 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-11865
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @critical
+  @hypershift-hosted
   Scenario: OCP-11865:Workloads Add perma-failed - Make a change outside pod template for failing deployment
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-1.yaml"
@@ -467,6 +498,12 @@ Feature: deployment related steps
 
   # @author chezhang@redhat.com
   # @case_id OCP-12009
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @critical
+  @hypershift-hosted
   Scenario: OCP-12009:Workloads Add perma-failed - Negative value test of progressDeadlineSeconds in failing deployment
     Given I have a project
     Given I obtain test data file "deployment/deployment-perme-failed-2.yaml"

--- a/features/cli/hpa.feature
+++ b/features/cli/hpa.feature
@@ -150,6 +150,12 @@ Feature: hpa scale
 
   # @author chezhang@redhat.com
   # @case_id OCP-11576
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-11576:Node Creates autoscaler for replication controller with invalid value
     Given I have a project
     Given I obtain test data file "hpa/rc-hello-openshift.yaml"

--- a/features/cli/oc_import_image.feature
+++ b/features/cli/oc_import_image.feature
@@ -51,6 +51,7 @@ Feature: oc import-image related feature
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @inactive
   Scenario: OCP-11089:ImageRegistry Tags should be added to ImageStream if image repository is from an external docker registry
     Given I have a project
     Given I obtain test data file "image-streams/external.json"

--- a/features/cli/replica_set.feature
+++ b/features/cli/replica_set.feature
@@ -3,6 +3,12 @@ Feature: replicaSet related tests
   # @author pruan@redhat.com
   # @case_id OCP-10917
   @smoke
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @connected
+  @critical
+  @hypershift-hosted
   Scenario: OCP-10917:Workloads Support endpoints of RS in OpenShift
     Given I have a project
     Given I obtain test data file "replicaSet/ocp10917/rs_endpoints.yaml"

--- a/features/cli/secrets.feature
+++ b/features/cli/secrets.feature
@@ -522,6 +522,12 @@ Feature: secrets related scenarios
   # @author xiuwang@redhat.com
   # @case_id OCP-12838
   @inactive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @noproxy @connected
+  @critical
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-12838:BuildAPI Use build source secret based on annotation on Secret --http
     Given I have a project
     When I have an http-git service in the project

--- a/features/images/jenkins.feature
+++ b/features/images/jenkins.feature
@@ -311,8 +311,8 @@ Feature: jenkins.feature
       | env_value| newvalue1                           |
     Then the step should fail
 
-    @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-    @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+    @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+    @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
     @upgrade-sanity
     @proxy @noproxy @connected
     @network-ovnkubernetes @network-openshiftsdn
@@ -329,8 +329,8 @@ Feature: jenkins.feature
   @flaky
   @console
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
   @noproxy @connected
   @network-ovnkubernetes @network-openshiftsdn

--- a/features/logging/cluster_log_forwarder.feature
+++ b/features/logging/cluster_log_forwarder.feature
@@ -12,6 +12,7 @@ Feature: cluster log forwarder features
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn
+  @amd64
   Scenario: OCP-25989:Logging ClusterLogForwarder `default` behavior testing
     Given the master version >= "4.6"
     # create project to generate logs
@@ -139,7 +140,7 @@ Feature: cluster log forwarder features
   @destructive
   @singlenode
   @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8 @logging5.5
+  @logging5.8 @logging5.7 @logging5.6 @logging5.5
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn
@@ -237,7 +238,7 @@ Feature: cluster log forwarder features
       | infra-container.log |
     """
     @upgrade-sanity
-    @logging5.6 @logging5.7 @logging5.8 @logging5.5
+    @logging5.8 @logging5.7 @logging5.6 @logging5.5
     @singlenode
     @proxy @noproxy @connected
     @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
@@ -308,7 +309,7 @@ Feature: cluster log forwarder features
 
     @singlenode
     @proxy @noproxy @disconnected @connected
-    @logging5.6 @logging5.7 @logging5.8 @logging5.5
+    @logging5.8 @logging5.7 @logging5.6 @logging5.5
     @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
     @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
     @network-ovnkubernetes @network-openshiftsdn
@@ -324,7 +325,7 @@ Feature: cluster log forwarder features
   @singlenode
   @proxy @noproxy @disconnected @connected
   @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8
+  @logging5.8 @logging5.7 @logging5.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn
@@ -395,7 +396,7 @@ Feature: cluster log forwarder features
     @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
     @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
     @network-ovnkubernetes @network-openshiftsdn
-    @logging5.6 @logging5.7 @logging5.8 @logging5.5
+    @logging5.8 @logging5.7 @logging5.6 @logging5.5
     @critical
     Examples:
       | case_id           | file                  | protocol |
@@ -408,13 +409,14 @@ Feature: cluster log forwarder features
   @admin
   @destructive
   @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8
+  @logging5.8 @logging5.7 @logging5.6
   @singlenode
   @proxy @noproxy @connected
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn
   @critical
+  @amd64
   Scenario: OCP-32697:Logging Forward logs to different kafka topics
     Given I switch to the first user
     And I create a project with non-leading digit name
@@ -462,7 +464,7 @@ Feature: cluster log forwarder features
   @singlenode
   @proxy @noproxy @connected
   @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8
+  @logging5.8 @logging5.7 @logging5.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn

--- a/features/logging/cluster_logging_operator.feature
+++ b/features/logging/cluster_logging_operator.feature
@@ -7,7 +7,7 @@ Feature: cluster-logging-operator related test
   @destructive
   @commonlogging
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8 @logging5.5
+  @logging5.8 @logging5.7 @logging5.6 @logging5.5
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
@@ -43,6 +43,7 @@ Feature: cluster-logging-operator related test
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy
+  @amd64
   Scenario: OCP-22492:Logging Scale Elasticsearch nodes by nodeCount 2->3->4 in clusterlogging
     Given I obtain test data file "logging/clusterlogging/scalebase.yaml"
     Given I create clusterlogging instance with:
@@ -164,7 +165,7 @@ Feature: cluster-logging-operator related test
   @destructive
   @commonlogging
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.5
+  @logging5.7 @logging5.6 @logging5.5
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode
@@ -200,7 +201,7 @@ Feature: cluster-logging-operator related test
   @singlenode
   @proxy @noproxy @disconnected @connected
   @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8
+  @logging5.8 @logging5.7 @logging5.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn
@@ -251,7 +252,7 @@ Feature: cluster-logging-operator related test
   @admin
   @destructive
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7
+  @logging5.7 @logging5.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode

--- a/features/logging/collector.feature
+++ b/features/logging/collector.feature
@@ -173,7 +173,7 @@ Feature: collector related tests
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn
-  @s390x @ppc64le
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
   Scenario: OCP-25768:Logging The container logs metadata check
     Given the master version >= "4.2"
     Given I switch to the first user
@@ -210,7 +210,7 @@ Feature: collector related tests
   @destructive
   @commonlogging
   @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8 @logging5.5
+  @logging5.8 @logging5.7 @logging5.6 @logging5.5
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
@@ -260,7 +260,7 @@ Feature: collector related tests
   @destructive
   @singlenode
   @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8
+  @logging5.8 @logging5.7 @logging5.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn

--- a/features/logging/elasticsearch.feature
+++ b/features/logging/elasticsearch.feature
@@ -6,7 +6,7 @@ Feature: Elasticsearch related tests
   @admin
   @destructive
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8 @logging5.5
+  @logging5.8 @logging5.7 @logging5.6 @logging5.5
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
@@ -57,6 +57,7 @@ Feature: Elasticsearch related tests
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn
+  @amd64
   Scenario: OCP-30776:Logging Elasticsearch6 new data modle indices
     Given I switch to the first user
     And I create a project with non-leading digit name
@@ -87,7 +88,7 @@ Feature: Elasticsearch related tests
   @destructive
   @singlenode
   @4.6
-  @logging5.6 @logging5.7 @logging5.8
+  @logging5.8 @logging5.7 @logging5.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn

--- a/features/logging/elasticsearch_operator.feature
+++ b/features/logging/elasticsearch_operator.feature
@@ -7,7 +7,7 @@ Feature: elasticsearch-operator related tests
   @destructive
   @commonlogging
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8 @logging5.5
+  @logging5.8 @logging5.7 @logging5.6 @logging5.5
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode
@@ -86,7 +86,7 @@ Feature: elasticsearch-operator related tests
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
     @heterogeneous @arm64 @amd64
-    @logging5.6 @logging5.7 @logging5.8
+    @logging5.8 @logging5.7 @logging5.6
     Examples:
       | case_id           | cluster_setting |
       | OCP-21530:Logging | transient       | # @case_id OCP-21530
@@ -99,7 +99,7 @@ Feature: elasticsearch-operator related tests
   @destructive
   @commonlogging
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8
+  @logging5.8 @logging5.7 @logging5.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode

--- a/features/logging/eventrouter.feature
+++ b/features/logging/eventrouter.feature
@@ -48,7 +48,7 @@ Feature: eventrouter related test
     @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
     @network-ovnkubernetes @network-openshiftsdn
     @hypershift-hosted
-    @logging5.6 @logging5.7 @logging5.8
+    @logging5.8 @logging5.7 @logging5.6
     @critical
     Examples:
     | case_id           | index_name  |

--- a/features/logging/forward_logs_to_external_elasticsearch.feature
+++ b/features/logging/forward_logs_to_external_elasticsearch.feature
@@ -93,7 +93,7 @@ Feature: Cases to test forward logs to external elasticsearch
     @network-ovnkubernetes @network-openshiftsdn
     @proxy @noproxy @disconnected @connected
     @heterogeneous @arm64 @amd64
-    @logging5.6 @logging5.7 @logging5.8 @logging5. @logging5.5
+    @logging5.8 @logging5.7 @logging5.6 @logging5. @logging5.5
     Examples:
       | case_id           | scheme | client_auth | file                 |
       | OCP-29845:Logging | https  | true        | clf-with-secret.yaml | # @case_id OCP-29845
@@ -207,7 +207,7 @@ Feature: Cases to test forward logs to external elasticsearch
     @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
     @proxy @noproxy @disconnected @connected
     @network-ovnkubernetes @network-openshiftsdn
-    @logging5.6 @logging5.7 @logging5.8 @logging5.5
+    @logging5.8 @logging5.7 @logging5.6 @logging5.5
     Examples:
       | case_id           | version | scheme | client_auth | username | password | secret_name |
       | OCP-41807:Logging | 7.17    | https  | true        | test1    | redhat   | test1       | # @case_id OCP-41807

--- a/features/logging/kibana.feature
+++ b/features/logging/kibana.feature
@@ -65,7 +65,7 @@ Feature: Kibana related features
   @console
   @destructive
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8 @logging5.5
+  @logging5.8 @logging5.7 @logging5.6 @logging5.5
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode
@@ -131,7 +131,7 @@ Feature: Kibana related features
   @console
   @destructive
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8
+  @logging5.8 @logging5.7 @logging5.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode
@@ -252,7 +252,7 @@ Feature: Kibana related features
   @console
   @proxy @noproxy @disconnected @connected
   @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8 @logging5.5
+  @logging5.8 @logging5.7 @logging5.6 @logging5.5
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode

--- a/features/logging/permission.feature
+++ b/features/logging/permission.feature
@@ -56,7 +56,7 @@ Feature: permission related test
   @destructive
   @commonlogging
   @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8 @logging5.5
+  @logging5.8 @logging5.7 @logging5.6 @logging5.5
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode
@@ -109,7 +109,7 @@ Feature: permission related test
   @destructive
   @commonlogging
   @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @logging5.6 @logging5.7 @logging5.8 @logging5.5
+  @logging5.8 @logging5.7 @logging5.6 @logging5.5
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode

--- a/features/machine/autoscaler.feature
+++ b/features/machine/autoscaler.feature
@@ -78,6 +78,12 @@ Feature: Cluster Autoscaler Tests
   # @case_id OCP-21516
   @admin
   @destructive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-21516:ClusterInfrastructure Cao listens and deploys cluster-autoscaler based on ClusterAutoscaler resource
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -95,6 +101,12 @@ Feature: Cluster Autoscaler Tests
   # @case_id OCP-21517
   @admin
   @destructive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-21517:ClusterInfrastructure CAO listens and annotations machineSets based on MachineAutoscaler resource
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user

--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -109,6 +109,7 @@ Feature: Machine features testing
     @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
     
+    @hypershift-hosted
     Examples:
       | case_id                         | url                                                                          |
       | OCP-25652:ClusterInfrastructure | https://machine-api-operator.openshift-machine-api.svc:8443/metrics          | # @case_id OCP-25652
@@ -125,6 +126,7 @@ Feature: Machine features testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @hypershift-hosted
   Scenario: OCP-25608:ClusterInfrastructure Machine should have immutable field providerID and nodeRef
     Given I have an IPI deployment
     Given I store the last provisioned machine in the :machine clipboard
@@ -181,7 +183,7 @@ Feature: Machine features testing
   @admin
   @destructive
   @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @aws-ipi @alicloud-ipi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64

--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -177,7 +177,7 @@ Feature: Machine misc features testing
   @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
-  @heterogeneous @arm64 @amd64
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
   @vsphere-ipi
   @vsphere-upi
   Scenario: OCP-37180:ClusterInfrastructure Report vCenter version to telemetry

--- a/features/networking/build.feature
+++ b/features/networking/build.feature
@@ -49,6 +49,7 @@ Feature: Testing the isolation during build scenarios
     @noproxy
     @heterogeneous @arm64 @amd64
     @critical
+    @inactive
     Examples:
       | case_id       | type   | repo                                                           | strategy       |
       | OCP-15741:SDN | Docker | https://github.com/zhaozhanqi/ruby-docker-test/#isolation      | dockerStrategy | # @case_id OCP-15741

--- a/features/networking/egress-ingress.feature
+++ b/features/networking/egress-ingress.feature
@@ -450,6 +450,7 @@ Feature: Egress-ingress related networking scenarios
   @network-ovnkubernetes
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @critical
   Scenario: OCP-33530:SDN EgressFirewall allows traffic to destination ports
     Given the cluster is not proxy cluster
     Given the env is using "OVNKubernetes" networkType

--- a/features/networking/egress-ip.feature
+++ b/features/networking/egress-ip.feature
@@ -12,6 +12,7 @@ Feature: Egress IP related features
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @inactive
   Scenario: OCP-15465:SDN Only cluster admin can add/remove egressIPs on hostsubnet
     Given the env is using "OpenShiftSDN" networkType
     Given I select a random node's host
@@ -37,6 +38,7 @@ Feature: Egress IP related features
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @inactive
   Scenario: OCP-15466:SDN Only cluster admin can add/remove egressIPs on netnamespaces
     Given the env is using "OpenShiftSDN" networkType
     # Try to add the egress ip to the netnamespace with normal user
@@ -62,6 +64,7 @@ Feature: Egress IP related features
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @inactive
   Scenario: OCP-15471:SDN All the pods egress connection will get out through the egress IP if the egress IP is set to netns and egress node can host the IP
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -124,6 +127,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-15472:SDN The egressIPs will be added to the node's primary NIC when it gets set on hostsubnet and will be removed after gets unset
     Given the env is using "OpenShiftSDN" networkType
     # add the egress ip to the hostsubnet
@@ -166,6 +170,7 @@ Feature: Egress IP related features
   @proxy @noproxy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-21812:SDN Should remove the egressIP from the array if it was not being used
     Given the env is using "OpenShiftSDN" networkType
     Given I store a random unused IP address from the reserved range to the clipboard
@@ -221,6 +226,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-15992:SDN The EgressNetworkPolicy should work well with egressIP
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -270,6 +276,7 @@ Feature: Egress IP related features
   @proxy @noproxy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-15473:SDN The related iptables/openflow rules will be removed once the egressIP gets removed from netnamespace
     Given the env is using "OpenShiftSDN" networkType
     Given the valid egress IP is added to the node
@@ -324,6 +331,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-19973:SDN The egressIP should still work fine after the node or network service restarted
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -367,6 +375,7 @@ Feature: Egress IP related features
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @hypershift-hosted
+  @inactive
   Scenario: OCP-15998:SDN Invalid egressIP should not be acceptable
     Given the env is using "OpenShiftSDN" networkType
     Given I select a random node's host
@@ -394,6 +403,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-25694:SDN Random outages with egressIP
     Given the env is using "OpenShiftSDN" networkType
     Given I store the schedulable workers in the :nodes clipboard
@@ -433,6 +443,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-25640:SDN Should be able to access to the service's externalIP with egressIP
     Given the env is using "OpenShiftSDN" networkType
     Given I have a project
@@ -494,6 +505,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-18316:SDN The egressIPs should work well when re-using the egressIP which is holding by a deleted project
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -532,6 +544,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-18315:SDN Add the removed egressIP back to the netnamespace would work well
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -576,6 +589,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-19785:SDN The pod should be able to access outside with the node source IP after the egressIP removed
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -628,6 +642,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-15989:SDN Pods will not be affected by the egressIP set on other netnamespace
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -662,6 +677,7 @@ Feature: Egress IP related features
   @qeci
   @proxy @noproxy @connected
   @network-openshiftsdn @network-networkpolicy
+  @inactive
   Scenario: OCP-15987:SDN The egressIP will be unavailable if it was set to multiple hostsubnets
     Given the env is using "OpenShiftSDN" networkType
     Given I store the schedulable workers in the :nodes clipboard
@@ -701,6 +717,7 @@ Feature: Egress IP related features
   @network-openshiftsdn @network-networkpolicy @network-multitenant
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-18586:SDN The same egressIP will not be assigned to different netnamespace
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -748,6 +765,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-40928:SDN Manually EgressIPs assignments:if a pod is on a node that is hosting an egressIP that pod will always use the egressIP of the node it is on
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -800,6 +818,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-40933:SDN Manually EgressIPs assignments: if a pod is not on a node hosting an egressIP it is random which egressIP it will use
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -853,6 +872,7 @@ Feature: Egress IP related features
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-40957:SDN Auto EgressIPs assignments: if a pod is not on a node hosting an egressIP it is random which egressIP it will use
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -907,6 +927,7 @@ Feature: Egress IP related features
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-40956:SDN Auto EgressIPs assignments:if a pod is on a node that is hosting an egressIP that pod will always use the egressIP of the node
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard
@@ -968,6 +989,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-46244:SDN Bug1926662 NodePort works when configuring an EgressIP address
     Given the env is using "OpenShiftSDN" networkType
     Given I store the schedulable workers in the :workers clipboard
@@ -1015,6 +1037,7 @@ Feature: Egress IP related features
   @network-openshiftsdn
   @noproxy
   @hypershift-hosted
+  @inactive
   Scenario: OCP-46637:SDN Bug2024880 EgressIP should work when configuring networkpolicy
     Given the env is using "OpenShiftSDN" networkType
     Given I save ipecho url to the clipboard

--- a/features/networking/ib-sriov.feature
+++ b/features/networking/ib-sriov.feature
@@ -58,6 +58,13 @@ Feature: Sriov IB related scenarios
       | ls | /dev/ |
     Then the output should contain "infiniband"
 
+    @s390x @ppc64le @heterogeneous @arm64 @amd64
+    @baremetal-ipi
+    @baremetal-upi
+    @critical
+    @hypershift-hosted
+    @network-ovnkubernetes @network-openshiftsdn
+    @proxy @noproxy
     Examples:
       | case_id       | cardname |
       | OCP-33812:SDN | cx4      | # @case_id OCP-33812
@@ -68,6 +75,7 @@ Feature: Sriov IB related scenarios
   # @case_id OCP-33852
   @destructive
   @admin
+  @inactive
   Scenario: OCP-33852:SDN Set the infiniband-guid for pod
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/ib/cx6/cx6-ib.yaml"

--- a/features/networking/isolation.feature
+++ b/features/networking/isolation.feature
@@ -3,6 +3,13 @@ Feature: networking isolation related scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-9565
   @admin
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @hypershift-hosted
+  @network-openshiftsdn @network-networkpolicy @network-multitenant
+  @proxy @noproxy
   Scenario: OCP-9565:SDN The pods in default namespace can communicate with all the other pods
     Given I have a project
     And evaluation of `project.name` is stored in the :u1p1 clipboard
@@ -87,9 +94,12 @@ Feature: networking isolation related scenarios
   # @author jechen@redhat.com
   # @case_id OCP-45077
   @admin
-  @network-multitenant
-  @s390x @ppc64le
+  @network-openshiftsdn @network-multitenant
+  @s390x @ppc64le @arm64 @amd64
   @4.16 @4.15 @4.14 @4.13
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @proxy @noproxy @disconnected @connected
   Scenario: Only the pods nested in a same namespace can communicate with each other
     Given the env is using multitenant network
     Given I have a project
@@ -451,7 +461,13 @@ Feature: networking isolation related scenarios
   # @author bmeng@redhat.com
   # @case_id OCP-9646
   @admin
-  @network-multitenant
+  @network-openshiftsdn @network-multitenant
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @hypershift-hosted
+  @proxy @noproxy
   Scenario: OCP-9646:SDN Isolate the network for the project which already make network global
     Given the env is using multitenant network
     Given I have a project

--- a/features/networking/multus.feature
+++ b/features/networking/multus.feature
@@ -568,6 +568,13 @@ Feature: Multus-CNI related scenarios
   # @author anusaxen@redhat.com
   # @case_id OCP-21946
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @vsphere-ipi @baremetal-ipi
+  @vsphere-upi @baremetal-upi
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-21946:SDN The multus admission controller should be able to detect the syntax issue in the net-attach-def
     # Make sure that the multus is enabled
     Given the multus is enabled on the cluster

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -98,6 +98,13 @@ Feature: Operator related networking scenarios
   # @case_id OCP-22419
   @admin
   @destructive
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @aws-ipi
+  @aws-upi
+  @proxy @noproxy @connected
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-22419:SDN The clusteroperator should be able to reflect the realtime status of the network when the config has problem
     Given the master version >= "4.1"
     # Check that the operator is not Degraded
@@ -150,6 +157,12 @@ Feature: Operator related networking scenarios
   # @case_id OCP-22202
   @admin
   @destructive
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @gcp-ipi @azure-ipi @aws-ipi
+  @noproxy @connected
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-22202:SDN The clusteroperator should be able to reflect the realtime status of the network when a new node added
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
@@ -281,6 +294,7 @@ Feature: Operator related networking scenarios
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @inactive
   Scenario: OCP-21574:SDN Should not allow to change the openshift-sdn config
     #Trying to change network mode to Subnet or any other
     Given as admin I successfully merge patch resource "networks.operator.openshift.io/cluster" with:

--- a/features/networking/ovn-egress-ip.feature
+++ b/features/networking/ovn-egress-ip.feature
@@ -14,6 +14,7 @@ Feature: OVN Egress IP related features
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @inactive
   Scenario: OCP-33618:SDN EgressIP works for all pods in the matched namespace when only configure namespaceSelector
     Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
@@ -88,6 +89,7 @@ Feature: OVN Egress IP related features
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @inactive
   Scenario: OCP-33723:SDN Multiple EgressIP objects can have multiple Egress IPs
     Given the env is using "OVNKubernetes" networkType		
     Given I save ipecho url to the clipboard
@@ -165,6 +167,7 @@ Feature: OVN Egress IP related features
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @inactive
   Scenario: OCP-33641:SDN Multi-project can share same EgressIP
     Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
@@ -242,6 +245,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-33699:SDN Removed matched labels from project will not use EgressIP
     Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
@@ -301,6 +305,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-33700:SDN Removed matched labels from pods will not use EgressIP
     Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
@@ -369,6 +374,7 @@ Feature: OVN Egress IP related features
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   @critical
+  @inactive
   Scenario: OCP-33631:SDN EgressIP was removed after delete egressIP object
     Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
@@ -424,6 +430,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-33704:SDN After reboot node or reboot OVN services EgressIP still work
     Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
@@ -489,6 +496,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-34938:SDN Warning event will be triggered if apply EgressIP object but no EgressIP nodes
     #Get unused IP as egress ip
     Given the env is using "OVNKubernetes" networkType
@@ -527,6 +535,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-33706:SDN The pod located on different node than EgressIP nodes
     Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
@@ -583,6 +592,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-33718:SDN Deleting EgressIP object and recreating it will work
     Given the env is using "OVNKubernetes" networkType
     Given I save ipecho url to the clipboard
@@ -650,6 +660,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-33710:SDN An EgressIP object can not have multiple egress IP assignments on the same node
     Given the env is using "OVNKubernetes" networkType
     Given I store the schedulable workers in the :nodes clipboard
@@ -686,6 +697,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-33617:SDN Common user cannot tag the nodes by labelling them as egressIP nodes
     Given the env is using "OVNKubernetes" networkType
     Given I select a random node's host
@@ -711,6 +723,7 @@ Feature: OVN Egress IP related features
   @noproxy @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-33719:SDN Any egress IP can only be assigned to one node only
     Given the env is using "OVNKubernetes" networkType
     Given I store the schedulable workers in the :nodes clipboard
@@ -763,6 +776,7 @@ Feature: OVN Egress IP related features
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-44250:SDN lr-policy-list and snat should be updated correctly after remove pods
     Given the env is using "OVNKubernetes" networkType
     Given I store the schedulable workers in the :nodes clipboard
@@ -876,6 +890,7 @@ Feature: OVN Egress IP related features
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-44251:SDN lr-policy-list and snat should be updated correctly after remove egressip objects 
     Given the env is using "OVNKubernetes" networkType	
     Given I store the schedulable workers in the :nodes clipboard

--- a/features/networking/ovn_ipsec.feature
+++ b/features/networking/ovn_ipsec.feature
@@ -5,10 +5,11 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @admin
   @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   @network-ovnkubernetes @ipsec
-  @vsphere-ipi @openstack-ipi @nutanix-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
-  @vsphere-upi @openstack-upi @nutanix-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @hypershift-hosted
   Scenario: OCP-38846:SDN Should be able to send node to node ESP traffic on IPsec clusters
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -58,6 +59,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @hypershift-hosted
   Scenario: OCP-38845:SDN Segfault on pluto IKE daemon should result in restarting pluto daemon and corresponding ovn-ipsec pod
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -86,10 +88,11 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @admin
   @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7
   @network-ovnkubernetes @ipsec
-  @vsphere-ipi @openstack-ipi @nutanix-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
-  @vsphere-upi @openstack-upi @nutanix-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @hypershift-hosted
   Scenario: OCP-37591:SDN Make sure IPsec SA's are establishing in a transport mode
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -109,6 +112,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @hypershift-hosted
   Scenario: OCP-39216:SDN Pod created on IPsec cluster should have appropriate MTU size to accomdate IPsec Header
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -133,6 +137,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @hypershift-hosted
   Scenario: OCP-37590:SDN Delete all ovn-ipsec containers and check if they gets recreated
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -152,6 +157,7 @@ Feature: OVNKubernetes IPsec related networking scenarios
   @vsphere-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @hypershift-hosted
   Scenario: OCP-37392:SDN pod to pod traffic on different nodes should be ESP encrypted
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is enabled on the cluster
@@ -200,13 +206,14 @@ Feature: OVNKubernetes IPsec related networking scenarios
   # @case_id OCP-40569
   @admin
   @destructive
-  @network-ovnkubernetes
+  @network-ovnkubernetes @network-openshiftsdn
   @4.14 @4.13 @4.12 @4.11
-  @vsphere-ipi @openstack-ipi @nutanix-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
-  @vsphere-upi @openstack-upi @nutanix-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @singlenode
+  @hypershift-hosted
   Scenario: OCP-40569:SDN Allow enablement/disablement ipsec at runtime
     Given the env is using "OVNKubernetes" networkType
     And the IPsec is disabled on the cluster

--- a/features/networking/pod.feature
+++ b/features/networking/pod.feature
@@ -233,6 +233,7 @@ Feature: Pod related networking scenarios
   @network-openshiftsdn
   @proxy @noproxy
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @hypershift-hosted
   Scenario: OCP-23893:SDN A pod in a namespace with an egress IP cannot access the MCS
     Given I store the masters in the :masters clipboard
     And the Internal IP of node "<%= cb.masters[0].name %>" is stored in the :master_ip clipboard
@@ -645,6 +646,12 @@ Feature: Pod related networking scenarios
   @long-duration
   @admin
   @destructive
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @disconnected @connected
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-41666:SDN Pod stuck in container creating - failed to run CNI IPAM ADD: failed to allocate for range 0: no IP addresses available in range set
     Given the env is using "OpenShiftSDN" networkType
     Given I switch to cluster admin pseudo user

--- a/features/networking/ptp_operator.feature
+++ b/features/networking/ptp_operator.feature
@@ -6,6 +6,7 @@ Feature: PTP related scenarios
   @stage-only
   @4.10 @4.9 @4.6
   @proxy @noproxy @disconnected @connected
+  @inactive
   Scenario: OCP-25940:SDN ptp operator can be deployed successfully
     Given I switch to cluster admin pseudo user
     And I use the "openshift-ptp" project
@@ -19,6 +20,7 @@ Feature: PTP related scenarios
   # @case_id OCP-25738
   @admin
   @destructive
+  @inactive
   Scenario: OCP-25738:SDN Linuxptp run as slave can sync to master
     Given the ptp operator is running well
     Given I switch to the first user
@@ -53,6 +55,7 @@ Feature: PTP related scenarios
   # @case_id OCP-25740
   @admin
   @destructive
+  @inactive
   Scenario: OCP-25740:SDN Linuxptp runs in transparent udp4 mode
     Given the ptp operator is running well
     Given I switch to the first user
@@ -93,6 +96,10 @@ Feature: PTP related scenarios
   @admin
   @destructive
   @4.10 @4.9
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @disconnected @connected
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-26187:SDN PTP operator starts linuxptp daemon based on nodeSelector configured in default PtpOperatorConfig CRD
     Given the ptp operator is running well
     And I use the "openshift-ptp" project

--- a/features/networking/sctp.feature
+++ b/features/networking/sctp.feature
@@ -5,6 +5,12 @@ Feature: SCTP related scenarios
   @admin
   @destructive
   @4.9
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @disconnected @connected
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-28757:SDN Establish pod to pod SCTP connections
     Given I store the ready and schedulable workers in the :workers clipboard
     And I install machineconfigs load-sctp-module
@@ -58,12 +64,13 @@ Feature: SCTP related scenarios
   @admin
   @destructive
   @4.9 @4.8 @4.7 @4.6
-  @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
-  @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
-  @heterogeneous @arm64 @amd64
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @hypershift-hosted
   Scenario: OCP-28758:SDN Expose SCTP ClusterIP Services
     Given I store the ready and schedulable workers in the :workers clipboard
     And I install machineconfigs load-sctp-module

--- a/features/networking/sdn.feature
+++ b/features/networking/sdn.feature
@@ -252,6 +252,7 @@ Feature: SDN related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @inactive
   Scenario: OCP-25707:SDN ovs-vswitchd process must be running on all ovs pods
     Given I switch to cluster admin pseudo user
     When I run cmds on all ovs pods:
@@ -268,6 +269,7 @@ Feature: SDN related networking scenarios
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-openshiftsdn
+  @inactive
   Scenario: OCP-25706:SDN Killing ovs process should not put sdn and ovs pods in bad shape
     Given I have a project
     And evaluation of `project.name` is stored in the :usr_project clipboard
@@ -317,6 +319,7 @@ Feature: SDN related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @heterogeneous @arm64 @amd64
+  @inactive
   Scenario: OCP-27655:SDN Networking should work on default namespace
   #Test for bug https://bugzilla.redhat.com/show_bug.cgi?id=1800324 and https://bugzilla.redhat.com/show_bug.cgi?id=1796157
     Given I switch to cluster admin pseudo user
@@ -372,6 +375,7 @@ Feature: SDN related networking scenarios
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @inactive
   Scenario: OCP-25787:SDN Don't write CNI configuration file until ovn-controller has done at least one iteration
     Given the env is using "OVNKubernetes" networkType
     And I store the masters in the :master clipboard
@@ -457,6 +461,7 @@ Feature: SDN related networking scenarios
   @baremetal-upi
   @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
+  @inactive
   Scenario: OCP-29299:SDN Without allow the migration operation, migration cannot be executed
     When I run the :annotate client command with:
        | resource     | network.operator.openshift.io                       |

--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -3,7 +3,13 @@ Feature: Service related networking scenarios
   # @author yadu@redhat.com
   # @case_id OCP-9604
   @admin
-  @network-multitenant
+  @network-openshiftsdn @network-multitenant
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @hypershift-hosted
+  @proxy @noproxy
   Scenario: OCP-9604:SDN tenants can access their own services
     # create pod and service in project1
     Given the env is using multitenant network
@@ -635,6 +641,7 @@ Feature: Service related networking scenarios
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @network-ovnkubernetes @network-openshiftsdn
+  @inactive
   Scenario: OCP-33850:SDN User cannot decrease the nodePort range in post action
     When I run the :patch admin command with:
       | resource      | networks.config.openshift.io                     |
@@ -845,6 +852,7 @@ Feature: Service related networking scenarios
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
+  @inactive
   Scenario: OCP-10770:SDN Be able to access the service via the nodeport
     Given I store the workers in the :workers clipboard
     And the Internal IP of node "<%= cb.workers[0].name %>" is stored in the :worker0_ip clipboard		

--- a/features/networking/sriov.feature
+++ b/features/networking/sriov.feature
@@ -24,6 +24,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-24702
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-24702:SDN netdevice VF for XXV710 can be worked well when sriovnetworknodepolicies is created for rhcos node
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/intel-netdevice.yaml"
@@ -75,6 +81,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-21364
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-21364:SDN Create pod with sriov-cni plugin and macvlan on the same interface
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/intel-netdevice.yaml"
@@ -136,6 +148,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-24713
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-24713:SDN NAD can be also updated when networknamespace is change
     Given the sriov operator is running well
     Given I switch to the first user
@@ -209,6 +227,12 @@ Feature: Sriov related scenarios
     Then the output should contain:
       | 10.56.217 |
 
+    @s390x @ppc64le @heterogeneous @arm64 @amd64
+    @baremetal-ipi
+    @baremetal-upi
+    @hypershift-hosted
+    @network-ovnkubernetes @network-openshiftsdn
+    @proxy @noproxy
     Examples:
       | case_id       | cardname |
       | OCP-24774:SDN | mlx277   | # @case_id OCP-24774
@@ -218,6 +242,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-24780
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-24780:SDN NAD will be deleted too when sriovnetwork is deleted
     Given the sriov operator is running well
     Given I switch to the first user
@@ -239,6 +269,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-25287
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-25287:SDN NAD should be able to restore by sriov operator when it was deleted
     Given the sriov operator is running well
     Given I switch to the first user
@@ -267,6 +303,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-25790
   @admin
   @destructive
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-25790:SDN SR-IOV network config daemon can be set by nodeselector
     Given the sriov operator is running well
     And all existing pods are ready with labels:
@@ -281,6 +323,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-26134
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-26134:SDN sriov can be shown in Metrics and telemetry
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/mlx278-netdevice.yaml"
@@ -367,6 +415,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-33454
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-33454:SDN VF mac can be set with container mac address
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/mlx278-netdevice.yaml"
@@ -456,6 +510,12 @@ Feature: Sriov related scenarios
     And the output should not contain "<keyword>"
     """
 
+    @s390x @ppc64le @heterogeneous @arm64 @amd64
+    @baremetal-ipi
+    @baremetal-upi
+    @hypershift-hosted
+    @network-ovnkubernetes @network-openshiftsdn
+    @proxy @noproxy
     Examples:
       | case_id       | sriov-feature            | keyword          |
       | OCP-25814:SDN | SR-IOV resource injector | injector         | # @case_id OCP-25814
@@ -465,6 +525,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-25835
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-25835:SDN SR-IOV resource injector should not overwrite the request memory and cpu
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/mlx278-netdevice.yaml"
@@ -522,6 +588,12 @@ Feature: Sriov related scenarios
     Then the step should fail
     And the output should contain "<Error message>"
 
+    @s390x @ppc64le @heterogeneous @arm64 @amd64
+    @baremetal-ipi
+    @baremetal-upi
+    @hypershift-hosted
+    @network-ovnkubernetes @network-openshiftsdn
+    @proxy @noproxy
     Examples:
       | file              | Error message                |
       | invalidname.yaml  | invalid characters           |
@@ -534,6 +606,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-28076
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-28076:SDN vf range should be correct if create sriovnetworkpolicy without pfNames
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/intel-netdevice-without-pf.yaml"
@@ -565,6 +643,13 @@ Feature: Sriov related scenarios
   # @case_id OCP-30268
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-30268:SDN user can set the loglevel for sriov config daemon
     Given the sriov operator is running well
     Given sriov config daemon is ready
@@ -589,6 +674,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-30277
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-30277:SDN Loglevel value should be explain in CRD
     Given the sriov operator is running well
     When I run the :explain client command with:
@@ -600,6 +691,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-32642
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-32642:SDN MTU can be set according to policy is specified
     Given the sriov operator is running well
     Given I obtain test data file "networking/sriov/sriovnetworkpolicy/mlx278-netdevice.yaml"
@@ -700,7 +797,7 @@ Feature: Sriov related scenarios
   @singlenode
   @proxy @noproxy @disconnected @connected
   @network-ovnkubernetes @network-openshiftsdn
-  @heterogeneous @arm64 @amd64
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-25321:SDN dpdk for intel card works well
     Given the sriov operator is running well
@@ -756,6 +853,12 @@ Feature: Sriov related scenarios
   # @case_id OCP-37458
   @destructive
   @admin
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @baremetal-ipi
+  @baremetal-upi
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-37458:SDN user can disable drain node by DisableDrain
     Given the sriov operator is running well
     #disable drain node by DisableDrain

--- a/features/node/nto.feature
+++ b/features/node/nto.feature
@@ -4,11 +4,13 @@ Feature: Node Tuning Operator related scenarios
   # @case_id OCP-27491
   @admin
   @destructive
-  @nutanix-ipi @ibmcloud-ipi @alicloud-ipi
-  @nutanix-upi @ibmcloud-upi @alicloud-upi
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @4.16 @4.15 @4.14 @4.13
   @hypershift-hosted
-  @s390x @ppc64le
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @proxy @noproxy @disconnected @connected
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-27491:PSAP Node tuning operator: tuning is working - add profile
     # Cleaning after test if some step failed
     Given admin ensures "nf-conntrack-max" tuned is deleted from the "openshift-cluster-node-tuning-operator" project after scenario

--- a/features/routing/abrouting.feature
+++ b/features/routing/abrouting.feature
@@ -3,6 +3,13 @@ Feature: Testing abrouting
   # @author yadu@redhat.com
   # @case_id OCP-12076
   @admin
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @noproxy
   Scenario: OCP-12076:NetworkEdge Set backends weight for unsecure route
     Given I switch to cluster admin pseudo user
     And I use the router project
@@ -85,6 +92,13 @@ Feature: Testing abrouting
   # @author yadu@redhat.com
   # @case_id OCP-11970
   @admin
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @noproxy @connected
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
   Scenario: OCP-11970:NetworkEdge Set backends weight for reencrypt route
     Given I switch to cluster admin pseudo user
     And I use the router project

--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -13,6 +13,7 @@ Feature: Testing haproxy router
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-11903:NetworkEdge haproxy cookies based sticky session for unsecure routes
     #create route and service which has two endpoints
     Given I have a project
@@ -78,6 +79,7 @@ Feature: Testing haproxy router
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-11130:NetworkEdge haproxy cookies based sticky session for edge termination routes
     #create route and service which has two endpoints
     Given I have a project
@@ -148,6 +150,7 @@ Feature: Testing haproxy router
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-11619:NetworkEdge Limit the number of TCP connection per IP in specified time period
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -356,6 +359,7 @@ Feature: Testing haproxy router
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-11679:NetworkEdge Disable haproxy hash based sticky session for unsecure routes
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"

--- a/features/routing/idle.feature
+++ b/features/routing/idle.feature
@@ -2,6 +2,13 @@ Feature: idle service related scenarios
 
   # @author hongli@redhat.com
   # @case_id OCP-10935
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-10935:NetworkEdge Pod can be changed to un-idle when there is unsecure or edge or passthrough route coming
     Given I have a project
     Given I obtain test data file "routing/web-server-rc.yaml"
@@ -97,6 +104,13 @@ Feature: idle service related scenarios
 
   # @author hongli@redhat.com
   # @case_id OCP-13837
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-13837:NetworkEdge Pod can be changed to un-idle when there is reencrypt route coming
     Given I have a project
     Given I obtain test data file "routing/web-server-rc.yaml"

--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -139,6 +139,7 @@ Feature: Testing route
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-12562:NetworkEdge The path specified in route can work well for edge terminated
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -224,6 +225,7 @@ Feature: Testing route
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-12564:NetworkEdge The path specified in route can work well for reencrypt terminated
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -274,6 +276,7 @@ Feature: Testing route
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-9651:NetworkEdge Config insecureEdgeTerminationPolicy to Redirect for route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -327,6 +330,7 @@ Feature: Testing route
   @network-ovnkubernetes @network-openshiftsdn
   @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
+  @inactive
   Scenario: OCP-9650:NetworkEdge Config insecureEdgeTerminationPolicy to Allow for route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -426,6 +430,7 @@ Feature: Testing route
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-11036:NetworkEdge Set insecureEdgeTerminationPolicy to Redirect for passthrough route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -484,6 +489,7 @@ Feature: Testing route
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-13839:NetworkEdge Set insecureEdgeTerminationPolicy to Redirect and Allow for reencrypt route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"
@@ -602,6 +608,7 @@ Feature: Testing route
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-13753:NetworkEdge Check the cookie if using secure mode when insecureEdgeTerminationPolicy to Redirect for edge/reencrypt route
     Given I have a project
     Given I obtain test data file "routing/web-server-1.yaml"

--- a/features/routing/timeout.feature
+++ b/features/routing/timeout.feature
@@ -12,6 +12,7 @@ Feature: Testing timeout route
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @rosa @osd_ccs @aro
   @critical
+  @hypershift-hosted
   Scenario: OCP-11635:NetworkEdge Set timeout server for passthough route
     Given I have a project
     Given I obtain test data file "routing/routetimeout/httpbin-pod.json"

--- a/features/routing/websocket.feature
+++ b/features/routing/websocket.feature
@@ -11,6 +11,7 @@ Feature: Testing websocket features
   @network-ovnkubernetes @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @critical
+  @hypershift-hosted
   Scenario: OCP-17145:NetworkEdge haproxy router support websocket via unsecure route
     Given I have a project
     Given I obtain test data file "routing/websocket/pod.json"

--- a/features/storage/cloud_provider.feature
+++ b/features/storage/cloud_provider.feature
@@ -68,6 +68,7 @@ Feature: kubelet restart and node restart
     @vsphere-upi
     @hypershift-hosted
     @critical
+    @inactive
     Examples:
       | case_id           | platform       |
       | OCP-13631:Storage | vsphere-volume | # @case_id OCP-13631

--- a/features/storage/csi.feature
+++ b/features/storage/csi.feature
@@ -287,8 +287,8 @@ Feature: CSI testing related feature
     Then the step should succeed
     And the output should contain "test data"
 
-    @openstack-ipi
-    @openstack-upi
+    @openstack-ipi @gcp-ipi
+    @openstack-upi @gcp-upi
     @qeci
     Examples:
       | case_id           | sc_name      |
@@ -344,8 +344,8 @@ Feature: CSI testing related feature
     And the output should contain "Hello OpenShift Storage"
 
     @rosa @osd_ccs @aro
-    @aws-ipi
-    @aws-upi
+    @gcp-ipi @aws-ipi
+    @gcp-upi @aws-upi
     Examples:
       | case_id           | sc_name | type | size  |
       | OCP-24546:Storage | gp2-csi | sc1  | 125Gi | # @case_id OCP-24546
@@ -403,8 +403,8 @@ Feature: CSI testing related feature
       | OCP-37557:Storage | cinder.csi.openstack.org | standard-csi | openstack-cinder-csi-driver-operator | openstack-cinder-csi-driver-controller | openstack-cinder-csi-driver-node | # @case_id OCP-37557
 
     @rosa @osd_ccs @aro
-    @aws-ipi
-    @aws-upi
+    @gcp-ipi @aws-ipi
+    @gcp-upi @aws-upi
     Examples:
       | case_id           | provisioner     | sc_name | deployment_operator         | deployment_controller         | daemonset_node          |
       | OCP-34144:Storage | ebs.csi.aws.com | gp2-csi | aws-ebs-csi-driver-operator | aws-ebs-csi-driver-controller | aws-ebs-csi-driver-node | # @case_id OCP-34144

--- a/features/storage/csi_resize.feature
+++ b/features/storage/csi_resize.feature
@@ -187,6 +187,11 @@ Feature: CSI Resizing related feature
     And the output should not contain:
       | No space left on device |
 
+    @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+    @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+    @s390x @ppc64le @heterogeneous @arm64 @amd64
+    @hypershift-hosted
+    @proxy @noproxy
     Examples:
       | case_id            | sc_name     |
       | OCP-41452::Storage | managed-csi | # @case_id OCP-41452

--- a/features/storage/storage_object_in_use_protection.feature
+++ b/features/storage/storage_object_in_use_protection.feature
@@ -3,6 +3,13 @@ Feature: Storage object in use protection
   # @author lxia@redhat.com
   # @case_id OCP-17253
   @storage
+  @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
+  @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-17253:Storage Delete pvc which is not in active use by pod should be deleted immediately
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -15,6 +22,13 @@ Feature: Storage object in use protection
   # @author lxia@redhat.com
   # @case_id OCP-17254
   @storage
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @vsphere-ipi @openstack-ipi @gcp-ipi @azure-ipi @aws-ipi
+  @vsphere-upi @openstack-upi @gcp-upi @azure-upi @aws-upi
+  @critical
+  @hypershift-hosted
+  @network-ovnkubernetes @network-openshiftsdn
+  @proxy @noproxy
   Scenario: OCP-17254:Storage Delete pvc which is in active use by pod should postpone deletion
     Given I have a project
     Given I obtain test data file "storage/misc/pvc.json"
@@ -54,6 +68,10 @@ Feature: Storage object in use protection
   # @case_id OCP-18796
   @admin
   @storage
+  @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @critical
+  @hypershift-hosted
+  @proxy @noproxy
   Scenario: OCP-18796:Storage Delete pv which is bind with pvc should postpone deletion
     Given I have a project
     Given I obtain test data file "storage/nfs/auto/pv-template.json"


### PR DESCRIPTION
There are many changes in Polarion after we batch add those tags in code. So resync the tags from Polarion.

Also some of the test cases in Polarion are wrongly marked as Upstream, so remove the check for Upstream field here.