### PR TITLE
Update 26910 as UI removed developer perspective

### DIFF
--- a/lib/rules/web/admin_console/4.19/check_links.xyaml
+++ b/lib/rules/web/admin_console/4.19/check_links.xyaml
@@ -102,13 +102,6 @@ navigate_to_admin_console:
         xpath: //div[@id='guided-tour-modal']//button[text()='Skip tour']
       timeout: 20
     ref: skip_dev_perspective_tour
-  elements:
-  - selector:
-      xpath: //button[@data-test-id='perspective-switcher-toggle']
-    op: click
-  - selector:
-      xpath: //li//h2[contains(., 'Administrator')]/ancestor::button[@role="option"]
-    op: click
 check_active_perspective:
   action:
     if_param:


### PR DESCRIPTION
Update 26910 as UI removed developer perspective in OCP4.19 only

Pass log: /Runner/1108310/
For ticket: https://issues.redhat.com/browse/OCPQE-28643 and https://issues.redhat.com/browse/OCPQE-28611