### PR TITLE
fix OCP-29300 for 4.18+

### DIFF
--- a/lib/rules/web/admin_console/4.18/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.18/monitoring_alerts.xyaml
@@ -138,7 +138,7 @@ click_alert_link_with_text:
 click_actions_button:
   element:
     selector:
-      xpath: //button[@class='pf-c-dropdown__toggle']
+      xpath: //button[@class='pf-v5-c-dropdown__toggle']
     op: click
 expire_alert_from_detail:
   action: click_first_action_icon

--- a/lib/rules/web/admin_console/4.18/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.18/monitoring_alerts.xyaml
@@ -196,7 +196,7 @@ wait_exipre_silence_loaded:
 click_duration_dropdown_button:
   element:
     selector:
-      xpath: //button[@class='pf-c-dropdown__toggle']
+      xpath: //button[@class='pf-v5-c-dropdown__toggle']
     op: click
 set_silence_duration:
   action: click_duration_dropdown_button


### PR DESCRIPTION
see from https://issues.redhat.com/browse/OCPBUGS-44797
4.18 OCP-29300 is failed due to click_actions_button action for 4.18+, debugged, need to update the xpath for it, only affect 4.18+, also update click_duration_dropdown_button xpath
