### PR TITLE
OCPQE-28472: Update ldap server contact for ipv6

### DIFF
--- a/features/step_definitions/helper_services.rb
+++ b/features/step_definitions/helper_services.rb
@@ -181,7 +181,7 @@ Given /^I have LDAP service in my project$/ do
 
     # Init the test data in ldap server.
     wait_for(60, interval: 5, stats: stats){
-      @result = pod.exec("ldapadd", "-x", "-h", "127.0.0.1", "-p", "389", "-D", "cn=Manager,dc=example,dc=com", "-w", "admin", stdin: File.read(cb.test_file), as: user)
+      @result = pod.exec("ldapadd", "-x", "-h", "localhost", "-p", "389", "-D", "cn=Manager,dc=example,dc=com", "-w", "admin", stdin: File.read(cb.test_file), as: user)
       @result[:success]
     }
     logger.info "after #{stats[:seconds]} seconds and #{stats[:iterations]} " <<


### PR DESCRIPTION
Failed to contact to ldap server on ipv6 due to the ipv4 adress hard code 
```
Shell Commands: oc exec ldapserver  --kubeconfig=/tmp/dir8/workdir/ocp4_testuser-8.kubeconfig -n stx3u  -i -- ldapadd -x -h 127.0.0.1 -p 389 -D cn\=Manager,dc\=example,dc\=com -w admin␛[0m␛[0m
ldap_sasl_bind(SIMPLE): Can't contact LDAP server (-1)
```
```
cat /etc/hosts
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
```