### PR TITLE
update multicast

### DIFF
--- a/features/networking/multicast.feature
+++ b/features/networking/multicast.feature
@@ -130,9 +130,6 @@ Feature: testing multicast scenarios
     And evaluation of `pod(0).name` is stored in the :pod1 clipboard
     And evaluation of `pod(1).ip` is stored in the :pod2ip clipboard
     And evaluation of `pod(1).name` is stored in the :pod2 clipboard
-
-    # Enable multicast in proj1
-    Given I enable multicast for the "<%= cb.proj1 %>" namespace
     
     # run omping as background on the pods
     When I run the :exec background client command with:
@@ -173,7 +170,7 @@ Feature: testing multicast scenarios
     And the output should match:
       | <%= cb.pod1ip %>.*joined \(S,G\) = \(\*, (232.43.211.234\|ff3e::4321:1234)\), pinging |
       | <%= cb.pod1ip %> : multicast, xmt/rcv/%loss |
-    And the output should not match:
+    And the output should match:
       | <%= cb.pod1ip %> : multicast, xmt/rcv/%loss = 5/0/100% |
     """
 

--- a/features/upgrade/sdn/multicast-upgrade.feature
+++ b/features/upgrade/sdn/multicast-upgrade.feature
@@ -88,8 +88,8 @@
       | <%= cb.pod1ip %>.*joined \(S,G\) = \(\*, (232.43.211.234\|ff3e::4321:1234)\), pinging |
       | <%= cb.pod2ip %>.*joined \(S,G\) = \(\*, (232.43.211.234\|ff3e::4321:1234)\), pinging |
     And the output should not match:
-      | <%= cb.pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
-      | <%= cb.pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
+      | <%= cb.pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/100% |
+      | <%= cb.pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/100% |
     """
 
   # @author weliang@redhat.com
@@ -170,6 +170,6 @@
       | <%= cb.pod1ip %>.*joined \(S,G\) = \(\*, (232.43.211.234\|ff3e::4321:1234)\), pinging |
       | <%= cb.pod2ip %>.*joined \(S,G\) = \(\*, (232.43.211.234\|ff3e::4321:1234)\), pinging |
     And the output should not match:
-      | <%= cb.pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
-      | <%= cb.pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/0% |
+      | <%= cb.pod1ip %>.*multicast, xmt/rcv/%loss = 5/0/100% |
+      | <%= cb.pod2ip %>.*multicast, xmt/rcv/%loss = 5/0/100% |
     """


### PR DESCRIPTION
Update OCP-12977 to make sure the steps testing 'SDN multicast is disabled by default if not annotate the namespace', or else we will miss this scenario. 
Update multicast upgrade case as current expectation is incorrect.

Test log:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/7608/console
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/7609/console
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/Runner-v3-smoke/7610/console

@openshift/team-sdn-qe  PTAL, thanks!


