### PR TITLE
Fix node's prepare scenario not in sync with test scenario

### DIFF
--- a/features/upgrade/node/hpa/upgrade.feature
+++ b/features/upgrade/node/hpa/upgrade.feature
@@ -10,7 +10,7 @@ Feature: basic verification for upgrade testing
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @heterogeneous @arm64 @amd64
-  @4.16 @4.15 @4.14 @4.13 @4.12 @4.11
+  @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11
   @s390x @ppc64le @heterogeneous @arm64 @amd64
   Scenario: OCP-13016:Upgrade - Make sure multiple resources work well after upgrade - prepare
     Given I switch to cluster admin pseudo user


### PR DESCRIPTION
This fixes the inconsistency in test preparation and test execution.

@liangxia @jiajliu @JianLi-RH @dis016 @weinliu PTAL

--- 
Failure: https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.18-amd64-nightly-4.18-upgrade-from-stable-4.17-aws-ipi-disc-priv-sts-ep-fips-f28/1858044038981095424