### PR TITLE
fix xpath for OCP-21150/OCP-29061 due to 4.19 UI changes

### DIFF
--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -67,7 +67,13 @@ check_alert_breadcrumb:
     link_url: /monitoring/alerts
 open_alertrules_detail:
   action: filter_alert
-  action: click_alert_link_with_text
+  action: click_alertrules_link_with_text
+click_alertrules_link_with_text:
+  element:
+    selector:
+      xpath: //a[contains(@href, '/monitoring/alertrules')]//span[text()='<alert_name>']
+    op: click
+    timeout: 60
 
 perform_action_item:
   params:
@@ -240,7 +246,17 @@ set_invalid_end_time_silence:
     label_text: Until...
     input_value: 2020/03/05 20:11:44
   action: set_silence_duration_null
-  action: set_label_input_simple
+  action: set_until_input_simple
+set_until_input_simple:
+  elements:
+  - selector: &label_input_value
+      xpath: //label//span[contains(text(),'<label_text>')]/ancestor::div[@class='pf-v6-c-form__group']//input
+    op: clear
+    type: input
+  - selector:
+      <<: *label_input_value
+    op: send_keys <input_value>
+    type: input
 
 status_specific_alert_no_clear:
   action: filter_alert


### PR DESCRIPTION
see [MON-4250](https://issues.redhat.com/browse/MON-4250)
this PR updates:
1. added click_alertrules_link_with_text action and replaced click_alert_link_with_text for open_alertrules_detail action
2. added set_until_input_simple action and replaced set_label_input_simple for set_invalid_end_time_silence action

4.19 runner [job](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/Runner/1115975/console) passed