### PR TITLE
Fix warning: unable to access '/opt/app-root/src/.config/git/config'

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -3,6 +3,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-nodejs-openshift-4.12
 LABEL vendor="Red Hat inc."
 LABEL maintainer="OCP QE Team"
 USER root
+WORKDIR /
 
 ADD . /verification-tests/
 ARG YQ_VERSION="v4.30.8"
@@ -42,8 +43,8 @@ RUN set -x && \
     CFT_VERSION='122.0.6261.57' && \
     npx @puppeteer/browsers install chrome@${CFT_VERSION} && \
     npx @puppeteer/browsers install chromedriver@${CFT_VERSION} && \
-    find /opt/app-root/src/chrome -type f -name chrome -exec ln -s {} /usr/local/bin/chrome \; && \
-    find /opt/app-root/src/chromedriver -type f -name chromedriver -exec ln {} /usr/local/bin/chromedriver \; && \
+    find /chrome -type f -name chrome -exec ln -s {} /usr/local/bin/chrome \; && \
+    find /chromedriver -type f -name chromedriver -exec ln {} /usr/local/bin/chromedriver \; && \
     chmod +x /usr/local/bin/chromedriver && \
     GECKODRIVER_SPEC="https://api.github.com/repos/mozilla/geckodriver/releases/latest" && \
     GECKODRIVER_RE='^.*"browser_download_url": ?"(http[^"]*linux64.tar.gz)".*$' && \


### PR DESCRIPTION
Log [link](https://gcsweb-qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/qe-private-deck/pr-logs/pull/openshift_release/53079/rehearse-53079-periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-azure-ipi-marketplace-mini-perm-f360/1800737927513247744/artifacts/azure-ipi-marketplace-mini-perm-f360/cucushift-e2e/build-log.txt), 
```
+ cucumber --tags '@4.16 and @amd64 and @azure-ipi and @network-ovnkubernetes and not @fips and @level0 and not @customer
        and not @flaky
        and not @inactive
        and not @prod-only
        and not @qeci
        and not @security
        and not @stage-only
        and not @upgrade-check
        and not @upgrade-prepare
 and not @destructive and not @long-duration and ((@console and @smoke) or @serial)' -p junit
warning: unable to access '/opt/app-root/src/.config/git/config': Permission denied
warning: unable to access '/opt/app-root/src/.config/git/config': Permission denied
warning: unable to access '/opt/app-root/src/.config/git/config': Permission denied
warning: unable to access '/opt/app-root/src/.config/git/config': Permission denied
Using the junit and dir_embedder profiles...
Feature: UI-about cluster setting page
```