### PR TITLE
OCPQE-29446: fix OCP-25809 resize failure message check

### DIFF
--- a/features/storage/csi_resize.feature
+++ b/features/storage/csi_resize.feature
@@ -98,7 +98,7 @@ Feature: CSI Resizing related feature
       | p             | {"spec":{"resources":{"requests":{"storage":"1Gi"}}}} |
     Then the step should fail
     And the output should match:
-      | Forbidden.*field can not be less than previous value |
+      | Forbidden.*field can not be less than (previous value\|status\.capacity) |
 
     @rosa @osd_ccs
     @aws-ipi


### PR DESCRIPTION
- In 4.19 we enable the recover the resize failure feature gate by default which makes resize failure message changes a bit.
   https://github.com/openshift/kubernetes/blob/master/pkg/apis/core/validation/validation.go#L2426-L2434

#### Test records Logs
<details> <summary>Click to expand full logs</summary>

```console
$ cucumber ./features/storage/csi_resize.feature:109
Using the default, devel and _devel profiles...
Feature: CSI Resizing related feature

  # @author chaoyang@redhat.com
  # @author wduan@redhat.com
  @singlenode @proxy @noproxy @disconnected @connected @network-ovnkubernetes @network-openshiftsdn @s390x @ppc64le @heterogeneous @arm64 @amd64 @4.19 @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6 @storage
  Scenario Outline: Resize negative test                                    # ./features/storage/csi_resize.feature:77
    Given I have a project                                                  # ./features/storage/csi_resize.feature:78
    Given I obtain test data file "storage/misc/pvc.json"                   # ./features/storage/csi_resize.feature:79
    When I create a dynamic pvc from "pvc.json" replacing paths:            # ./features/storage/csi_resize.feature:80
      | ["metadata"]["name"]                         | pvc-<%= project.name %> |
      | ["spec"]["storageClassName"]                 | <sc_name>               |
      | ["spec"]["resources"]["requests"]["storage"] | 2Gi                     |
    Then the step should succeed                                            # ./features/storage/csi_resize.feature:84
    Given I obtain test data file "storage/misc/pod.yaml"                   # ./features/storage/csi_resize.feature:86
    When I run oc create over "pod.yaml" replacing paths:                   # ./features/storage/csi_resize.feature:87
      | ["metadata"]["name"]                                         | mypod                   |
      | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
      | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/iaas               |
    Then the step should succeed                                            # ./features/storage/csi_resize.feature:91
    Given the pod named "mypod" becomes ready                               # ./features/storage/csi_resize.feature:92
    And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds # ./features/storage/csi_resize.feature:93
    When I run the :patch client command with:                              # ./features/storage/csi_resize.feature:95
      | resource      | pvc                                                   |
      | resource_name | pvc-<%= project.name %>                               |
      | p             | {"spec":{"resources":{"requests":{"storage":"1Gi"}}}} |
    Then the step should fail                                               # ./features/storage/csi_resize.feature:99
    And the output should match:                                            # ./features/storage/csi_resize.feature:100
      | Forbidden.*field can not be less than (previous value\|status\.capacity) |

    @rosa @osd_ccs @aws-ipi @aws-upi @hypershift-hosted
    Examples: 

      Example: | OCP-25809:Storage | gp2-csi |                                  # ./features/storage/csi_resize.feature:109:77
waiting for operation up to 3600 seconds..
      [03:30:17] INFO> === Before Scenario: Resize negative test ===
      [03:30:17] INFO> Shell Commands: mkdir -v -p '/Users/wangpenghao/workdir/pewang-mac-rootx'
      /Users/wangpenghao/workdir/pewang-mac-rootx
      [03:30:18] INFO> Exit Status: 0
      [03:30:18] INFO> === End Before Scenario: Resize negative test ===
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
        Given I have a project                                                  # features/step_definitions/project.rb:7
      [03:30:18] INFO> HTTP GET https://console-openshift-console.apps.meinliaws419-0429.qe.devcluster.openshift.com
      [03:30:19] INFO> HTTP GET took 1.085 sec: 200 OK | text/html 4261 bytes
      [03:30:19] INFO> HTTP GET https://api.meinliaws419-0429.qe.devcluster.openshift.com:6443/.well-known/oauth-authorization-server
      [03:30:20] INFO> HTTP GET took 0.932 sec: 200 OK | application/json 675 bytes
      [03:30:20] INFO> HTTP GET testuser-0@https://oauth-openshift.apps.meinliaws419-0429.qe.devcluster.openshift.com/oauth/authorize
      [03:30:21] INFO> HTTP GET took 1.139 sec: 302 Found
      [03:30:21] INFO> HTTP GET https://api.meinliaws419-0429.qe.devcluster.openshift.com:6443/apis/user.openshift.io/v1/users/~
      [03:30:24] INFO> HTTP GET took 2.091 sec: 200 OK | application/json 501 bytes
      [03:30:24] INFO> cleaning-up user testuser-0 projects
      [03:30:24] INFO> Shell Commands: rm  -f -- /Users/wangpenghao/workdir/pewang-mac-rootx/ocp4_testuser-0.kubeconfig
      
      [03:30:25] INFO> Exit Status: 0
      [03:30:26] INFO> Shell Commands: oc version -o yaml --client --kubeconfig=/var/folders/fl/wkjr1_ld75nfdb92ftdltyvh0000gn/T/kubeconfig20250429-77259-159849p
      clientVersion:
        buildDate: "2024-10-25T01:37:07Z"
        compiler: gc
        gitCommit: ee93eb5a82af5b61c625df9d3a9b50da9740a7d4
        gitTreeState: clean
        gitVersion: 4.18.0-202410241142.p0.gee93eb5.assembly.stream.el9-ee93eb5
        goVersion: go1.22.7 (Red Hat 1.22.7-1.el9_5)
        major: ""
        minor: ""
        platform: darwin/arm64
      kustomizeVersion: v5.4.2
      releaseClientVersion: 4.18.0-ec.3
      [03:30:27] INFO> Exit Status: 0
      WARNING: Using insecure TLS client config. Setting this option is not supported!
      
      Logged into "https://api.meinliaws419-0429.qe.devcluster.openshift.com:6443" as "testuser-0" using the token provided.
      
      You don't have any projects. You can try to create a new project, by running
      
          oc new-project <projectname>
      [03:30:31] INFO> Exit Status: 0
      [03:30:35] INFO> Shell Commands: oc new-project jn0vh --kubeconfig=/Users/wangpenghao/workdir/pewang-mac-rootx/ocp4_testuser-0.kubeconfig
      Now using project "jn0vh" on server "https://api.meinliaws419-0429.qe.devcluster.openshift.com:6443".
      
      You can add applications to this project with the 'new-app' command. For example, try:
      
          oc new-app rails-postgresql-example
      
      to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:
      
          kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname
      [03:30:38] INFO> Exit Status: 0
      [03:30:38] INFO> Shell Commands: oc get namespace jn0vh --template=\{\{\ index\ .metadata.annotations\ \"openshift.io/sa.scc.uid-range\"\ \}\} --kubeconfig=/Users/wangpenghao/workdir/pewang-mac-rootx/ocp4_testuser-0.kubeconfig
      1000730000/10000
      [03:30:40] INFO> Exit Status: 0
      [03:30:42] INFO> oc get projects jn0vh --output=yaml --kubeconfig=/Users/wangpenghao/workdir/pewang-mac-rootx/ocp4_testuser-0.kubeconfig
      [03:30:42] INFO> After 1 iterations and 2 seconds:
      apiVersion: project.openshift.io/v1
      kind: Project
      metadata:
        annotations:
          openshift.io/description: ""
          openshift.io/display-name: ""
          openshift.io/requester: testuser-0
          openshift.io/sa.scc.mcs: s0:c27,c14
          openshift.io/sa.scc.supplemental-groups: 1000730000/10000
          openshift.io/sa.scc.uid-range: 1000730000/10000
          security.openshift.io/MinimallySufficientPodSecurityStandard: restricted
        creationTimestamp: "2025-04-29T03:30:36Z"
        labels:
          kubernetes.io/metadata.name: jn0vh
          pod-security.kubernetes.io/audit: restricted
          pod-security.kubernetes.io/audit-version: latest
          pod-security.kubernetes.io/enforce: restricted
          pod-security.kubernetes.io/enforce-version: latest
          pod-security.kubernetes.io/warn: restricted
          pod-security.kubernetes.io/warn-version: latest
        name: jn0vh
        resourceVersion: "37903"
        uid: 9304e191-d081-4704-bace-bfb6cfb3bf27
      spec:
        finalizers:
        - kubernetes
      status:
        phase: Active
cp /Users/wangpenghao/Automation/verification-tests/testdata/storage/misc/pvc.json pvc.json
        Given I obtain test data file "storage/misc/pvc.json"                   # features/step_definitions/file.rb:1
waiting for operation up to 3600 seconds..
        When I create a dynamic pvc from "pvc.json" replacing paths:            # features/step_definitions/pvc.rb:69
          | ["metadata"]["name"]                         | pvc-<%= project.name %> |
          | ["spec"]["storageClassName"]                 | <sc_name>               |
          | ["spec"]["resources"]["requests"]["storage"] | 2Gi                     |
      [03:30:42] INFO> {"kind":"PersistentVolumeClaim","apiVersion":"v1","metadata":{"name":"pvc-jn0vh","annotations":{},"labels":{"name":"dynamic-pvc"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"storageClassName":"gp2-csi"}}
      [03:30:42] INFO> Shell Commands: oc create -f - --kubeconfig=/Users/wangpenghao/workdir/pewang-mac-rootx/ocp4_testuser-0.kubeconfig
      persistentvolumeclaim/pvc-jn0vh created
      [03:30:44] INFO> Exit Status: 0
        Then the step should succeed                                            # features/step_definitions/common.rb:4
cp /Users/wangpenghao/Automation/verification-tests/testdata/storage/misc/pod.yaml pod.yaml
        Given I obtain test data file "storage/misc/pod.yaml"                   # features/step_definitions/file.rb:1
waiting for operation up to 3600 seconds..
        When I run oc create over "pod.yaml" replacing paths:                   # features/step_definitions/cli.rb:66
          | ["metadata"]["name"]                                         | mypod                   |
          | ["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] | pvc-<%= project.name %> |
          | ["spec"]["containers"][0]["volumeMounts"][0]["mountPath"]    | /mnt/iaas               |
      [03:30:44] INFO> {"kind":"Pod","apiVersion":"v1","metadata":{"name":"mypod"},"spec":{"containers":[{"name":"dynamic","image":"quay.io/openshifttest/hello-openshift@sha256:56c354e7885051b6bb4263f9faa58b2c292d44790599b7dde0e49e7c466cf339","ports":[{"containerPort":80,"name":"http-server"}],"volumeMounts":[{"mountPath":"/mnt/iaas","name":"dynamic"}]}],"volumes":[{"name":"dynamic","persistentVolumeClaim":{"claimName":"pvc-jn0vh"}}]}}
      [03:30:44] INFO> Shell Commands: oc create -f - --kubeconfig=/Users/wangpenghao/workdir/pewang-mac-rootx/ocp4_testuser-0.kubeconfig
      pod/mypod created
      [03:30:46] INFO> Exit Status: 0
        Then the step should succeed                                            # features/step_definitions/common.rb:4
waiting for operation up to 900 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
        Given the pod named "mypod" becomes ready                               # features/step_definitions/pod.rb:18
      [03:30:48] INFO> oc get pods mypod --output=yaml --kubeconfig=/Users/wangpenghao/workdir/pewang-mac-rootx/ocp4_testuser-0.kubeconfig --namespace=jn0vh
      [03:31:12] INFO> After 9 iterations and 26 seconds:
      apiVersion: v1
      kind: Pod
      metadata:
        annotations:
          k8s.ovn.org/pod-networks: '{"default":{"ip_addresses":["10.131.2.9/23"],"mac_address":"0a:58:0a:83:02:09","gateway_ips":["10.131.2.1"],"routes":[{"dest":"10.128.0.0/14","nextHop":"10.131.2.1"},{"dest":"172.30.0.0/16","nextHop":"10.131.2.1"},{"dest":"169.254.0.5/32","nextHop":"10.131.2.1"},{"dest":"100.64.0.0/16","nextHop":"10.131.2.1"}],"ip_address":"10.131.2.9/23","gateway_ip":"10.131.2.1","role":"primary"}}'
          k8s.v1.cni.cncf.io/network-status: |-
            [{
                "name": "ovn-kubernetes",
                "interface": "eth0",
                "ips": [
                    "10.131.2.9"
                ],
                "mac": "0a:58:0a:83:02:09",
                "default": true,
                "dns": {}
            }]
          openshift.io/scc: restricted-v2
          seccomp.security.alpha.kubernetes.io/pod: runtime/default
        creationTimestamp: "2025-04-29T03:30:45Z"
        name: mypod
        namespace: jn0vh
        resourceVersion: "38071"
        uid: e05d3846-f652-4978-ba66-2b766baeb50a
      spec:
        containers:
        - image: quay.io/openshifttest/hello-openshift@sha256:56c354e7885051b6bb4263f9faa58b2c292d44790599b7dde0e49e7c466cf339
          imagePullPolicy: IfNotPresent
          name: dynamic
          ports:
          - containerPort: 80
            name: http-server
            protocol: TCP
          resources: {}
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            runAsNonRoot: true
            runAsUser: 1000730000
          terminationMessagePath: /dev/termination-log
          terminationMessagePolicy: File
          volumeMounts:
          - mountPath: /mnt/iaas
            name: dynamic
          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
            name: kube-api-access-vcbqx
            readOnly: true
        dnsPolicy: ClusterFirst
        enableServiceLinks: true
        imagePullSecrets:
        - name: default-dockercfg-mgpvp
        nodeName: ip-10-0-77-237.us-east-2.compute.internal
        preemptionPolicy: PreemptLowerPriority
        priority: 0
        restartPolicy: Always
        schedulerName: default-scheduler
        securityContext:
          fsGroup: 1000730000
          seLinuxOptions:
            level: s0:c27,c14
          seccompProfile:
            type: RuntimeDefault
        serviceAccount: default
        serviceAccountName: default
        terminationGracePeriodSeconds: 30
        tolerations:
        - effect: NoExecute
          key: node.kubernetes.io/not-ready
          operator: Exists
          tolerationSeconds: 300
        - effect: NoExecute
          key: node.kubernetes.io/unreachable
          operator: Exists
          tolerationSeconds: 300
        volumes:
        - name: dynamic
          persistentVolumeClaim:
            claimName: pvc-jn0vh
        - name: kube-api-access-vcbqx
          projected:
            defaultMode: 420
            sources:
            - serviceAccountToken:
                expirationSeconds: 3607
                path: token
            - configMap:
                items:
                - key: ca.crt
                  path: ca.crt
                name: kube-root-ca.crt
            - downwardAPI:
                items:
                - fieldRef:
                    apiVersion: v1
                    fieldPath: metadata.namespace
                  path: namespace
            - configMap:
                items:
                - key: service-ca.crt
                  path: service-ca.crt
                name: openshift-service-ca.crt
      status:
        conditions:
        - lastProbeTime: null
          lastTransitionTime: "2025-04-29T03:31:08Z"
          status: "True"
          type: PodReadyToStartContainers
        - lastProbeTime: null
          lastTransitionTime: "2025-04-29T03:30:48Z"
          status: "True"
          type: Initialized
        - lastProbeTime: null
          lastTransitionTime: "2025-04-29T03:31:08Z"
          status: "True"
          type: Ready
        - lastProbeTime: null
          lastTransitionTime: "2025-04-29T03:31:08Z"
          status: "True"
          type: ContainersReady
        - lastProbeTime: null
          lastTransitionTime: "2025-04-29T03:30:48Z"
          status: "True"
          type: PodScheduled
        containerStatuses:
        - containerID: cri-o://d3e213c2df72aef5bb929427816d99bca1c27d17e05332e6999209f0cec41802
          image: quay.io/openshifttest/hello-openshift@sha256:56c354e7885051b6bb4263f9faa58b2c292d44790599b7dde0e49e7c466cf339
          imageID: quay.io/openshifttest/hello-openshift@sha256:2b1a20c5faceb72a15b20ae0b5b83e3cf87fd76ee5375941071a0efbc196ea45
          lastState: {}
          name: dynamic
          ready: true
          restartCount: 0
          started: true
          state:
            running:
              startedAt: "2025-04-29T03:31:08Z"
          volumeMounts:
          - mountPath: /mnt/iaas
            name: dynamic
          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
            name: kube-api-access-vcbqx
            readOnly: true
            recursiveReadOnly: Disabled
        hostIP: 10.0.77.237
        hostIPs:
        - ip: 10.0.77.237
        phase: Running
        podIP: 10.131.2.9
        podIPs:
        - ip: 10.131.2.9
        qosClass: BestEffort
        startTime: "2025-04-29T03:30:48Z"
waiting for operation up to 120 seconds..
waiting for operation up to 3600 seconds..
        And the "pvc-<%= project.name %>" PVC becomes :bound within 120 seconds # features/step_definitions/pvc.rb:3
      [03:31:14] INFO> 
      [03:31:14] INFO> After 1 iterations and 2 seconds:
      matched status for persistentvolumeclaims pvc-jn0vh: 'bound' while expecting '[:bound]'
waiting for operation up to 3600 seconds..
        When I run the :patch client command with:                              # features/step_definitions/cli.rb:13
          | resource      | pvc                                                   |
          | resource_name | pvc-<%= project.name %>                               |
          | p             | {"spec":{"resources":{"requests":{"storage":"1Gi"}}}} |
      [03:31:14] INFO> Shell Commands: oc patch pvc pvc-jn0vh -p \{\"spec\":\{\"resources\":\{\"requests\":\{\"storage\":\"1Gi\"\}\}\}\} --kubeconfig=/Users/wangpenghao/workdir/pewang-mac-rootx/ocp4_testuser-0.kubeconfig
      
      STDERR:
      The PersistentVolumeClaim "pvc-jn0vh" is invalid: spec.resources.requests.storage: Forbidden: field can not be less than status.capacity
      [03:31:16] INFO> Exit Status: 1
        Then the step should fail                                               # features/step_definitions/common.rb:4
        And the output should match:                                            # features/step_definitions/common.rb:33
          | Forbidden.*field can not be less than (previous value\|status\.capacity) |
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
waiting for operation up to 3600 seconds..
      [03:31:16] INFO> === After Scenario: Resize negative test ===
      [03:31:16] INFO> cleaning-up user testuser-0 projects
      [03:31:18] INFO> Shell Commands: oc delete projects --all --kubeconfig=/Users/wangpenghao/workdir/pewang-mac-rootx/ocp4_testuser-0.kubeconfig
      project.project.openshift.io "jn0vh" deleted
      [03:31:33] INFO> Exit Status: 0
      [03:31:33] INFO> waiting up to 30 seconds for user clean-up to take place
      [03:31:35] INFO> HTTP DELETE https://api.meinliaws419-0429.qe.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthaccesstokens/sha256~oimvV-XmiN9NznjNq1XkkUOwoyKFnxNnRzIZQIVXm3g
      [03:31:36] INFO> HTTP DELETE took 0.972 sec: 200 OK | application/json 791 bytes
      [03:31:36] INFO> Shell Commands: rm -r -f -- /Users/wangpenghao/workdir/pewang-mac-rootx
      
      [03:31:37] INFO> Exit Status: 0
      [03:31:38] INFO> === End After Scenario: Resize negative test ===
# @author ropatil@redhat.com
# Create pvc with csi storage class
# Create deployment with pvc and check for pvc bound status
# Apply the patch command to resize the pvc storage size
# Scale the deployment and wait till it gets disappeared
#Check the pvc status whether its ready to enable pvc resize
# Scale the deployment and check for ready status
# Check the pv,pvc capacity size
# Write data

1 scenario (1 passed)
12 steps (12 passed)
1m20.759s
[03:31:38] INFO> === At Exit ===
```

</details>