### PR TITLE
Fix verification-tests image

### DIFF
--- a/tools/openshift-ci/Dockerfile
+++ b/tools/openshift-ci/Dockerfile
@@ -70,5 +70,4 @@ RUN set -x && \
 
 # Fix permission issues of loading .config/containers/registries.conf.d when runnig oc/skopeo tools
 RUN set -x && \
-    test -d /opt/app-root/src/.config && \
-    chmod -R 777 /opt/app-root/src/.config
+    ( chmod -R 777 /opt/app-root/src/.config || true )


### PR DESCRIPTION
Fix below issue,
```
STEP 12/14: RUN set -x &&     test -d /opt/app-root/src/.config &&     chmod -R 777 /opt/app-root/src/.config
+ test -d /opt/app-root/src/.config
error: build error: building at STEP "RUN set -x &&     test -d /opt/app-root/src/.config &&     chmod -R 777 /opt/app-root/src/.config": while running runtime: exit status 1
```
e.g, failure [job](https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/pr-logs/pull/openshift_verification-tests/3925/pull-ci-openshift-verification-tests-main-images/2041739985891102720)