### PR TITLE
OCPQE-18518: Fix OCP-22018 flake on external

### DIFF
--- a/features/step_definitions/storage_class.rb
+++ b/features/step_definitions/storage_class.rb
@@ -294,3 +294,14 @@ When /^admin creates new in-tree storageclass with:$/ do |table|
     raise "failed to clone StorageClass from: #{src_sc}"
   end  
 end
+
+Given(/^default storage class exists$/) do
+  ensure_admin_tagged
+  _sc = BushSlicer::StorageClass.get_matching(user: user) { |sc, sc_hash| sc.default? }.first
+  if _sc
+    logger.info "Default storage class: #{_sc.name} exists"
+  else
+    logger.warn "No default storageclass exist, skip for this scenario"
+    skip_this_scenario
+  end
+end


### PR DESCRIPTION
### Add check default sc exist util

[Flake record](https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/1198/485118?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26launchesLimit%3D1000%26isLatest%3Dfalse%26filter.in.status%3DFAILED%252CINTERRUPTED%26page.page%3D1%26filter.in.issueType%3Dti001%252Cti_1hrghcxlbgshc%252Cti_s4scyws6guht%252Cti_sok676b1k8j5%252Cti_r1ifkmkw19o1%26filter.cnt.name%3D%253AStorage) 

```console
Message: failed OCP-22018:Storage Admin can change default storage class to non-default
Type: failed

Text:

    Scenario: OCP-22018:Storage Admin can change default storage class to non-default

And the output should contain 1 times:

Message:



$ omc get sc
No resources storageclasses.storage.k8s.io found in default namespace. 
```

**Root cause**
- Most external platform profiles does not have storageclass in the test cluster

**Fix solution**
- Add check default sc exist util for skip no default sc exist test clusters

**Test record**
`Runner-v3-smoke/7520/console`
```console
1 scenario (1 skipped)
5 steps (5 skipped)
0m10.993s
```