### PR TITLE
Ocpqe 24183

### DIFF
--- a/lib/rules/web/admin_console/4.17/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.17/monitoring_metrics.xyaml
@@ -148,7 +148,7 @@ click_reset_zoom_button:
 check_zoom_value:
   element:
     selector:
-      xpath: //div[contains(@class,'query-browser__controls' )]//input[@value='<zoom_value>']
+      xpath: //div[contains(@class,'query-browser__wrapper' )]//input[@value='<zoom_value>']
 
 check_metric_query_result_not_exit:
   params:

--- a/lib/rules/web/admin_console/4.17/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.17/monitoring_metrics.xyaml
@@ -133,12 +133,12 @@ choose_zoom_value:
 click_chart_zoom_dropdown:
   element:
     selector:
-      xpath: //div[contains(@class,'query-browser__controls' )]//button[@id]
+      xpath: //div[contains(@class,'query-browser__wrapper' )]//button[@id]
     op: click
 click_zoom_value_button:
   element:
     selector:
-      xpath: //div[contains(@class,'query-browser__controls' )]//a[text()='<zoom_value>']
+      xpath: //div[contains(@class,'query-browser__wrapper' )]//a[text()='<zoom_value>']
     op: click
 click_reset_zoom_button:
   element:


### PR DESCRIPTION
see https://issues.redhat.com/browse/OCPQE-24183, due to 4.17 UI change, update xpath for `check_zoom_value` action and the xpath should be update for `choose_zoom_value` action and actions it's invoked
```
choose_zoom_value:
  action: click_chart_zoom_dropdown
  action: click_zoom_value_button 
```

4.17.0-0.nightly-2024-08-13-031847 [runner job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/1014166/console) passed