### PR TITLE
OCPQE-22684: fix permission issue of loading .config/containers/registries.conf.d

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -65,3 +65,8 @@ RUN git clone https://github.com/openshift/openshift-ansible.git /usr/share/ansi
 RUN set -x && \
     mkdir /.ansible /.local && \
     chmod -R 777 /.ansible /.local
+
+# Fix permission issues of loading .config/containers/registries.conf.d when runnig oc/skopeo tools
+RUN set -x && \
+    test -d /opt/app-root/src/.config && \
+    chmod -R 777 /opt/app-root/src/.config


### PR DESCRIPTION
Since https://github.com/openshift/verification-tests/pull/3613, several cucushift-upgrade prow ci steps hit such issues:
```
Extracting oc
error: reading registries.conf.d: lstat /opt/app-root/src/.config/containers/registries.conf.d: permission denied
```
Manually reproduce it locally.
```
$ podman run --rm -ti --entrypoint /bin/bash --user 1001:1001 registry.ci.openshift.org/ci/verification-tests:latest
bash-4.4$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.16.0-rc.3-x86_64
error: reading registries.conf.d: lstat /opt/app-root/src/.config/containers/registries.conf.d: permission denied
bash-4.4$ ls .config/
ls: cannot open directory '.config/': Permission denied
bash-4.4$ ls -ld .config
drwx------. 3 root root 25 Jun 11 09:34 .config
```
If run the container using root user, will not hit such issue, but in prow ci build farm, the containers using the image is not running as root user.

Per https://github.com/containers/image/blob/main/docs/containers-registries.conf.d.5.md#configuration-precedence, once `/etc/containers/registries.conf` exists, the conf files in `$HOME/.config/containers/registries.conf.d` are being loaded, so the permission issue happened.

`/etc/containers/registries.conf` is installed by `containers-common` package as a dependency of skopeo which is installed when running `tools/install_os_deps.sh`.