### PR TITLE
fix OCP-24601/OCP-32859 due to 4.19 UI change

### DIFF
--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -284,7 +284,7 @@ status_specific_alert_rule:
 check_specific_alert:
   element:
     selector:
-      xpath: //span[contains(text(),'<table_text>')]
+      xpath: //a//span[contains(text(),'<table_text>')]
 click_alertrule_expression:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_alerts.xyaml
@@ -284,7 +284,7 @@ status_specific_alert_rule:
 check_specific_alert:
   element:
     selector:
-      xpath: //a[contains(text(),'<table_text>')]
+      xpath: //span[contains(text(),'<table_text>')]
 click_alertrule_expression:
   element:
     selector:

--- a/lib/rules/web/admin_console/4.19/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_metrics.xyaml
@@ -133,22 +133,22 @@ choose_zoom_value:
 click_chart_zoom_dropdown:
   element:
     selector:
-      xpath: //div[contains(@class,'query-browser__wrapper' )]//button[@id]
+      xpath: //button[@class='pf-v6-c-menu-toggle' and @aria-label='graph timespan']
     op: click
 click_zoom_value_button:
   element:
     selector:
-      xpath: //div[contains(@class,'query-browser__wrapper' )]//a[text()='<zoom_value>']
+      xpath: //li[@class='pf-v6-c-menu__list-item']//span[text()='<zoom_value>']/ancestor::button
     op: click
 click_reset_zoom_button:
   element:
     selector:
-      xpath: //div[contains(@class,'query-browser__controls' )]/button
+      xpath: //span[text()='Reset zoom']/ancestor::button
     op: click
 check_zoom_value:
   element:
     selector:
-      xpath: //div[contains(@class,'query-browser__wrapper' )]//input[@value='<zoom_value>']
+      xpath: //div[contains(@class,'pf-v6-c-input-group' )]//input[@value='<zoom_value>']
 
 check_metric_query_result_not_exit:
   params:


### PR DESCRIPTION
see [MON-4253](https://issues.redhat.com/browse/MON-4253)
this PR updated:
1. updated xpath for click_chart_zoom_dropdown,click_zoom_value_button,click_reset_zoom_button,check_zoom_value actions
2. updated xpath for check_specific_alert action