### PR TITLE
update filters

### DIFF
--- a/lib/rules/web/admin_console/4.18/filters.xyaml
+++ b/lib/rules/web/admin_console/4.18/filters.xyaml
@@ -9,12 +9,12 @@ set_filter_strings:
 click_filter_dropdown:
   elements:
   - selector:
-      xpath: //button[contains(@aria-label,'Options menu')]
+      xpath: //div[@data-test-id="filter-dropdown-toggle"]//button[contains(@class,"menu-toggle")]
     op: click
 select_filter:
   elements:
   - selector:
-      xpath: //input[contains(@id,'<filter>')]
+      xpath: //label[@id="<filter>"]//input
     op: click
 clear_all_filters:
   params:


### PR DESCRIPTION
unable to have a complete pass log due to https://issues.redhat.com/browse/OCPBUGS-43873 
but it passed locally with my manual intervention
```
      [09:03:07] INFO> HTTP DELETE https://api.qe-uidaily-1028.qe.azure.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthaccesstokens/sha256~f7PukU5D6bhYepXnA6uWTXuzYpGeUdedn6DUdZVv4JM
      [09:03:08] INFO> HTTP DELETE took 1.057 sec: 200 OK | application/json 797 bytes
      [09:03:08] TRACE> HTTP response:
      {"kind":"OAuthAccessToken","apiVersion":"oauth.openshift.io/v1","metadata":{"name":"sha256~f7PukU5D6bhYepXnA6uWTXuzYpGeUdedn6DUdZVv4JM","uid":"36601841-99bd-4dcd-86be-f6209294445b","resourceVersion":"210195","creationTimestamp":"2024-10-28T08:58:56Z","managedFields":[{"manager":"oauth-server","operation":"Update","apiVersion":"oauth.openshift.io/v1","time":"2024-10-28T08:58:56Z","fieldsType":"FieldsV1","fieldsV1":{"f:clientName":{},"f:expiresIn":{},"f:redirectURI":{},"f:scopes":{},"f:userName":{},"f:userUID":{}}}]},"clientName":"openshift-challenging-client","expiresIn":86400,"scopes":["user:full"],"redirectURI":"https://oauth-openshift.apps.qe-uidaily-1028.qe.azure.devcluster.openshift.com/oauth/token/implicit","userName":"testuser-27","userUID":"843ae417-b670-411d-8917-e42157bb8125"}
      [09:03:08] INFO> Shell Commands: rm -r -f -- /Users/yapei/workdir/yapei-mac-yapeix
      
      [09:03:09] INFO> Exit Status: 0
      [09:03:10] INFO> === End After Scenario: OCP-19608:UserInterface Check route list and detail page ===
# @author yapei@redhat.com
# @case_id OCP-33744
# check the oauthaccesstoken by web console
# check the download route page

1 scenario (1 passed)
54 steps (54 passed)
4m20.326s
[09:03:11] INFO> === At Exit ===
```