### PR TITLE
Add users, case ID and team name to OCP-39845

### DIFF
--- a/features/upgrade/machines/machines.feature
+++ b/features/upgrade/machines/machines.feature
@@ -346,21 +346,23 @@ Feature: Machine-api components upgrade tests
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
+  @users=upuser1,upuser2
   @4.20 @4.19 @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
-  Scenario: Registering Components delays should not be more than liveliness probe - prepare
+  Scenario: OCP-39845:ClusterInfrastructure Registering Components delays should not be more than liveliness probe - prepare
     Given the expression should be true> "True" == "True"
 
   # @author miyadav@redhat.com
   # @case_id OCP-39845
   @upgrade-check
   @admin
-  @4.20 @4.19 @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
   @vsphere-ipi @openstack-ipi @ibmcloud-ipi @gcp-ipi @azure-ipi @aws-ipi @alicloud-ipi
   @upgrade
   @network-ovnkubernetes @network-openshiftsdn
   @proxy @noproxy @disconnected @connected
   @s390x @ppc64le @heterogeneous @arm64 @amd64
-  Scenario: Registering Components delays should not be more than liveliness probe
+  @users=upuser1,upuser2
+  @4.20 @4.19 @4.18 @4.17 @4.16 @4.15 @4.14 @4.13 @4.12 @4.11 @4.10 @4.9 @4.8 @4.7 @4.6
+  Scenario: OCP-39845:ClusterInfrastructure Registering Components delays should not be more than liveliness probe
     Given I have an IPI deployment
     And I switch to cluster admin pseudo user
     And I use the "openshift-machine-api" project


### PR DESCRIPTION
Fix below error,
```
[22:35:29] INFO> === End After Scenario: Registering Components delays should not be more than liveliness probe ===
no specification for user index 0 in a scenario @users tag (RuntimeError)
./lib/user_manager.rb:156:in `[]'
./lib/world.rb:182:in `user'
./features/step_definitions/machine.rb:23:in `block (2 levels) in <top (required)>'
./features/step_definitions/machine.rb:10:in `each'
./features/step_definitions/machine.rb:10:in `/^I have an IPI deployment$/'
features/upgrade/machines/machines.feature:364:in `I have an IPI deployment'
```