### PR TITLE
Fix OCP-11055

### DIFF
--- a/features/cli/pod.feature
+++ b/features/cli/pod.feature
@@ -198,6 +198,7 @@ Feature: pods related scenarios
     When I run the :exec client command with:
       | pod              | doublecontainers |
       | container        | hello-openshift  |
+      | oc_opts_end      |                  |
       | exec_command     | cat              |
       | exec_command_arg | /dev/shm/c1      |
     Then the step should succeed
@@ -206,6 +207,7 @@ Feature: pods related scenarios
     When I run the :exec client command with:
       | pod              | doublecontainers       |
       | container        | hello-openshift-fedora |
+      | oc_opts_end      |                        |
       | exec_command     | cat                    |
       | exec_command_arg | /dev/shm/c1            |
     Then the step should succeed

--- a/features/cli/pod.feature
+++ b/features/cli/pod.feature
@@ -224,6 +224,7 @@ Feature: pods related scenarios
     When I run the :exec client command with:
       | pod              | doublecontainers |
       | container        | hello-openshift  |
+      | oc_opts_end      |                  |
       | exec_command     | cat              |
       | exec_command_arg | /dev/shm/c2      |
     Then the step should succeed


### PR DESCRIPTION
This case failed many times in 4.18 due to error like: 
STDERR:
error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead

This pr fix above error and test passed in https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Runner/1078232/ 