### PR TITLE
OCPQE-28450 remove tag for hypershift hosted cluster

### DIFF
--- a/features/machine/machine.feature
+++ b/features/machine/machine.feature
@@ -113,7 +113,6 @@ Feature: Machine features testing
     @proxy @noproxy @disconnected @connected
     @s390x @ppc64le @heterogeneous @arm64 @amd64
     
-    @hypershift-hosted
     Examples:
       | case_id                         | url                                                                          |
       | OCP-25652:ClusterInfrastructure | https://machine-api-operator.openshift-machine-api.svc:8443/metrics          | # @case_id OCP-25652


### PR DESCRIPTION
Based on failures mentioned in Jira , we think it is ok to remove hypershift-hosted tags for these test.

@sunzhaohua2 @huali9 PTAL , when time permits.