### PR TITLE
fix the format of output for OCP-13022

### DIFF
--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -46,9 +46,9 @@ Feature: Node components upgrade tests
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
     And the output should contain:
-      | [\"]?imageMinimumGCAge[\"]?: [\"]?5m0s[\"]?         |
-      | [\"]?imageGCHighThresholdPercent[\"]?: 80 |
-      | [\"]?maxPods[\"]?: 240                    |
+      | [\"]?imageMinimumGCAge[\"]?: [\"]?5m0s[\"]? |
+      | [\"]?imageGCHighThresholdPercent[\"]?: 80   |
+      | [\"]?maxPods[\"]?: 240                      |
 
   # @author minmli@redhat.com
   # @case_id OCP-13022
@@ -77,7 +77,7 @@ Feature: Node components upgrade tests
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
     And the output should contain:
-      | [\"]?imageMinimumGCAge[\"]?: [\"]?5m0s[\"]?         |
-      | [\"]?imageGCHighThresholdPercent[\"]?: 80 |
-      | [\"]?maxPods[\"]?: 240                    |
+      | [\"]?imageMinimumGCAge[\"]?: [\"]?5m0s[\"]? |
+      | [\"]?imageGCHighThresholdPercent[\"]?: 80   |
+      | [\"]?maxPods[\"]?: 240                      |
       

--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -46,9 +46,9 @@ Feature: Node components upgrade tests
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
     And the output should match:
-      | [\"]?imageMinimumGCAge[\"]?: [\"]?5m0s[\"]? |
-      | [\"]?imageGCHighThresholdPercent[\"]?: 80   |
-      | [\"]?maxPods[\"]?: 240                      |
+      | "?imageMinimumGCAge"?: "?5m0s"? |
+      | "?imageGCHighThresholdPercent"?: 80   |
+      | "?maxPods"?: 240                      |
 
   # @author minmli@redhat.com
   # @case_id OCP-13022
@@ -77,7 +77,7 @@ Feature: Node components upgrade tests
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
     And the output should match:
-      | [\"]?imageMinimumGCAge[\"]?: [\"]?5m0s[\"]? |
-      | [\"]?imageGCHighThresholdPercent[\"]?: 80   |
-      | [\"]?maxPods[\"]?: 240                      |
+      | "?imageMinimumGCAge"?: "?5m0s"? |
+      | "?imageGCHighThresholdPercent"?: 80   |
+      | "?maxPods"?: 240                      |
       

--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -46,9 +46,9 @@ Feature: Node components upgrade tests
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
     And the output should contain:
-      | "imageMinimumGCAge": "5m0s"       |
-      | "imageGCHighThresholdPercent": 80 |
-      | "maxPods": 240                    |
+      | imageMinimumGCAge: 5m0s         |
+      | imageGCHighThresholdPercent: 80 |
+      | maxPods: 240                    |
 
   # @author minmli@redhat.com
   # @case_id OCP-13022
@@ -77,6 +77,6 @@ Feature: Node components upgrade tests
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
     And the output should contain:
-      | "imageMinimumGCAge": "5m0s"       |
-      | "imageGCHighThresholdPercent": 80 |
-      | "maxPods": 240                    |
+      | imageMinimumGCAge: 5m0s         |
+      | imageGCHighThresholdPercent: 80 |
+      | maxPods: 240                    |

--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -45,7 +45,7 @@ Feature: Node components upgrade tests
     When I run commands on the host:
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
-    And the output should contain:
+    And the output should match:
       | [\"]?imageMinimumGCAge[\"]?: [\"]?5m0s[\"]? |
       | [\"]?imageGCHighThresholdPercent[\"]?: 80   |
       | [\"]?maxPods[\"]?: 240                      |
@@ -76,7 +76,7 @@ Feature: Node components upgrade tests
     When I run commands on the host:
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
-    And the output should contain:
+    And the output should match:
       | [\"]?imageMinimumGCAge[\"]?: [\"]?5m0s[\"]? |
       | [\"]?imageGCHighThresholdPercent[\"]?: 80   |
       | [\"]?maxPods[\"]?: 240                      |

--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -46,9 +46,9 @@ Feature: Node components upgrade tests
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
     And the output should contain:
-      | ["]?imageMinimumGCAge["]?: ["]?5m0s["]?         |
-      | ["]?imageGCHighThresholdPercent["]?: 80 |
-      | ["]?maxPods["]?: 240                    |
+      | [\"]?imageMinimumGCAge[\"]?: [\"]?5m0s[\"]?         |
+      | [\"]?imageGCHighThresholdPercent[\"]?: 80 |
+      | [\"]?maxPods[\"]?: 240                    |
 
   # @author minmli@redhat.com
   # @case_id OCP-13022
@@ -77,6 +77,7 @@ Feature: Node components upgrade tests
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
     And the output should contain:
-      | ["]?imageMinimumGCAge["]?: ["]?5m0s["]?         |
-      | ["]?imageGCHighThresholdPercent["]?: 80 |
-      | ["]?maxPods["]?: 240                    |
+      | [\"]?imageMinimumGCAge[\"]?: [\"]?5m0s[\"]?         |
+      | [\"]?imageGCHighThresholdPercent[\"]?: 80 |
+      | [\"]?maxPods[\"]?: 240                    |
+      

--- a/features/upgrade/node/node-upgrade.feature
+++ b/features/upgrade/node/node-upgrade.feature
@@ -46,9 +46,9 @@ Feature: Node components upgrade tests
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
     And the output should contain:
-      | imageMinimumGCAge: 5m0s         |
-      | imageGCHighThresholdPercent: 80 |
-      | maxPods: 240                    |
+      | ["]?imageMinimumGCAge["]?: ["]?5m0s["]?         |
+      | ["]?imageGCHighThresholdPercent["]?: 80 |
+      | ["]?maxPods["]?: 240                    |
 
   # @author minmli@redhat.com
   # @case_id OCP-13022
@@ -77,6 +77,6 @@ Feature: Node components upgrade tests
       | cat /etc/kubernetes/kubelet.conf |
     Then the step should succeed
     And the output should contain:
-      | imageMinimumGCAge: 5m0s         |
-      | imageGCHighThresholdPercent: 80 |
-      | maxPods: 240                    |
+      | ["]?imageMinimumGCAge["]?: ["]?5m0s["]?         |
+      | ["]?imageGCHighThresholdPercent["]?: 80 |
+      | ["]?maxPods["]?: 240                    |


### PR DESCRIPTION
in 4.17 and 4.18, the kubeletconfig format changed from json to yaml, this pr fix the issue.
Test passed in https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/Runner/1081067/console 