### PR TITLE
[storage] [hotfix] [OCP-18737,OCP-14665,OCP-14673]

### DIFF
--- a/features/step_definitions/node.rb
+++ b/features/step_definitions/node.rb
@@ -683,3 +683,8 @@ Given /^I set all worker nodes status to unschedulable$/ do
    admin.cli_exec(:oadm_cordon_node, opts)
   end
 end
+
+Given /^I store the schedulable workers without taints in the#{OPT_SYM} clipboard$/ do |cb_name|
+  step %Q{I store the schedulable workers in the :#{cb_name} clipboard}
+  cb.nodes = cb.nodes.reject{|w| w.taints.first}
+end 

--- a/features/step_definitions/node.rb
+++ b/features/step_definitions/node.rb
@@ -685,6 +685,7 @@ Given /^I set all worker nodes status to unschedulable$/ do
 end
 
 Given /^I store the schedulable workers without taints in the#{OPT_SYM} clipboard$/ do |cb_name|
+  cb_name ||= :nodes
   step %Q{I store the schedulable workers in the :#{cb_name} clipboard}
   cb.nodes = cb.nodes.reject{|w| w.taints.first}
 end 

--- a/features/step_definitions/project.rb
+++ b/features/step_definitions/project.rb
@@ -193,7 +193,7 @@ Given /^admin creates a project with a random schedulable node selector$/ do
     | project_name  | #{project_name}       |
     | node_selector | #{project_name}=label |
     })
-  step %Q/I store the ready and schedulable workers in the :nodes clipboard/
+  step %Q/I store the schedulable workers without taints in the :nodes clipboard/
   step %Q/label "<%= project.name %>=label" is added to the "<%= node.name %>" node/
   step %Q/the appropriate pod security labels are applied to the namespace/
   step %Q/I switch to cluster admin pseudo user/


### PR DESCRIPTION
Hi Team, 

PR fix for: https://issues.redhat.com/browse/OCPQE-25056

2 Solutions on TC: OCP-18737, 
1. Add toleration to pods/deployment
2. Deploy the pods on non tainted nodes: Implemented this one currently

Jenkins Logs:
oc get nodes | grep "worker"
NAME                          STATUS   ROLES                  AGE     VERSION
ip-10-0-128-33.ec2.internal   Ready    edge,worker,wscan      5h49m   v1.30.3
ip-10-0-52-209.ec2.internal   Ready    worker,wscan           6h6m    v1.30.3
ip-10-0-79-213.ec2.internal   Ready    worker,wscan           6h7m    v1.30.3
ip-10-0-95-138.ec2.internal   Ready    worker,wscan           6h6m    v1.30.3
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/1022559/console
Pod got deployed on node: ip-10-0-52-209.ec2.internal

oc get nodes | grep "worker"
ip-10-0-128-33.ec2.internal   Ready                      edge,worker,wscan      5h50m   v1.30.3
ip-10-0-52-209.ec2.internal   Ready,SchedulingDisabled   worker,wscan           6h7m    v1.30.3
ip-10-0-79-213.ec2.internal   Ready,SchedulingDisabled   worker,wscan           6h8m    v1.30.3
ip-10-0-95-138.ec2.internal   Ready                      worker,wscan           6h7m    v1.30.3
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/1022560/
Pod got deployed on node:: ip-10-0-95-138.ec2.internal

/assign @duanwei33 @chao007 @Phaow @radeore 