### PR TITLE
skip rhel nodes only for versions < 4.19

### DIFF
--- a/features/step_definitions/machine.rb
+++ b/features/step_definitions/machine.rb
@@ -20,13 +20,14 @@ Given(/^I have an IPI deployment$/) do
       logger.warn "We will skip this scenario, even though it is IPI deployment"
       skip_this_scenario
     end
-    
-  rhel_nodes = BushSlicer::Node.get_labeled("node.openshift.io/os_id=rhel", user: admin)
-    if rhel_nodes.length > 0
-      logger.warn "There are rhel nodes and rhel nodes may created by machineset, tests running by copying existing machinesets will fail."
-      logger.warn "We will skip this scenario, even though it is IPI deployment"
-      skip_this_scenario
-    end 
+  if env.version_lt("4.19", user: user)  
+    rhel_nodes = BushSlicer::Node.get_labeled("node.openshift.io/os_id=rhel", user: admin)
+      if rhel_nodes.length > 0
+        logger.warn "There are rhel nodes and rhel nodes may created by machineset, tests running by copying existing machinesets will fail."
+        logger.warn "We will skip this scenario, even though it is IPI deployment"
+        skip_this_scenario
+      end
+    end
   end
 end
 


### PR DESCRIPTION
@huali9 @miyadav PTAL
discussion https://redhat-internal.slack.com/archives/CH76YSYSC/p1744944722558809
Example job: https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/Runner/1115414/console 
Fix job: https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/Runner/1115415/console

```
04-18 17:32:38.169        [09:32:37] WARN> There are rhel nodes and rhel nodes may created by machineset, tests running by copying existing machinesets will fail.
04-18 17:32:38.169        [09:32:37] WARN> We will skip this scenario, even though it is IPI deployment
```