### PR TITLE
removing ocp-11619 from 4.12+ branches

### DIFF
--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -140,7 +140,7 @@ Feature: Testing haproxy router
 
   # @author bmeng@redhat.com
   # @case_id OCP-11619
-  @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity


### PR DESCRIPTION
OCP-11619 is shifted to ginkgo framework(https://github.com/openshift/openshift-tests-private/pull/19337), removed executing this case from 4.12+

@lihongan @ShudiLi @rhamini3 please help review the update, thanks.