### PR TITLE
OCPQE-26258: Fix: iscsi targetPortal format for ipv6

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -539,6 +539,12 @@ Given /^I have a iSCSI setup in the environment$/ do
   iscsi_ip = cb.iscsi_ip = _service.ip(user: admin)
   @result = _pod.exec("targetcli", "/iscsi/iqn.2016-04.test.com:storage.target00/tpg1/portals", "create", iscsi_ip, as: admin)
   raise "could not create portal to iSCSI service" unless @result[:success] unless @result[:stderr].include?("This NetworkPortal already exists in configFS")
+    
+  # The cb.iscsi_ip will be used for the static pv definition with port for ipv6 address with port needs add '[]' to meet the ipv6 standard
+  if cb.iscsi_ip.include?(':')
+    cb.iscsi_ip = "[#{cb.iscsi_ip}]"
+  end
+  
 end
 
 # Using after step: I have a iSCSI setup in the environment

--- a/features/step_definitions/pv.rb
+++ b/features/step_definitions/pv.rb
@@ -161,7 +161,12 @@ When /^admin creates a PV from "([^"]*)" where:$/ do |location, table|
   end
 
   table.raw.each do |path, value|
-    eval "pv_hash#{path} = YAML.load value" unless path == ''
+    # Expected targetPortal IPv6 address e.g. '[fd03::3066]:3260' value load as string instead YAML.load as a list
+    if value.include?(']:')
+      eval "pv_hash#{path} = value" unless path == ''
+    else
+      eval "pv_hash#{path} = YAML.load value" unless path == ''
+    end
     # e.g. pv_hash["spec"]["nfs"]["server"] = 10.10.10.10
   end
 


### PR DESCRIPTION
### [OCPQE-26258](https://issues.redhat.com//browse/OCPQE-26258):  Fix: iscsi targetPortal format for ipv6
**Root cause**
- ipv6 address with port needs add '[]' to meet the ipv6 standard.

[failure record](https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/1572/639299/90583247/90583460/log?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26launchesLimit%3D1000%26isLatest%3Dfalse%26filter.in.status%3DFAILED%252CINTERRUPTED%26page.page%3D1%26filter.in.issueType%3Dti001%252Cti_1hrghcxlbgshc%252Cti_s4scyws6guht%252Cti_sok676b1k8j5%252Cti_r1ifkmkw19o1%26filter.cnt.name%3D%253AStorage)
```console
 [36m---[0m
      [36mapiVersion: v1[0m
      [36mkind: PersistentVolume[0m
      [36mmetadata:[0m
      [36m  name: pv-rvp0m[0m
      [36mspec:[0m
      [36m  capacity:[0m
      [36m    storage: 5Gi[0m
      [36m  accessModes:[0m
      [36m  - ReadWriteOnce[0m
      [36m  iscsi:[0m
      [36m    targetPortal: fd03::546c:3260[0m
      [36m    iqn: iqn.2016-04.test.com:storage.target00[0m
      [36m    lun: 0[0m
      [36m    iface: default[0m
      [36m    fsType: ext4[0m
      [36m    readOnly: false[0m
      [36m    initiatorName: iqn.2016-04.test.com:test.img[0m
      [36m  persistentVolumeReclaimPolicy: Retain[0m
      [36m  volumeMode: Block[0m[0m 

...
Message: failed OCP-19110:Storage iSCSI block volumeMode support
Type: failed

Text:

    Scenario: OCP-19110:Storage iSCSI block volumeMode support

And the pod named "mypod" becomes ready

Message:

    mypod pod did not become ready (RuntimeError)
./features/step_definitions/pod.rb:24:in `/^the pod(?: named "(.+)")? becomes ready$/'
features/tierN/storage/iscsi.feature:115:in `the pod named "mypod" becomes ready'

```

**Fix solution**
- Compatible targetPortal format for ipv6 single stack.

**Test record on ipv6 single stack cluster**
- Runner-v3-smoke/7777/console
```console
...
    [09:07:58] INFO> Creating PV:
      ---
      apiVersion: v1
      kind: PersistentVolume
      metadata:
        name: pv-couo4
      spec:
        capacity:
          storage: 5Gi
        accessModes:
        - ReadWriteOnce
        iscsi:
          targetPortal: "[fd03::3066]:3260"
          iqn: iqn.2016-04.test.com:storage.target00
          lun: 0
          iface: default
          fsType: ext4
          readOnly: false
          initiatorName: iqn.2016-04.test.com:test.img
        persistentVolumeReclaimPolicy: Retain
        volumeMode: Block
...

1 scenario (1 passed)
14 steps (14 passed)
0m50.065s


```

