### PR TITLE
Fix OCP-23044 edit node taints xpath on 4.19

### DIFF
--- a/lib/rules/web/admin_console/4.19/node.xyaml
+++ b/lib/rules/web/admin_console/4.19/node.xyaml
@@ -59,11 +59,11 @@ remove_taint_from_node:
 node_affinity_modal_value:
   element:
     selector: &value
-      xpath: //div[text()='Value']/following-sibling::input
+      xpath: //div[text()='Value']/following-sibling::span//input
 node_affinity_modal_key:
   element:
     selector: &key
-      xpath: //div[text()='Key']/following-sibling::input
+      xpath: //div[text()='Key']/following-sibling::span//input
 node_affinity_modal_dropdown:
   element:
     selector: &dropdown


### PR DESCRIPTION
Fix OCP-23044 Xpath for 'edit node taints' on 4.19

Pass log: job/Runner/1110647/
For ticket: https://issues.redhat.com/browse/OCPQE-28736