### PR TITLE
remove ocp44790 from 4.19 and 4.18

### DIFF
--- a/features/upgrade/sdn/externalIP-upgrade.feature
+++ b/features/upgrade/sdn/externalIP-upgrade.feature
@@ -9,7 +9,7 @@ Feature: SDN externalIP compoment upgrade testing
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @hypershift-hosted
-  @4.19 @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9
+  @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9
   Scenario: Check the externalIP works well after upgrade - prepare
     Given I switch to cluster admin pseudo user
     And I run the :new_project client command with:
@@ -57,7 +57,7 @@ Feature: SDN externalIP compoment upgrade testing
   # @case_id OCP-44790
   @admin
   @upgrade-check
-  @4.19 @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9
+  @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade


### PR DESCRIPTION
Remove ocp44790 from 4.19 and 4.18, will cover it in ginkgo framework, then we can test UDN and default network together, please refer to PR https://github.com/openshift/openshift-tests-private/pull/23027
@openshift/team-sdn-qe PTAL, thanks a lot!