### PR TITLE
OCPBUGS-42799 - modifying metrics name

### DIFF
--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -187,8 +187,8 @@ Feature: Machine misc features testing
   Scenario: OCP-37180:ClusterInfrastructure Report vCenter version to telemetry
     Given I switch to cluster admin pseudo user
     When I perform the GET prometheus rest client with:
-      | path  | /api/v1/query?                         |
-      | query | cloudprovider_vsphere_vcenter_versions |
+      | path  | /api/v1/query?       |
+      | query | vsphere_vcenter_info |
     Then the step should succeed
     And the expression should be true> @result[:parsed]["data"]["result"][0]["metric"]["version"] =~ /7.0|8.0/
 


### PR DESCRIPTION
The in-tree to out-tree migration resulted in below change . 

Validation - https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/Runner/1081033/console

```
`curl -H "Authorization: Bearer xxxxxxxxxxxxxxx" https://prometheus-k8s-openshift-monitoring.apps.miyadav-1112v.qe.devcluster.openshift.com/api/v1/query?query=vsphere_vcenter_info --insecure
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"vsphere_vcenter_info","api_version":"8.0.3.0","build":"24322831","container":"vsphere-problem-detector-operator","endpoint":"vsphere-metrics","instance":"10.130.0.17:8444","job":"vsphere-problem-detector-metrics","namespace":"openshift-cluster-storage-operator","pod":"vsphere-problem-detector-operator-867cb6c87d-c7g4j","service":"vsphere-problem-detector-metrics","uuid":"4fa3ddd9-9377-4bfb-ae7f-418e579c1495","version":"8.0.3"},"value":[1733899334.149,"1"]}]}}`
```
@sunzhaohua2  @huali9 PTAL when time permits.