### PR TITLE
OCPQE-21203: Fix get_secret_names undefined method `map' for nil when image registry is disabled

### DIFF
--- a/lib/openshift/service_account.rb
+++ b/lib/openshift/service_account.rb
@@ -33,7 +33,7 @@ module BushSlicer
 
     def get_secret_names(user: nil, cached: true, quiet: true)
       rr = raw_resource(user: user, cached: cached, quiet: quiet)
-      return rr["secrets"].map {|s| s['name']}
+      return rr["secrets"]&.map {|s| s['name']}
     end
 
     def get_secrets(user: nil, cached: true, quiet: true)


### PR DESCRIPTION
There are failures for `Given I find a bearer token of the demo service account` due to the `map` method is applied on a `nil`. The failure stack:
```
    Given I find a bearer token of the demo service account                                                                     # features/step_definitions/user.rb:25
      undefined method `map' for nil:NilClass (NoMethodError)
      /verification-tests/lib/openshift/service_account.rb:36:in `get_secret_names'
      /verification-tests/lib/openshift/service_account.rb:41:in `get_secrets'
      /verification-tests/lib/openshift/service_account.rb:29:in `load_bearer_tokens'
      /verification-tests/features/step_definitions/user.rb:26:in `/^I find a bearer token of the(?: (.+?))? service account$/'
      features/cli/serviceaccount.feature:31:in `I find a bearer token of the demo service
```
The stack `/verification-tests/lib/openshift/service_account.rb:36:in `get_secret_names'` indicates the line of root cause:
```
36      return rr["secrets"].map {|s| s['name']}
```

In normal env, any searviceaccount's yaml looks like:
```
$ oc get sa default -o yaml
apiVersion: v1
imagePullSecrets:
- name: default-dockercfg-whmzx
kind: ServiceAccount
metadata:
  creationTimestamp: "2024-04-28T01:48:16Z"
  name: default
  namespace: default
  ...
secrets:
- name: default-dockercfg-whmzx
```

But in image-registry disabled env, it looks like as below, no `imagePullSecrets` field and `secrets` field:
```
$ oc get sa default -o yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  creationTimestamp: "2024-04-28T03:02:40Z"
  name: default
  namespace: xxia-test
  resourceVersion: "19514"
  uid: f1166197-2da3-4d7b-b479-13faeca078f4
```

So, `rr["secrets"]` will be nil in image-registry disabled env. The fix is: return nil if `rr["secrets"]` is nil. Luckily, Ruby has the safe `&.` operator https://stackoverflow.com/questions/36812647/what-does-ampersand-dot-mean-in-ruby so that we need not use `if else`.

Passed in both normal env (job/ocp-common/job/Runner/944183/console) and image-registry disabled env (job/ocp-common/job/Runner/944153/console).

@deepakpunia / @liangxia , please help review.