### PR TITLE
added steps to support FIPS check without exiting

### DIFF
--- a/features/test/fips.feature
+++ b/features/test/fips.feature
@@ -1,0 +1,6 @@
+Feature: fips enabled test
+
+  @admin @fips
+  Scenario: FIPS mode checking command without exiting
+    And I skip testcase if fips is enabled inside node
+    And I create the "foo-bar" directory


### PR DESCRIPTION
This PR adds support to check a cluster's FIPS status and save it to the global @clipboard[:fips_enabled] variable without exiting the step.  This minor feature is requested by @ropatil010.  PTAL @liangxia 