### PR TITLE
remove tags for releases converted to GO

### DIFF
--- a/features/routing/timeout.feature
+++ b/features/routing/timeout.feature
@@ -2,7 +2,7 @@ Feature: Testing timeout route
 
   # @author yadu@redhat.com
   # @case_id OCP-11635
-  @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity


### PR DESCRIPTION
Converted OCP-11635 to GO for releases 4.12-4.18
https://issues.redhat.com/browse/OCPQE-20374 