### PR TITLE
print out actual master version

### DIFF
--- a/features/step_definitions/env.rb
+++ b/features/step_definitions/env.rb
@@ -60,7 +60,8 @@ end
 # Example: Given the master version >= "3.4"
 Given /^the master version ([<>=]=?) #{QUOTED}$/ do |op, ver|
   unless env.version_cmp(ver, user: user).send(op.to_sym, 0)
-    raise "master version not #{op} #{ver}"
+    full_version, major, minor = env.get_version(user: user)
+    raise "master version '#{full_version}' not #{op} '#{ver}'"
   end
 end
 


### PR DESCRIPTION
print out actual master version to help with debugging.

current error message is `master version not >= 4.5`
new error message is something like `master version '4.16.0-rc.6' not >= '4.26'`