### PR TITLE
update set_silence_duration_null xpath for 4.18/4.19

### DIFF
--- a/lib/rules/web/admin_console/4.18/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.18/monitoring_alerts.xyaml
@@ -208,7 +208,7 @@ set_silence_duration_null:
   action: click_duration_dropdown_button
   element:
     selector:
-      xpath: //ul[@class='pf-c-dropdown__menu']//a[text()='-']
+      xpath: //ul[@class='pf-v5-c-dropdown__menu']//a[text()='-']
     op: click
 check_silence_duration_null:
   element:

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -196,7 +196,7 @@ wait_exipre_silence_loaded:
 click_duration_dropdown_button:
   element:
     selector:
-      xpath: //button[@class='pf-v5-c-dropdown__toggle']
+      xpath: //button[@class='pf-v5-c-menu-toggle pf-m-full-width']
     op: click
 set_silence_duration:
   action: click_duration_dropdown_button

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -208,7 +208,7 @@ set_silence_duration_null:
   action: click_duration_dropdown_button
   element:
     selector:
-      xpath: //ul[@class='pf-c-dropdown__menu']//a[text()='-']
+      xpath: //ul[@class='pf-v5-c-menu__list']//span[text()='-']
     op: click
 check_silence_duration_null:
   element:


### PR DESCRIPTION
see https://issues.redhat.com/browse/OCPBUGS-47492, due to 4.18+ UI change, update set_silence_duration_null xpath for 4.18/4.19, 4.19 also updated click_duration_dropdown_button due to 4.19 UI change only
[4.18 runner job](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/Runner/1087067/console) passed

[4.19 runner job](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/Runner/1087071/console) passed