### PR TITLE
Update e2e tests for progressing=false checkpoint for OCPBUGS-23435 bug fix

### DIFF
--- a/features/step_definitions/oauth.rb
+++ b/features/step_definitions/oauth.rb
@@ -77,5 +77,6 @@ Given /^authentication successfully rolls out after config changes$/ do
     end
   }
   raise error unless success
+  raise "#### In 4.18+ (ref: https://issues.redhat.com/browse/OCPBUGS-45051), given the operator reports Progressing=False, the Terminating (Running) old-generation operand pod should already disappear. But the result showed it still took #{stats[:iterations]} iterations (#{stats[:seconds]} seconds) for the disappearing." if env.version_ge("4.18", user: user) && stats[:iterations] > 1
 end
 


### PR DESCRIPTION
In 4.18+, with OCPBUGS-45051 fix, given the auth operator reports Progressing=False for a rollout, the Terminating (Running) old-generation operand pod should already disappear. In https://github.com/openshift/cucushift/pull/8378 years earlier, noticed this issue, but didn't consider it a bug. This PR covers the bug fix in auto for all cases that trigger auth rollout and wait for Progress=False (i.e. those that call `And authentication successfully rolls out after config changes` step).

4.18 pass log: /job/ocp-common/job/Runner/1077780/console (no Terminating, i.e. running pod of old generation)
4.17 pass log: /job/ocp-common/job/Runner/1077782/console (no bug fix backport to 4.17 thus the issue is still seen, as the pasted log snippet as below)
```
12-04 16:24:43.646        [08:24:34] INFO> #### After 64.05502083292231 seconds and 4 iterations operator authentication becomes: {"Available"=>"True", "Progressing"=>"False", "Degraded"=>"False"}
12-04 16:24:43.646        [08:24:34] INFO> Shell Commands: oc get pod -l app\=oauth-openshift --kubeconfig=/home/jenkins/ws/workspace/ocp-common/Runner/workdir/ocp4_admin.kubeconfig -n openshift-authentication
12-04 16:24:43.646        NAME                               READY   STATUS              RESTARTS   AGE
12-04 16:24:43.646        oauth-openshift-77865d5866-2mbp9   1/1     Running             0          81s
12-04 16:24:43.646        oauth-openshift-77865d5866-kwq5v   1/1     Running             0          58s
12-04 16:24:43.646        oauth-openshift-77865d5866-pdm2j   0/1     ContainerCreating   0          26s
12-04 16:24:43.646        oauth-openshift-86c9bdd97c-cb5bp   0/1     Terminating         0          14m
```
CC @gangwgr 