### PR TITLE
revert change in #3593

### DIFF
--- a/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.13/monitoring_alerts.xyaml
@@ -132,7 +132,7 @@ click_alert_link_with_text:
 click_actions_button:
   element:
     selector:
-      xpath: //button[contains(@class,'dropdown__toggle')]
+      xpath: //button[@class='pf-c-dropdown__toggle']
     op: click
 expire_alert_from_detail:
   action: click_first_action_icon

--- a/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.14/monitoring_alerts.xyaml
@@ -132,7 +132,7 @@ click_alert_link_with_text:
 click_actions_button:
   element:
     selector:
-      xpath: //button[contains(@class,'dropdown__toggle')]
+      xpath: //button[@class='pf-c-dropdown__toggle']
     op: click
 expire_alert_from_detail:
   action: click_first_action_icon

--- a/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.15/monitoring_alerts.xyaml
@@ -138,7 +138,7 @@ click_alert_link_with_text:
 click_actions_button:
   element:
     selector:
-      xpath: //button[contains(@class,'dropdown__toggle')]
+      xpath: //button[@class='pf-c-dropdown__toggle']
     op: click
 expire_alert_from_detail:
   action: click_first_action_icon

--- a/lib/rules/web/admin_console/4.16/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.16/monitoring_alerts.xyaml
@@ -138,7 +138,7 @@ click_alert_link_with_text:
 click_actions_button:
   element:
     selector:
-      xpath: //button[contains(@class,'dropdown__toggle')]
+      xpath: //button[@class='pf-c-dropdown__toggle']
     op: click
 expire_alert_from_detail:
   action: click_first_action_icon

--- a/lib/rules/web/admin_console/4.17/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.17/monitoring_alerts.xyaml
@@ -138,7 +138,7 @@ click_alert_link_with_text:
 click_actions_button:
   element:
     selector:
-      xpath: //button[contains(@class,'dropdown__toggle')]
+      xpath: //button[@class='pf-c-dropdown__toggle']
     op: click
 expire_alert_from_detail:
   action: click_first_action_icon


### PR DESCRIPTION
see from [OCPQE-22458](https://issues.redhat.com/browse/OCPQE-22458)
change in https://github.com/openshift/verification-tests/pull/3593 caused OCP-32858,OCP-21144,OCP-32857 failed. revert the xpath for `click_actions_button:` from
`xpath: //button[contains(@class,'dropdown__toggle')]`
to
`xpath: //button[@class='pf-c-dropdown__toggle']`
would make the cases passed. details please see from [OCPQE-22458](https://issues.redhat.com/browse/OCPQE-22458)

[4.13 runner job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/965186/console) passed

[4.14 runner job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/965187/console) passed

[4.15 runner job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/965188/console) passed

[4.16 runner job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/965189/console) passed
