### PR TITLE
fix OCP-32857 for 4.18+

### DIFF
--- a/lib/rules/web/admin_console/4.18/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.18/monitoring_alerts.xyaml
@@ -401,7 +401,7 @@ click_alert_filter_dropdown:
 click_alert_filter_item:
   element:
     selector:
-      xpath: //input[@id='<filter_item>']
+      xpath: //label[@id='<filter_item>']
     op: click
 click_label_filter_dropdown:
   params:


### PR DESCRIPTION
see [OCPBUGS-44797](https://issues.redhat.com/browse/OCPBUGS-44797), to fix OCP-32857 error, need to update click_alert_filter_item action for 4.18+, update xpath from
```
xpath: //input[@id='<filter_item>'] 
```
to
```
xpath: //label[@id='<filter_item>'] 
```
can fix the issue.

4.18 [runner job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/1071678/console) passed
