### PR TITLE
OCPQE-21298: Update machineset name with infrastructureName

### DIFF
--- a/features/machine/autoscaler.feature
+++ b/features/machine/autoscaler.feature
@@ -19,7 +19,8 @@ Feature: Cluster Autoscaler Tests
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-28108"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-28108"
 
     # Create clusterautoscaler
     Given I obtain test data file "cloud/cluster-autoscaler.yml"
@@ -113,7 +114,8 @@ Feature: Cluster Autoscaler Tests
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-21517"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-21517"
     Given I obtain test data file "cloud/machine-autoscaler.yml"
     When I run oc create over "machine-autoscaler.yml" replacing paths:
       | ["metadata"]["name"]               | maotest                                      |
@@ -155,9 +157,11 @@ Feature: Cluster Autoscaler Tests
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-22102"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-22102"
     And evaluation of `machine_set_machine_openshift_io.name` is stored in the :machineset_clone_22102 clipboard
-    Given I clone a machineset and name it "machineset-clone-22102-2"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-22102-2"
     And evaluation of `machine_set_machine_openshift_io.name` is stored in the :machineset_clone_22102_2 clipboard
 
     Given I obtain test data file "cloud/machine-autoscaler.yml"

--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -74,8 +74,8 @@ Feature: Machine features testing
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
-
-    Given I clone a machineset and name it "machineset-clone-25436"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-25436"
 
     Given I scale the machineset to +2
     Then the step should succeed
@@ -193,8 +193,9 @@ Feature: Machine features testing
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-27609"
-    Then as admin I successfully merge patch resource "machinesets.machine.openshift.io/machineset-clone-27609" with:
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-27609"
+    Then as admin I successfully merge patch resource "machinesets.machine.openshift.io/<%= cb.infraName %>-27609" with:
       | {"spec":{"template": {"spec":{"providerSpec":{"value":{"publicIP": true}}}}}} |
     And I scale the machineset to +2
     Then the machineset should have expected number of running machines
@@ -215,7 +216,8 @@ Feature: Machine features testing
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-24363"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-24363"
     And evaluation of `machine_set_machine_openshift_io.machines.first.node_name` is stored in the :noderef_name clipboard
     And evaluation of `machine_set_machine_openshift_io.machines.first.name` is stored in the :machine_name clipboard
 
@@ -248,6 +250,7 @@ Feature: Machine features testing
 
     #Create a spot machineset
     Given I use the "openshift-machine-api" project
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
     Given I create a spot instance machineset and name it "<machineset_name>" on <iaas_type>
     And evaluation of `machine_set_machine_openshift_io.machines.first.node_name` is stored in the :noderef_name clipboard
     And evaluation of `machine_set_machine_openshift_io.machines.first.name` is stored in the :machine_name clipboard
@@ -322,8 +325,8 @@ Feature: Machine features testing
 
     @aws-ipi
     Examples:
-      | case_id                         | iaas_type | machineset_name        |
-      | OCP-29199:ClusterInfrastructure | aws       | machineset-clone-29199 | # @case_id OCP-29199
+      | case_id                         | iaas_type | machineset_name           |
+      | OCP-29199:ClusterInfrastructure | aws       | <%= cb.infraName %>-29199 | # @case_id OCP-29199
 
     @gcp-ipi
     @s390x @ppc64le @heterogeneous @arm64 @amd64
@@ -331,8 +334,8 @@ Feature: Machine features testing
     @network-ovnkubernetes @network-openshiftsdn
     
     Examples:
-      | case_id                         | iaas_type | machineset_name        |
-      | OCP-32126:ClusterInfrastructure | gcp       | machineset-clone-32126 | # @case_id OCP-32126
+      | case_id                         | iaas_type | machineset_name           |
+      | OCP-32126:ClusterInfrastructure | gcp       | <%= cb.infraName %>-32126 | # @case_id OCP-32126
 
   # @author zhsun@redhat.com
   # @case_id OCP-32620
@@ -350,8 +353,9 @@ Feature: Machine features testing
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-32620"
-    Given as admin I successfully merge patch resource "machinesets.machine.openshift.io/machineset-clone-32620" with:
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-32620"
+    Given as admin I successfully merge patch resource "machinesets.machine.openshift.io/<%= cb.infraName %>-32620" with:
       | {"spec":{"template":{"spec":{"metadata":{"labels":{"node-role.kubernetes.io/infra": ""}}}}}} |
     Then the step should succeed
 

--- a/features/machine/machine_healthcheck.feature
+++ b/features/machine/machine_healthcheck.feature
@@ -16,7 +16,8 @@ Feature: MachineHealthCheck Test Scenarios
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-25897"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-25897"
 
     # Create MHC
     Given I obtain test data file "cloud/mhc/mhc1.yaml"
@@ -57,7 +58,8 @@ Feature: MachineHealthCheck Test Scenarios
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-26311"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-26311"
 
     # Create unhealthyCondition before createing a MHC
     Given I create the 'Ready' unhealthyCondition
@@ -90,7 +92,8 @@ Feature: MachineHealthCheck Test Scenarios
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-25734"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-25734"
 
     # Create MHCs
     Given I run the steps 2 times:
@@ -124,7 +127,8 @@ Feature: MachineHealthCheck Test Scenarios
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
-    Given I clone a machineset and name it "machineset-clone-25691"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-25691"
 
     # Create MHC
     Given I obtain test data file "cloud/mhc/mhc1.yaml"
