### PR TITLE
Update rule for OCP-29198

### DIFF
--- a/lib/rules/web/admin_console/4.14/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.14/operator_hub.xyaml
@@ -31,7 +31,7 @@ create_cr_infinispancluster:
     api: Infinispan Cluster
   action: create_custom_resource
   action: switch_to_yaml_view
-  action: click_create_button 
+  action: click_create_button
 create_operand:
   params:
     tab_name: <operand_kind>
@@ -451,7 +451,7 @@ check_proxy_infra_value:
 check_fips_infra_value:
   params:
     label: Infrastructure features
-    value: FIPS Mode
+    value: Designed for FIPS
   action: check_property_label_and_value
 check_singlenodecluster_infra_value:
   params:
@@ -488,7 +488,7 @@ click_checkbox_proxy_from_infrastructure_features:
 click_checkbox_fips_from_infrastructure_features:
   params:
     filter_type_value: infraFeatures
-    checkbox_text: FIPS Mode
+    checkbox_text: Designed for FIPS
   action: wait_filter_section_loaded
   action: choose_one_checkbox
 click_checkbox_singlenodecluster_from_infrastructure_features:

--- a/lib/rules/web/admin_console/4.15/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.15/operator_hub.xyaml
@@ -451,7 +451,7 @@ check_proxy_infra_value:
 check_fips_infra_value:
   params:
     label: Infrastructure features
-    value: FIPS Mode
+    value: Designed for FIPS
   action: check_property_label_and_value
 check_singlenodecluster_infra_value:
   params:
@@ -488,7 +488,7 @@ click_checkbox_proxy_from_infrastructure_features:
 click_checkbox_fips_from_infrastructure_features:
   params:
     filter_type_value: infraFeatures
-    checkbox_text: FIPS Mode
+    checkbox_text: Designed for FIPS
   action: wait_filter_section_loaded
   action: choose_one_checkbox
 click_checkbox_singlenodecluster_from_infrastructure_features:

--- a/lib/rules/web/admin_console/4.16/operator_hub.xyaml
+++ b/lib/rules/web/admin_console/4.16/operator_hub.xyaml
@@ -461,7 +461,7 @@ check_proxy_infra_value:
 check_fips_infra_value:
   params:
     label: Infrastructure features
-    value: FIPS Mode
+    value: Designed for FIPS
   action: check_property_label_and_value
 check_singlenodecluster_infra_value:
   params:
@@ -498,7 +498,7 @@ click_checkbox_proxy_from_infrastructure_features:
 click_checkbox_fips_from_infrastructure_features:
   params:
     filter_type_value: infraFeatures
-    checkbox_text: FIPS Mode
+    checkbox_text: Designed for FIPS
   action: wait_filter_section_loaded
   action: choose_one_checkbox
 click_checkbox_singlenodecluster_from_infrastructure_features:


### PR DESCRIPTION
- According to the new change in OCPBUGS-32741- Change the display text of the filtering option for FIPS to “Designed for FIPS, 
- The changes will impact 4.16, 4.15, 4.14

Pass log: 
4.16:job/Runner/957154/