### PR TITLE
OCPQE-22529: Pin down epel repository location

### DIFF
--- a/tools/jenkins/slaves/Dockerfile.gpc.rhel8
+++ b/tools/jenkins/slaves/Dockerfile.gpc.rhel8
@@ -31,6 +31,8 @@ RUN set -x && \
     curl -sSL $GITHUB_API_CURL_OPTS "$GECKODRIVER_SPEC" | sed -En "s#$GECKODRIVER_RE#\1#p" | xargs -d '\n' curl -sSL | bsdtar -xvf - -C /usr/local/bin && \
     chmod +x /usr/local/bin/chromedriver /usr/local/bin/geckodriver && \
     dnf -y install --setopt=tsflags=nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    sed --in-place=.orig --regexp-extended 's%#baseurl=https://download.example/pub/epel/%baseurl=https://mirrors.edge.kernel.org/fedora-epel/%g' /etc/yum.repos.d/epel*.repo && \
+    sed --in-place --regexp-extended 's%^metalink=%#metalink=%g' /etc/yum.repos.d/epel*.repo && \
     dnf config-manager --disable epel && \
     dnf -y --enablerepo=epel install git-crypt && \
     dnf -y module list ruby && \


### PR DESCRIPTION
Even though Fedora EPEL repository's configuration points to an HTTPS location, the default location of `mirrors.fedoraproject.org` is a redirect service that redirects to a close-by but non-deterministic mirror. It's hard to define the ingress/egress rules for a non-deterministic url. Since most of the mirrors urls are Denied by default, it loops though those mirrors which take a long time (more than an hour) to get repo/packages info.
This PR aims to help in pinning down the repository location to a known FQDN `mirrors.edge.kernel.org`, so it can be set in the allowlists, without affecting the performance of downloads.

I've tested this, with another change in the gitlab  (merge_requests/2244 in the jcasc repo), the time cost in command `dnf install xxx` from epel decreased from hours to seconds.