### PR TITLE
Update Xpath for OCP-27586 on 4.19

### DIFF
--- a/lib/rules/web/admin_console/4.19/overview.xyaml
+++ b/lib/rules/web/admin_console/4.19/overview.xyaml
@@ -164,7 +164,7 @@ click_groupby_dropdown_button:
 check_dropdown_menu_item:
   element:
     selector: &dropdown_item
-      xpath: //button[contains(@class,'dropdown__menu-item') and text()='<dropdown_menu_item>']
+      xpath: //button[contains(@data-test-id,'dropdown-menu') and contains(text(),'<dropdown_menu_item>')]
 click_dropdown_menu_item:
   element:
     selector:


### PR DESCRIPTION
Update Xpath for OCP-27586 on 4.19
Note: OCP-29799 is affected by this change, and since multiple parts need to be updated for that case. The update will be submitted in a separate PR

Pass log: /job/Runner/1113513/