### PR TITLE
Add action for OCP-19608 on 4.19

### DIFF
--- a/lib/rules/web/admin_console/4.19/route.xyaml
+++ b/lib/rules/web/admin_console/4.19/route.xyaml
@@ -115,14 +115,14 @@ set_weight_for_main_service:
   elements:
   - selector: &weight
       xpath: //input[@id='service-weight']
-    op: clear 
+    op: clear
   - selector: *weight
     op: send_keys <service_weight>
 set_weight_for_alternative_service:
   elements:
   - selector: &alternate-weight
       xpath: //input[contains(@id,'alternate-service-weight')]
-    op: clear          
+    op: clear
   - selector: *alternate-weight
     op: send_keys <alternative_service_weight>
 set_alternative_service:
@@ -249,6 +249,7 @@ enable_status_filter:
     op: click
     timeout: 20
 select_all_filters:
+  action: click_filter_dropdown
   action: clear_all_filters
 check_rejected_icon_and_text:
   params:


### PR DESCRIPTION
Added action for OCP-19608 on 4.19 to fix the dropdown menu not closing without the click, it will impact to click the 'Clear All Filters' button

Pass log:job/Runner/1113826/
For ticket: https://issues.redhat.com/browse/OCPQE-28886