### PR TITLE
OCPBUGS-53048 add spec.terminationGracePeriodSeconds with default value 30s

### DIFF
--- a/testdata/infrastructure/cluster-capacity/cluster-capacity-configmap.yaml
+++ b/testdata/infrastructure/cluster-capacity/cluster-capacity-configmap.yaml
@@ -10,6 +10,7 @@ data:
         app: guestbook
         tier: frontend
     spec:
+      terminationGracePeriodSeconds: 30
       containers:
       - name: php-redis
         image: quay.io/openshifttest/gb-frontend:v4


### PR DESCRIPTION
add `terminationGracePeriodSeconds: 30` for small-pod spec to fix stage testing failure mentioned in [OCPBUGS-53048](https://issues.redhat.com/browse/OCPBUGS-53048)