### PR TITLE
removed OCP-10043 and OCP-11679

### DIFF
--- a/features/routing/haproxy-router.feature
+++ b/features/routing/haproxy-router.feature
@@ -297,7 +297,7 @@ Feature: Testing haproxy router
   # @author bmeng@redhat.com
   # @case_id OCP-10043
   @admin
-  @4.20 @4.19 @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity
@@ -349,7 +349,7 @@ Feature: Testing haproxy router
 
   # @author yadu@redhat.com
   # @case_id OCP-11679
-  @4.20 @4.19 @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @nutanix-ipi @ibmcloud-ipi @gcp-ipi @baremetal-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @vsphere-upi @openstack-upi @nutanix-upi @ibmcloud-upi @gcp-upi @baremetal-upi @azure-upi @aws-upi @alicloud-upi
   @upgrade-sanity


### PR DESCRIPTION
Since OCP-10043 and OCP-11679 were migrated(https://github.com/openshift/openshift-tests-private/pull/25777), removed them from the verification-tests

@lihongan @melvinjoseph86 @rhamini3 please help review, thanks.