### PR TITLE
Marking few cases inactive and fixing one for networktype

### DIFF
--- a/features/networking/operator.feature
+++ b/features/networking/operator.feature
@@ -203,7 +203,7 @@ Feature: Operator related networking scenarios
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @proxy @noproxy @disconnected @connected
-  @network-ovnkubernetes @network-openshiftsdn
+  @network-openshiftsdn
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   @hypershift-hosted
   Scenario: OCP-24918:SDN Service should not get unidle when config flag is disabled under CNO
@@ -327,6 +327,7 @@ Feature: Operator related networking scenarios
   @flaky
   @admin
   @destructive
+  @inactive
   @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
@@ -412,6 +413,7 @@ Feature: Operator related networking scenarios
   # @case_id OCP-27333
   @admin
   @destructive
+  @inactive
   @network-ovnkubernetes
   @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi


### PR DESCRIPTION
Couple of cases were pending to be marked inactive as per dev comments on that feedback epic. 
Also one case is strictly operating for sdn so removing @network-ovnkubernetes tag from it

@openshift/team-sdn-qe PTAL