### PR TITLE
OCPQE-27132: Fix for PodSecurityXXXReview due to 4.18 APIs change

### DIFF
--- a/testdata/authorization/scc/PodSecurityPolicyReview.json
+++ b/testdata/authorization/scc/PodSecurityPolicyReview.json
@@ -1,9 +1,6 @@
 {
     "kind": "PodSecurityPolicyReview",
     "apiVersion": "security.openshift.io/v1",
-    "metadata": {
-        "name": "pspsr"
-    },
     "spec": {
         "template": {
             "spec": {
@@ -17,9 +14,6 @@
                             "protocol": "TCP"
                         }
                     ],
-                    "resources": {
-
-                    },
                     "volumeMounts": [
                         {
                             "name": "tmp",
@@ -31,7 +25,6 @@
                     "imagePullPolicy": "IfNotPresent",
                     "securityContext": {
                         "capabilities": {
-
                         },
                         "privileged": false
                     }
@@ -41,7 +34,6 @@
                 {
                     "name": "tmp",
                     "emptyDir": {
-
                     }
                 }
             ],
@@ -52,12 +44,6 @@
         },
         "serviceAccountNames": [
             "default"
-        ],
-        "groups": [
-            "system:authenticated"
         ]
-    },
-    "status": {
-
     }
 }

--- a/testdata/authorization/scc/PodSecurityPolicySubjectReview.json
+++ b/testdata/authorization/scc/PodSecurityPolicySubjectReview.json
@@ -1,9 +1,6 @@
 {
     "kind": "PodSecurityPolicySubjectReview",
     "apiVersion": "security.openshift.io/v1",
-    "metadata": {
-        "name": "pspsr"
-    },
     "spec": {
         "template": {
             "spec": {
@@ -17,21 +14,15 @@
                             "protocol": "TCP"
                         }
                     ],
-                    "resources": {
-
-                    },
                     "volumeMounts": [
                         {
                             "name": "tmp",
                             "mountPath": "/tmp"
                         }
                     ],
-                    "terminationMessagePath": "/dev/termination-log",
-                    "terminationMessagePolicy": "FallbackToLogsOnError",
                     "imagePullPolicy": "IfNotPresent",
                     "securityContext": {
                         "capabilities": {
-
                         },
                         "privileged": false
                     }
@@ -41,7 +32,6 @@
                 {
                     "name": "tmp",
                     "emptyDir": {
-
                     }
                 }
             ],
@@ -54,8 +44,5 @@
         "groups": [
             "system:authenticated"
         ]
-    },
-    "status": {
-
     }
 }

--- a/testdata/authorization/scc/PodSecurityPolicySubjectReview_privileged_false.json
+++ b/testdata/authorization/scc/PodSecurityPolicySubjectReview_privileged_false.json
@@ -1,9 +1,6 @@
 {
     "kind": "PodSecurityPolicySelfSubjectReview",
     "apiVersion": "security.openshift.io/v1",
-    "metadata": {
-        "name": "pspsr"
-    },
     "spec": {
         "template": {
             "spec": {
@@ -17,17 +14,12 @@
                             "protocol": "TCP"
                         }
                     ],
-                    "resources": {
-
-                    },
                     "volumeMounts": [
                         {
                             "name": "tmp",
                             "mountPath": "/tmp"
                         }
                     ],
-                    "terminationMessagePath": "/dev/termination-log",
-                    "terminationMessagePolicy": "FallbackToLogsOnError",
                     "imagePullPolicy": "IfNotPresent",
                     "securityContext": {
                         "capabilities": {
@@ -50,8 +42,5 @@
             "serviceAccount": "default"
             }
         }
-    },
-	"status": {
-
-	}
+    }
 }

--- a/testdata/authorization/scc/PodSecurityPolicySubjectReview_privileged_true.json
+++ b/testdata/authorization/scc/PodSecurityPolicySubjectReview_privileged_true.json
@@ -1,9 +1,6 @@
 {
     "kind": "PodSecurityPolicySelfSubjectReview",
     "apiVersion": "security.openshift.io/v1",
-    "metadata": {
-        "name": "pspsr"
-    },
     "spec": {
         "template": {
             "spec": {
@@ -17,21 +14,15 @@
                             "protocol": "TCP"
                         }
                     ],
-                    "resources": {
-
-                    },
                     "volumeMounts": [
                         {
                             "name": "tmp",
                             "mountPath": "/tmp"
                         }
                     ],
-                    "terminationMessagePath": "/dev/termination-log",
-                    "terminationMessagePolicy": "FallbackToLogsOnError",
                     "imagePullPolicy": "IfNotPresent",
                     "securityContext": {
                         "capabilities": {
-
                         },
                         "privileged": true
                     }
@@ -41,7 +32,6 @@
                 {
                     "name": "tmp",
                     "emptyDir": {
-
                     }
                 }
             ],
@@ -50,8 +40,5 @@
             "serviceAccount": "default"
             }
         }
-    },
-    "status": {
-
     }
 }


### PR DESCRIPTION
Due to the 4.18 rebase PR https://github.com/openshift/openshift-apiserver/pull/458 brought API changes to the PodSecurityPolicyXXXXReview resources, related Auth cases failed; checked the response body when it failed, it showed like:
```
The PodSecurityPolicySelfSubjectReview "" is invalid: metadata: Invalid value: v1.ObjectMeta{Name:"pspsr", ...}: must be empty
```
https://github.com/openshift/openshift-apiserver/pull/458/files indeed introduced the `must be empty` validations.

Fixing it by removing .metadata from the test files.

Tested both 4.17 and 4.18. Both passed:
4.17 logs /job/ocp-common/job/Runner/1073944/console
4.18 logs /job/ocp-common/job/Runner/1073943/console