### PR TITLE
fix [ocp-14665, 14673] select nodes from clipboard

### DIFF
--- a/features/step_definitions/project.rb
+++ b/features/step_definitions/project.rb
@@ -194,7 +194,7 @@ Given /^admin creates a project with a random schedulable node selector$/ do
     | node_selector | #{project_name}=label |
     })
   step %Q/I store the schedulable workers without taints in the :nodes clipboard/
-  step %Q/label "<%= project.name %>=label" is added to the "<%= node.name %>" node/
+  step %Q/label "<%= project.name %>=label" is added to the "<%= cb.nodes[0].name %>" node/
   step %Q/the appropriate pod security labels are applied to the namespace/
   step %Q/I switch to cluster admin pseudo user/
   step %Q/I use the "<%= project.name %>" project/


### PR DESCRIPTION
Hi Team,

Fix for the issue: https://issues.redhat.com/browse/OCPQE-27283. PTAL. 

It is selecting random schedulable worker node instead from the saved clipboard nodes 
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/1076543/console
12-02 13:14:01.893        [07:43:45] INFO> Exit Status: 0
12-02 13:14:01.893        [07:43:46] INFO> here checking !!!!!!!! ropatil-122az1-jtxss-ingress-4nfvw
12-02 13:14:01.893        [07:43:46] INFO> here checking !!!!!!!! ropatil-122az1-jtxss-worker-westus-89f9g
12-02 13:14:01.893        [07:43:46] INFO> here checking !!!!!!!! ropatil-122az1-jtxss-ingress-4nfvw
12-02 13:14:01.893        [07:43:46] INFO> here checking !!!!!!!! ropatil-122az1-jtxss-worker-westus-89f9g
12-02 13:14:01.894        [07:43:47] INFO> Shell Commands: oc label node ropatil-122az1-jtxss-worker-westus-rcgwm --overwrite=true e1aql\=label --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_admin.kubeconfig

Fix: 
It is selecting from the saved clipboard node
OCP-14665 https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/1076552/console
OCP-14673 https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/1076560/console

/assign @Phaow @duanwei33 @chao007 @radeore 