### PR TITLE
fix OCP-32857 due to 4.19 UI change

### DIFF
--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -132,7 +132,7 @@ silence_alert_from_detail_check_fields:
 click_alert_link_with_text:
   element:
     selector:
-      xpath: //a[text()='<alert_name>' and @data-test-id='alert-resource-link']
+      xpath: //a[text()='<alert_name>' and @data-test-id='alert-resource-link' and contains(@href, '/monitoring/alerts')]
     op: click
     timeout: 60
 click_actions_button:

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -159,7 +159,7 @@ click_silence_link_with_text:
 click_actions_button:
   element:
     selector:
-      xpath: //button[@class='pf-v6-c-menu-toggle pf-m-expanded']
+      xpath: //button[@class='pf-v6-c-menu-toggle']
     op: click
 expire_alert_from_detail:
   action: click_first_action_icon
@@ -212,7 +212,7 @@ expire_alert_from_actions:
 wait_exipre_silence_loaded:
   elements:
   - selector:
-      xpath: //button[text()='Expire silence']
+      xpath: //button//span[text()='Expire silence']
     timeout: 60
 click_duration_dropdown_button:
   element:

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -362,7 +362,7 @@ hide_show_alert_graph_button:
 Disable_all_filters:
   element:
     selector:
-      xpath: //button[text()='Clear all filters']
+      xpath: //button/span[text()='Clear all filters']
     op: click
     timeout: 60
 clear_specifc_filter:

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -37,9 +37,16 @@ set_span_class:
       xpath: //span[contains(@class, '<class_text>')]//input[@data-test-id='item-filter']
     op: send_keys <input_value>
     type: input
+expand_alert_button:
+  element:
+    selector:
+      xpath: //button/span[@class='pf-v6-c-button__icon']
+    op: click
+    timeout: 60
 open_alert_detail:
   action: Disable_all_filters
   action: filter_alert
+  action: expand_alert_button
   action: click_alert_link_with_text
 open_alert_detail_href:
   action: Disable_all_filters

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -132,7 +132,7 @@ silence_alert_from_detail_check_fields:
 click_alert_link_with_text:
   element:
     selector:
-      xpath: //a[text()='<alert_name>']
+      xpath: //a[text()='<alert_name>' and @data-test-id='alert-resource-link']
     op: click
     timeout: 60
 click_actions_button:

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -240,7 +240,7 @@ status_specific_alert_no_clear:
   action: filter_alert
   element:
     selector:
-      xpath: //tbody[@class='pf-v6-c-table__tbody']//td[text()='<status>'][1]
+      xpath: //tbody[@class='pf-v6-c-table__tbody']//td//span[text()='<status>'][1]
 status_specific_alert:
   action: Disable_all_filters
   action: filter_alert

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -159,7 +159,7 @@ click_silence_link_with_text:
 click_actions_button:
   element:
     selector:
-      xpath: //button[@class='pf-v5-c-dropdown__toggle']
+      xpath: //button[@class='pf-v6-c-menu-toggle pf-m-expanded']
     op: click
 expire_alert_from_detail:
   action: click_first_action_icon

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -93,9 +93,17 @@ check_regular_expression_link:
       xpath: //a[@href='https://github.com/google/re2/wiki/Syntax']
 input_silence_comments:
   params:
-    label_text: Comment
+    aria_label_text: Comment
     input_value: <comment_text>
-  action: set_label_textarea
+  elements:
+  - selector: &label_textarea
+      xpath: //span/textarea[@aria-label='<aria_label_text>']
+    op: clear
+    type: textarea
+  - selector:
+      <<: *label_textarea
+    op: send_keys <input_value>
+    type: textarea
 perform_silence:
   action: submit_changes
 check_silence_detail:

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -240,7 +240,7 @@ status_specific_alert_no_clear:
   action: filter_alert
   element:
     selector:
-      xpath: //div[@aria-label='Alerts']//td[text()='<status>'][1]
+      xpath: //tbody[@class='pf-v6-c-table__tbody']//td[text()='<status>'][1]
 status_specific_alert:
   action: Disable_all_filters
   action: filter_alert

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -55,7 +55,7 @@ open_alert_detail_href:
 open_silence_detail:
   action: filter_alert
   action: clear_pending_filter_if_exists
-  action: click_alert_link_with_text
+  action: click_silence_link_with_text
 check_alert_detail:
   params:
     content: alertname=Watchdog
@@ -148,6 +148,12 @@ click_alert_link_with_text:
   element:
     selector:
       xpath: //a[text()='<alert_name>' and @data-test-id='alert-resource-link' and contains(@href, '/monitoring/alerts')]
+    op: click
+    timeout: 60
+click_silence_link_with_text:
+  element:
+    selector:
+      xpath: //a[text()='<alert_name>' and @data-test-id='silence-resource-link' and contains(@href, '/monitoring/silences')]
     op: click
     timeout: 60
 click_actions_button:


### PR DESCRIPTION
see from
https://issues.redhat.com/browse/OCPBUGS-55802
https://issues.redhat.com/browse/OCPQE-29279
this PR fix OCP-32857 due to 4.19 UI changes
changes: 
1. 4.19 xpath for Disable_all_filters changed, the xpath now is updated to `//button/span[text()='Clear all filters']`
2. 4.19 xpath for click_alert_link_with_text changed, the xpath now is updated to `//a[text()='<alert_name>' and @data-test-id='alert-resource-link' and contains(@href, '/monitoring/alerts')]`
3. added expand_alert_button action to open_alert_detail
4. updated input_silence_comments action
5. updated xpath for status_specific_alert_no_clear to `//tbody[@class='pf-v6-c-table__tbody']//td[text()='<status>'][1]`
6. added click_silence_link_with_text action and replaced click_alert_link_with_text action in open_silence_detail
7. updated xpath for click_actions_button
8. updated xpath for wait_exipre_silence_loaded