### PR TITLE
OCPQE-22037: Exclude OCP-34144 for hcp

### DIFF
--- a/features/storage/csi.feature
+++ b/features/storage/csi.feature
@@ -407,7 +407,6 @@ Feature: CSI testing related feature
     @rosa @osd_ccs
     @aws-ipi
     @aws-upi
-    @hypershift-hosted
     Examples:
       | case_id           | provisioner     | sc_name | deployment_operator         | deployment_controller         | daemonset_node          |
       | OCP-34144:Storage | ebs.csi.aws.com | gp2-csi | aws-ebs-csi-driver-operator | aws-ebs-csi-driver-controller | aws-ebs-csi-driver-node | # @case_id OCP-34144


### PR DESCRIPTION
### [OCPQE-22037](https://issues.redhat.com//browse/OCPQE-22037): Exclude OCP-34144 for hcp

**Root cause**
- OCP-34144 check the CSI Driver Operator installation should be excluded for hcp jobs since the csi driver controller and operator are in the control plane which only could be access from mgmt cluster

[failure record](https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/1260/557050/69991570/69992557/log?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26launchesLimit%3D1000%26isLatest%3Dfalse%26filter.in.status%3DFAILED%252CINTERRUPTED%26page.page%3D1%26filter.in.issueType%3Dti001%252Cti_1hrghcxlbgshc%252Cti_s4scyws6guht%252Cti_sok676b1k8j5%252Cti_r1ifkmkw19o1%26filter.cnt.name%3D%253AStorage)

```console
$ oc -n clusters-hypershift-ci-282780 get po | grep 'aws-ebs-csi-'
aws-ebs-csi-driver-controller-d8c7f654-78vws          12/12   Running     0              125m
aws-ebs-csi-driver-operator-d49dddcd-hdqtq            1/1     Running     0              126m
```