### PR TITLE
Update Xpath for OCP-20954 on 4.19

### DIFF
--- a/lib/rules/web/admin_console/4.19/environments.xyaml
+++ b/lib/rules/web/admin_console/4.19/environments.xyaml
@@ -37,16 +37,16 @@ add_env_var_name:
 add_env_var_pair_value:
   elements:
   - selector:
-      xpath: //button//*[contains(text(),'Select a resource')]
+      xpath: (//button//*[contains(.,'Select a resource')])[1]
     op: click
   - selector:
-      xpath: //li//*[text()='<env_source_name>']
+      xpath: //li//*[.='<env_source_name>']
     op: click
   - selector:
-      xpath: //button//*[contains(text(),'Select a key')]
+      xpath: //button//*[contains(.,'Select a key')]
     op: click
   - selector:
-      xpath: //li//*[text()='<env_source_key>']
+      xpath: //li//*[.='<env_source_key>']
     op: click
 add_env_var_value:
   element:


### PR DESCRIPTION
Update Xpath for OCP-20954 on 4.19 
- The issue occurs because two elements match on the page, causing the dropdown click action to fail

Pass log: job/Runner/1113814/
For ticket: https://issues.redhat.com/browse/OCPQE-28877
