### PR TITLE
add "op: click" for click_run_queries_button action

### DIFF
--- a/lib/rules/web/admin_console/4.19/monitoring_metrics.xyaml
+++ b/lib/rules/web/admin_console/4.19/monitoring_metrics.xyaml
@@ -11,6 +11,7 @@ click_run_queries_button:
   element:
     selector:
       xpath: //button[@type='submit']//span[text()='Run queries']
+    op: click
 check_sample_query_area:
   element:
     selector:


### PR DESCRIPTION
see [MON-4258](https://issues.redhat.com/browse/MON-4258)
click_run_queries_button action missed op: click in PR: https://github.com/openshift/verification-tests/commit/1fe63f62e411f15719ad2e5436a49694c93feb72
this PR added "op: click" for click_run_queries_button action, and click_run_queries_button is only used for OCP-43747 now, won't affect other cases
4.19 runner [job](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/Runner/1116066/console) passed