### PR TITLE
skip case if infrastructure is none

### DIFF
--- a/features/machine/machine_misc.feature
+++ b/features/machine/machine_misc.feature
@@ -186,6 +186,7 @@ Feature: Machine misc features testing
   @mapi
   Scenario: OCP-37180:ClusterInfrastructure Report vCenter version to telemetry
     Given I switch to cluster admin pseudo user
+    Then I check the cluster platform is not None
     When I perform the GET prometheus rest client with:
       | path  | /api/v1/query?       |
       | query | vsphere_vcenter_info |


### PR DESCRIPTION
@sunzhaohua2 @huali9 PTAL when time permits . 

for Cucushift test failures on OCP 4.18(ppc64le) installed using Agent Based Installer the infra was None , yet our test was executing and getting failed .