### PR TITLE
fix OCP-22308

### DIFF
--- a/lib/rules/web/admin_console/4.11/goto.xyaml
+++ b/lib/rules/web/admin_console/4.11/goto.xyaml
@@ -341,7 +341,10 @@ goto_machineconfigs_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfig
 goto_machineconfig_pools_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfigPool
-  action: wait_box_loaded
+  element:
+    selector:
+      xpath: //span[text()='MachineConfigPools']
+    timeout: 30
 goto_machine_sets_page:
   url: k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~MachineSet
   action: wait_box_loaded

--- a/lib/rules/web/admin_console/4.12/goto.xyaml
+++ b/lib/rules/web/admin_console/4.12/goto.xyaml
@@ -341,7 +341,10 @@ goto_machineconfigs_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfig
 goto_machineconfig_pools_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfigPool
-  action: wait_box_loaded
+  element:
+    selector:
+      xpath: //span[text()='MachineConfigPools']
+    timeout: 30
 goto_machine_sets_page:
   url: k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~MachineSet
   action: wait_box_loaded

--- a/lib/rules/web/admin_console/4.13/goto.xyaml
+++ b/lib/rules/web/admin_console/4.13/goto.xyaml
@@ -341,7 +341,10 @@ goto_machineconfigs_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfig
 goto_machineconfig_pools_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfigPool
-  action: wait_box_loaded
+  element:
+    selector:
+      xpath: //span[text()='MachineConfigPools']
+    timeout: 30
 goto_machine_sets_page:
   url: k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~MachineSet
   action: wait_box_loaded

--- a/lib/rules/web/admin_console/4.14/goto.xyaml
+++ b/lib/rules/web/admin_console/4.14/goto.xyaml
@@ -341,7 +341,10 @@ goto_machineconfigs_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfig
 goto_machineconfig_pools_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfigPool
-  action: wait_box_loaded
+  element:
+    selector:
+      xpath: //span[text()='MachineConfigPools']
+    timeout: 30
 goto_machine_sets_page:
   url: k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~MachineSet
   action: wait_box_loaded

--- a/lib/rules/web/admin_console/4.15/goto.xyaml
+++ b/lib/rules/web/admin_console/4.15/goto.xyaml
@@ -341,7 +341,10 @@ goto_machineconfigs_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfig
 goto_machineconfig_pools_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfigPool
-  action: wait_box_loaded
+  element:
+    selector:
+      xpath: //span[text()='MachineConfigPools']
+    timeout: 30
 goto_machine_sets_page:
   url: k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~MachineSet
   action: wait_box_loaded

--- a/lib/rules/web/admin_console/4.16/goto.xyaml
+++ b/lib/rules/web/admin_console/4.16/goto.xyaml
@@ -341,7 +341,10 @@ goto_machineconfigs_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfig
 goto_machineconfig_pools_page:
   url: k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfigPool
-  action: wait_box_loaded
+  element:
+    selector:
+      xpath: //span[text()='MachineConfigPools']
+    timeout: 30
 goto_machine_sets_page:
   url: k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~MachineSet
   action: wait_box_loaded


### PR DESCRIPTION
"wait_box_loaded" will check table loaded, but some clusters have not machineconfigpool listed. Replace it with other selector.
pass log on 4.16 https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/942624/console 
@yapei 