### PR TITLE
udpate method name to exist, instead of the deprecated exists

### DIFF
--- a/features/step_definitions/web.rb
+++ b/features/step_definitions/web.rb
@@ -70,7 +70,7 @@ Given /^I have a browser with:$/ do |table|
     File.expand_path('../browser_opts.yml', init_params[:rules].first)
   ]
   browser_opts.any? do |file|
-    if File.exists? file
+    if File.exist? file
       init_params.merge! YAML.load_file(file)
     end
   end

--- a/lib/admin_credentials.rb
+++ b/lib/admin_credentials.rb
@@ -84,7 +84,7 @@ module BushSlicer
       # export OPENSHIFT_ENV_OCP4_ADMIN_CREDS_SPEC=file:///~/.kube/config
       if opts[:spec].start_with? 'file:///'
         path = File.expand_path(opts[:spec].split("file://")[1])
-        raise "kubeconfig does not exists" unless File.exists? File.expand_path(path)
+        raise "kubeconfig does not exists" unless File.exist? File.expand_path(path)
         config = File.open(path).read
       else
         url = opts[:spec]

--- a/test/lib/launchers/o_c_m_cluster_test.rb
+++ b/test/lib/launchers/o_c_m_cluster_test.rb
@@ -55,7 +55,7 @@ class MyTest < Test::Unit::TestCase
     assert_equal('{"name":"myosd4","managed":true,"multi_az":true,"ccs":{"enabled":false}}', json)
   end
 
-  def test_generating_cluster_data_with_multi_az_envvars    
+  def test_generating_cluster_data_with_multi_az_envvars
     ENV['OCM_MULTI_AZ'] = "true"
     options = { :token => "abc" }
     ocm = BushSlicer::OCMCluster.new(options)
@@ -135,7 +135,7 @@ class MyTest < Test::Unit::TestCase
     options = { :token => "abc" }
     ocm = BushSlicer::OCMCluster.new(options)
     ocm_cli = ocm.download_ocm_cli
-    assert(File.exists?(ocm_cli), "File '#{ocm_cli}' was not downloaded")
+    assert(File.exist?(ocm_cli), "File '#{ocm_cli}' was not downloaded")
     output = ocm.exec("version")
     assert_equal("0.1.46", output)
   end


### PR DESCRIPTION
Since ruby 2.2.0 File.exists? is deprecated use instead File.exist?  Although older ruby has been lenient with this deprecation, for ruby > 3.2 this will be flagged as an error.  @liangxia PTAL.

https://ruby-doc.org/core-2.2.0/File.html#exist-3F-method