### PR TITLE
remove rate limit tests due to migration OCPQE-29445

### DIFF
--- a/features/routing/rate-limit.feature
+++ b/features/routing/rate-limit.feature
@@ -3,7 +3,7 @@ Feature: Testing haproxy rate limit related features
   # @author hongli@redhat.com
   # @case_id OCP-18482
   @admin
-  @4.19 @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity


### PR DESCRIPTION
Removing rate limit tests from cucushift repo due to migration into ginkgo
JIRA: https://issues.redhat.com/browse/OCPQE-29445 

CC @melvinjoseph86 @ShudiLi @lihongan 