### PR TITLE
Fix OCP-22330 & OCP-22640 dropdown xpath on 4.19

### DIFF
--- a/lib/rules/web/admin_console/base/logout.xyaml
+++ b/lib/rules/web/admin_console/base/logout.xyaml
@@ -1,7 +1,7 @@
 click_logout:
   elements:
   - selector:
-      xpath: //*[@data-test='user-dropdown']
+      xpath: //*[@data-test='user-dropdown-toggle']
     op: click
   - selector:
       xpath: //button[contains(., 'Log out')]


### PR DESCRIPTION
Fix OCP-22330 & 22640 dropdown xpath on 4.19

Pass log: job/Runner/1110608/   (OCP-22330)
                 job/Runner/1110619/   (OCP-22640)
For ticket: https://issues.redhat.com/browse/OCPQE-28734