### PR TITLE
OCPQE-22529: Remove reportportal-agent-ruby from Jenkins agents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ gem 'watir'
 gem 'headless'
 gem 'selenium-webdriver', '4.8.0'
 gem 'protobuf'
-gem 'reportportal'
 
 ## Docs
 # beware https://github.com/pry/pry/issues/1465

--- a/tools/jenkins/slaves/Dockerfile.rhel8
+++ b/tools/jenkins/slaves/Dockerfile.rhel8
@@ -43,11 +43,6 @@ RUN set -x && \
     chmod -R g=u "$HOME" && \
     "$HOME/verification-tests/tools/install_os_deps.sh" && \
     "$HOME/verification-tests/tools/hack_bundle.rb" && \
-    git clone --depth 1 --single-branch https://github.com/openshift-qe/reportportal-agent-ruby.git && \
-    cd reportportal-agent-ruby && \
-    gem build reportportal && \
-    gem install reportportal-*.gem && \
-    cd .. && rm -rf reportportal-agent-ruby && \
     rpm -qa && \
     dnf clean all -y && \
     rm -rf $HOME/verification-tests /var/cache/yum /var/tmp/* /tmp/*


### PR DESCRIPTION
This is part of the effort to migrate our CI tool chains off ocp-c1 cluster.

I'm trying to build the Jenkins agent images on the gpc cluster, and got
```
+ gem install reportportal-1.0.gem
Building native extensions. This could take a while...
ERROR:  Error installing reportportal-1.0.gem:
        ffi requires RubyGems version >= 3.3.22. The current RubyGems version is 3.1.6. Try 'gem update --system' to update RubyGems itself.
```
Following the advice, and run `gem update --system`,
```
bash-4.4# gem update --system
Updating rubygems-update
ERROR:  Error installing rubygems-update:
        rubygems-update requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
```
I think we don't have the plan to upgrade ruby at the moment.

As we haven't using reportportal-agent for a long time, I think we can remove it directly to simplify the migration process.