@@ -180,7 +184,8 @@ Feature: MachineHealthCheck Test Scenarios
     Then I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-28718"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-28718"
 
     # Create MHC with configurable node startup timeout
     Given I obtain test data file "cloud/mhc/mhc_configurabletimeout.yaml"
@@ -223,7 +228,8 @@ Feature: MachineHealthCheck Test Scenarios
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-25727"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-25727"
 
     Given I obtain test data file "cloud/mhc/mhc1.yaml"
     When I run oc create over "mhc1.yaml" replacing paths:
@@ -274,7 +280,8 @@ Feature: MachineHealthCheck Test Scenarios
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-28859"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-28859"
 
     # Create MHC
     Given I obtain test data file "cloud/mhc/mhc1.yaml"

--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -200,7 +200,8 @@ Feature: Machine misc features testing
   Scenario: OCP-40665:ClusterInfrastructure Deattach disk before destroying vm from vsphere
     Given I switch to cluster admin pseudo user
     Then I use the "openshift-machine-api" project
-    And I clone a machineset and name it "machineset-clone-40665"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-40665"
 
     Given I store the last provisioned machine in the :new_machine clipboard
     And evaluation of `machine_machine_openshift_io(cb.new_machine).node_name` is stored in the :nodeRef clipboard

--- a/features/machine/upi_gcp.feature
+++ b/features/machine/upi_gcp.feature
@@ -27,7 +27,8 @@ Feature: UPI GCP Tests
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-25034"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-25034"
 
     # Create clusterautoscaler
     Given I obtain test data file "cloud/cluster-autoscaler.yml"

--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -174,7 +174,8 @@ Feature: Operator related networking scenarios
     """
 
     And admin ensures machine number is restored after scenario
-    Given I clone a machineset and name it "machineset-clone-sdn"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-sdn"
 
     # Check that the status of Progressing is truned to True during the new node provisioning
     Given I wait up to 360 seconds for the steps to pass:

--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -146,7 +146,8 @@ Feature: Machine-api components upgrade tests
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-22612"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-22612"
 
     Given I scale the machineset to +2
     Then the step should succeed
@@ -168,6 +169,7 @@ Feature: Machine-api components upgrade tests
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
     And I pick a random machineset to scale
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
 
     # Create a machineset
     Given I get project machine_set_machine_openshift_io named "<%= machine_set_machine_openshift_io.name %>" as YAML
@@ -196,14 +198,14 @@ Feature: Machine-api components upgrade tests
 
     @aws-ipi
     Examples:
-      | iaas_type | machineset_name        | value                   |
-      | aws       | machineset-clone-41175 | "spotMarketOptions": {} |
+      | iaas_type | machineset_name           | value                   |
+      | aws       | <%= cb.infraName %>-41175 | "spotMarketOptions": {} |
 
     @gcp-ipi
     @flaky
     Examples:
-      | iaas_type | machineset_name        | value                   |
-      | gcp       | machineset-clone-41803 | "preemptible": true     |
+      | iaas_type | machineset_name           | value                   |
+      | gcp       | <%= cb.infraName %>-41803 | "preemptible": true     |
 
   # @author zhsun@redhat.com
   @upgrade-check
@@ -218,6 +220,7 @@ Feature: Machine-api components upgrade tests
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project
     And admin ensures "<machineset_name>" machine_set_machine_openshift_io is deleted after scenario
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
 
     Given "machine-api-termination-handler" daemonset becomes ready in the "openshift-machine-api" project
     And 1 pod becomes ready with labels:
@@ -236,14 +239,14 @@ Feature: Machine-api components upgrade tests
 
     @aws-ipi
     Examples:
-      | case_id                         | iaas_type | machineset_name        | value                   |
-      | OCP-41175:ClusterInfrastructure | aws       | machineset-clone-41175 | "spotMarketOptions": {} | # @case_id OCP-41175
+      | case_id                         | iaas_type | machineset_name           | value                   |
+      | OCP-41175:ClusterInfrastructure | aws       | <%= cb.infraName %>-41175 | "spotMarketOptions": {} | # @case_id OCP-41175
 
     @gcp-ipi
     @flaky
     Examples:
-      | case_id                         | iaas_type | machineset_name        | value               |
-      | OCP-41803:ClusterInfrastructure | gcp       | machineset-clone-41803 | "preemptible": true | # @case_id OCP-41803
+      | case_id                         | iaas_type | machineset_name           | value               |
+      | OCP-41803:ClusterInfrastructure | gcp       | <%= cb.infraName %>-41803 | "preemptible": true | # @case_id OCP-41803
 
   @upgrade-prepare
   @destructive
@@ -285,7 +288,8 @@ Feature: Machine-api components upgrade tests
     And I use the "openshift-machine-api" project
     And admin ensures machine number is restored after scenario
 
-    Given I clone a machineset and name it "machineset-clone-30783"
+    And evaluation of `infrastructure("cluster").infra_name` is stored in the :infraName clipboard
+    Given I clone a machineset and name it "<%= cb.infraName %>-30783"
 
     # Delete clusterautoscaler after scenario
     Given admin ensures "default" clusterautoscaler is deleted after scenario


### PR DESCRIPTION
As IBMCloud/gcp will not delete the resources that prefix is not infrastructureName, so if the cases were interrupted due to some reason like timeout, the resources will not be removed automatically when destroy cluster. This will update all machineset name prefix with infrastructureName. cc @MayXuQQ
@huali9 @miyadav @shellyyang1989 PTAL

 OCP-25436 https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/964372/console 