### PR TITLE
Non relevant case for Hosted cluster

### DIFF
--- a/features/networking/service.feature
+++ b/features/networking/service.feature
@@ -798,7 +798,6 @@ Feature: Service related networking scenarios
   @proxy @noproxy @connected
   @network-ovnkubernetes @FdpOvnOvs
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  @hypershift-hosted
   Scenario: OCP-47087:SDN Other node cannot be accessed for nodePort when externalTrafficPolicy is Local
     Given the env is using "OVNKubernetes" networkType
     Given I store the masters in the :masters clipboard


### PR DESCRIPTION
A non-relevant usecase for hosted cluster scenario due to masters absense. The funcationality however is being checked in various cases in [private repro](https://github.com/openshift/openshift-tests-private/blob/19ba5d028e4ecfb5855927582c7c64f8ef2d34f9/test/extended/networking/services.go) though 

@openshift/team-sdn-qe 