### PR TITLE
Verify presubmit job check-upgrade-tags

### DIFF
--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -53,7 +53,7 @@ Feature: Machine-api components upgrade tests
   @4.11 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi
   @vsphere-upi @openstack-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi
-  Scenario:  Cloud-controller-manager cluster operator should be available after upgrade - prepare
+  Scenario: Cloud-controller-manager cluster operator should be available after upgrade - prepare
     Given the expression should be true> "True" == "True"
 
   # @author zhsun@redhat.com


### PR DESCRIPTION
Found a small typo in our upgrade scenarios.  Using it to test out the newly added presubmit check job, [check-upgrade-tags](https://github.com/openshift/release/pull/59493).
Currently the job is optional, we will move it as gate jobs ( must pass ) after several verification PRs.