### PR TITLE
OCPQE-25263: Update iscsi image to keep consistent with disconnect mirror

### DIFF
--- a/testdata/storage/iscsi/iscsi-target.json
+++ b/testdata/storage/iscsi/iscsi-target.json
@@ -27,7 +27,7 @@
         "containers": [
             {
                 "name": "iscsi-target",
-                "image": "quay.io/openshifttest/iscsi@sha256:6a1be064e9374cbd6b075f396343307b10a108c72eea34206942355343385141",
+                "image": "quay.io/openshifttest/iscsi@sha256:d941ccc221e05d765dfa1088200746f816075e525096aa8aef197b64c9ce497b",
                 "securityContext": {
                     "privileged": true
                 },


### PR DESCRIPTION
### [OCPQE-25263](https://issues.redhat.com//browse/OCPQE-25263):   Update iscsi image to keep consistent with disconnect mirror
- The failures are caused by the iscsi image tag is not the latest is not consistent with disconnect env mirror list.
[failure record on aws-sc2s-ipi-disc-priv-fips-f2](https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/1572/613635/83698756/83699285/log?item1Params=filter.in.status%3DFAILED%26page.page%3D1)
```console
Message: failed OCP-19110:Storage iSCSI block volumeMode support
Type: failed

Text:

    Scenario: OCP-19110:Storage iSCSI block volumeMode support

Given I have a iSCSI setup in the environment

Message:

    iSCSI pod did not become ready (RuntimeError)
./features/step_definitions/helper_services.rb:538:in `/^I have a iSCSI setup in the environment$/'
features/tierN/storage/iscsi.feature:92:in `I have a iSCSI setup in the environment'
  
```

**Fix solution**
- Update iscsi image to keep consistent with disconnect mirror.
