### PR TITLE
fix OCP-10024 for 4.18

### DIFF
--- a/features/routing/route.feature
+++ b/features/routing/route.feature
@@ -416,7 +416,7 @@ Feature: Testing route
       | resource_name | service-unsecure1                       |
       | p             | {"spec":{"host":"www.changeroute.com"}} |
     Then the output should contain:
-      | spec.host: Invalid value: "www.changeroute.com": field is immutable |
+      | spec.host: Invalid value: "www.changeroute.com" |
 
   # @author zzhao@redhat.com
   # @case_id OCP-11036


### PR DESCRIPTION
The error message is updated with 4.18 as below
```
$ oc patch route service-unsecure1 -p '{"spec":{"host":"www.changeroute.com"}}'
The Route "service-unsecure1" is invalid: spec.host: Invalid value: "www.changeroute.com": you do not have permission to set the host field of the route
```
so updating the script accordingly. 

@melvinjoseph86 @ShudiLi @rhamini3 PTAL, thanks
