### PR TITLE
update xpath for OCP-21132/OCP-21192 due to 4.19 UI changes

### DIFF
--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -325,7 +325,7 @@ check_info_of_silence_detail_reg:
 check_silence_name:
   element:
     selector:
-      xpath: //dd[contains(text(), '<silence_name>')]
+      xpath: //dd//text()[normalize-space(.)='<silence_name>']
 check_silenced_alert_name:
   element:
     selector:
@@ -356,7 +356,7 @@ check_alert_rule_details:
 check_rule_name:
   element:
     selector:
-      xpath: //dd[contains(text(), '<rule_name>')]
+      xpath: //dd//text()[normalize-space(.)='<rule_name>']
 check_ruel_expression:
   params:
     text: vector(1)

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -350,14 +350,14 @@ check_alert_rule_details:
   params:
     rule_name: Watchdog
   action: check_rule_name
-  action: check_ruel_expression
+  action: check_rule_expression
   action: check_active_alerts
   action: check_rule_breadcrumb
 check_rule_name:
   element:
     selector:
       xpath: //dd[contains(., '<rule_name>')]
-check_ruel_expression:
+check_rule_expression:
   params:
     text: vector(1)
     link_url: /monitoring/query-browser?query0=vector(1)
@@ -372,12 +372,12 @@ check_rule_breadcrumb:
   action: check_link_and_text
 check_view_metrics:
   params:
-    text: View in Metrics
+    text: Inspect
     link_url: /monitoring/query-browser?query0=vector(1)
   action: check_link_and_text
 click_view_metrics:
   params:
-    text: View in Metrics
+    text: Inspect
     link_url: /monitoring/query-browser?query0=vector(1)
   action: click_link_with_text
 check_alert_description_on_rule_detail:

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -325,7 +325,7 @@ check_info_of_silence_detail_reg:
 check_silence_name:
   element:
     selector:
-      xpath: //dd//text()[normalize-space(.)='<silence_name>']
+      xpath: //dd//text()[contains(., '<silence_name>']
 check_silenced_alert_name:
   element:
     selector:
@@ -356,7 +356,7 @@ check_alert_rule_details:
 check_rule_name:
   element:
     selector:
-      xpath: //dd//text()[normalize-space(.)='<rule_name>']
+      xpath: //dd//text()[contains(., '<rule_name>')]
 check_ruel_expression:
   params:
     text: vector(1)

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -325,7 +325,7 @@ check_info_of_silence_detail_reg:
 check_silence_name:
   element:
     selector:
-      xpath: //dd//text()[contains(., '<silence_name>']
+      xpath: //dd[contains(., '<silence_name>')]
 check_silenced_alert_name:
   element:
     selector:
@@ -356,7 +356,7 @@ check_alert_rule_details:
 check_rule_name:
   element:
     selector:
-      xpath: //dd//text()[contains(., '<rule_name>')]
+      xpath: //dd[contains(., '<rule_name>')]
 check_ruel_expression:
   params:
     text: vector(1)


### PR DESCRIPTION
see [MON-4252](https://issues.redhat.com/browse/MON-4252)
this PR updates:
1. xpath for check_rule_name action
2. xpath for check_silence_name action
3. update text for check_view_metrics and click_view_metric actions
4. fix typo