### PR TITLE
[OCPQE-22132] Skip auth missing ImageRegistry baselinecap test failure

### DIFF
--- a/features/cli/serviceaccount.feature
+++ b/features/cli/serviceaccount.feature
@@ -101,6 +101,7 @@ Feature: ServiceAccount and Policy Managerment
   @hypershift-hosted
   @critical
   Scenario: OCP-11249:Authentication User can get the serviceaccount token via client
+    Given the "ImageRegistry" capability is enabled
     Given I have a project
     When I run the :create_token client command with:
       | serviceaccount | default |


### PR DESCRIPTION
@xingxingxia Please help review this PR to skip auth cap failure due to missing ImageRegistry baseline capabilities

Below is the execution result:
With enabled baselinecap ImageRegistry: https://privatebin.corp.redhat.com/?d9be5ce58aa8e22a#Q2qxSXkv2qp7XXpz28QBnDVTJrrvL5m5zg64KEZb9t4 

Without enabled baselinecap ImageRegistry: https://privatebin.corp.redhat.com/?44a4ba7072b0638f#BY2ELCtn3CZem6rFAn7xZrB9LUBmCr4qaYiXnoTvuuxP